### PR TITLE
Adafatfs write capabilities

### DIFF
--- a/ARM/STM32/drivers/sd/sdio/stm32-sdmmc.ads
+++ b/ARM/STM32/drivers/sd/sdio/stm32-sdmmc.ads
@@ -24,6 +24,7 @@ package STM32.SDMMC is
       Unsupported_Card,
       Rx_Overrun,
       Tx_Underrun,
+      Startbit_Not_Detected,
       Request_Not_Applicable,
       CRC_Check_Fail,
       Illegal_Cmd,
@@ -44,7 +45,8 @@ package STM32.SDMMC is
       WP_Erase_Skip,
       Erase_Reset,
       AKE_SEQ_Error,
-      Invalid_Voltage_Range);
+      Invalid_Voltage_Range,
+      DMA_Alignment_Error);
 
    type Supported_SD_Memory_Cards is
      (STD_Capacity_SD_Card_V1_1,
@@ -64,7 +66,7 @@ package STM32.SDMMC is
       Data_Read_Access_Time_2          : Byte; --  In CLK Cycles
       Max_Bus_Clock_Frequency          : Byte;
       Card_Command_Class               : Short;
-      Max_Read_Data_Block_Length       : Byte;
+      Max_Read_Data_Block_Length       : Byte; -- ld (blocksize in bytes)
       Partial_Block_For_Read_Allowed   : Boolean;
       Write_Block_Missalignment        : Boolean;
       Read_Block_Missalignment         : Boolean;
@@ -82,7 +84,7 @@ package STM32.SDMMC is
       Write_Protect_Group_Enable       : Boolean;
       Manufacturer_Default_ECC         : Byte;
       Write_Speed_Factor               : Byte;
-      Max_Write_Data_Block_Length      : Byte;
+      Max_Write_Data_Block_Length      : Byte; -- =Max_Read_Data_Block_Length
       Partial_Blocks_For_Write_Allowed : Boolean;
       Reserved_3                       : Byte;
       Content_Protection_Application   : Boolean;
@@ -186,7 +188,16 @@ package STM32.SDMMC is
       Addr       : Unsigned_64;
       DMA        : STM32.DMA.DMA_Controller;
       Stream     : STM32.DMA.DMA_Stream_Selector;
-      Data       : out SD_Data) return SD_Error;
+      Data       : out SD_Data) return SD_Error
+     with Pre => Data'Length <= 65535;
+
+   function Write_Blocks_DMA
+     (Controller : in out SDMMC_Controller;
+      Addr       : Unsigned_64;
+      DMA        : STM32.DMA.DMA_Controller;
+      Stream     : STM32.DMA.DMA_Stream_Selector;
+      Data       : SD_Data) return SD_Error
+     with Pre => Data'Length <= 65535;
 
    function Stop_Transfer
      (Controller : in out SDMMC_Controller) return SD_Error;
@@ -203,7 +214,8 @@ package STM32.SDMMC is
       Data_Timeout,
       RX_Overrun,
       TX_Underrun,
-      RX_Active);
+      RX_Active,
+      TX_Active);
 
    subtype SDMMC_Clearable_Flags is SDMMC_Flags range Data_End .. TX_Underrun;
 
@@ -377,7 +389,8 @@ private
           when Data_Timeout  => Controller.Periph.STA.DTIMEOUT,
           when RX_Overrun    => Controller.Periph.STA.RXOVERR,
           when TX_Underrun   => Controller.Periph.STA.TXUNDERR,
-          when RX_Active     => Controller.Periph.STA.RXACT);
+          when RX_Active     => Controller.Periph.STA.RXACT,
+          when TX_Active     => Controller.Periph.STA.TXACT);
 
    function Last_Operation
      (Controller : SDMMC_Controller) return SDMMC_Operation

--- a/ARM/STM32/drivers/sd/sdmmc/stm32-sdmmc.ads
+++ b/ARM/STM32/drivers/sd/sdmmc/stm32-sdmmc.ads
@@ -24,6 +24,7 @@ package STM32.SDMMC is
       Unsupported_Card,
       Rx_Overrun,
       Tx_Underrun,
+      Startbit_Not_Detected,
       Request_Not_Applicable,
       CRC_Check_Fail,
       Illegal_Cmd,
@@ -44,7 +45,8 @@ package STM32.SDMMC is
       WP_Erase_Skip,
       Erase_Reset,
       AKE_SEQ_Error,
-      Invalid_Voltage_Range);
+      Invalid_Voltage_Range,
+      DMA_Alignment_Error);
 
    type Supported_SD_Memory_Cards is
      (STD_Capacity_SD_Card_V1_1,
@@ -64,7 +66,7 @@ package STM32.SDMMC is
       Data_Read_Access_Time_2          : Byte; --  In CLK Cycles
       Max_Bus_Clock_Frequency          : Byte;
       Card_Command_Class               : Short;
-      Max_Read_Data_Block_Length       : Byte;
+      Max_Read_Data_Block_Length       : Byte; -- ld (blocksize in bytes)
       Partial_Block_For_Read_Allowed   : Boolean;
       Write_Block_Missalignment        : Boolean;
       Read_Block_Missalignment         : Boolean;
@@ -82,7 +84,7 @@ package STM32.SDMMC is
       Write_Protect_Group_Enable       : Boolean;
       Manufacturer_Default_ECC         : Byte;
       Write_Speed_Factor               : Byte;
-      Max_Write_Data_Block_Length      : Byte;
+      Max_Write_Data_Block_Length      : Byte; -- =Max_Read_Data_Block_Length
       Partial_Blocks_For_Write_Allowed : Boolean;
       Reserved_3                       : Byte;
       Content_Protection_Application   : Boolean;
@@ -186,7 +188,16 @@ package STM32.SDMMC is
       Addr       : Unsigned_64;
       DMA        : STM32.DMA.DMA_Controller;
       Stream     : STM32.DMA.DMA_Stream_Selector;
-      Data       : out SD_Data) return SD_Error;
+      Data       : out SD_Data) return SD_Error
+     with Pre => Data'Length <= 65535;
+
+   function Write_Blocks_DMA
+     (Controller : in out SDMMC_Controller;
+      Addr       : Unsigned_64;
+      DMA        : STM32.DMA.DMA_Controller;
+      Stream     : STM32.DMA.DMA_Stream_Selector;
+      Data       : SD_Data) return SD_Error
+     with Pre => Data'Length <= 65535;
 
    function Stop_Transfer
      (Controller : in out SDMMC_Controller) return SD_Error;
@@ -203,7 +214,8 @@ package STM32.SDMMC is
       Data_Timeout,
       RX_Overrun,
       TX_Underrun,
-      RX_Active);
+      RX_Active,
+      TX_Active);
 
    subtype SDMMC_Clearable_Flags is SDMMC_Flags range Data_End .. TX_Underrun;
 
@@ -377,7 +389,8 @@ private
           when Data_Timeout  => Controller.Periph.STA.DTIMEOUT,
           when RX_Overrun    => Controller.Periph.STA.RXOVERR,
           when TX_Underrun   => Controller.Periph.STA.TXUNDERR,
-          when RX_Active     => Controller.Periph.STA.RXACT);
+          when RX_Active     => Controller.Periph.STA.RXACT,
+          when TX_Active     => Controller.Periph.STA.TXACT);
 
    function Last_Operation
      (Controller : SDMMC_Controller) return SDMMC_Operation

--- a/ARM/STM32/drivers/stm32-dma.ads
+++ b/ARM/STM32/drivers/stm32-dma.ads
@@ -86,7 +86,7 @@ with Ada.Real_Time;  use Ada.Real_Time;
 
 private with STM32_SVD.DMA;
 
-package STM32.DMA is
+package STM32.DMA with SPARK_Mode => Off is
 
    type DMA_Controller is limited private;
 
@@ -130,7 +130,7 @@ package STM32.DMA is
        Post =>
          not Enabled (Unit, Stream)                               and
          Operating_Mode (Unit, Stream) = Normal_Mode              and
-         Current_Counter (Unit, Stream) = 0                       and
+         Current_NDT (Unit, Stream) = 0                           and
          Selected_Channel (Unit, Stream) = Channel_0              and
          Transfer_Direction (Unit, Stream) = Peripheral_To_Memory and
          not Double_Buffered (Unit, Stream)                       and
@@ -276,25 +276,33 @@ package STM32.DMA is
       Timeout        : Time_Span;
       Result         : out DMA_Error_Code);
 
-   procedure Set_Counter
+   procedure Set_NDT
      (Unit       : DMA_Controller;
       Stream     : DMA_Stream_Selector;
       Data_Count : Short)
      with
        Pre  => not Enabled (Unit, Stream),
-       Post => Current_Counter (Unit, Stream) = Data_Count,
+       Post => Current_NDT (Unit, Stream) = Data_Count,
        Inline;
    --  Sets the number of data items to be transferred on the stream.
    --  The Data_Count parameter specifies the number of data items to be
    --  transferred (from 0 to 65535) on the next transfer. The value is
    --  as described for procedure Configure_Data_Flow.
 
-   function Current_Counter
+   function Items_Transferred
+     (Unit   : DMA_Controller;
+      Stream : DMA_Stream_Selector)
+      return Short;
+   --  returns the number of items transfetred
+
+   function Current_NDT
      (Unit   : DMA_Controller;
       Stream : DMA_Stream_Selector)
       return Short
      with Inline;
