### PR TITLE
added DMA write to SD card drivers

### DIFF
--- a/ARM/STM32/drivers/sd/sdio/stm32-sdmmc.ads
+++ b/ARM/STM32/drivers/sd/sdio/stm32-sdmmc.ads
@@ -24,6 +24,7 @@ package STM32.SDMMC is
       Unsupported_Card,
       Rx_Overrun,
       Tx_Underrun,
+      Startbit_Not_Detected,
       Request_Not_Applicable,
       CRC_Check_Fail,
       Illegal_Cmd,
@@ -44,7 +45,8 @@ package STM32.SDMMC is
       WP_Erase_Skip,
       Erase_Reset,
       AKE_SEQ_Error,
-      Invalid_Voltage_Range);
+      Invalid_Voltage_Range,
+      DMA_Alignment_Error);
 
    type Supported_SD_Memory_Cards is
      (STD_Capacity_SD_Card_V1_1,
@@ -64,7 +66,7 @@ package STM32.SDMMC is
       Data_Read_Access_Time_2          : Byte; --  In CLK Cycles
       Max_Bus_Clock_Frequency          : Byte;
       Card_Command_Class               : Short;
-      Max_Read_Data_Block_Length       : Byte;
+      Max_Read_Data_Block_Length       : Byte; -- ld (blocksize in bytes)
       Partial_Block_For_Read_Allowed   : Boolean;
       Write_Block_Missalignment        : Boolean;
       Read_Block_Missalignment         : Boolean;
@@ -82,7 +84,7 @@ package STM32.SDMMC is
       Write_Protect_Group_Enable       : Boolean;
       Manufacturer_Default_ECC         : Byte;
       Write_Speed_Factor               : Byte;
-      Max_Write_Data_Block_Length      : Byte;
+      Max_Write_Data_Block_Length      : Byte; -- =Max_Read_Data_Block_Length
       Partial_Blocks_For_Write_Allowed : Boolean;
       Reserved_3                       : Byte;
       Content_Protection_Application   : Boolean;
@@ -186,7 +188,16 @@ package STM32.SDMMC is
       Addr       : Unsigned_64;
       DMA        : STM32.DMA.DMA_Controller;
       Stream     : STM32.DMA.DMA_Stream_Selector;
-      Data       : out SD_Data) return SD_Error;
+      Data       : out SD_Data) return SD_Error
+     with Pre => Data'Length <= 65535;
+
+   function Write_Blocks_DMA
+     (Controller : in out SDMMC_Controller;
+      Addr       : Unsigned_64;
+      DMA        : STM32.DMA.DMA_Controller;
+      Stream     : STM32.DMA.DMA_Stream_Selector;
+      Data       : SD_Data) return SD_Error
+     with Pre => Data'Length <= 65535;
 
    function Stop_Transfer
      (Controller : in out SDMMC_Controller) return SD_Error;
@@ -203,7 +214,8 @@ package STM32.SDMMC is
       Data_Timeout,
       RX_Overrun,
       TX_Underrun,
-      RX_Active);
+      RX_Active,
+      TX_Active);
 
    subtype SDMMC_Clearable_Flags is SDMMC_Flags range Data_End .. TX_Underrun;
 
@@ -381,7 +393,8 @@ private
           when Data_Timeout  => Controller.Periph.STA.DTIMEOUT,
           when RX_Overrun    => Controller.Periph.STA.RXOVERR,
           when TX_Underrun   => Controller.Periph.STA.TXUNDERR,
-          when RX_Active     => Controller.Periph.STA.RXACT);
+          when RX_Active     => Controller.Periph.STA.RXACT,
+          when TX_Active     => Controller.Periph.STA.TXACT);
 
    function Last_Operation
      (Controller : SDMMC_Controller) return SDMMC_Operation

--- a/ARM/STM32/drivers/sd/stm32-sdmmc.adb
+++ b/ARM/STM32/drivers/sd/stm32-sdmmc.adb
@@ -1,5 +1,6 @@
 with Ada.Unchecked_Conversion;
 with Ada.Real_Time;   use Ada.Real_Time;
+with System;          use System;
 with System.Machine_Code;
 
 package body STM32.SDMMC is
@@ -1297,9 +1298,9 @@ package body STM32.SDMMC is
          --  Wide bus mode enable bit
          WIDBUS         => Bus_Wide_1B,
          --  SDIO_CK dephasing selection bit
-         NEGEDGE        => Edge_Rising,
+         NEGEDGE        => Edge_Rising, -- Errata sheet STM: NEGEDGE=1 (falling) should *not* be used
          --  HW Flow Control enable
