### PR TITLE
Fixed missing NAK for last 2 Bytes read

### DIFF
--- a/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
+++ b/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
@@ -796,6 +796,8 @@ package body STM32.I2C is
 
          elsif Idx + 1 = Data'Last then
             --  Two bytes to read
+            Handle.Periph.CR1.ACK := False;
+
             Wait_Flag (Handle,
                        Byte_Transfer_Finished,
                        False,
@@ -1049,6 +1051,8 @@ package body STM32.I2C is
 
          elsif Idx + 1 = Data'Last then
             --  Two bytes to read
+            Handle.Periph.CR1.ACK := False;
+            
             Wait_Flag (Handle, Byte_Transfer_Finished, False, Timeout, Status);
             if Status /= HAL.I2C.Ok then
                return;


### PR DESCRIPTION
I think I found a bug in I2C multibyte read.

If an even number of bytes > 2 is read, the receive method will end up in the `elsif Idx + 1 = Data'Last then` branch. However in there, the ACK is not disabled. After receiving all bytes the master will ACK the last byte and the slave will try to send more bytes but the master disables the Clock.

In my case the slave was pulling down SDA forever and the I2C bus was stuck.