### PR TITLE
Submodules should use https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "embedded-runtimes"]
 	path = embedded-runtimes
-	url = git@github.com:AdaCore/embedded-runtimes.git
+	url = https://github.com/AdaCore/embedded-runtimes.git


### PR DESCRIPTION
Submodules break when the user doesn't have a github SSH key configured. HTTPS avoids this issue.  See error below:


% git clone https://github.com/AdaCore/Ada_Drivers_Library.git
Cloning into 'Ada_Drivers_Library'...
remote: Counting objects: 8934, done.
remote: Compressing objects: 100% (222/222), done.
remote: Total 8934 (delta 98), reused 0 (delta 0), pack-reused 8709
Receiving objects: 100% (8934/8934), 3.25 MiB | 3.29 MiB/s, done.
Resolving deltas: 100% (5576/5576), done.
Checking connectivity... done.
% cd Ada_Drivers_Library

% git submodule update --recursive
**_Cloning into 'embedded-runtimes'...
Permission denied (publickey).
fatal: Could not read from remote repository._**

**_Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:AdaCore/embedded-runtimes.git' into submodule path 'embedded-runtimes' failed_**