-         HWFC_EN        => False,
+         HWFC_EN        => False, -- Errata sheet STM: glitches => DCRCFAIL asserted. Do not use.
          others         => <>);
 
       Controller.Periph.DTIMER := SD_DATATIMEOUT;
@@ -1500,6 +1501,11 @@ package body STM32.SDMMC is
       elsif Controller.Periph.STA.RXOVERR then
          Controller.Periph.ICR.RXOVERRC := True;
          return Rx_Overrun;
+
+      elsif Controller.Periph.STA.STBITERR then
+         Controller.Periph.ICR.STBITERRC := True;
+         return Startbit_Not_Detected;
+
       end if;
 
       for J in Unsigned_32'(1) .. SD_DATATIMEOUT loop
@@ -1526,12 +1532,24 @@ package body STM32.SDMMC is
       Read_Address : constant Unsigned_64 :=
                        (if Controller.Card_Type = High_Capacity_SD_Card
                         then Addr / 512 else Addr);
-      Err          : SD_Error;
-      N_Blocks     : constant Positive := Data'Length / 512;
-      Command      : SDMMC_Command;
-      use STM32.DMA;
 
+      Data_Len_Bytes : constant Natural := (Data'Length / 512) * 512;
+      Data_Len_Words : constant Natural := Data_Len_Bytes / 4;
+      N_Blocks       : constant Natural := Data_Len_Bytes / 512;
+      Data_Addr      : constant Address := Data (Data'First)'Address;
+
+      Err            : SD_Error;
+      Command        : SDMMC_Command;
+      use STM32.DMA;
    begin
+      if not STM32.DMA.Compatible_Alignments (DMA,
+                                              Stream,
+                                              Controller.Periph.FIFO'Address,
+                                              Data_Addr)
+      then
+         return DMA_Alignment_Error;
+      end if;
+
       --  After a data write, data cannot be written to this register
       --  for three SDMMCCLK (@ 48 MHz) clock periods plus two PCLK2 clock
       --  periods (@ ~90MHz).
@@ -1544,6 +1562,17 @@ package body STM32.SDMMC is
       Enable_Interrupt (Controller, Data_Timeout_Interrupt);
       Enable_Interrupt (Controller, Data_End_Interrupt);
       Enable_Interrupt (Controller, RX_Overrun_Interrupt);
+
+      STM32.DMA.Start_Transfer_with_Interrupts
+        (Unit               => DMA,
+         Stream             => Stream,
+         Source             => Controller.Periph.FIFO'Address,
+         Destination        => Data_Addr,
+         Data_Count         => Unsigned_16 (Data_Len_Words), -- because DMA is set up with words
+         Enabled_Interrupts => (Transfer_Error_Interrupt    => True,
+                                FIFO_Error_Interrupt        => True,
+                                Transfer_Complete_Interrupt => True,
+                                others                      => False));
 
       Send_Command
         (Controller,
@@ -1567,17 +1596,6 @@ package body STM32.SDMMC is
          DPSM               => True,
          DMA_Enabled        => True);
 
-      STM32.DMA.Start_Transfer_with_Interrupts
-        (Unit               => DMA,
-         Stream             => Stream,
-         Source             => Controller.Periph.FIFO'Address,
-         Destination        => Data (Data'First)'Address,
-         Data_Count         => Data'Length / 4,
-         Enabled_Interrupts => (Transfer_Error_Interrupt    => True,
-                                FIFO_Error_Interrupt        => True,
-                                Transfer_Complete_Interrupt => True,
-                                others                      => False));
-
       if N_Blocks > 1 then
          Command := Read_Multi_Block;
          Controller.Operation := Read_Multiple_Blocks_Operation;
@@ -1598,6 +1616,155 @@ package body STM32.SDMMC is
       return Err;
    end Read_Blocks_DMA;
 
+   ---------------------
+   --  Write_Blocks_DMA
+   ---------------------
+
+   function Write_Blocks_DMA
+     (Controller : in out SDMMC_Controller;
+      Addr       : Unsigned_64;
+      DMA        : STM32.DMA.DMA_Controller;
+      Stream     : STM32.DMA.DMA_Stream_Selector;
+      Data       : SD_Data) return SD_Error
+   is
+      Write_Address : constant Unsigned_64 :=
+                       (if Controller.Card_Type = High_Capacity_SD_Card
+                        then Addr / 512 else Addr); -- 512 is the min. block size of SD 2.0 card
+
+      Data_Len_Bytes : constant Natural := (Data'Length / 512) * 512;
+      Data_Len_Words : constant Natural := Data_Len_Bytes / 4;
+      N_Blocks       : constant Natural := Data_Len_Bytes / 512;
+      Data_Addr      : constant Address := Data (Data'First)'Address;
+
+      Err        : SD_Error;
+      cardstatus : HAL.Word;
+      start      : constant Time := Clock;
+      Timeout    : Boolean := False;
+      Command    : SDMMC_Command;
+
+      use STM32.DMA;
+   begin
+
+      if not STM32.DMA.Compatible_Alignments (DMA,
+                                              Stream,
+                                              Controller.Periph.FIFO'Address,
+                                              Data_Addr)
+      then
+         return DMA_Alignment_Error;
+      end if;
+
+      --  this is all according tom STM RM0090 sec.31.3.2 p. 1036. But something is wrong.
+      DCTRL_Write_Delay;
+      Controller.Periph.DCTRL := (DTEN   => False,
+                                  others => <>);
+      --  Wait 1ms: After a data write, data cannot be written to this register
+      --  for three SDMMCCLK (48 MHz) clock periods plus two PCLK2 clock
+      --  periods.
+      DCTRL_Write_Delay;
+
+      Clear_Static_Flags (Controller);
+
+      --  wait until card is ready for data added
+      Wait_Ready_Loop :
+      loop
+         declare
+            now : constant Time := Clock;
+         begin
+            if now - start > Milliseconds (100) then
+               Timeout := True;
+               exit Wait_Ready_Loop;
+            end if;
+         end;
+
+         Send_Command
+           (Controller,
+            Command_Index      => Send_Status,
+            Argument           => Controller.RCA,
+            Response           => Short_Response,
+            CPSM               => True,
+            Wait_For_Interrupt => False);
+         Err := Response_R1_Error (Controller, Send_Status);
+
+         if Err /= OK then
+            return Err;
+         end if;
+
+         cardstatus := Controller.Periph.RESP1;
+         exit Wait_Ready_Loop when (cardstatus and 16#100#) /= 0;
+      end loop Wait_Ready_Loop;
+
+      if Timeout then
+         return Timeout_Error;
+      end if;
+
+      Enable_Interrupt (Controller, Data_CRC_Fail_Interrupt);
+      Enable_Interrupt (Controller, Data_Timeout_Interrupt);
+      Enable_Interrupt (Controller, Data_End_Interrupt);
+      Enable_Interrupt (Controller, TX_Underrun_Interrupt);
+
+      --  start DMA first (gives time to setup)
+      STM32.DMA.Start_Transfer_with_Interrupts
+        (Unit               => DMA,
+         Stream             => Stream,
+         Destination        => Controller.Periph.FIFO'Address,
+         Source             => Data_Addr,
+         Data_Count         => Unsigned_16 (Data_Len_Words), -- because DMA is set up with words
+         Enabled_Interrupts => (Transfer_Error_Interrupt    => True,
+                                FIFO_Error_Interrupt        => True, -- test: comment to see what happens
+                                Transfer_Complete_Interrupt => True,
+                                others                      => False));
+
+      --  set block size
+      Send_Command
+        (Controller,
+         Command_Index      => Set_Blocklen,
+         Argument           => 512,
+         Response           => Short_Response,
+         CPSM               => True,
+         Wait_For_Interrupt => False);
+      Err := Response_R1_Error (Controller, Set_Blocklen);
+
+      if Err /= OK then
+         return Err;
+      end if;
+
+      --  set write address & single/multi mode
+      if N_Blocks > 1 then
+         Command := Write_Multi_Block;
+         Controller.Operation := Write_Multiple_Blocks_Operation;
+      else
+         Command := Write_Single_Block;
+         Controller.Operation := Write_Single_Block_Operation;
+      end if;
+      Send_Command
+        (Controller,
+         Command_Index      => Command,
+         Argument           => Word (Write_Address),
+         Response           => Short_Response,
+         CPSM               => True,
+         Wait_For_Interrupt => False);
+      Err := Response_R1_Error (Controller, Command);
+      --  according to RM0090 we should wait for SDIO_STA[6] = CMDREND interrupt, which is this:
+      if Err /= OK then
+         return Err;
+      end if;
+
+      --  and now enable the card with DTEN, which is this:
+      Configure_Data
+        (Controller,
+         Data_Length        => UInt25 (N_Blocks) * 512,
+         Data_Block_Size    => Block_512B,
+         Transfer_Direction => Write,
+         Transfer_Mode      => Block,
+         DPSM               => True,
+         DMA_Enabled        => True);
+
+      --  according to RM0090: wait for STA[10]=DBCKEND
+      --  check that no channels are still enabled by polling DMA Enabled Channel Status Reg
+
+      return Err;
+   end Write_Blocks_DMA;
+
    -------------------------
    -- Get_Transfer_Status --
    -------------------------
@@ -1611,8 +1778,16 @@ package body STM32.SDMMC is
          return Timeout_Error;
 
       elsif Controller.Periph.STA.DCRCFAIL then
-         Controller.Periph.ICR.DCRCFAILC := True;
+         Controller.Periph.ICR.DCRCFAILC := True; -- clear
          return CRC_Check_Fail;
+
+      elsif Controller.Periph.STA.TXUNDERR then
+         Controller.Periph.ICR.TXUNDERRC := True;
+         return Tx_Underrun;
+
+      elsif Controller.Periph.STA.STBITERR then
+         Controller.Periph.ICR.STBITERRC := True;
+         return Startbit_Not_Detected;
 
       elsif Controller.Periph.STA.RXOVERR then
          Controller.Periph.ICR.RXOVERRC := True;

--- a/ARM/STM32/drivers/stm32-dma.ads
+++ b/ARM/STM32/drivers/stm32-dma.ads
@@ -86,7 +86,7 @@ with Ada.Real_Time;  use Ada.Real_Time;
 
 private with STM32_SVD.DMA;
 
-package STM32.DMA is
+package STM32.DMA with SPARK_Mode => Off is
 
    type DMA_Controller is limited private;
 
@@ -130,7 +130,7 @@ package STM32.DMA is
        Post =>
          not Enabled (Unit, Stream)                               and
          Operating_Mode (Unit, Stream) = Normal_Mode              and
-         Current_Counter (Unit, Stream) = 0                       and
+         Current_NDT (Unit, Stream) = 0                           and
          Selected_Channel (Unit, Stream) = Channel_0              and
          Transfer_Direction (Unit, Stream) = Peripheral_To_Memory and
          not Double_Buffered (Unit, Stream)                       and
@@ -276,25 +276,33 @@ package STM32.DMA is
       Timeout        : Time_Span;
       Result         : out DMA_Error_Code);
 
-   procedure Set_Counter
+   procedure Set_NDT
      (Unit       : DMA_Controller;
       Stream     : DMA_Stream_Selector;
       Data_Count : Short)
      with
        Pre  => not Enabled (Unit, Stream),
-       Post => Current_Counter (Unit, Stream) = Data_Count,
+       Post => Current_NDT (Unit, Stream) = Data_Count,
        Inline;
    --  Sets the number of data items to be transferred on the stream.
    --  The Data_Count parameter specifies the number of data items to be
    --  transferred (from 0 to 65535) on the next transfer. The value is
    --  as described for procedure Configure_Data_Flow.
 
-   function Current_Counter
+   function Items_Transferred
+     (Unit   : DMA_Controller;
+      Stream : DMA_Stream_Selector)
+      return Short;
+   --  returns the number of items transfetred
+
+   function Current_NDT
      (Unit   : DMA_Controller;
       Stream : DMA_Stream_Selector)
       return Short
      with Inline;
-   --  Returns the number of remaining data units to be transferred
+   --  Returns the value of the NDT register. Should not be used directly,
+   --  as the meaning changes depending on transfer mode. rather use
+   --  Items_Transferred()
 
    function Circular_Mode
      (Unit   : DMA_Controller;

--- a/examples/sdcard/adafatfs/media_reader.ads
+++ b/examples/sdcard/adafatfs/media_reader.ads
@@ -15,4 +15,9 @@ package Media_Reader is
       Block_Number : Unsigned_32;
       Data         : out Block) return Boolean is abstract;
 
+   function Write_Block
+     (Controller   : in out Media_Controller;
+      Block_Number : Unsigned_32;
+      Data         : Block) return Boolean is abstract;
+
 end Media_Reader;

--- a/examples/sdcard/src/media_reader-sdcard.ads
+++ b/examples/sdcard/src/media_reader-sdcard.ads
@@ -26,6 +26,12 @@ package Media_Reader.SDCard is
       Block_Number : Unsigned_32;
       Data         : out Block) return Boolean;
 
+   overriding function Write_Block
+     (Controller   : in out SDCard_Controller;
+      Block_Number : Unsigned_32;
+      Data         : Block) return Boolean;
+
+
 private
 
    type SDCard_Controller is limited new Media_Controller with record


### PR DESCRIPTION
Successfully tested on a STM32F427VIT and merged back into this library for public use.

The TX_Active bit is hanging around for a bit, leaving a single DMA transfer to be a bit slow, yet (~2msec).