-   --  Returns the number of remaining data units to be transferred
+   --  Returns the value of the NDT register. Should not be used directly,
+   --  as the meaning changes depending on transfer mode. rather use
+   --  Items_Transferred()
 
    function Circular_Mode
      (Unit   : DMA_Controller;

--- a/examples/sdcard/src/fat_filesystem-directories-files.adb
+++ b/examples/sdcard/src/fat_filesystem-directories-files.adb
@@ -1,0 +1,388 @@
+--  Institution: Technische Universitaet Muenchen
+--  Department:  Real-Time Computer Systems (RCS)
+--  Project:     StratoX
+--  Authors:     Martin Becker (becker@rcs.ei.tum.de)
+--
+--  XXX! Nothing here is proven thread-safe!
+with Ada.Unchecked_Conversion;
+with FAT_Filesystem; use FAT_Filesystem;
+
+--  @summary File handling for FAT FS
+package body FAT_Filesystem.Directories.Files is
+
+   -------------------
+   --  File_Create
+   -------------------
+
+   function File_Create
+     (Parent    : in out Directory_Handle;
+      newname   : String;
+      Overwrite : Boolean := False;
+      File      : out File_Handle) return Status_Code
+   is
+      subtype Entry_Data is Block (1 .. 32);
+      function From_Entry is new Ada.Unchecked_Conversion
+        (FAT_Directory_Entry, Entry_Data);
+
+      F_Entry  : FAT_Directory_Entry;
+      Ent_Addr : FAT_Address;
+      Status   : Status_Code;
+   begin
+
+      File.Is_Open := False;
+      if Parent.FS.Version /= FAT32 then
+         --  we only support FAT32 for now.
+         return Internal_Error;
+      end if;
+
+      --  find a place for another entry and return it
+      Status := Allocate_Entry (Parent, newname, Ent_Addr);
+      if Status /= OK then
+         if Status = Already_Exists and Overwrite then
+            ---------------
+            --  Overwrite
+            ---------------
+            if not Get_Entry (Parent => Parent, E_Name => newname, Ent => File.D_Entry) then
+               return Internal_Error;
+            end if;
+            if File.D_Entry.Attributes.Subdirectory then
+               return Already_Exists; -- overwrite subdirectory with file -> no!
+            end if;
+
+            --  wipe cluster chain in FAT..just keep first cluster
+            declare
+               cluster_cur  : Unsigned_32 := File.D_Entry.Start_Cluster;
+               cluster_info : Unsigned_32;
+               FAT_updated  : Boolean;
+            begin
+               Wipe_Chain_Loop :
+               loop
+                  cluster_info := Parent.FS.Get_FAT (cluster_cur);
+                  --  either points to next cluster, or indicates that
+                  --  current cluster is bad (FIXME) or free
+
+                  if cluster_cur = File.D_Entry.Start_Cluster then
+                     --  mark as tail
+                     FAT_updated := Parent.FS.Set_FAT (cluster_cur, LAST_CLUSTER_VALUE);
+                  else
+                     --  mark unused
+                     FAT_updated := Parent.FS.Set_FAT (cluster_cur, FREE_CLUSTER_VALUE);
+                  end if;
+                  if not FAT_updated then
+                     return Internal_Error;
+                  end if;
+
+                  --  check FAT entry for successor cluster
+                  if Parent.FS.Is_Last_Cluster (cluster_info) or
+                    Parent.FS.Is_Free_Cluster (cluster_info) -- for robustness
+                  then
+                     exit Wipe_Chain_Loop;
+                  end if;
+
+                  cluster_cur := cluster_info;
+               end loop Wipe_Chain_Loop;
+            end;
+
+            File.D_Entry.Size := 0;
+            File.D_Entry.Attributes.Archive := True; -- for backup
+            --  no need to write the FAT entry, yet.
+         else
+            return Status;
+         end if;
+      else
+         --------------
+         --  new file
+         --------------
+         declare
+            new_cluster : constant Unsigned_32 := Parent.FS.Get_Free_Cluster;
+         begin
+            if new_cluster = INVALID_CLUSTER then
+               return Device_Full;
+            end if;
+
+            --  allocate first cluster for data
+            if not Parent.FS.Allocate_Cluster (new_cluster)
+            then
+               return Allocation_Error;
+            end if;
+
+            --  read complete block to write the entry
+            Status := Parent.FS.Ensure_Block (Ent_Addr.Block_LBA);
+            if Status /= OK then
+               return Status;
+            end if;
+
+            --  fill entry attrs to make it a directory
+            File.D_Entry.FS := Parent.FS;
+            File.D_Entry.Attributes.Read_Only := False;
+            File.D_Entry.Attributes.Hidden := False;
+            File.D_Entry.Attributes.Archive := True; -- for backup: mark new files with archive flag
+            File.D_Entry.Attributes.System_File := False;
+            File.D_Entry.Attributes.Volume_Label := False;
+            File.D_Entry.Attributes.Subdirectory := False;
+            File.D_Entry.Start_Cluster := new_cluster;
+            File.D_Entry.Entry_Address := Ent_Addr;
+            File.D_Entry.Size := 0; -- file is empty, yet
+            Set_Name (newname, File.D_Entry);
+
+            --  encode into FAT entry
+            Status := Directory_To_FAT_Entry (File.D_Entry, F_Entry);
+            if Status /= OK then
+               return Status;
+            end if;
+
+            --  copy FAT entry to window
+            Parent.FS.Window (Ent_Addr.Block_Off .. Ent_Addr.Block_Off +
+                                ENTRY_SIZE - 1) := From_Entry (F_Entry);
+
+            --  write back the window to disk
+            Status := Parent.FS.Write_Window (Ent_Addr.Block_LBA);
+            if Status /= OK then
+               return Status;
+            end if;
+         end;
+      end if;
+
+      --  set up file handle
+      File.FS := Parent.FS;
+      File.Start_Cluster := File.D_Entry.Start_Cluster;
+      File.Current_Cluster := File.D_Entry.Start_Cluster;
+      File.Current_Block := Parent.FS.Cluster_To_Block (File.D_Entry.Start_Cluster);
+      File.Buffer_Level := 0;
+      File.Mode := Write_Mode;
+      File.Bytes_Total := 0;
+      File.Is_Open := True;
+      return OK;
+   end File_Create;
+
+   -------------------
+   --  Update_Entry
+   -------------------
+
+   function Update_Entry (File : in out File_Handle) return Status_Code is
+      Status : Status_Code;
+   begin
+      Status := File.FS.Ensure_Block (File.D_Entry.Entry_Address.Block_LBA);
+      if Status /= OK then
+         return Status;
+      end if;
+
+      --  a bit of a hack, to save us from the work of re-generating the entire entry
+      declare
+         Size_Off : constant Unsigned_16 := 28;
+         subtype Entry_Data is Block (1 .. 4);
+         function Bytes_From_Size is new Ada.Unchecked_Conversion
+           (Unsigned_32, Entry_Data);
+
+         win_lo : constant Unsigned_16 := File.D_Entry.Entry_Address.Block_Off + Size_Off;
+         win_hi : constant Unsigned_16 := win_lo + 3;
+      begin
+         File.FS.Window (win_lo .. win_hi) := Bytes_From_Size (File.D_Entry.Size);
+      end;
+
+      Status := File.FS.Write_Window (File.D_Entry.Entry_Address.Block_LBA);
+      return Status;
+   end Update_Entry;
+
+   -------------------
+   --  File_Write
+   -------------------
+
+   function File_Write
+     (File   : in out File_Handle;
+      Data   : File_Data;
+      Status : out Status_Code) return Integer
+   is
+      n_processed : Natural := 0;
+      this_chunk  : Natural := 0;
+   begin
+      if not File.Is_Open or File.Mode /= Write_Mode then
+         return -1;
+      end if;
+
+      if Data'Length < 1 then
+         return 0;
+      end if;
+
+      --  if buffer is full, write to disk
+      Write_Loop : loop
+         --  determine how much the buffer can take
+         declare
+            n_remain : constant Natural := Data'Length - n_processed;
+            cap      : Natural;
+         begin
+            cap := File.Buffer'Length - File.Buffer_Level;
+            this_chunk := (if cap >= n_remain then n_remain else cap);
+         end;
+
+         --  copy max amount to buffer.
+         declare
+            newlevel : constant Natural     := File.Buffer_Level + this_chunk;
+            buf_lo   : constant Unsigned_16 := File.Buffer'First + Unsigned_16 (File.Buffer_Level);
+            buf_hi   : constant Unsigned_16 := File.Buffer'First + Unsigned_16 (newlevel) - 1;
+            cnk_lo   : constant Unsigned_16 := Data'First + Unsigned_16 (n_processed);
+            cnk_hi   : constant Unsigned_16 := cnk_lo + Unsigned_16 (this_chunk) - 1;
+         begin
+            --  FIXME: save this copy if we have a full buffer. takes ~16usec
+            File.Buffer (buf_lo .. buf_hi) := Data (cnk_lo .. cnk_hi);
+            File.Buffer_Level := newlevel;
+         end;
+
+         --  book keeping
+         File.Bytes_Total := File.Bytes_Total + Unsigned_32 (this_chunk);
+         File.D_Entry.Size := File.Bytes_Total;
+
+         --  write buffer to disk only if full
+         if File.Buffer_Level = File.Buffer'Length then
+            File.FS.Window := File.Buffer;
+            Status := File.FS.Write_Window (File.Current_Block); -- ~2.7msec (too slow!)
+            if Status /= OK then
+               return n_processed;
+            end if;
+
+            --  now check whether the next block fits in the cluster.
+            --  Otherwise alloc next cluster and update FAT.
+            File.Current_Block := File.Current_Block + 1;
+            if File.Current_Block - File.FS.Cluster_To_Block (File.Current_Cluster) =
+              Unsigned_32 (File.FS.Number_Of_Blocks_Per_Cluster)
+            then
+               --  require another cluster
+               declare
+                  New_Cluster : Unsigned_32;
+               begin
+                  Status := File.FS.Append_Cluster
+                    (Last_Cluster => File.Current_Cluster,
+                     New_Cluster => New_Cluster);
+                  if Status /= OK then
+                     return n_processed;
+                  end if;
+                  File.Current_Cluster := New_Cluster;
+                  File.Current_Block := File.FS.Cluster_To_Block (File.Current_Cluster);
+               end;
+            end if;
+            File.Buffer_Level := 0; -- now it is empty
+
+            --  update directory entry on disk (size has changed)
+            declare
+               Status_Up : Status_Code := Update_Entry (File);
+               pragma Unreferenced (Status_Up); -- don't care, that size is optional for us
+            begin
+               null;
+            end;
+         end if;
+
+         n_processed := n_processed + this_chunk;
+         exit Write_Loop when n_processed = Data'Length;
+      end loop Write_Loop;
+
+      return n_processed;
+   end File_Write;
+
+   ------------------------
+   --  File_Open_Readonly
+   ------------------------
+
+   function File_Open_Readonly
+     (Ent  : in out Directory_Entry;
+      File : in out File_Data) return Status_Code
+   is
+      pragma Unreferenced (Ent, File);
+   begin
+      --  TODO: not yet implemented
+      return Internal_Error;
+   end File_Open_Readonly;
+
+   ---------------
+   --  File_Read
+   ---------------
+
+   function File_Read
+     (File : in out File_Handle;
+      Data : out File_Data) return Integer
+   is
+      pragma Unreferenced (Data);
+   begin
+      if not File.Is_Open or File.Mode /= Read_Mode then
+         return -1;
+      end if;
+
+      --  TODO: not yet implemented
+      File.Bytes_Total := File.Bytes_Total + 0;
+      return -1;
+   end File_Read;
+
+   ----------------
+   --  File_Close
+   ----------------
+
+   procedure File_Close (File : in out File_Handle) is
+   begin
+      if not File.Is_Open then
+         return;
+      end if;
+
+      if File.Mode = Write_Mode and then File.Buffer_Level > 0 then
+         --  flush buffer to disk
+         File.FS.Window := File.Buffer;
+         declare
+            Status : Status_Code := File.FS.Write_Window (File.Current_Block);
+            pragma Unreferenced (Status);
+         begin
+            null;
+         end;
+         --  we assume that the directory entry is already maintained by File_Write
+      end if;
+      File.Is_Open := False;
+   end File_Close;
+
+   ----------------
+   --  File_Flush
+   ----------------
+
+   function File_Flush (File : in out File_Handle) return Status_Code is
+      Status : Status_Code;
+   begin
+      if not File.Is_Open then
+         return Invalid_Object_Entry;
+      end if;
+
+      if File.Mode = Write_Mode and then File.Buffer_Level > 0 then
+         --  flush data block, even if not full
+         File.FS.Window := File.Buffer;
+         Status := File.FS.Write_Window (File.Current_Block);
+
+         --  force-update directory entry on disk
+         declare
+            Status_Up : Status_Code := Update_Entry (File);
+            pragma Unreferenced (Status_Up); -- don't care, that size is optional for us
+         begin
+            null;
+         end;
+      end if;
+
+      return Status;
+   end File_Flush;
+
+   ----------------
+   --  File_Size
+   ----------------
+
+   function File_Size (File : File_Handle) return Unsigned_32 is (File.Bytes_Total);
+
+   ------------------
+   --  To_File_Data
+   ------------------
+
+   function To_File_Data (S : String) return File_Data is
+      d   : File_Data (1 .. S'Length);
+      idx : Unsigned_16 := d'First;
+   begin
+      --  FIXME: inefficient. use unchecked conversion
+      for k in S'Range loop
+         d (idx) := Character'Pos (S (k));
+         idx := idx + 1;
+      end loop;
+      return d;
+   end To_File_Data;
+
+end FAT_Filesystem.Directories.Files;

--- a/examples/sdcard/src/fat_filesystem-directories-files.ads
+++ b/examples/sdcard/src/fat_filesystem-directories-files.ads
@@ -1,0 +1,80 @@
+--  Institution: Technische Universitaet Muenchen
+--  Department:  Real-Time Computer Systems (RCS)
+--  Project:     StratoX
+--  Authors:     Martin Becker (becker@rcs.ei.tum.de)
+--
+--  XXX! Nothing here is proven thread-safe!
+with FAT_Filesystem;
+with FAT_Filesystem.Directories; use FAT_Filesystem.Directories;
+
+--  @summary File handling for FAT FS
+package FAT_Filesystem.Directories.Files with SPARK_Mode => Off is
+
+   type File_Handle is private;
+
+   type File_Mode is (Read_Mode, Write_Mode);
+
+   subtype File_Data is Media_Reader.Block;
+
+   function File_Create
+     (Parent    : in out Directory_Handle;
+      newname   : String;
+      Overwrite : Boolean := False;
+      File      : out File_Handle) return Status_Code;
+   --  create a new file in the given directory, and return
+   --  handle for write access
+
+   function File_Write
+     (File   : in out File_Handle;
+      Data   : File_Data;
+      Status : out Status_Code) return Integer;
+   --  write to file
+   --  @return number of bytes written (at most Data'Length), or -1 on error.
+
+   function File_Flush
+     (File : in out File_Handle) return Status_Code;
+   --  force writing file to disk at this very moment (slow!)
+
+   function File_Size (File : File_Handle) return Unsigned_32;
+
+   function File_Open_Readonly
+     (Ent  : in out Directory_Entry;
+      File : in out File_Data) return Status_Code
+     with Pre => Is_System_File (Ent);
+   --  open the file given by the directory entry and return
+   --  handle for read access;
+
+   function File_Read
+     (File : in out File_Handle;
+      Data : out File_Data) return Integer;
+   --  read data from file.
+   --  @return number of bytes read (at most Data'Length), or -1 on error.
+
+   procedure File_Close (File : in out File_Handle);
+   --  invalidates the handle, and ensures that
+   --  everything is flushed to the disk
+
+   function To_File_Data (S : String) return File_Data;
+   --  convenience function to turn plain-text into file data
+
+private
+   pragma SPARK_Mode (Off);
+
+   type File_Handle is record
+      Is_Open             : Boolean := False;
+      FS                  : FAT_Filesystem_Access;
+      Mode                : File_Mode := Read_Mode;
+      Start_Cluster       : Unsigned_32 := INVALID_CLUSTER; -- first cluster; file begin
+      Current_Cluster     : Unsigned_32 := 0; -- where we are currently reading/writing
+      Current_Block       : Unsigned_32 := 0; -- same, but block
+      Buffer              : File_Data (1 .. 512); --  size of one block in FAT/SD card
+      Buffer_Level        : Natural := 0; -- how much data in Buffer is meaningful
+      Bytes_Total         : Unsigned_32 := 0; -- how many bytes were read/written
+      D_Entry             : Directory_Entry; -- the associated directory entry
+   end record;
+   --  used to access files
+
+   function Update_Entry (File : in out File_Handle) return Status_Code;
+   --  maintain the directory entry (file size)
+
+end FAT_Filesystem.Directories.Files;

--- a/examples/sdcard/src/fat_filesystem-directories.adb
+++ b/examples/sdcard/src/fat_filesystem-directories.adb
@@ -1,6 +1,13 @@
+--  Project: StratoX
+--  System:  Stratosphere Balloon Flight Controller
+--  Author:  Martin Becker (becker@rcs.ei.tum.de)
+--  based on AdaCore's Ada_Driver_Library
+--  XXX! Nothing here is thread-safe!
+
 with Ada.Unchecked_Conversion;
 
-package body FAT_Filesystem.Directories is
+--  @summary Directory (end directory entries) handling for FAT FS
+package body FAT_Filesystem.Directories with SPARK_Mode => Off is
 
    -------------------------
    -- Open_Root_Directory --
@@ -13,38 +20,208 @@ package body FAT_Filesystem.Directories is
 
    begin
       if FS.Version = FAT16 then
-         Dir.Start_Cluster   := 0;
-         Dir.Current_Block   :=
-           Unsigned_32 (FS.Reserved_Blocks) +
-           FS.FAT_Table_Size_In_Blocks *
-             Unsigned_32 (FS.Number_Of_FATs);
+         Dir.Dir_Begin := (Cluster => 0, Index => 0, Block =>
+                             Unsigned_32 (FS.Reserved_Blocks) +
+                             FS.FAT_Table_Size_In_Blocks *
+                               Unsigned_32 (FS.Number_Of_FATs));
       else
-         Dir.Start_Cluster := FS.Root_Dir_Cluster;
-         Dir.Current_Block := FS.Cluster_To_Block (FS.Root_Dir_Cluster);
+         Dir.Dir_Begin := (Cluster => FS.Root_Dir_Cluster,
+                           Block => FS.Cluster_To_Block (FS.Root_Dir_Cluster),
+                           Index => 0);
       end if;
-
       Dir.FS := FS;
-      Dir.Current_Cluster := Dir.Start_Cluster;
-      Dir.Current_Index   := 0;
-
+      Rewind (Dir);
       return OK;
    end Open_Root_Directory;
 
-   ----------
-   -- Open --
-   ----------
+   -------------------------
+   --  Make_Directory
+   -------------------------
+
+   function Make_Directory
+     (Parent  : in out Directory_Handle;
+      newname : String;
+      D_Entry : out Directory_Entry) return Status_Code
+   is
+      subtype Entry_Data is Block (1 .. 32);
+      function From_Entry is new Ada.Unchecked_Conversion
+        (FAT_Directory_Entry, Entry_Data);
+
+      procedure Fill_Entry_Subdirectory (Sub_Entry     : in out Directory_Entry;
+                                         Sub_Name      : String;
+                                         Start_Cluster : Unsigned_32;
+                                         Ent_Addr      : FAT_Address);
+      procedure Fill_Entry_Subdirectory (Sub_Entry     : in out Directory_Entry;
+                                         Sub_Name      : String;
+                                         Start_Cluster : Unsigned_32;
+                                         Ent_Addr      : FAT_Address) is
+      begin
+         Sub_Entry.FS := Parent.FS;
+         Sub_Entry.Attributes.Read_Only := False;
+         Sub_Entry.Attributes.Hidden := False;
+         Sub_Entry.Attributes.Archive := False;
+         Sub_Entry.Attributes.System_File := False;
+         Sub_Entry.Attributes.Volume_Label := False;
+         Sub_Entry.Attributes.Subdirectory := True;
+         Sub_Entry.Start_Cluster := Start_Cluster;
+         Sub_Entry.Size := 0; -- directories always carry zero
+         Sub_Entry.Entry_Address := Ent_Addr;
+         Set_Name (Sub_Name, Sub_Entry); -- FIXME: something isn't right here. The implicit dot (8+3) is shown on my Linux machine
+      end Fill_Entry_Subdirectory;
+
+      function Entry_To_Window (Sub_Entry : Directory_Entry) return Status_Code;
+      function Entry_To_Window (Sub_Entry : Directory_Entry) return Status_Code is
+         F_Entry : FAT_Directory_Entry;
+         Status  : Status_Code;
+      begin
+         Status := Directory_To_FAT_Entry (Sub_Entry, F_Entry);
+         if Status /= OK then
+            return Status;
+         end if;
+
+         --  now write the directory entry in the parent
+         Status := Parent.FS.Ensure_Block (Sub_Entry.Entry_Address.Block_LBA);
+         if Status /= OK then
+            return Status;
+         end if;
+         Parent.FS.Window (Sub_Entry.Entry_Address.Block_Off .. Sub_Entry.Entry_Address.Block_Off
+                           + ENTRY_SIZE - 1) := From_Entry (F_Entry);
+         return OK;
+      end Entry_To_Window;
+
+      NewDir_Addr    : FAT_Address;
+      Status         : Status_Code;
+      NewDir_Cluster : Unsigned_32 := INVALID_CLUSTER;
+   begin
+      if Parent.FS.Version /= FAT32 then
+         --  we only support FAT32 for now.
+         return Internal_Error;
+      end if;
+
+      --  find a place for another entry and return it
+      Status := Allocate_Entry (Parent, newname, NewDir_Addr);
+      if Status = Already_Exists then
+         --  FIXME: this is a bit inefficient.
+         if Get_Entry (Parent, newname, D_Entry) then
+            return Already_Exists;
+         else
+            return Internal_Error;
+         end if;
+      elsif Status /= OK then
+         return Status;
+      end if;
+
+      --  if we are here, then a new entry was created
+
+      --  first, allocate a new cluster for the directory contents
+      NewDir_Cluster := Parent.FS.Get_Free_Cluster;
+      if NewDir_Cluster = INVALID_CLUSTER then
+         return Device_Full;
+      end if;
+      if not Parent.FS.Allocate_Cluster (NewDir_Cluster)
+      then
+         return Allocation_Error;
+      end if;
+
+      --  fill entry attrs to make it a directory
+      Fill_Entry_Subdirectory (Sub_Entry => D_Entry, Sub_Name => newname,
+                               Start_Cluster => NewDir_Cluster, Ent_Addr => NewDir_Addr);
+
+      --  write back to disk
+      Status := Entry_To_Window (D_Entry);
+      if Status /= OK then
+         return Status;
+      end if;
+      Status := Parent.FS.Write_Window (D_Entry.Entry_Address.Block_LBA);
+      if Status /= OK then
+         return Status;
+      end if;
+
+      -------------------------------------------------------------
+      --  create obligatory entries "." and ".." in new directory
+      -------------------------------------------------------------
+      --  we cannot use Allocate_Entry for this, because the directory
+      --  doesn't have a terminator, yet. And it's not required, because
+      --  block size is > 3 entries anyway.
+      pragma Assert (Parent.FS.Block_Size_In_Bytes >= 3 * ENTRY_SIZE);
+
+      declare
+         Dot_Addr  : FAT_Address := (Block_LBA => Parent.FS.Cluster_To_Block (NewDir_Cluster),
+                                     Block_Off => 0);
+         Dot_Entry : Directory_Entry;
+      begin
+         --  entry "."
+         Fill_Entry_Subdirectory (Sub_Entry => Dot_Entry,
+                                  Sub_Name => ".",
+                                  Start_Cluster => NewDir_Cluster,  -- "." points to same cluster
+                                  Ent_Addr => Dot_Addr);
+         Status := Entry_To_Window (Dot_Entry);
+         if Status /= OK then
+            return Status;
+         end if;
+
+         --  entry ".."
+         Dot_Addr.Block_Off := Dot_Addr.Block_Off + ENTRY_SIZE;
+         Fill_Entry_Subdirectory (Sub_Entry => Dot_Entry,
+                                  Sub_Name => "..",
+                                  Start_Cluster => Parent.Dir_Begin.Cluster, -- FIXME: Microsoft wants zero if Parent = Root
+                                  Ent_Addr => Dot_Addr);
+         Status := Entry_To_Window (Dot_Entry);
+         if Status /= OK then
+            return Status;
+         end if;
+
+         --  terminator
+         Dot_Addr.Block_Off := Dot_Addr.Block_Off + ENTRY_SIZE;
+         Parent.FS.Window (Dot_Addr.Block_Off)  := 0;
+
+         --  finally .. write back the block with the new directory contents
+         Status := Parent.FS.Write_Window (Parent.FS.Cluster_To_Block (NewDir_Cluster));
+      end;
+
+      return Status;
+   end Make_Directory;
+
+   -------------------------
+   --  Invalidate_Handle_Pointer
+   -------------------------
+
+   procedure Invalidate_Handle_Pointer (h : in out Directory_Handle_Pointer) is
+   begin
+      h.Cluster := INVALID_CLUSTER;
+   end Invalidate_Handle_Pointer;
+
+   -------------------------
+   --  Valid_Handle_Pointer
+   -------------------------
+
+   function Valid_Handle_Pointer (h : Directory_Handle_Pointer) return Boolean
+   is (h.Cluster /= INVALID_CLUSTER);
+
+   -------------------------
+   --  Rewind
+   -------------------------
+
+   procedure Rewind (Dir : in out Directory_Handle) is
+   begin
+      Dir.Dir_Current := Dir.Dir_Begin;
+      Invalidate_Handle_Pointer (Dir.Dir_End);
+   end Rewind;
+
+   -------------------------
+   --  Open
+   -------------------------
 
    function Open
      (E   : Directory_Entry;
       Dir : out Directory_Handle) return Status_Code
    is
    begin
-      Dir.Start_Cluster := E.Start_Cluster;
-      Dir.Current_Block := E.FS.Cluster_To_Block (E.Start_Cluster);
       Dir.FS := E.FS;
-      Dir.Current_Cluster := Dir.Start_Cluster;
-      Dir.Current_Index   := 0;
-
+      Dir.Dir_Begin := (Cluster => E.Start_Cluster,
+                        Index => 0,
+                        Block => E.FS.Cluster_To_Block (E.Start_Cluster));
+      Rewind (Dir);
       return OK;
    end Open;
 
@@ -56,37 +233,56 @@ package body FAT_Filesystem.Directories is
    is
    begin
       Dir.FS              := null;
-      Dir.Current_Index   := 0;
-      Dir.Start_Cluster   := 0;
-      Dir.Current_Cluster := 0;
-      Dir.Current_Block   := 0;
+      Dir.Dir_Begin   := (Cluster => INVALID_CLUSTER, Block => 0, Index => 0);
+      Rewind (Dir);
    end Close;
 
-   ----------
-   -- Read --
-   ----------
+   --  @summary encode Directory_Entry into FAT_Directory_Entry
+   function Directory_To_FAT_Entry
+     (D_Entry : in Directory_Entry;
+      F_Entry : out FAT_Directory_Entry) return Status_Code
+   is
+   begin
+      F_Entry.Date := 0; -- FIXME: set date/time
+      F_Entry.Time := 0;
+      F_Entry.Size := D_Entry.Size;
+      F_Entry.Attributes := D_Entry.Attributes;
+      Set_Name (Get_Name (D_Entry), F_Entry);
+      F_Entry.Cluster_L := Unsigned_16 (D_Entry.Start_Cluster and 16#FFFF#);
+      if D_Entry.FS.Version = FAT16 then
+         F_Entry.Cluster_H := 0;
+      else
+         F_Entry.Cluster_H := Unsigned_16 (Shift_Right
+              (D_Entry.Start_Cluster and 16#FFFF_0000#, 16));
+      end if;
 
-   function Read (Dir    : in out Directory_Handle;
-                  DEntry : out Directory_Entry) return Status_Code
+      return OK;
+   end Directory_To_FAT_Entry;
+
+   ----------------------------
+   -- FAT_To_Directory_Entry --
+   ----------------------------
+
+   function FAT_To_Directory_Entry
+     (FS : FAT_Filesystem_Access;
+      F_Entry : in FAT_Directory_Entry;
+      D_Entry : in out Directory_Entry;
+      Last_Seq : in out VFAT_Sequence_Number) return Status_Code
    is
       procedure Prepend
-        (Name : Wide_String;
+        (VName : Wide_String;
          Full : in out String;
          Idx  : in out Natural);
 
-      -------------
-      -- Prepend --
-      -------------
-
       procedure Prepend
-        (Name : Wide_String;
+        (VName : Wide_String;
          Full : in out String;
          Idx  : in out Natural)
       is
          Val : Unsigned_16;
       begin
-         for J in reverse Name'Range loop
-            Val := Wide_Character'Pos (Name (J));
+         for J in reverse VName'Range loop
+            Val := Wide_Character'Pos (VName (J));
             if Val /= 16#FFFF#
               and then Val /= 0
             then
@@ -103,174 +299,485 @@ package body FAT_Filesystem.Directories is
          end loop;
       end Prepend;
 
-      Ret     : Status_Code;
-      D_Entry : FAT_Directory_Entry;
-      V_Entry : VFAT_Directory_Entry;
-      subtype Entry_Data is Block (1 .. 32);
-      function To_Entry is new Ada.Unchecked_Conversion
-        (Entry_Data, FAT_Directory_Entry);
       function To_VFAT_Entry is new Ada.Unchecked_Conversion
         (FAT_Directory_Entry, VFAT_Directory_Entry);
-
-      C           : Unsigned_8;
-      Last_Seq    : VFAT_Sequence_Number := 0;
-      CRC         : Unsigned_8 := 0;
-      Matches     : Boolean;
-      Current_CRC : Unsigned_8;
-      Block_Off   : Unsigned_16;
-
+      V_Entry     : VFAT_Directory_Entry;
+      Is_VFAT_Ent : Boolean;
    begin
-      if Dir.Start_Cluster = 0
-        and then Dir.Current_Index >= Dir.FS.Number_Of_Entries_In_Root_Dir
-      then
-         return Invalid_Object_Entry;
-      elsif Dir.Current_Index = 16#FFFF# then
-         return Invalid_Object_Entry;
-      end if;
 
-      Ret := Dir.FS.Ensure_Block (Dir.Current_Block);
+      if F_Entry.Attributes = VFAT_Directory_Entry_Attribute then
+         Is_VFAT_Ent := True;
+         V_Entry := To_VFAT_Entry (F_Entry);
 
-      if Ret /= OK then
-         return Ret;
-      end if;
-
-      DEntry.L_Name_First := DEntry.L_Name'Last + 1;
-
-      loop
-         Block_Off :=
-           Unsigned_16
-             (Unsigned_32 (Dir.Current_Index) * 32
-              mod Dir.FS.Block_Size_In_Bytes);
-
-         if Dir.Current_Index > 0
-           and then Block_Off = 0
-         then
-            Dir.Current_Block := Dir.Current_Block + 1;
-            if Dir.Current_Block -
-              Dir.FS.Cluster_To_Block (Dir.Current_Cluster) =
-              Unsigned_32 (Dir.FS.Number_Of_Blocks_Per_Cluster)
+         if V_Entry.VFAT_Attr.Stop_Bit then
+            D_Entry.Name_First := D_Entry.Name'Last + 1;  --  starts here. invalidate long name.
+            Last_Seq := 0;
+         else
+            if Last_Seq = 0
+              or else Last_Seq - 1 /= V_Entry.VFAT_Attr.Sequence
             then
-               Dir.Current_Cluster := Dir.FS.Get_FAT (Dir.Current_Cluster);
-
-               if Dir.Current_Cluster = 1
-                 or else Dir.FS.EOC (Dir.Current_Cluster)
-               then
-                  return Internal_Error;
-               end if;
-
-               Dir.Current_Block :=
-                 Dir.FS.Cluster_To_Block (Dir.Current_Cluster);
+               D_Entry.Name_First := D_Entry.Name'Last + 1;
             end if;
 
-            Ret := Dir.FS.Ensure_Block (Dir.Current_Block);
+            Last_Seq := V_Entry.VFAT_Attr.Sequence;
 
-            if Ret /= OK then
-               return Ret;
+            Prepend (V_Entry.Name_3, D_Entry.Name, D_Entry.Name_First);
+            Prepend (V_Entry.Name_2, D_Entry.Name, D_Entry.Name_First);
+            Prepend (V_Entry.Name_1, D_Entry.Name, D_Entry.Name_First);
+
+            if V_Entry.VFAT_Attr.Sequence = 1 then
+               D_Entry.CRC := V_Entry.Checksum;
             end if;
          end if;
-
-         if Dir.FS.Window (Block_Off) = 0 then
-            --  End of entries
-            Dir.Current_Index := 16#FFFF#;
-            return Invalid_Object_Entry;
-         end if;
-
-         D_Entry := To_Entry (Dir.FS.Window (Block_Off .. Block_Off + 31));
-         Dir.Current_Index := Dir.Current_Index + 1;
-
-         --  Check if we have a VFAT entry here by checking that the
-         --  attributes are 16#0F# (e.g. all attributes set except
-         --  subdirectory and archive)
-         if D_Entry.Attributes = VFAT_Directory_Entry_Attribute then
-            V_Entry := To_VFAT_Entry (D_Entry);
-
-            if V_Entry.VFAT_Attr.Stop_Bit then
-               DEntry.L_Name_First := DEntry.L_Name'Last + 1;
+         --  VFAT needs more data...cannot return "OK", yet
+      elsif not F_Entry.Attributes.Volume_Label --  Ignore Volumes
+        and then (not Is_Deleted (F_Entry))
+      then
+         --  either the "tail" of a VFAT entry, or a regular entry
+         if D_Entry.Name_First not in D_Entry.Name'Range then
+            --  regular entry
+            Is_VFAT_Ent := False;
+         else
+            --  VFAT tail. must check crc
+            Is_VFAT_Ent := True;
+            declare
+               Current_CRC : Unsigned_8 := 0;
+               C           : Unsigned_8 := 0;
+               shortname   : constant String := F_Entry.Filename & F_Entry.Extension;
+            begin
                Last_Seq := 0;
-
-            else
-               if Last_Seq = 0
-                 or else Last_Seq - 1 /= V_Entry.VFAT_Attr.Sequence
-               then
-                  DEntry.L_Name_First := DEntry.L_Name'Last + 1;
-               end if;
-
-               Last_Seq := V_Entry.VFAT_Attr.Sequence;
-
-               Prepend (V_Entry.Name_3, DEntry.L_Name, DEntry.L_Name_First);
-               Prepend (V_Entry.Name_2, DEntry.L_Name, DEntry.L_Name_First);
-               Prepend (V_Entry.Name_1, DEntry.L_Name, DEntry.L_Name_First);
-
-               if V_Entry.VFAT_Attr.Sequence = 1 then
-                  CRC := V_Entry.Checksum;
-               end if;
-            end if;
-
-         elsif not D_Entry.Attributes.Volume_Label --  Ignore Volumes
-           and then Character'Pos (D_Entry.Filename (1)) /= 16#E5# --  Ignore deleted files
-         then
-            if DEntry.L_Name_First not in DEntry.L_Name'Range then
-               Matches := False;
-            else
-               Current_CRC := 0;
-               Last_Seq := 0;
-
-               for Ch of String'(D_Entry.Filename & D_Entry.Extension) loop
+               for Ch of shortname loop
                   C := Character'Enum_Rep (Ch);
                   Current_CRC := Shift_Right (Current_CRC and 16#FE#, 1)
                     or Shift_Left (Current_CRC and 16#01#, 7);
                   --  Modulo addition
                   Current_CRC := Current_CRC + C;
                end loop;
-
-               Matches := Current_CRC = CRC;
-            end if;
-
-            declare
-               Base   : String renames Trim (D_Entry.Filename);
-               Ext    : String renames Trim (D_Entry.Extension);
-               S_Name : constant String :=
-                          Base &
-                          (if Ext'Length > 0
-                           then "." & Trim (D_Entry.Extension)
-                           else "");
-            begin
-               DEntry.S_Name (1 .. S_Name'Length) := S_Name;
-               DEntry.S_Name_Last := S_Name'Length;
+               Is_VFAT_Ent := Current_CRC = D_Entry.CRC; -- if mismatch, drop VFAT entry
             end;
-
-            DEntry.Attributes    := D_Entry.Attributes;
-            DEntry.Start_Cluster := Unsigned_32 (D_Entry.Cluster_L);
-            DEntry.Size          := D_Entry.Size;
-            DEntry.FS            := Dir.FS;
-
-            if Dir.FS.Version = FAT32 then
-               DEntry.Start_Cluster :=
-                 DEntry.Start_Cluster or
-                 Shift_Left (Unsigned_32 (D_Entry.Cluster_H), 16);
-            end if;
-
-            if not Matches then
-               DEntry.L_Name_First := DEntry.L_Name'Last + 1;
-            end if;
-
-            return OK;
          end if;
-      end loop;
+
+         if Is_VFAT_Ent then
+            --  terminate string
+            D_Entry.Name_Last := D_Entry.Name'Last;
+         else
+            --  set short name for regular entries
+            if not F_Entry.Attributes.Subdirectory then
+               declare
+                  Base   : String renames RTrim (F_Entry.Filename);
+                  Ext    : String renames RTrim (F_Entry.Extension);
+                  Ent_Name : constant String :=
+                    Base & (if Ext'Length > 0 then "." & Ext else "");
+               begin
+                  Set_Name (Ent_Name, D_Entry);
+               end;
+            else
+               declare
+                  Cat_Name : constant String := F_Entry.Filename & F_Entry.Extension;
+                  Ent_Name : String renames RTrim (Cat_Name);
+               begin
+                  Set_Name (Ent_Name, D_Entry);
+               end;
+            end if;
+         end if;
+
+         D_Entry.Attributes    := F_Entry.Attributes;
+         D_Entry.Start_Cluster := Unsigned_32 (F_Entry.Cluster_L);
+         D_Entry.Size          := F_Entry.Size;
+         D_Entry.FS            := FS;
+         --  FIXME: add date and time
+
+         if FS.Version = FAT32 then
+            D_Entry.Start_Cluster :=
+              D_Entry.Start_Cluster or
+              Shift_Left (Unsigned_32 (F_Entry.Cluster_H), 16);
+         end if;
+
+         return OK; -- finished fetching next entry
+      end if;
+      return Invalid_Name;
+   end FAT_To_Directory_Entry;
+
+   ---------------
+   --  Is_Deleted
+   ---------------
+
+   function Is_Deleted (F_Entry : FAT_Directory_Entry) return Boolean
+   is (Character'Pos (F_Entry.Filename (1)) = 16#E5#);
+
+   ---------------
+   --  Read Dir
+   ---------------
+
+   function Read (Dir    : in out Directory_Handle;
+                  DEntry : out Directory_Entry;
+                  Deleted : Boolean := False) return Status_Code
+   is
+      subtype Entry_Data is Block (1 .. 32);
+      function To_Entry is new Ada.Unchecked_Conversion (Entry_Data, FAT_Directory_Entry);
+      Ret         : Status_Code;
+      F_Entry     : FAT_Directory_Entry;
+      Last_Seq    : VFAT_Sequence_Number := 0;
+      Block_Off   : Unsigned_16;
+   begin
+      if Dir.Dir_Begin.Cluster = 0
+        and then Dir.Dir_Current.Index >= Dir.FS.Number_Of_Entries_In_Root_Dir
+      then
+         return Invalid_Object_Entry;
+      elsif Dir.Dir_Current.Index = 16#FFFF# then -- we are at the end
+         return Invalid_Object_Entry;
+      end if;
+
+      Ret := Dir.FS.Ensure_Block (Dir.Dir_Current.Block);
+      if Ret /= OK then
+         return Ret;
+      end if;
+
+      --  invalidate name
+      DEntry.Name_First := DEntry.Name'Last + 1;
+      DEntry.Name_Last := DEntry.Name'First - 1;
+
+      --  Dir_Current.index has been incremented before (in the previous call)
+      Fetch_Next : loop
+         Block_Off :=
+           Unsigned_16
+             (Unsigned_32 (Dir.Dir_Current.Index) * ENTRY_SIZE
+              mod Dir.FS.Block_Size_In_Bytes);
+         --  offset of entry within current block
+
+         --  do we need to fetch the next block?
+         if Dir.Dir_Current.Index > 0
+           and then Block_Off = 0
+         then
+            Dir.Dir_Current.Block := Dir.Dir_Current.Block + 1;
+            --  do we need to fetch the next cluster?
+            if Dir.Dir_Current.Block -
+              Dir.FS.Cluster_To_Block (Dir.Dir_Current.Cluster) =
+              Unsigned_32 (Dir.FS.Number_Of_Blocks_Per_Cluster)
+            then
+               Dir.Dir_Current.Cluster := Dir.FS.Get_FAT (Dir.Dir_Current.Cluster);
+
+               if Dir.Dir_Current.Cluster = INVALID_CLUSTER
+                 or else Dir.FS.Is_Last_Cluster (Dir.Dir_Current.Cluster)
+               then
+                  return Internal_Error;
+               end if;
+
+               Dir.Dir_Current.Block :=
+                 Dir.FS.Cluster_To_Block (Dir.Dir_Current.Cluster);
+            end if;
+
+            --  read next block
+            Ret := Dir.FS.Ensure_Block (Dir.Dir_Current.Block);
+
+            if Ret /= OK then
+               return Ret;
+            end if;
+         end if;
+
+         --  are we at the end of the entries?
+         if Dir.FS.Window (Block_Off) = 0 then
+            Dir.Dir_Current.Index := 16#FFFF#;
+            --  invalidates the handle...next call to this will return.
+            --  because Dir_current.block is already invalid now
+            return Invalid_Object_Entry;
+         end if;
+
+         --  okay, there are more entries. each entry is 32bytes:
+         Dir.Dir_End := Dir.Dir_Current; -- remember last valid
+         F_Entry := To_Entry (Dir.FS.Window (Block_Off .. Block_Off + ENTRY_SIZE - 1));
+
+         --  move forward for next call of Read()
+         Dir.Dir_Current.Index := Dir.Dir_Current.Index + 1;
+
+         --  continue until we have an entry...because VFAT has multiple parts
+         if Deleted and then Is_Deleted (F_Entry) then
+            --  caller also wants deleted...we found one
+            DEntry.FS := null;
+            exit Fetch_Next;
+         else
+            if FAT_To_Directory_Entry
+              (Dir.FS, F_Entry, DEntry, Last_Seq) = OK
+            then
+               exit Fetch_Next;
+            end if;
+         end if;
+      end loop Fetch_Next;
+      --  if we are here, then we have an entry
+      DEntry.Entry_Address := (Block_LBA => Dir.Dir_Current.Block, Block_Off => Block_Off);
+      return OK;
    end Read;
 
-   ----------
-   -- Name --
-   ----------
+   ---------------
+   --  Set_Name
+   ---------------
 
-   function Name (E : Directory_Entry) return String
+   procedure Set_Name (newname : String; D : in out Directory_Entry) is
+      trimname : String renames LTrim (newname); -- leading spaces not allowed in FAT
+      maxlen   : constant Integer := trimname'Length;
+      newlast  : constant Integer := D.Name'First + maxlen - 1;
+   begin
+      D.Name (D.Name'First .. newlast) := trimname;
+      D.Name_First := D.Name'First;
+      D.Name_Last := newlast;
+   end Set_Name;
+
+   ---------------
+   --  Set_Name
+   ---------------
+
+   procedure Set_Name (newname : String; E : in out FAT_Directory_Entry) is
+   begin
+      if E.Attributes.Subdirectory then
+         StrCpySpace (outstring => E.Filename, instring => newname);
+         if newname'Length > E.Filename'Length then
+            StrCpySpace (E.Extension, newname (newname'First + E.Filename'Length .. newname'Last));
+         else
+            StrCpySpace (E.Extension, "");
+         end if;
+      else
+         --  file: remove '.' and limit to 8+3...
+         declare
+            base  : String (1 .. 8);
+            ext   : String (1 .. 3);
+            dotpos : constant Integer := StrChr (newname, '.');
+         begin
+            if dotpos in newname'Range then
+               if dotpos = newname'First then
+                  StrCpySpace (base, "");
+               else
+                  StrCpySpace (base, newname (newname'First .. dotpos - 1));
+               end if;
+               if dotpos = newname'Last then
+                  StrCpySpace (ext, "");
+               else
+                  StrCpySpace (ext, newname (dotpos + 1 .. newname'Last));
+               end if;
+            else
+               StrCpySpace (base, newname);
+               StrCpySpace (ext, "");
+            end if;
+            E.Filename := base;
+            E.Extension := ext;
+         end;
+      end if;
+   end Set_Name;
+
+   ---------------
+   --  Get_Name
+   ---------------
+
+   function Get_Name (E : Directory_Entry) return String is
+   begin
+      if E.Name_First in E.Name'Range and then E.Name_Last in E.Name'Range then
+         return E.Name (E.Name_First .. E.Name_Last);
+      else
+         return "";
+      end if;
+   end Get_Name;
+
+   -------------------------
+   --  Get_Entry_Or_Deleted
+   --------------------------
+
+   function Get_Entry_Or_Deleted
+     (Parent  : in out Directory_Handle;
+      E_Name  : String;
+      Ent     : out Directory_Entry;
+      Deleted : out Boolean) return Boolean
+   is
+      FAT_Approx_Name : String renames Trim (E_Name);
+      --  FIXME: this isn't completely right, since ent_name
+      --  went through FAT name compression, but E_Name not.
+   begin
+      Rewind (Parent); Deleted := False;
+      while Read (Parent, Ent, True) = OK loop
+         if Ent.FS = null then
+            Deleted := True;
+            return True;
+         else
+            declare
+               Ent_Name : constant String := Get_Name (Ent);
+            begin
+               if Ent_Name = FAT_Approx_Name then
+                  return True;
+               end if;
+            end;
+         end if;
+      end loop;
+
+      return False;
+   end Get_Entry_Or_Deleted;
+
+   ---------------
+   --  Get_Entry
+   ---------------
+
+   function Get_Entry
+     (Parent  : in out Directory_Handle;
+      E_Name  : String;
+      Ent     : out Directory_Entry) return Boolean
    is
    begin
-      if E.L_Name_First in E.L_Name'Range then
-         return E.L_Name (E.L_Name_First .. E.L_Name'Last);
-      else
-         return E.S_Name (E.S_Name'First .. E.S_Name_Last);
-      end if;
-   end Name;
+      Rewind (Parent);
+      while Read (Parent, Ent, False) = OK loop
+         declare
+            ent_name : constant String := Get_Name (Ent);
+         begin
+            --  FIXME: this isn't completely right, since ent_name
+            --  went through FAT name compression, but New_Name not.
+            if ent_name = E_Name then
+               return True;
+            end if;
+         end;
+      end loop;
 
+      return False;
+   end Get_Entry;
+
+   ---------------------
+   --  Goto_Last_Entry
+   ---------------------
+
+   procedure Goto_Last_Entry (Parent   : in out Directory_Handle) is
+      Tmp : Directory_Entry;
+   begin
+      while (Read (Parent, Tmp)) = OK loop
+         null;
+      end loop;
+   end Goto_Last_Entry;
+
+   --------------------
+   --  Allocate_Entry
+   --------------------
+
+   function Allocate_Entry
+     (Parent   : in out Directory_Handle;
+      New_Name : String;
+      Ent_Addr : out FAT_Address) return Status_Code
+   is
+      Block_Off : Unsigned_16;
+   begin
+      if Parent.FS.Version /= FAT32 then
+         --  we only support FAT32 for now.
+         return Internal_Error;
+      end if;
+
+      declare
+         Ent : Directory_Entry;
+         Deleted : Boolean;
+      begin
+         if Get_Entry_Or_Deleted (Parent => Parent, E_Name => New_Name,
+                                  Ent => Ent, Deleted => Deleted)
+         then
+            if Deleted then
+               --  silently re-use the deleted entry
+               Ent_Addr := Ent.Entry_Address;
+               return OK;
+            else
+               return Already_Exists;
+            end if;
+         end if;
+      end;
+
+      --  if we are here, we really need to add a new entry.
+      Goto_Last_Entry (Parent);
+
+      if not Valid_Handle_Pointer (Parent.Dir_End) then
+         --  this means the directory is completely empty. should never happen
+         --  FIXME: for more robustness, we need to be able to start at index zero
+         return Internal_Error;
+      end if;
+
+      --  now append
+      Parent.Dir_End.Index := Parent.Dir_End.Index + 1;
+
+      --  if we are here, then we reached the last entry in the directory.
+      --  see whether block_off is small enough to accommodate another entry
+      --  block_Off .. Block_Off + 31 must be available, otherwise we need a
+      --  the next block
+      Block_Off := Unsigned_16 (Unsigned_32
+                                (Parent.Dir_End.Index) * ENTRY_SIZE
+                                mod Parent.FS.Block_Size_In_Bytes);
+
+
+      --  do we need a new block?
+      if Block_Off = 0 and then Parent.Dir_End.Index > 0 then
+         --  need a new block
+         Parent.Dir_End.Block := Parent.Dir_End.Block + 1;
+         --  do we need to allocate a new cluster for the new block?
+         if Parent.Dir_End.Block -
+           Parent.FS.Cluster_To_Block (Parent.Dir_End.Cluster) =
+           Unsigned_32 (Parent.FS.Number_Of_Blocks_Per_Cluster)
+         then
+            --  need another cluster. find free one and allocate it
+            declare
+               New_Cluster : Unsigned_32;
+               Status      : Status_Code;
+            begin
+               Status := Parent.FS.Append_Cluster
+                 (Last_Cluster => Parent.Dir_End.Cluster,
+                  New_Cluster => New_Cluster);
+               if Status /= OK then
+                  return Status;
+               end if;
+               Parent.Dir_End.Cluster := New_Cluster;
+               Parent.Dir_End.Block :=
+                 Parent.FS.Cluster_To_Block (Parent.Dir_End.Cluster);
+            end;
+         end if;
+      end if;
+
+      --  FIXME: refactor following to separate procedure (too long function)
+      --  we added a new entry. make sure the directory has a terminator:
+      --  check if there is more space in the cluster after the new entry
+      --  if yes, terminate the directory by writing a zero.
+      --  Actually, Microsoft recommends to zero the entire cluster to
+      --  avoid this ugly hack. But this should be faster and is less wearout.
+      declare
+         Terminator_Off : constant Unsigned_16 :=
+           Unsigned_16 (Unsigned_32
+                        (Parent.Dir_End.Index + 1) * ENTRY_SIZE
+                        mod Parent.FS.Block_Size_In_Bytes);
+         Status : Status_Code;
+      begin
+         if Terminator_Off /= 0 then
+            --  there is space in the same block, terminate at Terminator_Off.
+            Status := Parent.FS.Ensure_Block (Parent.Dir_End.Block);
+            if Status /= OK then
+               return Status;
+            end if;
+            Parent.FS.Window (Terminator_Off) := 0;
+            Status := Parent.FS.Write_Window (Parent.Dir_End.Block);
+            if Status /= OK then
+               return Status;
+            end if;
+         else
+            --  need a new block. This is only relevant if it is still the same cluster
+            declare
+               Terminator_Block : constant Unsigned_32 := Parent.Dir_End.Block + 1;
+            begin
+               if Terminator_Block - Parent.FS.Cluster_To_Block (Parent.Dir_End.Cluster) <
+                 Unsigned_32 (Parent.FS.Number_Of_Blocks_Per_Cluster)
+               then
+                  --  terminate in Terminator_Block at pos 0.
+                  Status := Parent.FS.Ensure_Block (Terminator_Block);
+                  if Status /= OK then
+                     return Status;
+                  end if;
+                  Parent.FS.Window (Parent.FS.Window'First) := 0;
+                  Status := Parent.FS.Write_Window (Terminator_Block);
+                  if Status /= OK then
+                     return Status;
+                  end if;
+               end if;
+            end;
+         end if;
+      end;
+
+      --  return the allocated space
+      Ent_Addr.Block_LBA := Parent.Dir_End.Block;
+      Ent_Addr.Block_Off := Block_Off;
+      return OK;
+   end Allocate_Entry;
 end FAT_Filesystem.Directories;

--- a/examples/sdcard/src/fat_filesystem-directories.ads
+++ b/examples/sdcard/src/fat_filesystem-directories.ads
@@ -1,24 +1,47 @@
-package FAT_Filesystem.Directories is
+--  Project: StratoX
+--  System:  Stratosphere Balloon Flight Controller
+--  Author: Martin Becker (becker@rcs.ei.tum.de)
+--  based on AdaCore's Ada_Driver_Library
+--  XXX! Nothing here is thread-safe!
 
-   type Directory_Handle is private;
+--  @summary Directory (end directory entries) handling for FAT FS
+package FAT_Filesystem.Directories with SPARK_Mode => Off is
+
+   type Directory_Handle is private; -- used to read directories
 
    function Open_Root_Directory
      (FS  : FAT_Filesystem_Access;
       Dir : out Directory_Handle) return Status_Code;
 
-   type Directory_Entry is private;
+   type Directory_Entry is private; -- used to represent one item in directory
 
    function Open
      (E   : Directory_Entry;
       Dir : out Directory_Handle) return Status_Code
-   with Pre => Is_Subdirectory (E);
+     with Pre => Is_Subdirectory (E);
+   --  get handle of given item. Handle can be used with Read().
+
+   function Make_Directory
+     (Parent  : in out Directory_Handle;
+      newname : String;
+      D_Entry : out Directory_Entry) return Status_Code
+     with Pre => newname'Length < 12;
+   --  create a new directory within the given one
+   --  we only allow short names for now.
+   --  if directory already exists, returns its entry.
 
    procedure Close (Dir : in out Directory_Handle);
 
-   function Read (Dir : in out Directory_Handle;
-                  DEntry : out Directory_Entry) return Status_Code;
+   function Read (Dir     : in out Directory_Handle;
+                  DEntry  : out Directory_Entry;
+                  Deleted : Boolean := False) return Status_Code;
+   --  @summary get the next entry in the given directory
+   --  after calling this, Dir.Dir_Current are invalid iff return /= OK.
+   --  However, the Dir_Begin and Dir_End components are always valid.
+   --  if Deleted is true, then deleted entries are also returned and
+   --  marked with FS=null
 
-   function Name (E : Directory_Entry) return String;
+   function Get_Name (E : Directory_Entry) return String;
 
    function Is_Read_Only (E : Directory_Entry) return Boolean;
 
@@ -31,7 +54,7 @@ package FAT_Filesystem.Directories is
    function Is_Archive (E : Directory_Entry) return Boolean;
 
 private
-
+   pragma SPARK_Mode (Off);
 
    type FAT_Directory_Entry_Attribute is record
       Read_Only : Boolean;
@@ -51,8 +74,8 @@ private
       Time       : Unsigned_16;
       Date       : Unsigned_16;
       Cluster_L  : Unsigned_16;
-      Size       : Unsigned_32;
-   end record with Size => 32 * 8;
+      Size       : Unsigned_32; -- TODO: what is this?
+   end record with Size => 32 * 8; --  32 Byte per entry
 
    for FAT_Directory_Entry use record
       Filename   at 16#00# range 0 .. 63;
@@ -65,6 +88,8 @@ private
       Cluster_L  at 16#1A# range 0 .. 15;
       Size       at 16#1C# range 0 .. 31;
    end record;
+
+   ENTRY_SIZE : constant := 32;
 
    VFAT_Directory_Entry_Attribute : constant FAT_Directory_Entry_Attribute :=
                                       (Subdirectory => False,
@@ -102,24 +127,92 @@ private
 --        Current_Cluster : Unsigned_32;
 --     end record;
 
-   type Directory_Handle is record
-      FS              : FAT_Filesystem_Access;
-      Current_Index   : Unsigned_16;
-      Start_Cluster   : Unsigned_32;
-      Current_Cluster : Unsigned_32;
-      Current_Block   : Unsigned_32;
+   --  FIXME: encapsulate this, and provide function "move_forward" or something.
+   type Directory_Handle_Pointer is record
+      Index   : Unsigned_16;
+      Cluster : Unsigned_32;
+      Block   : Unsigned_32;
    end record;
 
-   type Directory_Entry is record
-      FS            : FAT_Filesystem_Access;
-      L_Name        : String (1 .. 128);
-      L_Name_First  : Natural := 129;
-      S_Name        : String (1 .. 12);
-      S_Name_Last   : Natural := 0;
-      Attributes    : FAT_Directory_Entry_Attribute;
-      Start_Cluster : Unsigned_32;
-      Size          : Unsigned_32;
+   procedure Invalidate_Handle_Pointer (h : in out Directory_Handle_Pointer);
+   function  Valid_Handle_Pointer (h : Directory_Handle_Pointer) return Boolean;
+
+   type Directory_Handle is record
+      FS          : FAT_Filesystem_Access;
+      Dir_Begin   : Directory_Handle_Pointer; -- points to the first entry of the directory
+      Dir_Current : Directory_Handle_Pointer; -- points to the current, valid entry
+      Dir_End     : Directory_Handle_Pointer; -- points past the last valid entry
    end record;
+   --  used to read directories
+
+   type Directory_Entry is record
+      FS               : FAT_Filesystem_Access;
+
+      Name             : String (1 .. 128);
+      Name_First       : Natural := 129; -- where the string starts within 'Name'
+      Name_Last        : Natural := 0; -- where the string ends within 'Name'
+
+      CRC              : Unsigned_8 := 0;
+
+      Attributes       : FAT_Directory_Entry_Attribute;
+      Start_Cluster    : Unsigned_32; -- the address of the data/contents of the entry
+      Size             : Unsigned_32;
+      Entry_Address    : FAT_Address; -- the address of the entry itself
+      --  FIXME: add time stamps, attributes, etc.
+   end record;
+   --  each item in a directory is described by this in high-level view
+
+   procedure Rewind (Dir : in out Directory_Handle);
+
+   function Get_Entry_Or_Deleted
+     (Parent   : in out Directory_Handle;
+      E_Name   : String;
+      Ent      : out Directory_Entry;
+      Deleted  : out Boolean) return Boolean;
+   --  search for entry with the given name.
+   --  if Deleted is true, then the 'Ent' points
+   --  to an empty directory entry that can be
+   --  re-used. If Deleted is false, then an entry
+   --  with the given name was actually found
+
+   function Is_Deleted (F_Entry : FAT_Directory_Entry) return Boolean;
+
+   function Get_Entry
+     (Parent   : in out Directory_Handle;
+      E_Name   : String;
+      Ent      : out Directory_Entry) return Boolean;
+   --  search for entry with the given name.
+
+   procedure Goto_Last_Entry (Parent   : in out Directory_Handle);
+   --  proceed to last entry in given directory
+
+   function Allocate_Entry
+     (Parent   : in out Directory_Handle;
+      New_Name : String;
+      Ent_Addr : out FAT_Address) return Status_Code;
+   --  find a location for a new entry within Parent_Ent
+   --  and make sure that the directory stays terminated
+
+   procedure Set_Name (newname : String; D : in out Directory_Entry)
+     with Pre => newname'Length > 0;
+
+   procedure Set_Name (newname : String; E : in out FAT_Directory_Entry)
+     with Pre => newname'Length > 0;
+
+   function Directory_To_FAT_Entry
+     (D_Entry : in Directory_Entry;
+      F_Entry : out FAT_Directory_Entry) return Status_Code;
+
+   function FAT_To_Directory_Entry
+     (FS : FAT_Filesystem_Access;
+      F_Entry : in FAT_Directory_Entry;
+      D_Entry : in out Directory_Entry;
+      Last_Seq : in out VFAT_Sequence_Number) return Status_Code;
+   --  @summary decypher the raw entry (file/dir name, etc) and write
+   --           to record.
+   --  @return OK when decipher is complete, otherwise needs to be
+   --          called again with the next entry (VFAT entries have
+   --          multiple parts)
 
    function Is_Read_Only (E : Directory_Entry) return Boolean
    is (E.Attributes.Read_Only);

--- a/examples/sdcard/src/fat_filesystem.adb
+++ b/examples/sdcard/src/fat_filesystem.adb
@@ -1,3 +1,4 @@
+--  XXX! Nothing here is thread-safe!
 with Ada.Unchecked_Conversion;
 
 package body FAT_Filesystem is
@@ -9,21 +10,105 @@ package body FAT_Filesystem is
      (FS     : in out FAT_Filesystem;
       Status : out Status_Code);
 
-   ----------
-   -- Trim --
-   ----------
+   function Allocate_Cluster (FS : in out FAT_Filesystem;
+                              cluster : Unsigned_32) return Boolean
+   is
+      LAST_CLUSTER : constant Unsigned_32 := 16#FFFF_FFFF#;
+   begin
+      if FS.Set_FAT (cluster, LAST_CLUSTER) then
+         FS.FSInfo.Free_Clusters := FS.FSInfo.Free_Clusters - 1;
+         FS.FSInfo.Last_Allocated_Cluster := cluster;
+         FS.Writeback_FsInfo;
+         return True;
+      else
+         return False;
+      end if;
+   end Allocate_Cluster;
 
-   function Trim (S : String) return String
+   function Append_Cluster
+     (FS : in out FAT_Filesystem;
+      Last_Cluster : Unsigned_32;
+      New_Cluster  : out Unsigned_32) return Status_Code
    is
    begin
-      for J in reverse S'Range loop
-         if S (J) /= ' ' then
-            return S (S'First .. J);
-         end if;
-      end loop;
+      New_Cluster := FS.Get_Free_Cluster;
+      if New_Cluster = INVALID_CLUSTER then
+         return Device_Full;
+      end if;
+      if not FS.Allocate_Cluster (New_Cluster) then
+         return Allocation_Error;
+      end if;
+      --  chain it to the formerly last cluster
+      if not FS.Set_FAT (Last_Cluster, New_Cluster) then
+         return Allocation_Error;
+      end if;
+      return OK;
+   end Append_Cluster;
 
-      return "";
-   end Trim;
+   procedure Writeback_FsInfo
+     (FS : in out FAT_Filesystem)
+   is
+      subtype FSInfo_Block is Block (0 .. 11);
+      function From_FSInfo is new Ada.Unchecked_Conversion
+        (FAT_FS_Info, FSInfo_Block);
+
+      Status : Status_Code;
+      fat_begin_lba : constant Unsigned_32 :=
+        FS.LBA + Unsigned_32 (FS.FSInfo_Block_Number);
+      ret : Status_Code;
+      pragma Unreferenced (ret);
+   begin
+      FS.Window_Block := 16#FFFF_FFFF#;
+      Status := FS.Ensure_Block (fat_begin_lba);
+
+      if Status /= OK then
+         return;
+      end if;
+
+      --  again, check the generic FAT block signature
+      if FS.Window (510 .. 511) /= (16#55#, 16#AA#) then
+         return;
+      end if;
+
+      --  good. now we got the entire FSinfo in our window.
+      --  modify that part of the window and writeback.
+      FS.Window (16#1E4# .. 16#1EF#) := From_FSInfo (FS.FSInfo);
+      ret := FS.Write_Window (Block_Arg => fat_begin_lba);
+   end Writeback_FsInfo;
+
+   function Get_Free_Cluster (FS : in out FAT_Filesystem) return Unsigned_32 is
+      cand : Unsigned_32 := FS.Most_Recently_Allocated_Cluster;
+   begin
+      if FS.Version = FAT32 then
+         --  try shortcut: last allocated + 1 could be free
+         if cand /= INVALID_CLUSTER and then cand < FS.Num_Clusters then
+            cand := cand + 1;
+            if FS.Is_Free_Cluster (FS.Get_FAT (cand)) then
+               return cand;
+            end if;
+         end if;
+      end if;
+
+      --  otherwise exhaustively search for first free cluster
+      declare
+         c : Unsigned_32 := FIRST_CLUSTER;
+      begin
+         Scan_Loop : loop
+            if FS.Is_Free_Cluster (FS.Get_FAT (c)) then
+               return c;
+            end if;
+            exit Scan_Loop when c = FS.Num_Clusters;
+            c := c + 1;
+         end loop Scan_Loop;
+      end;
+
+      return INVALID_CLUSTER;
+   end Get_Free_Cluster;
+
+   function Is_FAT_Partition (typecode : Unsigned_8) return Boolean is
+     (typecode = 16#0b#) or (typecode = 16#0c#) or --  FAT32
+     (typecode = 16#0e#) or (typecode = 16#0f#) or --  FAT32
+     (typecode = 16#04#); -- FAT16
 
    ----------
    -- Open --
@@ -40,6 +125,8 @@ package body FAT_Filesystem is
       P_Idx    : Unsigned_16;
       P_Data   : Media_Reader.Block (0 .. 15);
       N_Blocks : Unsigned_32;
+
+      BOOTCODE_SIZE : constant := 446;
 
    begin
       --  Find a free Volume handle
@@ -60,7 +147,7 @@ package body FAT_Filesystem is
       Ret.Mounted := True;
       Ret.Controller := Controller;
 
-      --  Let's read the MBR
+      --  Let's read the MBR (first 512B)
       Status := Ret.Ensure_Block (0);
 
       if Status /= OK then
@@ -77,30 +164,38 @@ package body FAT_Filesystem is
          return null;
       end if;
 
-      --  Now check the partition entries: 4 partitions for the MBR
-      for P in 1 .. 4 loop
+      --  Now check the partition entries: 4 partitions for the MBR,
+      --  right after the boot code, which occupies the first 446B
+      --  of the MBR. Then open the first FAT partition that we find.
+      Partition_Loop : for P in 1 .. 4 loop
          --  Partitions are defined as an array of 16 bytes from
          --  base MBR + 446 (16#1BE#)
-         P_Idx  := 446 + Unsigned_16 (P - 1) * 16;
+         P_Idx  := BOOTCODE_SIZE + Unsigned_16 (P - 1) * 16;
          P_Data := Ret.Window (P_Idx .. P_Idx + 15);
 
-         --  Retrieve the number of blocks in the partition.
+         --  Retrieve the number of blocks/sectors in the partition.
          N_Blocks := To_Word (P_Data (12 .. 15));
 
          if N_Blocks > 0 then
             --  The partition is valid
-            Ret.LBA := To_Word (P_Data (8 .. 11));
-
-            exit;
+            declare
+               typecode : constant Unsigned_8 := P_Data (4);
+            begin
+               if Is_FAT_Partition (typecode) then
+                  Ret.LBA := To_Word (P_Data (8 .. 11)); -- start address/LBA
+                  exit Partition_Loop;
+               end if;
+            end;
 
          elsif P = 4 then
-            --  Last of the partition is not valid: there's no valid partition
+            --  Last of the partition is also not valid.
+            --  Thus, there's no valid partition at all.
             Status := No_Partition_Found;
             Ret.Mounted := False;
 
             return null;
          end if;
-      end loop;
+      end loop Partition_Loop;
 
       Initialize_FS (Ret.all, Status);
 
@@ -159,6 +254,7 @@ package body FAT_Filesystem is
    -- Initialize_FS --
    -------------------
 
+   --  @summary read FAT volume ID (first 512 B)
    procedure Initialize_FS
      (FS     : in out FAT_Filesystem;
       Status : out Status_Code)
@@ -173,12 +269,13 @@ package body FAT_Filesystem is
 
    begin
       FS.Window_Block := 16#FFFF_FFFF#;
-      Status := FS.Ensure_Block (FS.LBA);
+      Status := FS.Ensure_Block (FS.LBA); -- read partition's first block ("volume id")
 
       if Status /= OK then
          return;
       end if;
 
+      --  check volume signature: must be 55,AA
       if FS.Window (510 .. 511) /= (16#55#, 16#AA#) then
          Status := No_Filesystem;
          return;
@@ -187,15 +284,20 @@ package body FAT_Filesystem is
       FS.Disk_Parameters :=
         To_Disk_Parameter (FS.Window (0 .. 91));
 
+      --  read the first file allocation table (FAT) and get FS info (#free, etc.)
       if FS.Version = FAT32 then
-         Status :=
-           FS.Ensure_Block (FS.LBA + Unsigned_32 (FS.FSInfo_Block_Number));
+         declare
+            fat_begin_lba : constant Unsigned_32 :=
+              FS.LBA + Unsigned_32 (FS.FSInfo_Block_Number);
+         begin
+            Status := FS.Ensure_Block (fat_begin_lba);
+         end;
 
          if Status /= OK then
             return;
          end if;
 
-         --  Check the generic FAT block signature
+         --  again, check the generic FAT block signature
          if FS.Window (510 .. 511) /= (16#55#, 16#AA#) then
             Status := No_Filesystem;
             return;
@@ -203,9 +305,12 @@ package body FAT_Filesystem is
 
          FS.FSInfo :=
            To_FSInfo (FS.Window (16#1E4# .. 16#1EF#));
+         --  read #free clusters, last alloc'd cluster, signature
       end if;
 
+      --  compute LBA for FAT and data clusters
       declare
+         --  where the clusters with data start relative to Volume ID LBA
          Data_Offset_In_Block : constant Unsigned_32 :=
                                   Unsigned_32 (FS.Reserved_Blocks) +
                                   FS.FAT_Table_Size_In_Blocks *
@@ -243,34 +348,86 @@ package body FAT_Filesystem is
       FS.Mounted := False;
    end Close;
 
+   function Write_Window
+     (FS : in out FAT_Filesystem;
+      Block_Arg : Unsigned_32) return Status_Code
+   is
+   begin
+      FS.Window_Block := Block_Arg; -- now we hold this block in the window
+      if not FS.Controller.Write_Block (FS.Window_Block, FS.Window) then
+         return Disk_Error;
+      end if;
+      return OK;
+   end Write_Window;
+
    ------------------
    -- Ensure_Block --
    ------------------
 
    function Ensure_Block
      (FS    : in out FAT_Filesystem;
-      Block : Unsigned_32) return Status_Code
+      Block_Arg : Unsigned_32) return Status_Code
    is
    begin
       --  ??? Should use re-entrance protection here
-      if FS.Window_Block = Block then
+      if FS.Window_Block = Block_Arg then
          return OK;
       end if;
 
-      if not FS.Controller.Read_Block (Block, FS.Window) then
+      if not FS.Controller.Read_Block (Block_Arg, FS.Window) then
          FS.Window_Block  := 16#FFFF_FFFF#;
-
          return Disk_Error;
       end if;
 
-      FS.Window_Block := Block;
+      FS.Window_Block := Block_Arg;
 
       return OK;
    end Ensure_Block;
 
-   -------------
-   -- Get_FAT --
-   -------------
+   function Set_FAT
+     (FS      : in out FAT_Filesystem;
+      Cluster : Unsigned_32;
+      Value   : Unsigned_32) return Boolean
+   is
+      Status    : Status_Code;
+      Idx       : Unsigned_16;
+      subtype B2 is Block (1 .. 2);
+      subtype B4 is Block (1 .. 4);
+      function From_Int16 is new Ada.Unchecked_Conversion
+        (Unsigned_16, B2);
+      function From_Int32 is new Ada.Unchecked_Conversion
+        (Unsigned_32, B4);
+
+      fat_block : Unsigned_32;
+   begin
+
+      case FS.Version is
+         when FAT16 =>
+            fat_block := FS.FAT_Addr + Cluster * 2 / FS.Block_Size_In_Bytes;
+            Status := Ensure_Block (FS, fat_block);
+
+            if Status /= OK then
+               return False;
+            end if;
+
+            Idx := Unsigned_16 ((Cluster * 2) mod FS.Block_Size_In_Bytes);
+            FS.Window (Idx .. Idx + 1) := From_Int16 (Unsigned_16 (Value and 16#FFFF#));
+
+         when FAT32 =>
+            fat_block := FS.FAT_Addr + Cluster * 4 / FS.Block_Size_In_Bytes;
+            Status := Ensure_Block (FS, fat_block);
+
+            if Status /= OK then
+               return False;
+            end if;
+
+            Idx := Unsigned_16 ((Cluster * 4) mod FS.Block_Size_In_Bytes);
+            FS.Window (Idx .. Idx + 3) := From_Int32 (Value);
+      end case;
+
+      --  write FAT back to disk
+      return OK = FS.Write_Window (fat_block);
+   end Set_FAT;
 
    function Get_FAT
      (FS      : in out FAT_Filesystem;
@@ -286,8 +443,8 @@ package body FAT_Filesystem is
         (B4, Unsigned_32);
 
    begin
-      if Cluster < 2 or else Cluster >= FS.Num_Clusters then
-         return 1;
+      if Cluster < FIRST_CLUSTER or else Cluster >= FS.Num_Clusters then
+         return INVALID_CLUSTER;
       end if;
 
       case FS.Version is
@@ -301,7 +458,6 @@ package body FAT_Filesystem is
             end if;
 
             Idx := Unsigned_16 ((Cluster * 2) mod FS.Block_Size_In_Bytes);
-
             return Unsigned_32 (To_Int16 (FS.Window (Idx .. Idx + 1)));
 
          when FAT32 =>
@@ -310,13 +466,42 @@ package body FAT_Filesystem is
                FS.FAT_Addr + Cluster * 4 / FS.Block_Size_In_Bytes);
 
             if Status /= OK then
-               return 1;
+               return INVALID_CLUSTER;
             end if;
 
             Idx := Unsigned_16 ((Cluster * 4) mod FS.Block_Size_In_Bytes);
-
             return To_Int32 (FS.Window (Idx .. Idx + 3)) and 16#0FFF_FFFF#;
       end case;
    end Get_FAT;
+
+   function Image (s : Status_Code) return String is
+   begin
+      case s is
+      when OK => return "OK";
+      when Disk_Error => return "DiskErr";
+      when Internal_Error => return "IntErr";
+      when No_Such_File => return "NoSuchFile";
+      when Invalid_Name => return "InvName";
+      when Already_Exists => return "Exists";
+      when Invalid_Object_Entry => return "InvEnt";
+      when No_MBR_Found => return "NoMBR";
+      when Device_Full => return "DevFull";
+      when Allocation_Error => return "AllocErr";
+      when No_Partition_Found => return "NoPart";
+      when others => return "unknown";
+      end case;
+   end Image;
+
+   function Is_Reserved_Cluster
+     (FS  : FAT_Filesystem;
+      ent : FAT_Entry) return Boolean is
+   begin
+      case Version (FS) is
+         when FAT16 =>
+            return ent > FS.Num_Clusters and ent <= 16#FFF6#;
+         when FAT32 =>
+            return ent > FS.Num_Clusters and ent <= 16#FFFF_FFF6#;
+      end case;
+   end Is_Reserved_Cluster;
 
 end FAT_Filesystem;

--- a/examples/sdcard/src/media_reader-sdcard.adb
+++ b/examples/sdcard/src/media_reader-sdcard.adb
@@ -28,15 +28,21 @@ package body Media_Reader.SDCard is
 
       procedure Clear_Transfer_State;
 
+      function Buffer_Error return Boolean;
+
       entry Wait_Transfer (Status : out DMA_Error_Code);
 
    private
 
-      procedure Interrupt
+      procedure Interrupt_RX
         with Attach_Handler => Rx_IRQ, Unreferenced;
 
+      procedure Interrupt_TX
+        with Attach_Handler => Tx_IRQ, Unreferenced;
+
       Finished   : Boolean := True;
-      DMA_Status : DMA_Error_Code;
+      DMA_Status : DMA_Error_Code := DMA_No_Error;
+      Had_Buffer_Error : Boolean := False;
    end DMA_Interrupt_Handler;
 
    ------------------
@@ -226,6 +232,8 @@ package body Media_Reader.SDCard is
    protected body DMA_Interrupt_Handler
    is
 
+      function Buffer_Error return Boolean is (Had_Buffer_Error);
+
       -------------------
       -- Wait_Transfer --
       -------------------
@@ -244,6 +252,7 @@ package body Media_Reader.SDCard is
       begin
          Finished := False;
          DMA_Status := DMA_No_Error;
+         Had_Buffer_Error := False;
       end Set_Transfer_State;
 
       --------------------------
@@ -261,24 +270,8 @@ package body Media_Reader.SDCard is
       -- Interrupt --
       ---------------
 
-      procedure Interrupt is
+      procedure Interrupt_RX is
       begin
-         if Status (SD_DMA, SD_DMA_Rx_Stream, FIFO_Error_Indicated) then
-            Disable_Interrupt (SD_DMA, SD_DMA_Rx_Stream, FIFO_Error_Interrupt);
-            Clear_Status (SD_DMA, SD_DMA_Rx_Stream, FIFO_Error_Indicated);
-
-            DMA_Status := DMA_FIFO_Error;
-            Finished := True;
-         end if;
-
-         if Status (SD_DMA, SD_DMA_Rx_Stream, Transfer_Error_Indicated) then
-            Disable_Interrupt
-              (SD_DMA, SD_DMA_Rx_Stream, Transfer_Error_Interrupt);
-            Clear_Status (SD_DMA, SD_DMA_Rx_Stream, Transfer_Error_Indicated);
-
-            DMA_Status := DMA_Transfer_Error;
-            Finished := True;
-         end if;
 
          if Status (SD_DMA, SD_DMA_Rx_Stream, Transfer_Complete_Indicated) then
             Disable_Interrupt
@@ -290,12 +283,70 @@ package body Media_Reader.SDCard is
             Finished := True;
          end if;
 
+         if Status (SD_DMA, SD_DMA_Rx_Stream, FIFO_Error_Indicated) then
+            Disable_Interrupt (SD_DMA, SD_DMA_Rx_Stream, FIFO_Error_Interrupt);
+            Clear_Status (SD_DMA, SD_DMA_Rx_Stream, FIFO_Error_Indicated);
+
+            --  see Interrupt_TX
+            Had_Buffer_Error := True;
+         end if;
+
+         if Status (SD_DMA, SD_DMA_Rx_Stream, Transfer_Error_Indicated) then
+            Disable_Interrupt
+              (SD_DMA, SD_DMA_Rx_Stream, Transfer_Error_Interrupt);
+            Clear_Status (SD_DMA, SD_DMA_Rx_Stream, Transfer_Error_Indicated);
+
+            DMA_Status := DMA_Transfer_Error;
+            Finished := True;
+         end if;
+
          if Finished then
             for Int in STM32.DMA.DMA_Interrupt loop
                Disable_Interrupt (SD_DMA, SD_DMA_Rx_Stream, Int);
             end loop;
          end if;
-      end Interrupt;
+      end Interrupt_RX;
+
+      procedure Interrupt_TX is
+      begin
+
+         if Status (SD_DMA, SD_DMA_Tx_Stream, Transfer_Complete_Indicated) then
+            Disable_Interrupt
+              (SD_DMA, SD_DMA_Tx_Stream, Transfer_Complete_Interrupt);
+            Clear_Status
+              (SD_DMA, SD_DMA_Tx_Stream, Transfer_Complete_Indicated);
+
+            DMA_Status := DMA_No_Error;
+            Finished := True;
+         end if;
+
+         if Status (SD_DMA, SD_DMA_Tx_Stream, FIFO_Error_Indicated) then
+            --  this signal can be ignored when transfer is completed
+            --  however, it comes before Transfer_Complete_Indicated and
+            --  We cannot use the value of the NDT register either, because
+            --  it's a race condition (the register lacks behind).
+            --  As a result, we have to ignore it.
+            Disable_Interrupt (SD_DMA, SD_DMA_Tx_Stream, FIFO_Error_Interrupt);
+            Clear_Status (SD_DMA, SD_DMA_Tx_Stream, FIFO_Error_Indicated);
+            Had_Buffer_Error := True;
+
+         end if;
+
+         if Status (SD_DMA, SD_DMA_Tx_Stream, Transfer_Error_Indicated) then
+            Disable_Interrupt
+              (SD_DMA, SD_DMA_Tx_Stream, Transfer_Error_Interrupt);
+            Clear_Status (SD_DMA, SD_DMA_Tx_Stream, Transfer_Error_Indicated);
+
+            DMA_Status := DMA_Transfer_Error;
+            Finished := True;
+         end if;
+
+         if Finished then
+            for Int in STM32.DMA.DMA_Interrupt loop
+               Disable_Interrupt (SD_DMA, SD_DMA_Tx_Stream, Int);
+            end loop;
+         end if;
+      end Interrupt_TX;
 
    end DMA_Interrupt_Handler;
 
@@ -373,6 +424,66 @@ package body Media_Reader.SDCard is
       end Interrupt;
 
    end SDMMC_Interrupt_Handler;
+
+   overriding function Write_Block
+     (Controller   : in out SDCard_Controller;
+      Block_Number : Unsigned_32;
+      Data         : Block) return Boolean
+   is
+      Ret     : SD_Error;
+      DMA_Err : DMA_Error_Code;
+   begin
+      Ensure_Card_Informations (Controller);
+
+
+         --  Flush the data cache
+         Cortex_M.Cache.Invalidate_DCache
+           (Start => Data (Data'First)'Address,
+            Len   => Data'Length);
+
+         DMA_Interrupt_Handler.Set_Transfer_State;
+         SDMMC_Interrupt_Handler.Set_Transfer_State (Controller);
+
+         Clear_All_Status (SD_DMA, SD_DMA_Tx_Stream);
+         Ret := Write_Blocks_DMA
+           (Controller.Device,
+            Unsigned_64 (Block_Number) *
+                Unsigned_64 (Controller.Info.Card_Block_Size),
+            SD_DMA,
+            SD_DMA_Tx_Stream,
+            SD_Data (Data));
+         --  this always leaves the last 12 byte standing. Why?
+         --  also...NDTR is not what it should be.
+
+         if Ret /= OK then
+            DMA_Interrupt_Handler.Clear_Transfer_State;
+            SDMMC_Interrupt_Handler.Clear_Transfer_State;
+            Abort_Transfer (SD_DMA, SD_DMA_Tx_Stream, DMA_Err);
+
+            return False;
+         end if;
+
+         DMA_Interrupt_Handler.Wait_Transfer (DMA_Err); -- this unblocks
+         SDMMC_Interrupt_Handler.Wait_Transfer (Ret); -- TX underrun!
+
+         --  this seems slow. Do we have to wait?
+         loop
+            --  FIXME: some people claim, that this goes wrong with multiblock, see
+            --  http://blog.frankvh.com/2011/09/04/stm32f2xx-sdio-sd-card-interface/
+            exit when not Get_Flag (Controller.Device, TX_Active);
+         end loop;
+
+         Clear_All_Status (SD_DMA, SD_DMA_Tx_Stream);
+         Disable (SD_DMA, SD_DMA_Tx_Stream);
+
+         declare
+         data_incomplete : constant Boolean := DMA_Interrupt_Handler.Buffer_Error and then
+              Items_Transferred (SD_DMA, SD_DMA_Tx_Stream) /= Data'Length / 4;
+         begin
+            return Ret = OK and then DMA_Err = DMA_No_Error and then not data_incomplete;
+         end;
+
+   end Write_Block;
 
    ----------------
    -- Read_Block --

--- a/examples/sdcard/src/media_reader-sdcard.ads
+++ b/examples/sdcard/src/media_reader-sdcard.ads
@@ -26,6 +26,12 @@ package Media_Reader.SDCard is
       Block_Number : Unsigned_32;
       Data         : out Block) return Boolean;
 
+   overriding function Write_Block
+     (Controller   : in out SDCard_Controller;
+      Block_Number : Unsigned_32;
+      Data         : Block) return Boolean;
+
+
 private
 
    type SDCard_Controller is limited new Media_Controller with record

--- a/examples/sdcard/src/media_reader.ads
+++ b/examples/sdcard/src/media_reader.ads
@@ -15,4 +15,9 @@ package Media_Reader is
       Block_Number : Unsigned_32;
       Data         : out Block) return Boolean is abstract;
 
+   function Write_Block
+     (Controller   : in out Media_Controller;
+      Block_Number : Unsigned_32;
+      Data         : Block) return Boolean is abstract;
+
 end Media_Reader;

--- a/examples/sdcard/src/mystrings.adb
+++ b/examples/sdcard/src/mystrings.adb
@@ -1,0 +1,84 @@
+--  Institution: Technische Universitaet Muenchen
+--  Department:  Real-Time Computer Systems (RCS)
+--  Project:     StratoX
+--  Authors:     Martin Becker (becker@rcs.ei.tum.de)
+
+--  @summary String functions
+package body MyStrings with SPARK_Mode is
+
+   procedure StrCpySpace (outstring : out String; instring : String) is
+   begin
+      if instring'Length >= outstring'Length then
+         --  trim
+         outstring := instring (instring'First .. instring'First - 1 + outstring'Length);
+      else
+         --  pad
+         declare
+            lastidx : constant Natural := outstring'First + instring'Length - 1;
+         begin
+            outstring := (others => ' ');
+            outstring (outstring'First .. lastidx) := instring;
+         end;
+      end if;
+   end StrCpySpace;
+
+   function RTrim (S : String) return String is
+   begin
+      for J in reverse S'Range loop
+         if S (J) /= ' ' then
+            return S (S'First .. J);
+         end if;
+      end loop;
+
+      return "";
+   end RTrim;
+
+   function LTrim (S : String) return String is
+   begin
+      for J in S'Range loop
+         if S (J) /= ' ' then
+            return S (J .. S'Last);
+         end if;
+      end loop;
+
+      return "";
+   end LTrim;
+
+   function Trim (S : String) return String is
+   begin
+      return LTrim (RTrim (S));
+   end Trim;
+
+   function StrChr (S : String; C : Character) return Integer is
+   begin
+      for idx in S'Range loop
+         if S (idx) = C then
+            return idx;
+         end if;
+      end loop;
+      return S'Last + 1;
+   end StrChr;
+
+   function Is_AlNum (c : Character) return Boolean is
+   begin
+      return (c in 'a' .. 'z') or (c in 'A' .. 'Z') or (c in '0' .. '9');
+   end Is_AlNum;
+
+   function Strip_Non_Alphanum (s : String) return String with SPARK_Mode => Off is
+      tmp : String (1 .. s'Length) := s;
+      len : Integer := 0;
+   begin
+      for c in s'Range loop
+         if Is_AlNum (s (c)) then
+            len := len + 1;
+            tmp (len) := s (c);
+         end if;
+      end loop;
+      declare
+         ret : constant String (1 .. len) := tmp (1 .. len); --  SPARK: "subtype constraint cannot depend on len"
+      begin
+         return ret;
+      end;
+   end Strip_Non_Alphanum;
+
+end MyStrings;

--- a/examples/sdcard/src/mystrings.ads
+++ b/examples/sdcard/src/mystrings.ads
@@ -1,0 +1,32 @@
+--  Institution: Technische Universitaet Muenchen
+--  Department:  Real-Time Computer Systems (RCS)
+--  Project:     StratoX
+--  Authors:     Martin Becker (becker@rcs.ei.tum.de)
+
+--  @summary String functions
+package MyStrings with SPARK_Mode is
+   function Is_AlNum (c : Character) return Boolean;
+   --  is the given character alphanumeric?
+
+   function Strip_Non_Alphanum (s : String) return String;
+   --  remove all non-alphanumeric characters from string
+
+   function StrChr (S : String; C : Character) return Integer with
+     Pre => S'Last < Natural'Last;
+   --  search for occurence of character in string.
+   --  return index in S, or S'Last + 1 if not found.
+
+   procedure StrCpySpace (outstring : out String; instring : String);
+   --  turn a string into a fixed-length string:
+   --  if too short, pad with spaces until it reaches the given length
+   --  if too long, then crop
+
+   function RTrim (S : String) return String;
+   --  remove trailing spaces
+
+   function LTrim (S : String) return String;
+   --  remove leading spaces
+
+   function Trim (S : String) return String;
+   --  remove leading and trailing spaces
+end MyStrings;

--- a/examples/sdcard/src/sdcard_demo.adb
+++ b/examples/sdcard/src/sdcard_demo.adb
@@ -1,4 +1,3 @@
-with Ada.Exceptions;
 with Ada.Unchecked_Conversion;
 with Interfaces;                 use Interfaces;
 
@@ -183,28 +182,5 @@ begin
          end loop;
       end if;
    end loop;
-
-exception
-   when E : others =>
-      Display.Get_Hidden_Buffer (1).Fill (White);
-      Draw_String
-        (Display.Get_Hidden_Buffer (1),
-         (0, 0),
-         Ada.Exceptions.Exception_Information (E),
-         BMP_Fonts.Font12x12,
-         Black,
-         White);
-      Draw_String
-        (Display.Get_Hidden_Buffer (1),
-         (0, 14),
-         Ada.Exceptions.Exception_Message (E),
-         BMP_Fonts.Font12x12,
-         Black,
-         White);
-      Display.Update_Layer (1);
-
-      loop
-         null;
-      end loop;
 
 end SDCard_Demo;

--- a/examples/sdcard/src/stm32f7/device_sd_configuration.ads
+++ b/examples/sdcard/src/stm32f7/device_sd_configuration.ads
@@ -29,8 +29,8 @@ package Device_SD_Configuration is
 
    SD_Interrupt      : Ada.Interrupts.Interrupt_ID renames
                          Ada.Interrupts.Names.SDMMC1_Interrupt;
-   SD_Device         : STM32_SVD.SDMMC.SDMMC1_Peripheral renames
-                         STM32_SVD.SDMMC.SDMMC1_Periph;
+   SD_Device         : STM32_SVD.SDMMC.SDMMC_Peripheral renames
+                         STM32_SVD.SDMMC.SDMMC_Periph;
 
    procedure Enable_Clock_Device;
    procedure Reset_Device;

--- a/examples/sdcard/src/stm32f7/device_sd_configuration.ads
+++ b/examples/sdcard/src/stm32f7/device_sd_configuration.ads
@@ -29,8 +29,8 @@ package Device_SD_Configuration is
 
    SD_Interrupt      : Ada.Interrupts.Interrupt_ID renames
                          Ada.Interrupts.Names.SDMMC1_Interrupt;
-   SD_Device         : STM32_SVD.SDMMC.SDMMC_Peripheral renames
-                         STM32_SVD.SDMMC.SDMMC_Periph;
+   SD_Device         : STM32_SVD.SDMMC.SDMMC1_Peripheral renames
+                         STM32_SVD.SDMMC.SDMMC1_Periph;
 
    procedure Enable_Clock_Device;
    procedure Reset_Device;


### PR DESCRIPTION
This is a pull request for my adafatfs write implementation, tested successfully on STM32F427. Capabilities: create directories, create files, write to files, overwrite files and some related things. Names so far limited to 8+3 (i.e., no VFAT entries are created).

This request is split into two commits:
 1. 7100ec8: a backport of the recently merged pull request #33 (SD DMA write) to the branch point
 2. 7321bbd: patches to adafatfs to add write capabiities

The first part can be ignored when merging, since this is all contained in master's HEAD already (these are the relevant patches that I needed to set up this pull request). The second part needs manual merging, since our two adafatfs implementations diverged to a fair amount.

It certainly could use some refactoring and optimization, but it works reliably so far.