### PR TITLE
fix build problem due to case issue

### DIFF
--- a/boards/crazyflie.gpr
+++ b/boards/crazyflie.gpr
@@ -18,7 +18,7 @@ aggregate library project Crazyflie is
 
    for Project_Path use ("OpenMV2");
 
-   for Project_Files use ("Crazyflie/board.gpr");
+   for Project_Files use ("crazyflie/board.gpr");
 
    for Library_Dir use "lib/crazyflie/" & RTS & "/" & Build;
    for Library_Name use "crazyflie";


### PR DESCRIPTION
Hi,

We tried to build the latest version of certyflie but we encounter build issue due to case problems. I suppose it works on a case insensitive file system (FAT Windows ?) but on Linux it's quite uncommon.