### PR TITLE
Rename Word to UInt32 and Short to UInt16

### DIFF
--- a/ARM/STM32/devices/stm32f40x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f40x/stm32-device.adb
@@ -44,10 +44,10 @@ package body STM32.Device is
    HSI_VALUE : constant := 16_000_000;
    --  Internal oscillator in Hz
 
-   HPRE_Presc_Table : constant array (UInt4) of Word :=
+   HPRE_Presc_Table : constant array (UInt4) of UInt32 :=
      (1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 8, 16, 64, 128, 256, 512);
 
-   PPRE_Presc_Table : constant array (UInt3) of Word :=
+   PPRE_Presc_Table : constant array (UInt3) of UInt32 :=
      (1, 1, 1, 1, 2, 4, 8, 16);
 
    ------------------
@@ -545,13 +545,15 @@ package body STM32.Device is
             --  PLL as source
             declare
                HSE_Source : constant Boolean := RCC_Periph.PLLCFGR.PLLSRC;
-               Pllm       : constant Word :=
-                              Word (RCC_Periph.PLLCFGR.PLLM);
-               Plln       : constant Word :=
-                              Word (RCC_Periph.PLLCFGR.PLLN);
-               Pllp       : constant Word :=
-                              (Word (RCC_Periph.PLLCFGR.PLLP) + 1) * 2;
-               Pllvco     : Word;
+               Pllm       : constant UInt32 :=
+                 UInt32 (RCC_Periph.PLLCFGR.PLLM);
+               Plln       : constant
+                 UInt32 :=
+                   UInt32 (RCC_Periph.PLLCFGR.PLLN);
+               Pllp       : constant
+                 UInt32 :=
+                   (UInt32 (RCC_Periph.PLLCFGR.PLLP) + 1) * 2;
+               Pllvco     : UInt32;
             begin
                if not HSE_Source then
                   Pllvco := (HSI_VALUE / Pllm) * Plln;

--- a/ARM/STM32/devices/stm32f40x/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f40x/stm32-device.ads
@@ -384,12 +384,12 @@ package STM32.Device is
    -----------------------------
 
    type RCC_System_Clocks is record
-      SYSCLK  : Word;
-      HCLK    : Word;
-      PCLK1   : Word;
-      PCLK2   : Word;
-      TIMCLK1 : Word;
-      TIMCLK2 : Word;
+      SYSCLK  : UInt32;
+      HCLK    : UInt32;
+      PCLK1   : UInt32;
+      PCLK2   : UInt32;
+      TIMCLK1 : UInt32;
+      TIMCLK2 : UInt32;
    end record;
 
    function System_Clock_Frequencies return RCC_System_Clocks;

--- a/ARM/STM32/devices/stm32f40x/stm32-rcc.adb
+++ b/ARM/STM32/devices/stm32f40x/stm32-rcc.adb
@@ -37,13 +37,13 @@ with STM32_SVD.RCC;            use STM32_SVD.RCC;
 package body STM32.RCC is
 
    function To_AHB1RSTR_T is new Ada.Unchecked_Conversion
-     (Word, AHB1RSTR_Register);
+     (UInt32, AHB1RSTR_Register);
    function To_AHB2RSTR_T is new Ada.Unchecked_Conversion
-     (Word, AHB2RSTR_Register);
+     (UInt32, AHB2RSTR_Register);
    function To_APB1RSTR_T is new Ada.Unchecked_Conversion
-     (Word, APB1RSTR_Register);
+     (UInt32, APB1RSTR_Register);
    function To_APB2RSTR_T is new Ada.Unchecked_Conversion
-     (Word, APB2RSTR_Register);
+     (UInt32, APB2RSTR_Register);
 
    ---------------------------------------------------------------------------
    -------  Enable/Disable/Reset Routines  -----------------------------------

--- a/ARM/STM32/devices/stm32f40x/stm32-rcc.ads
+++ b/ARM/STM32/devices/stm32f40x/stm32-rcc.ads
@@ -33,12 +33,12 @@ pragma Restrictions (No_Elaboration_Code);
 package STM32.RCC is
 
 --     type RCC_System_Clocks is record
---        SYSCLK  : Word;
---        HCLK    : Word;
---        PCLK1   : Word;
---        PCLK2   : Word;
---        TIMCLK1 : Word;
---        TIMCLK2 : Word;
+--        SYSCLK  : UInt32;
+--        HCLK    : UInt32;
+--        PCLK1   : UInt32;
+--        PCLK2   : UInt32;
+--        TIMCLK1 : UInt32;
+--        TIMCLK2 : UInt32;
 --     end record;
 --
 --     function System_Clock_Frequencies return RCC_System_Clocks;

--- a/ARM/STM32/devices/stm32f42x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f42x/stm32-device.adb
@@ -39,17 +39,17 @@ with STM32_SVD.RCC; use STM32_SVD.RCC;
 
 package body STM32.Device is
 
-   HSE_VALUE : constant Word :=
-                 Word (System.BB.Parameters.HSE_Clock);
+   HSE_VALUE : constant UInt32 :=
+                 UInt32 (System.BB.Parameters.HSE_Clock);
    --  External oscillator in Hz
 
    HSI_VALUE : constant := 16_000_000;
    --  Internal oscillator in Hz
 
-   HPRE_Presc_Table : constant array (UInt4) of Word :=
+   HPRE_Presc_Table : constant array (UInt4) of UInt32 :=
      (1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 8, 16, 64, 128, 256, 512);
 
-   PPRE_Presc_Table : constant array (UInt3) of Word :=
+   PPRE_Presc_Table : constant array (UInt3) of UInt32 :=
      (1, 1, 1, 1, 2, 4, 8, 16);
 
    ------------------
@@ -596,13 +596,13 @@ package body STM32.Device is
             --  PLL as source
             declare
                HSE_Source : constant Boolean := RCC_Periph.PLLCFGR.PLLSRC;
-               Pllm       : constant Word :=
-                              Word (RCC_Periph.PLLCFGR.PLLM);
-               Plln       : constant Word :=
-                              Word (RCC_Periph.PLLCFGR.PLLN);
-               Pllp       : constant Word :=
-                              (Word (RCC_Periph.PLLCFGR.PLLP) + 1) * 2;
-               Pllvco     : Word;
+               Pllm       : constant UInt32 :=
+                              UInt32 (RCC_Periph.PLLCFGR.PLLM);
+               Plln       : constant UInt32 :=
+                              UInt32 (RCC_Periph.PLLCFGR.PLLN);
+               Pllp       : constant UInt32 :=
+                              (UInt32 (RCC_Periph.PLLCFGR.PLLP) + 1) * 2;
+               Pllvco     : UInt32;
             begin
                if not HSE_Source then
                   Pllvco := (HSI_VALUE / Pllm) * Plln;

--- a/ARM/STM32/devices/stm32f42x/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f42x/stm32-device.ads
@@ -431,12 +431,12 @@ package STM32.Device is
    -----------------------------
 
    type RCC_System_Clocks is record
-      SYSCLK  : Word;
-      HCLK    : Word;
-      PCLK1   : Word;
-      PCLK2   : Word;
-      TIMCLK1 : Word;
-      TIMCLK2 : Word;
+      SYSCLK  : UInt32;
+      HCLK    : UInt32;
+      PCLK1   : UInt32;
+      PCLK2   : UInt32;
+      TIMCLK1 : UInt32;
+      TIMCLK2 : UInt32;
    end record;
 
    function System_Clock_Frequencies return RCC_System_Clocks;

--- a/ARM/STM32/devices/stm32f42x/stm32-rcc.adb
+++ b/ARM/STM32/devices/stm32f42x/stm32-rcc.adb
@@ -37,13 +37,13 @@ with STM32_SVD.RCC;            use STM32_SVD.RCC;
 package body STM32.RCC is
 
    function To_AHB1RSTR_T is new Ada.Unchecked_Conversion
-     (Word, AHB1RSTR_Register);
+     (UInt32, AHB1RSTR_Register);
    function To_AHB2RSTR_T is new Ada.Unchecked_Conversion
-     (Word, AHB2RSTR_Register);
+     (UInt32, AHB2RSTR_Register);
    function To_APB1RSTR_T is new Ada.Unchecked_Conversion
-     (Word, APB1RSTR_Register);
+     (UInt32, APB1RSTR_Register);
    function To_APB2RSTR_T is new Ada.Unchecked_Conversion
-     (Word, APB2RSTR_Register);
+     (UInt32, APB2RSTR_Register);
 
    ---------------------------------------------------------------------------
    -------  Enable/Disable/Reset Routines  -----------------------------------

--- a/ARM/STM32/devices/stm32f42x/stm32-rcc.ads
+++ b/ARM/STM32/devices/stm32f42x/stm32-rcc.ads
@@ -33,12 +33,12 @@ pragma Restrictions (No_Elaboration_Code);
 package STM32.RCC is
 
 --     type RCC_System_Clocks is record
---        SYSCLK  : Word;
---        HCLK    : Word;
---        PCLK1   : Word;
---        PCLK2   : Word;
---        TIMCLK1 : Word;
---        TIMCLK2 : Word;
+--        SYSCLK  : UInt32;
+--        HCLK    : UInt32;
+--        PCLK1   : UInt32;
+--        PCLK2   : UInt32;
+--        TIMCLK1 : UInt32;
+--        TIMCLK2 : UInt32;
 --     end record;
 --
 --     function System_Clock_Frequencies return RCC_System_Clocks;

--- a/ARM/STM32/devices/stm32f46_79x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f46_79x/stm32-device.adb
@@ -38,17 +38,17 @@ with STM32_SVD.RCC; use STM32_SVD.RCC;
 
 package body STM32.Device is
 
-   HSE_VALUE : constant Word :=
-                 Word (System.BB.Parameters.HSE_Clock);
+   HSE_VALUE : constant UInt32 :=
+                 UInt32 (System.BB.Parameters.HSE_Clock);
    --  External oscillator in Hz
 
    HSI_VALUE : constant := 16_000_000;
    --  Internal oscillator in Hz
 
-   HPRE_Presc_Table : constant array (UInt4) of Word :=
+   HPRE_Presc_Table : constant array (UInt4) of UInt32 :=
      (1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 8, 16, 64, 128, 256, 512);
 
-   PPRE_Presc_Table : constant array (UInt3) of Word :=
+   PPRE_Presc_Table : constant array (UInt3) of UInt32 :=
      (1, 1, 1, 1, 2, 4, 8, 16);
 
    function PLLSAI_Enabled return Boolean;
@@ -604,11 +604,11 @@ package body STM32.Device is
    -- Get_Input_Clock --
    ---------------------
 
-   function Get_Input_Clock (Periph : SAI_Port) return Word
+   function Get_Input_Clock (Periph : SAI_Port) return UInt32
    is
       Input_Selector  : UInt2;
-      VCO_Input       : Word;
-      SAI_First_Level : Word;
+      VCO_Input       : UInt32;
+      SAI_First_Level : UInt32;
    begin
       if Periph'Address /= SAI_Base then
          raise Unknown_Device;
@@ -624,10 +624,10 @@ package body STM32.Device is
 
       if not RCC_Periph.PLLCFGR.PLLSRC then
          --  PLLSAI SRC is HSI
-         VCO_Input := HSI_VALUE / Word (RCC_Periph.PLLCFGR.PLLM);
+         VCO_Input := HSI_VALUE / UInt32 (RCC_Periph.PLLCFGR.PLLM);
       else
          --  PLLSAI SRC is HSE
-         VCO_Input := HSE_VALUE / Word (RCC_Periph.PLLCFGR.PLLM);
+         VCO_Input := HSE_VALUE / UInt32 (RCC_Periph.PLLCFGR.PLLM);
       end if;
 
       if Input_Selector = 0 then
@@ -636,19 +636,19 @@ package body STM32.Device is
          --  VCO out = VCO in & PLLSAIN
          --  SAI firstlevel = VCO out / PLLSAIQ
          SAI_First_Level :=
-           VCO_Input * Word (RCC_Periph.PLLSAICFGR.PLLSAIN) /
-           Word (RCC_Periph.PLLSAICFGR.PLLSAIQ);
+           VCO_Input * UInt32 (RCC_Periph.PLLSAICFGR.PLLSAIN) /
+           UInt32 (RCC_Periph.PLLSAICFGR.PLLSAIQ);
 
          --  SAI frequency is SAI First level / PLLSAIDIVQ
-         return SAI_First_Level / Word (RCC_Periph.DCKCFGR.PLLSAIDIVQ);
+         return SAI_First_Level / UInt32 (RCC_Periph.DCKCFGR.PLLSAIDIVQ);
 
       else
          --  PLLI2S as clock source
          SAI_First_Level :=
-           VCO_Input * Word (RCC_Periph.PLLI2SCFGR.PLLI2SN) /
-           Word (RCC_Periph.PLLI2SCFGR.PLLI2SQ);
+           VCO_Input * UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SN) /
+           UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SQ);
          --  SAI frequency is SAI First level / PLLI2SDIVQ
-         return SAI_First_Level / Word (RCC_Periph.DCKCFGR.PLLIS2DIVQ + 1);
+         return SAI_First_Level / UInt32 (RCC_Periph.DCKCFGR.PLLIS2DIVQ + 1);
       end if;
    end Get_Input_Clock;
 
@@ -701,13 +701,13 @@ package body STM32.Device is
             --  PLL as source
             declare
                HSE_Source : constant Boolean := RCC_Periph.PLLCFGR.PLLSRC;
-               Pllm       : constant Word :=
-                              Word (RCC_Periph.PLLCFGR.PLLM);
-               Plln       : constant Word :=
-                              Word (RCC_Periph.PLLCFGR.PLLN);
-               Pllp       : constant Word :=
-                              (Word (RCC_Periph.PLLCFGR.PLLP) + 1) * 2;
-               Pllvco     : Word;
+               Pllm       : constant UInt32 :=
+                              UInt32 (RCC_Periph.PLLCFGR.PLLM);
+               Plln       : constant UInt32 :=
+                              UInt32 (RCC_Periph.PLLCFGR.PLLN);
+               Pllp       : constant UInt32 :=
+                              (UInt32 (RCC_Periph.PLLCFGR.PLLP) + 1) * 2;
+               Pllvco     : UInt32;
             begin
                if not HSE_Source then
                   Pllvco := (HSI_VALUE / Pllm) * Plln;

--- a/ARM/STM32/devices/stm32f46_79x/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f46_79x/stm32-device.ads
@@ -507,7 +507,7 @@ package STM32.Device is
 
    procedure Enable_Clock (This : in out SAI_Port);
    procedure Reset (This : in out SAI_Port);
-   function Get_Input_Clock (Periph : SAI_Port) return Word;
+   function Get_Input_Clock (Periph : SAI_Port) return UInt32;
 
    -----------
    -- SDMMC --
@@ -523,12 +523,12 @@ package STM32.Device is
    -----------------------------
 
    type RCC_System_Clocks is record
-      SYSCLK  : Word;
-      HCLK    : Word;
-      PCLK1   : Word;
-      PCLK2   : Word;
-      TIMCLK1 : Word;
-      TIMCLK2 : Word;
+      SYSCLK  : UInt32;
+      HCLK    : UInt32;
+      PCLK1   : UInt32;
+      PCLK2   : UInt32;
+      TIMCLK1 : UInt32;
+      TIMCLK2 : UInt32;
    end record;
 
    function System_Clock_Frequencies return RCC_System_Clocks;

--- a/ARM/STM32/devices/stm32f46_79x/stm32-rcc.adb
+++ b/ARM/STM32/devices/stm32f46_79x/stm32-rcc.adb
@@ -37,13 +37,13 @@ with STM32_SVD.RCC;            use STM32_SVD.RCC;
 package body STM32.RCC is
 
    function To_AHB1RSTR_T is new Ada.Unchecked_Conversion
-     (Word, AHB1RSTR_Register);
+     (UInt32, AHB1RSTR_Register);
    function To_AHB2RSTR_T is new Ada.Unchecked_Conversion
-     (Word, AHB2RSTR_Register);
+     (UInt32, AHB2RSTR_Register);
    function To_APB1RSTR_T is new Ada.Unchecked_Conversion
-     (Word, APB1RSTR_Register);
+     (UInt32, APB1RSTR_Register);
    function To_APB2RSTR_T is new Ada.Unchecked_Conversion
-     (Word, APB2RSTR_Register);
+     (UInt32, APB2RSTR_Register);
 
    ---------------------------------------------------------------------------
    -------  Enable/Disable/Reset Routines  -----------------------------------

--- a/ARM/STM32/devices/stm32f46_79x/stm32-rcc.ads
+++ b/ARM/STM32/devices/stm32f46_79x/stm32-rcc.ads
@@ -33,12 +33,12 @@ pragma Restrictions (No_Elaboration_Code);
 package STM32.RCC is
 
 --     type RCC_System_Clocks is record
---        SYSCLK  : Word;
---        HCLK    : Word;
---        PCLK1   : Word;
---        PCLK2   : Word;
---        TIMCLK1 : Word;
---        TIMCLK2 : Word;
+--        SYSCLK  : UInt32;
+--        HCLK    : UInt32;
+--        PCLK1   : UInt32;
+--        PCLK2   : UInt32;
+--        TIMCLK1 : UInt32;
+--        TIMCLK2 : UInt32;
 --     end record;
 --
 --     function System_Clock_Frequencies return RCC_System_Clocks;

--- a/ARM/STM32/devices/stm32f7x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f7x/stm32-device.adb
@@ -35,10 +35,10 @@ with STM32_SVD.RCC; use STM32_SVD.RCC;
 package body STM32.Device is
 
 
-   HPRE_Presc_Table : constant array (UInt4) of Word :=
+   HPRE_Presc_Table : constant array (UInt4) of UInt32 :=
      (1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 8, 16, 64, 128, 256, 512);
 
-   PPRE_Presc_Table : constant array (UInt3) of Word :=
+   PPRE_Presc_Table : constant array (UInt3) of UInt32 :=
      (1, 1, 1, 1, 2, 4, 8, 16);
 
    function PLLSAI_Enabled return Boolean;
@@ -554,11 +554,11 @@ package body STM32.Device is
    -- Get_Input_Clock --
    ---------------------
 
-   function Get_Input_Clock (Periph : SAI_Port) return Word
+   function Get_Input_Clock (Periph : SAI_Port) return UInt32
    is
       Input_Selector  : UInt2;
-      VCO_Input       : Word;
-      SAI_First_Level : Word;
+      VCO_Input       : UInt32;
+      SAI_First_Level : UInt32;
    begin
       if Periph'Address = SAI1_Base then
          Input_Selector := RCC_Periph.DKCFGR1.SAI1SEL;
@@ -577,10 +577,10 @@ package body STM32.Device is
 
       if not RCC_Periph.PLLCFGR.PLLSRC then
          --  PLLSAI SRC is HSI
-         VCO_Input := HSI_VALUE / Word (RCC_Periph.PLLCFGR.PLLM);
+         VCO_Input := HSI_VALUE / UInt32 (RCC_Periph.PLLCFGR.PLLM);
       else
          --  PLLSAI SRC is HSE
-         VCO_Input := HSE_VALUE / Word (RCC_Periph.PLLCFGR.PLLM);
+         VCO_Input := HSE_VALUE / UInt32 (RCC_Periph.PLLCFGR.PLLM);
       end if;
 
       if Input_Selector = 0 then
@@ -589,19 +589,19 @@ package body STM32.Device is
          --  VCO out = VCO in & PLLSAIN
          --  SAI firstlevel = VCO out / PLLSAIQ
          SAI_First_Level :=
-           VCO_Input * Word (RCC_Periph.PLLSAICFGR.PLLSAIN) /
-           Word (RCC_Periph.PLLSAICFGR.PLLSAIQ);
+           VCO_Input * UInt32 (RCC_Periph.PLLSAICFGR.PLLSAIN) /
+           UInt32 (RCC_Periph.PLLSAICFGR.PLLSAIQ);
 
          --  SAI frequency is SAI First level / PLLSAIDIVQ
-         return SAI_First_Level / Word (RCC_Periph.DKCFGR1.PLLSAIDIVQ);
+         return SAI_First_Level / UInt32 (RCC_Periph.DKCFGR1.PLLSAIDIVQ);
 
       else
          --  PLLI2S as clock source
          SAI_First_Level :=
-           VCO_Input * Word (RCC_Periph.PLLI2SCFGR.PLLI2SN) /
-           Word (RCC_Periph.PLLI2SCFGR.PLLI2SQ);
+           VCO_Input * UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SN) /
+           UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SQ);
          --  SAI frequency is SAI First level / PLLI2SDIVQ
-         return SAI_First_Level / Word (RCC_Periph.DKCFGR1.PLLI2SDIV + 1);
+         return SAI_First_Level / UInt32 (RCC_Periph.DKCFGR1.PLLI2SDIV + 1);
       end if;
    end Get_Input_Clock;
 
@@ -654,13 +654,13 @@ package body STM32.Device is
             --  PLL as source
             declare
                HSE_Source : constant Boolean := RCC_Periph.PLLCFGR.PLLSRC;
-               Pllm       : constant Word :=
-                              Word (RCC_Periph.PLLCFGR.PLLM);
-               Plln       : constant Word :=
-                              Word (RCC_Periph.PLLCFGR.PLLN);
-               Pllp       : constant Word :=
-                              (Word (RCC_Periph.PLLCFGR.PLLP) + 1) * 2;
-               Pllvco     : Word;
+               Pllm       : constant UInt32 :=
+                              UInt32 (RCC_Periph.PLLCFGR.PLLM);
+               Plln       : constant UInt32 :=
+                              UInt32 (RCC_Periph.PLLCFGR.PLLN);
+               Pllp       : constant UInt32 :=
+                              (UInt32 (RCC_Periph.PLLCFGR.PLLP) + 1) * 2;
+               Pllvco     : UInt32;
             begin
                if not HSE_Source then
                   Pllvco := (HSI_VALUE / Pllm) * Plln;

--- a/ARM/STM32/devices/stm32f7x/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f7x/stm32-device.ads
@@ -70,7 +70,7 @@ package STM32.Device is
    HSI_VALUE      : constant := 16_000_000;
    --  Internal oscillator in Hz
 
-   HSE_VALUE      : constant Word;
+   HSE_VALUE      : constant UInt32;
    --  External oscillator in Hz
 
    procedure Enable_Clock (This : aliased in out GPIO_Port)
@@ -504,7 +504,7 @@ package STM32.Device is
 
    procedure Enable_Clock (This : in out SAI_Port);
    procedure Reset (This : in out SAI_Port);
-   function Get_Input_Clock (Periph : SAI_Port) return Word;
+   function Get_Input_Clock (Periph : SAI_Port) return UInt32;
 
    -----------
    -- SDMMC --
@@ -520,12 +520,12 @@ package STM32.Device is
    -----------------------------
 
    type RCC_System_Clocks is record
-      SYSCLK  : Word;
-      HCLK    : Word;
-      PCLK1   : Word;
-      PCLK2   : Word;
-      TIMCLK1 : Word;
-      TIMCLK2 : Word;
+      SYSCLK  : UInt32;
+      HCLK    : UInt32;
+      PCLK1   : UInt32;
+      PCLK2   : UInt32;
+      TIMCLK1 : UInt32;
+      TIMCLK2 : UInt32;
    end record;
 
    function System_Clock_Frequencies return RCC_System_Clocks;
@@ -558,7 +558,7 @@ package STM32.Device is
 
 private
 
-   HSE_VALUE : constant Word := System.BB.Parameters.HSE_Clock;
+   HSE_VALUE : constant UInt32 := System.BB.Parameters.HSE_Clock;
 
    GPIO_AF_0_RTC_50Hz  : constant GPIO_Alternate_Function := 0;
    GPIO_AF_0_MCO       : constant GPIO_Alternate_Function := 0;

--- a/ARM/STM32/devices/stm32f7x9/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f7x9/stm32-device.adb
@@ -35,10 +35,10 @@ with STM32_SVD.RCC; use STM32_SVD.RCC;
 package body STM32.Device is
 
 
-   HPRE_Presc_Table : constant array (UInt4) of Word :=
+   HPRE_Presc_Table : constant array (UInt4) of UInt32 :=
      (1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 8, 16, 64, 128, 256, 512);
 
-   PPRE_Presc_Table : constant array (UInt3) of Word :=
+   PPRE_Presc_Table : constant array (UInt3) of UInt32 :=
      (1, 1, 1, 1, 2, 4, 8, 16);
 
    function PLLSAI_Enabled return Boolean;
@@ -611,11 +611,11 @@ package body STM32.Device is
    -- Get_Input_Clock --
    ---------------------
 
-   function Get_Input_Clock (Periph : SAI_Port) return Word
+   function Get_Input_Clock (Periph : SAI_Port) return UInt32
    is
       Input_Selector  : UInt2;
-      VCO_Input       : Word;
-      SAI_First_Level : Word;
+      VCO_Input       : UInt32;
+      SAI_First_Level : UInt32;
    begin
       if Periph'Address = SAI1_Base then
          Input_Selector := RCC_Periph.DKCFGR1.SAI1SEL;
@@ -634,10 +634,10 @@ package body STM32.Device is
 
       if not RCC_Periph.PLLCFGR.PLLSRC then
          --  PLLSAI SRC is HSI
-         VCO_Input := HSI_VALUE / Word (RCC_Periph.PLLCFGR.PLLM);
+         VCO_Input := HSI_VALUE / UInt32 (RCC_Periph.PLLCFGR.PLLM);
       else
          --  PLLSAI SRC is HSE
-         VCO_Input := HSE_VALUE / Word (RCC_Periph.PLLCFGR.PLLM);
+         VCO_Input := HSE_VALUE / UInt32 (RCC_Periph.PLLCFGR.PLLM);
       end if;
 
       if Input_Selector = 0 then
@@ -646,19 +646,19 @@ package body STM32.Device is
          --  VCO out = VCO in & PLLSAIN
          --  SAI firstlevel = VCO out / PLLSAIQ
          SAI_First_Level :=
-           VCO_Input * Word (RCC_Periph.PLLSAICFGR.PLLSAIN) /
-           Word (RCC_Periph.PLLSAICFGR.PLLSAIQ);
+           VCO_Input * UInt32 (RCC_Periph.PLLSAICFGR.PLLSAIN) /
+           UInt32 (RCC_Periph.PLLSAICFGR.PLLSAIQ);
 
          --  SAI frequency is SAI First level / PLLSAIDIVQ
-         return SAI_First_Level / Word (RCC_Periph.DKCFGR1.PLLSAIDIVQ);
+         return SAI_First_Level / UInt32 (RCC_Periph.DKCFGR1.PLLSAIDIVQ);
 
       else
          --  PLLI2S as clock source
          SAI_First_Level :=
-           VCO_Input * Word (RCC_Periph.PLLI2SCFGR.PLLI2SN) /
-           Word (RCC_Periph.PLLI2SCFGR.PLLI2SQ);
+           VCO_Input * UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SN) /
+           UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SQ);
          --  SAI frequency is SAI First level / PLLI2SDIVQ
-         return SAI_First_Level / Word (RCC_Periph.DKCFGR1.PLLI2SDIV + 1);
+         return SAI_First_Level / UInt32 (RCC_Periph.DKCFGR1.PLLI2SDIV + 1);
       end if;
    end Get_Input_Clock;
 
@@ -717,13 +717,13 @@ package body STM32.Device is
             --  PLL as source
             declare
                HSE_Source : constant Boolean := RCC_Periph.PLLCFGR.PLLSRC;
-               Pllm       : constant Word :=
-                              Word (RCC_Periph.PLLCFGR.PLLM);
-               Plln       : constant Word :=
-                              Word (RCC_Periph.PLLCFGR.PLLN);
-               Pllp       : constant Word :=
-                              (Word (RCC_Periph.PLLCFGR.PLLP) + 1) * 2;
-               Pllvco     : Word;
+               Pllm       : constant UInt32 :=
+                              UInt32 (RCC_Periph.PLLCFGR.PLLM);
+               Plln       : constant UInt32 :=
+                              UInt32 (RCC_Periph.PLLCFGR.PLLN);
+               Pllp       : constant UInt32 :=
+                              (UInt32 (RCC_Periph.PLLCFGR.PLLP) + 1) * 2;
+               Pllvco     : UInt32;
             begin
                if not HSE_Source then
                   Pllvco := (HSI_VALUE / Pllm) * Plln;

--- a/ARM/STM32/devices/stm32f7x9/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f7x9/stm32-device.ads
@@ -72,7 +72,7 @@ package STM32.Device is
    HSI_VALUE      : constant := 16_000_000;
    --  Internal oscillator in Hz
 
-   HSE_VALUE      : constant Word;
+   HSE_VALUE      : constant UInt32;
    --  External oscillator in Hz
 
    procedure Enable_Clock (This : aliased in out GPIO_Port)
@@ -518,7 +518,7 @@ package STM32.Device is
 
    procedure Enable_Clock (This : in out SAI_Port);
    procedure Reset (This : in out SAI_Port);
-   function Get_Input_Clock (Periph : SAI_Port) return Word;
+   function Get_Input_Clock (Periph : SAI_Port) return UInt32;
 
    --------------
    -- DSI Host --
@@ -541,12 +541,12 @@ package STM32.Device is
    -----------------------------
 
    type RCC_System_Clocks is record
-      SYSCLK  : Word;
-      HCLK    : Word;
-      PCLK1   : Word;
-      PCLK2   : Word;
-      TIMCLK1 : Word;
-      TIMCLK2 : Word;
+      SYSCLK  : UInt32;
+      HCLK    : UInt32;
+      PCLK1   : UInt32;
+      PCLK2   : UInt32;
+      TIMCLK1 : UInt32;
+      TIMCLK2 : UInt32;
    end record;
 
    function System_Clock_Frequencies return RCC_System_Clocks;
@@ -579,7 +579,7 @@ package STM32.Device is
 
 private
 
-   HSE_VALUE : constant Word := System.BB.Parameters.HSE_Clock;
+   HSE_VALUE : constant UInt32 := System.BB.Parameters.HSE_Clock;
 
    GPIO_AF_0_RTC_50Hz  : constant GPIO_Alternate_Function := 0;
    GPIO_AF_0_MCO       : constant GPIO_Alternate_Function := 0;

--- a/ARM/STM32/drivers/dma/stm32-dma.adb
+++ b/ARM/STM32/drivers/dma/stm32-dma.adb
@@ -52,11 +52,11 @@ package body STM32.DMA is
       --  number of data register
       NDTR : S0NDTR_Register;
       --  peripheral address register
-      PAR  : Word;
+      PAR  : UInt32;
       --  memory 0 address register
-      M0AR : Word;
+      M0AR : UInt32;
       --  memory 1 address register
-      M1AR : Word;
+      M1AR : UInt32;
       --  FIFO control register
       FCR  : S0FCR_Register;
    end record with Volatile;
@@ -255,7 +255,7 @@ package body STM32.DMA is
       Stream      : DMA_Stream_Selector;
       Source      : Address;
       Destination : Address;
-      Data_Count  : Short)
+      Data_Count  : UInt16)
    is
    begin
       Disable (This, Stream);  --  per the RM, eg section 10.5.6 for the NDTR
@@ -279,7 +279,7 @@ package body STM32.DMA is
       Stream             : DMA_Stream_Selector;
       Source             : Address;
       Destination        : Address;
-      Data_Count         : Short;
+      Data_Count         : UInt16;
       Enabled_Interrupts : Interrupt_Selections := (others => True))
    is
    begin
@@ -312,11 +312,11 @@ package body STM32.DMA is
       Stream      : DMA_Stream_Selector;
       Source      : Address;
       Destination : Address;
-      Data_Count  : Short)
+      Data_Count  : UInt16)
    is
       This_Stream : DMA_Stream renames Get_Stream (This, Stream);
       function W is new Ada.Unchecked_Conversion
-        (Address, Word);
+        (Address, UInt32);
    begin
       --  the following assignment has NO EFFECT if flow is controlled by
       --  peripheral. The hardware resets it to 16#FFFF#, see RM0090 10.3.15.
@@ -733,7 +733,7 @@ package body STM32.DMA is
    procedure Set_NDT
      (This       : DMA_Controller;
       Stream     : DMA_Stream_Selector;
-      Data_Count : Short)
+      Data_Count : UInt16)
    is
       This_Stream : DMA_Stream renames Get_Stream (This, Stream);
    begin
@@ -743,7 +743,7 @@ package body STM32.DMA is
    function Items_Transferred
      (This   : DMA_Controller;
       Stream : DMA_Stream_Selector)
-      return Short
+      return UInt16
    is
       ndt : constant Unsigned_16 := Current_NDT (This, Stream);
       items : Unsigned_16;
@@ -759,7 +759,7 @@ package body STM32.DMA is
    function Current_NDT
      (This   : DMA_Controller;
       Stream : DMA_Stream_Selector)
-      return Short
+      return UInt16
    is
       This_Stream : DMA_Stream renames Get_Stream (This, Stream);
    begin
@@ -973,7 +973,7 @@ package body STM32.DMA is
       To     : System.Address)
    is
       function W is new Ada.Unchecked_Conversion
-        (System.Address, Word);
+        (System.Address, UInt32);
       This_Stream : DMA_Stream renames Get_Stream (This, Stream);
    begin
       case Buffer is

--- a/ARM/STM32/drivers/dma/stm32-dma.ads
+++ b/ARM/STM32/drivers/dma/stm32-dma.ads
@@ -157,7 +157,7 @@ package STM32.DMA with SPARK_Mode => Off is
       Stream      : DMA_Stream_Selector;
       Source      : Address;
       Destination : Address;
-      Data_Count  : Short)
+      Data_Count  : UInt16)
      with
        Pre =>
          not Enabled (This, Stream) and
@@ -196,7 +196,7 @@ package STM32.DMA with SPARK_Mode => Off is
       Stream      : DMA_Stream_Selector;
       Source      : Address;
       Destination : Address;
-      Data_Count  : Short)
+      Data_Count  : UInt16)
      with
        Pre  =>
             Valid_Addresses (Source, Destination)
@@ -227,7 +227,7 @@ package STM32.DMA with SPARK_Mode => Off is
       Stream             : DMA_Stream_Selector;
       Source             : Address;
       Destination        : Address;
-      Data_Count         : Short;
+      Data_Count         : UInt16;
       Enabled_Interrupts : Interrupt_Selections := (others => True))
      with
        Pre =>
@@ -279,7 +279,7 @@ package STM32.DMA with SPARK_Mode => Off is
    procedure Set_NDT
      (This       : DMA_Controller;
       Stream     : DMA_Stream_Selector;
-      Data_Count : Short)
+      Data_Count : UInt16)
      with
        Pre  => not Enabled (This, Stream),
        Post => Current_NDT (This, Stream) = Data_Count,
@@ -292,13 +292,13 @@ package STM32.DMA with SPARK_Mode => Off is
    function Items_Transferred
      (This   : DMA_Controller;
       Stream : DMA_Stream_Selector)
-      return Short;
+      return UInt16;
    --  returns the number of items transfetred
 
    function Current_NDT
      (This   : DMA_Controller;
       Stream : DMA_Stream_Selector)
-      return Short
+      return UInt16
      with Inline;
    --  Returns the value of the NDT register. Should not be used directly,
    --  as the meaning changes depending on transfer mode. rather use

--- a/ARM/STM32/drivers/dma2d/stm32-dma2d.adb
+++ b/ARM/STM32/drivers/dma2d/stm32-dma2d.adb
@@ -36,10 +36,10 @@ with STM32_SVD.RCC;           use STM32_SVD.RCC;
 
 package body STM32.DMA2D is
 
-   function To_Word is new Ada.Unchecked_Conversion (System.Address, Word);
+   function To_Word is new Ada.Unchecked_Conversion (System.Address, UInt32);
 
    function Offset (Buffer : DMA2D_Buffer;
-                    X, Y   : Integer) return Word with Inline_Always;
+                    X, Y   : Integer) return UInt32 with Inline_Always;
 
    DMA2D_Init_Transfer_Int : DMA2D_Sync_Procedure := null;
    DMA2D_Wait_Transfer_Int : DMA2D_Sync_Procedure := null;
@@ -83,9 +83,9 @@ package body STM32.DMA2D is
    ------------
 
    function Offset (Buffer : DMA2D_Buffer;
-                    X, Y   : Integer) return Word
+                    X, Y   : Integer) return UInt32
    is
-      Off : constant Word := Word (X + Buffer.Width * Y);
+      Off : constant UInt32 := UInt32 (X + Buffer.Width * Y);
    begin
       case Buffer.Color_Mode is
          when ARGB8888 =>
@@ -107,10 +107,10 @@ package body STM32.DMA2D is
 
    procedure DMA2D_Fill
      (Buffer      : DMA2D_Buffer;
-      Color       : Word;
+      Color       : UInt32;
       Synchronous : Boolean := False)
    is
-      function Conv is new Ada.Unchecked_Conversion (Word, OCOLR_Register);
+      function Conv is new Ada.Unchecked_Conversion (UInt32, OCOLR_Register);
    begin
       DMA2D_Wait_Transfer_Int.all;
 
@@ -119,7 +119,7 @@ package body STM32.DMA2D is
       DMA2D_Periph.OCOLR     := Conv (Color);
       DMA2D_Periph.OMAR      := To_Word (Buffer.Addr);
       DMA2D_Periph.OOR       := (LO => 0, others => <>);
-      DMA2D_Periph.NLR       := (NL     => Short (Buffer.Height),
+      DMA2D_Periph.NLR       := (NL     => UInt16 (Buffer.Height),
                                  PL     => UInt14 (Buffer.Width),
                                  others => <>);
 
@@ -136,15 +136,15 @@ package body STM32.DMA2D is
 
    procedure DMA2D_Fill_Rect
      (Buffer      : DMA2D_Buffer;
-      Color       : Word;
+      Color       : UInt32;
       X           : Integer;
       Y           : Integer;
       Width       : Integer;
       Height      : Integer;
       Synchronous : Boolean := False)
    is
-      function Conv is new Ada.Unchecked_Conversion (Word, OCOLR_Register);
-      Off    : constant Word := Offset (Buffer, X, Y);
+      function Conv is new Ada.Unchecked_Conversion (UInt32, OCOLR_Register);
+      Off    : constant UInt32 := Offset (Buffer, X, Y);
 
    begin
       DMA2D_Wait_Transfer_Int.all;
@@ -157,7 +157,7 @@ package body STM32.DMA2D is
       DMA2D_Periph.OMAR   := To_Word (Buffer.Addr) + Off;
       DMA2D_Periph.OOR.LO := UInt14 (Buffer.Width -  Width);
       DMA2D_Periph.NLR :=
-        (NL => Short (Height), PL => UInt14 (Width), others => <>);
+        (NL => UInt16 (Height), PL => UInt14 (Width), others => <>);
 
       DMA2D_Init_Transfer_Int.all;
       if Synchronous then
@@ -171,7 +171,7 @@ package body STM32.DMA2D is
 
    procedure DMA2D_Draw_Rect
      (Buffer    : DMA2D_Buffer;
-      Color     : Word;
+      Color     : UInt32;
       X         : Integer;
       Y         : Integer;
       Width     : Integer;
@@ -202,8 +202,8 @@ package body STM32.DMA2D is
       Height     : Natural;
       Synchronous  : Boolean := False)
    is
-      Src_Off : constant Word := Offset (Src_Buffer, X_Src, Y_Src);
-      Dst_Off : constant Word := Offset (Dst_Buffer, X_Dst, Y_Dst);
+      Src_Off : constant UInt32 := Offset (Src_Buffer, X_Src, Y_Src);
+      Dst_Off : constant UInt32 := Offset (Dst_Buffer, X_Dst, Y_Dst);
 
    begin
       DMA2D_Wait_Transfer_Int.all;
@@ -234,7 +234,7 @@ package body STM32.DMA2D is
 
       if Bg_Buffer /= Null_Buffer then
          declare
-            Bg_Off  : constant Word := Offset (Bg_Buffer, X_Bg, Y_Bg);
+            Bg_Off  : constant UInt32 := Offset (Bg_Buffer, X_Bg, Y_Bg);
          begin
             DMA2D_Periph.BGPFCCR.CM    :=
               DMA2D_Color_Mode'Enum_Rep (Bg_Buffer.Color_Mode);
@@ -254,7 +254,7 @@ package body STM32.DMA2D is
       DMA2D_Periph.OOR       := (LO     => UInt14 (Dst_Buffer.Width - Width),
                                   others => <>);
 
-      DMA2D_Periph.NLR       := (NL     => Short (Height),
+      DMA2D_Periph.NLR       := (NL     => UInt16 (Height),
                                  PL     => UInt14 (Width),
                               others => <>);
 
@@ -270,7 +270,7 @@ package body STM32.DMA2D is
 
    procedure DMA2D_Draw_Vertical_Line
      (Buffer    : DMA2D_Buffer;
-      Color     : Word;
+      Color     : UInt32;
       X         : Integer;
       Y         : Integer;
       Height    : Integer;
@@ -303,7 +303,7 @@ package body STM32.DMA2D is
 
    procedure DMA2D_Draw_Horizontal_Line
      (Buffer    : DMA2D_Buffer;
-      Color     : Word;
+      Color     : UInt32;
       X         : Integer;
       Y         : Integer;
       Width     : Integer;
@@ -337,11 +337,11 @@ package body STM32.DMA2D is
    procedure DMA2D_Set_Pixel
      (Buffer      : DMA2D_Buffer;
       X, Y        : Integer;
-      Color       : Word;
+      Color       : UInt32;
       Synchronous : Boolean := False)
    is
-      function Conv is new Ada.Unchecked_Conversion (Word, OCOLR_Register);
-      Off  : constant Word := Offset (Buffer, X, Y);
+      function Conv is new Ada.Unchecked_Conversion (UInt32, OCOLR_Register);
+      Off  : constant UInt32 := Offset (Buffer, X, Y);
       Dead : Boolean := False with Unreferenced;
    begin
       if X < 0 or else Y < 0
@@ -375,7 +375,7 @@ package body STM32.DMA2D is
       Color       : DMA2D_Color;
       Synchronous : Boolean := False)
    is
-      Off  : constant Word := Offset (Buffer, X, Y);
+      Off  : constant UInt32 := Offset (Buffer, X, Y);
       Dead : Boolean := False with Unreferenced;
    begin
       if X < 0 or else Y < 0

--- a/ARM/STM32/drivers/dma2d/stm32-dma2d.ads
+++ b/ARM/STM32/drivers/dma2d/stm32-dma2d.ads
@@ -176,7 +176,7 @@ package STM32.DMA2D is
 
    procedure DMA2D_Fill
      (Buffer      : DMA2D_Buffer;
-      Color       : Word;
+      Color       : UInt32;
       Synchronous : Boolean := False)
      with Pre => Buffer.Color_Mode in Output_Color_Mode;
    --  Same as above, using the destination buffer native color representation
@@ -184,7 +184,7 @@ package STM32.DMA2D is
    procedure DMA2D_Set_Pixel
      (Buffer      : DMA2D_Buffer;
       X, Y        : Integer;
-      Color       : Word;
+      Color       : UInt32;
       Synchronous : Boolean := False)
      with Pre => Buffer.Color_Mode in Output_Color_Mode;
    --  Same as above, using the destination buffer native color representation
@@ -198,7 +198,7 @@ package STM32.DMA2D is
 
    procedure DMA2D_Fill_Rect
      (Buffer      : DMA2D_Buffer;
-      Color       : Word;
+      Color       : UInt32;
       X           : Integer;
       Y           : Integer;
       Width       : Integer;
@@ -209,7 +209,7 @@ package STM32.DMA2D is
 
    procedure DMA2D_Draw_Rect
      (Buffer    : DMA2D_Buffer;
-      Color     : Word;
+      Color     : UInt32;
       X         : Integer;
       Y         : Integer;
       Width     : Integer;
@@ -242,7 +242,7 @@ package STM32.DMA2D is
 
    procedure DMA2D_Draw_Vertical_Line
      (Buffer    : DMA2D_Buffer;
-      Color     : Word;
+      Color     : UInt32;
       X         : Integer;
       Y         : Integer;
       Height    : Integer;
@@ -252,7 +252,7 @@ package STM32.DMA2D is
 
    procedure DMA2D_Draw_Horizontal_Line
      (Buffer    : DMA2D_Buffer;
-      Color     : Word;
+      Color     : UInt32;
       X         : Integer;
       Y         : Integer;
       Width     : Integer;

--- a/ARM/STM32/drivers/dma_stm32f769/stm32-dma.adb
+++ b/ARM/STM32/drivers/dma_stm32f769/stm32-dma.adb
@@ -214,7 +214,7 @@ package body STM32.DMA is
       Stream      : DMA_Stream_Selector;
       Source      : Address;
       Destination : Address;
-      Data_Count  : Short)
+      Data_Count  : UInt16)
    is
    begin
       Disable (This, Stream);  --  per the RM, eg section 10.5.6 for the NDTR
@@ -238,7 +238,7 @@ package body STM32.DMA is
       Stream             : DMA_Stream_Selector;
       Source             : Address;
       Destination        : Address;
-      Data_Count         : Short;
+      Data_Count         : UInt16;
       Enabled_Interrupts : Interrupt_Selections := (others => True))
    is
    begin
@@ -271,11 +271,11 @@ package body STM32.DMA is
       Stream      : DMA_Stream_Selector;
       Source      : Address;
       Destination : Address;
-      Data_Count  : Short)
+      Data_Count  : UInt16)
    is
       This_Stream : DMA_Stream renames Get_Stream (This, Stream);
       function W is new Ada.Unchecked_Conversion
-        (Address, Word);
+        (Address, UInt32);
    begin
       --  the following assignment has NO EFFECT if flow is controlled by
       --  peripheral. The hardware resets it to 16#FFFF#, see RM0090 10.3.15.
@@ -692,7 +692,7 @@ package body STM32.DMA is
    procedure Set_NDT
      (This       : DMA_Controller;
       Stream     : DMA_Stream_Selector;
-      Data_Count : Short)
+      Data_Count : UInt16)
    is
       This_Stream : DMA_Stream renames Get_Stream (This, Stream);
    begin
@@ -702,7 +702,7 @@ package body STM32.DMA is
    function Items_Transferred
      (This   : DMA_Controller;
       Stream : DMA_Stream_Selector)
-      return Short
+      return UInt16
    is
       ndt : constant Unsigned_16 := Current_NDT (This, Stream);
       items : Unsigned_16;
@@ -718,7 +718,7 @@ package body STM32.DMA is
    function Current_NDT
      (This   : DMA_Controller;
       Stream : DMA_Stream_Selector)
-      return Short
+      return UInt16
    is
       This_Stream : DMA_Stream renames Get_Stream (This, Stream);
    begin
@@ -932,7 +932,7 @@ package body STM32.DMA is
       To     : System.Address)
    is
       function W is new Ada.Unchecked_Conversion
-        (System.Address, Word);
+        (System.Address, UInt32);
       This_Stream : DMA_Stream renames Get_Stream (This, Stream);
    begin
       case Buffer is

--- a/ARM/STM32/drivers/dma_stm32f769/stm32-dma.ads
+++ b/ARM/STM32/drivers/dma_stm32f769/stm32-dma.ads
@@ -157,7 +157,7 @@ package STM32.DMA with SPARK_Mode => Off is
       Stream      : DMA_Stream_Selector;
       Source      : Address;
       Destination : Address;
-      Data_Count  : Short)
+      Data_Count  : UInt16)
      with
        Pre =>
          not Enabled (This, Stream) and
@@ -196,7 +196,7 @@ package STM32.DMA with SPARK_Mode => Off is
       Stream      : DMA_Stream_Selector;
       Source      : Address;
       Destination : Address;
-      Data_Count  : Short)
+      Data_Count  : UInt16)
      with
        Pre  =>
             Valid_Addresses (Source, Destination)
@@ -227,7 +227,7 @@ package STM32.DMA with SPARK_Mode => Off is
       Stream             : DMA_Stream_Selector;
       Source             : Address;
       Destination        : Address;
-      Data_Count         : Short;
+      Data_Count         : UInt16;
       Enabled_Interrupts : Interrupt_Selections := (others => True))
      with
        Pre =>
@@ -279,7 +279,7 @@ package STM32.DMA with SPARK_Mode => Off is
    procedure Set_NDT
      (This       : DMA_Controller;
       Stream     : DMA_Stream_Selector;
-      Data_Count : Short)
+      Data_Count : UInt16)
      with
        Pre  => not Enabled (This, Stream),
        Post => Current_NDT (This, Stream) = Data_Count,
@@ -292,13 +292,13 @@ package STM32.DMA with SPARK_Mode => Off is
    function Items_Transferred
      (This   : DMA_Controller;
       Stream : DMA_Stream_Selector)
-      return Short;
+      return UInt16;
    --  returns the number of items transfetred
 
    function Current_NDT
      (This   : DMA_Controller;
       Stream : DMA_Stream_Selector)
-      return Short
+      return UInt16
      with Inline;
    --  Returns the value of the NDT register. Should not be used directly,
    --  as the meaning changes depending on transfer mode. rather use

--- a/ARM/STM32/drivers/dsi/stm32-dsi.adb
+++ b/ARM/STM32/drivers/dsi/stm32-dsi.adb
@@ -170,15 +170,15 @@ package body STM32.DSI is
       --  Where F_PHY_Mhz = (PLLNDIV * HSE_MHz) / (IDF * ODF)
       --  => UIX4 = 4_000 * IDF * ODV / (PLLNDIV * HSE_MHz)
       declare
-         HSE_MHz          : constant Word := HSE_Clock / 1_000_000;
-         IDF              : constant Word :=
+         HSE_MHz          : constant UInt32 := HSE_Clock / 1_000_000;
+         IDF              : constant UInt32 :=
                               (if PLL_IN_Div > 0
-                               then Word (PLL_IN_Div) else 1);
-         ODF              : constant Word :=
+                               then UInt32 (PLL_IN_Div) else 1);
+         ODF              : constant UInt32 :=
                               Shift_Left
                                 (1, DSI_PLL_ODF'Enum_Rep (PLL_OUT_Div));
-         PLLN             : constant Word := Word (PLL_N_Div);
-         Unit_Interval_x4 : constant Word :=
+         PLLN             : constant UInt32 := UInt32 (PLL_N_Div);
+         Unit_Interval_x4 : constant UInt32 :=
                               ((4_000 * IDF * ODF) / (PLLN * HSE_MHz));
       begin
          This.Periph.DSI_WPCR1.UIX4 := UInt6 (Unit_Interval_x4);
@@ -325,7 +325,7 @@ package body STM32.DSI is
      (This                        : in out DSI_Host;
       Virtual_Channel             : DSI_Virtual_Channel_ID;
       Color_Coding                : DSI_Color_Mode;
-      Command_Size                : Short;
+      Command_Size                : UInt16;
       Tearing_Effect_Source       : DSI_Tearing_Effect_Source;
       Tearing_Effect_Polarity     : DSI_TE_Polarity;
       HSync_Polarity              : DSI_Polarity;
@@ -534,8 +534,8 @@ package body STM32.DSI is
       Start : Time;
       Off   : Natural := 0;
       Value : DSI_GPDR_Register;
-      Val1  : Word;
-      Val2  : Word;
+      Val1  : UInt32;
+      Val2  : UInt32;
 
    begin
       --  Wait for FIFO empty
@@ -564,8 +564,8 @@ package body STM32.DSI is
          This.Periph.DSI_GPDR := Value;
       end if;
 
-      Val1 := Word (Parameters'Length + 1) and 16#FF#;
-      Val2 := Shift_Right (Word (Parameters'Length + 1) and 16#FF00#, 8);
+      Val1 := UInt32 (Parameters'Length + 1) and 16#FF#;
+      Val2 := Shift_Right (UInt32 (Parameters'Length + 1) and 16#FF00#, 8);
       This.DSI_Config_Packet_Header
         (Channel_Id, Mode, Byte (Val1), Byte (Val2));
    end DSI_Long_Write;

--- a/ARM/STM32/drivers/dsi/stm32-dsi.ads
+++ b/ARM/STM32/drivers/dsi/stm32-dsi.ads
@@ -159,7 +159,7 @@ package STM32.DSI is
      (This                        : in out DSI_Host;
       Virtual_Channel             : HAL.DSI.DSI_Virtual_Channel_ID;
       Color_Coding                : DSI_Color_Mode;
-      Command_Size                : Short;
+      Command_Size                : UInt16;
       Tearing_Effect_Source       : DSI_Tearing_Effect_Source;
       Tearing_Effect_Polarity     : DSI_TE_Polarity;
       HSync_Polarity              : DSI_Polarity;

--- a/ARM/STM32/drivers/fmc/stm32-fmc.adb
+++ b/ARM/STM32/drivers/fmc/stm32-fmc.adb
@@ -182,7 +182,7 @@ package body STM32.FMC is
    -- FMC_Set_Refresh_Count --
    ---------------------------
 
-   procedure FMC_Set_Refresh_Count (Cnt : Word) is
+   procedure FMC_Set_Refresh_Count (Cnt : UInt32) is
    begin
       FMC_Periph.SDRTR.COUNT := UInt13 (Cnt);
    end FMC_Set_Refresh_Count;

--- a/ARM/STM32/drivers/fmc/stm32-fmc.ads
+++ b/ARM/STM32/drivers/fmc/stm32-fmc.ads
@@ -243,7 +243,7 @@ package STM32.FMC is
    function FMC_SDRAM_Get_Status
      (Bank : FMC_SDRAM_Bank_Type) return FMC_SDRAM_Status_Mode;
 
-   procedure FMC_Set_Refresh_Count (Cnt : Word)
+   procedure FMC_Set_Refresh_Count (Cnt : UInt32)
      with Pre => Cnt < 2 ** 13;
 
 end STM32.FMC;

--- a/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
+++ b/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
@@ -108,7 +108,7 @@ package body STM32.I2C is
    procedure Mem_Request_Write
      (This          : in out I2C_Port;
       Addr          :        HAL.I2C.I2C_Address;
-      Mem_Addr      :        Short;
+      Mem_Addr      :        UInt16;
       Mem_Addr_Size :        HAL.I2C.I2C_Memory_Address_Size;
       Timeout       :        Natural;
       Status        :    out HAL.I2C.I2C_Status);
@@ -116,7 +116,7 @@ package body STM32.I2C is
    procedure Mem_Request_Read
      (This          : in out I2C_Port;
       Addr          :        HAL.I2C.I2C_Address;
-      Mem_Addr      :        Short;
+      Mem_Addr      :        UInt16;
       Mem_Addr_Size :        HAL.I2C.I2C_Memory_Address_Size;
       Timeout       :        Natural;
       Status        :    out HAL.I2C.I2C_Status);
@@ -132,8 +132,8 @@ package body STM32.I2C is
       CR1        : CR1_Register;
       CCR        : CCR_Register;
       OAR1       : OAR1_Register;
-      PCLK1      : constant Word := System_Clock_Frequencies.PCLK1;
-      Freq_Range : constant Short := Short (PCLK1 / 1_000_000);
+      PCLK1      : constant UInt32 := System_Clock_Frequencies.PCLK1;
+      Freq_Range : constant UInt16 := UInt16 (PCLK1 / 1_000_000);
 
    begin
       if This.State /= Reset then
@@ -189,7 +189,7 @@ package body STM32.I2C is
          end if;
 
          This.Periph.TRISE.TRISE :=
-           UInt6 ((Word (Freq_Range) * 300) / 1000 + 1);
+           UInt6 ((UInt32 (Freq_Range) * 300) / 1000 + 1);
       end if;
 
       This.Periph.CCR := CCR;
@@ -420,7 +420,7 @@ package body STM32.I2C is
       else
          declare
             MSB : constant Byte :=
-                    Byte (Shift_Right (Short (Addr) and 16#300#, 7));
+                    Byte (Shift_Right (UInt16 (Addr) and 16#300#, 7));
             LSB : constant Byte :=
                     Byte (Addr and 16#FF#);
          begin
@@ -466,7 +466,7 @@ package body STM32.I2C is
       else
          declare
             MSB : constant Byte :=
-                    Byte (Shift_Right (Short (Addr) and 16#300#, 7));
+                    Byte (Shift_Right (UInt16 (Addr) and 16#300#, 7));
             LSB : constant Byte :=
                     Byte (Addr and 16#FF#);
          begin
@@ -516,7 +516,7 @@ package body STM32.I2C is
    procedure Mem_Request_Write
      (This          : in out I2C_Port;
       Addr          :        HAL.I2C.I2C_Address;
-      Mem_Addr      :        Short;
+      Mem_Addr      :        UInt16;
       Mem_Addr_Size :        HAL.I2C.I2C_Memory_Address_Size;
       Timeout       :        Natural;
       Status        :    out HAL.I2C.I2C_Status)
@@ -570,7 +570,7 @@ package body STM32.I2C is
    procedure Mem_Request_Read
      (This          : in out I2C_Port;
       Addr          :        HAL.I2C.I2C_Address;
-      Mem_Addr      :        Short;
+      Mem_Addr      :        UInt16;
       Mem_Addr_Size :        HAL.I2C.I2C_Memory_Address_Size;
       Timeout       :        Natural;
       Status        :    out HAL.I2C.I2C_Status)
@@ -885,7 +885,7 @@ package body STM32.I2C is
    procedure Mem_Write
      (This          : in out I2C_Port;
       Addr          : HAL.I2C.I2C_Address;
-      Mem_Addr      : Short;
+      Mem_Addr      : UInt16;
       Mem_Addr_Size : HAL.I2C.I2C_Memory_Address_Size;
       Data          : HAL.I2C.I2C_Data;
       Status        : out HAL.I2C.I2C_Status;
@@ -976,7 +976,7 @@ package body STM32.I2C is
    procedure Mem_Read
      (This          : in out I2C_Port;
       Addr          : HAL.I2C.I2C_Address;
-      Mem_Addr      : Short;
+      Mem_Addr      : UInt16;
       Mem_Addr_Size : HAL.I2C.I2C_Memory_Address_Size;
       Data          : out HAL.I2C.I2C_Data;
       Status        : out HAL.I2C.I2C_Status;

--- a/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.ads
+++ b/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.ads
@@ -65,7 +65,7 @@ package STM32.I2C is
       Addressing_Mode_10bit);
 
    type I2C_Configuration is record
-      Clock_Speed              : Word;
+      Clock_Speed              : UInt32;
       Mode                     : I2C_Device_Mode := I2C_Mode;
       Duty_Cycle               : I2C_Duty_Cycle  := DutyCycle_2;
 
@@ -113,7 +113,7 @@ package STM32.I2C is
    procedure Mem_Write
      (This          : in out I2C_Port;
       Addr          : HAL.I2C.I2C_Address;
-      Mem_Addr      : Short;
+      Mem_Addr      : UInt16;
       Mem_Addr_Size : HAL.I2C.I2C_Memory_Address_Size;
       Data          : HAL.I2C.I2C_Data;
       Status        : out HAL.I2C.I2C_Status;
@@ -123,7 +123,7 @@ package STM32.I2C is
    procedure Mem_Read
      (This          : in out I2C_Port;
       Addr          : HAL.I2C.I2C_Address;
-      Mem_Addr      : Short;
+      Mem_Addr      : UInt16;
       Mem_Addr_Size : HAL.I2C.I2C_Memory_Address_Size;
       Data          : out HAL.I2C.I2C_Data;
       Status        : out HAL.I2C.I2C_Status;

--- a/ARM/STM32/drivers/i2c_stm32f7/stm32-i2c.adb
+++ b/ARM/STM32/drivers/i2c_stm32f7/stm32-i2c.adb
@@ -543,7 +543,7 @@ package body STM32.I2C is
    procedure Mem_Write
      (This          : in out I2C_Port;
       Addr          : I2C_Address;
-      Mem_Addr      : Short;
+      Mem_Addr      : UInt16;
       Mem_Addr_Size : I2C_Memory_Address_Size;
       Data          : I2C_Data;
       Status        : out I2C_Status;
@@ -684,7 +684,7 @@ package body STM32.I2C is
    procedure Mem_Read
      (This          : in out I2C_Port;
       Addr          : I2C_Address;
-      Mem_Addr      : Short;
+      Mem_Addr      : UInt16;
       Mem_Addr_Size : I2C_Memory_Address_Size;
       Data          : out I2C_Data;
       Status        : out I2C_Status;

--- a/ARM/STM32/drivers/i2c_stm32f7/stm32-i2c.ads
+++ b/ARM/STM32/drivers/i2c_stm32f7/stm32-i2c.ads
@@ -40,7 +40,7 @@ package STM32.I2C is
       Addressing_Mode_10bit);
 
    type I2C_Configuration is record
-      Clock_Speed              : Word;
+      Clock_Speed              : UInt32;
       Addressing_Mode          : I2C_Addressing_Mode;
       Own_Address              : UInt10;
 
@@ -96,7 +96,7 @@ package STM32.I2C is
    procedure Mem_Write
      (This          : in out I2C_Port;
       Addr          : HAL.I2C.I2C_Address;
-      Mem_Addr      : Short;
+      Mem_Addr      : UInt16;
       Mem_Addr_Size : HAL.I2C.I2C_Memory_Address_Size;
       Data          : HAL.I2C.I2C_Data;
       Status        : out HAL.I2C.I2C_Status;
@@ -107,7 +107,7 @@ package STM32.I2C is
    procedure Mem_Read
      (This          : in out I2C_Port;
       Addr          : HAL.I2C.I2C_Address;
-      Mem_Addr      : Short;
+      Mem_Addr      : UInt16;
       Mem_Addr_Size : HAL.I2C.I2C_Memory_Address_Size;
       Data          : out HAL.I2C.I2C_Data;
       Status        : out HAL.I2C.I2C_Status;

--- a/ARM/STM32/drivers/ltdc/stm32-ltdc.adb
+++ b/ARM/STM32/drivers/ltdc/stm32-ltdc.adb
@@ -87,10 +87,10 @@ package body STM32.LTDC is
       LBFCR      : L1BFCR_Register;
       --  Layerx Blending Factors Configuration Register
 
-      Reserved_0 : Word;
-      Reserved_1 : Word;
+      Reserved_0 : UInt32;
+      Reserved_1 : UInt32;
 
-      LCFBAR     : Word;
+      LCFBAR     : UInt32;
       --  Layerx Color Frame Buffer Address Register
 
       LCFBLR     : L1CFBLR_Register;
@@ -99,9 +99,9 @@ package body STM32.LTDC is
       LCFBLNR    : L1CFBLNR_Register;
       --  Layerx ColorFrame Buffer Line Number Register
 
-      Reserved_2 : Word;
-      Reserved_3 : Word;
-      Reserved_4 : Word;
+      Reserved_2 : UInt32;
+      Reserved_3 : UInt32;
+      Reserved_4 : UInt32;
 
       LCLUTWR    : L1CLUTWR_Register;
       --  Layerx CLUT Write Register
@@ -427,7 +427,7 @@ package body STM32.LTDC is
      (Layer : LCD_Layer; Addr : Frame_Buffer_Access)
    is
       function To_Word is new Ada.Unchecked_Conversion
-        (Frame_Buffer_Access, Word);
+        (Frame_Buffer_Access, UInt32);
    begin
       if Layer = Layer1 then
          LTDC_Periph.L1CFBAR := To_Word (Addr);
@@ -446,7 +446,7 @@ package body STM32.LTDC is
    is
       L : constant Layer_Access := Get_Layer (Layer);
       function To_FBA is new Ada.Unchecked_Conversion
-        (Word, Frame_Buffer_Access);
+        (UInt32, Frame_Buffer_Access);
    begin
       return To_FBA (L.LCFBAR);
    end Get_Frame_Buffer;
@@ -456,8 +456,8 @@ package body STM32.LTDC is
    --------------------
 
    procedure Set_Background (R, G, B : Byte) is
-      RShift : constant Word := Shift_Left (Word (R), 16);
-      GShift : constant Word := Shift_Left (Word (G), 8);
+      RShift : constant UInt32 := Shift_Left (UInt32 (R), 16);
+      GShift : constant UInt32 := Shift_Left (UInt32 (G), 8);
    begin
       LTDC_Periph.BCCR.BC :=
         UInt24 (RShift) or UInt24 (GShift) or UInt24 (B);

--- a/ARM/STM32/drivers/sai/stm32-sai.adb
+++ b/ARM/STM32/drivers/sai/stm32-sai.adb
@@ -71,7 +71,7 @@ package body STM32.SAI is
       --  AClear flag register
       CLRFR : ACLRFR_Register;
       --  AData register
-      DR    : Word;
+      DR    : UInt32;
    end record with Volatile;
    for Block_Registers use record
       CR1   at 0 range 0 .. 31;
@@ -266,9 +266,9 @@ package body STM32.SAI is
       Companding_Mode : SAI_Companding_Mode := No_Companding)
    is
       Block_Reg : constant Block_Registers_Access := Get_Block (This, Block);
-      Freq      : Word;
-      Tmp_Clock : Word;
-      Mckdiv    : Word;
+      Freq      : UInt32;
+      Tmp_Clock : UInt32;
+      Mckdiv    : UInt32;
    begin
       Deinitialize (This, Block);
 
@@ -349,7 +349,7 @@ package body STM32.SAI is
         (FBOFF  => First_Bit_Offset,
          SLOTSZ => SAI_Slot_Size'Enum_Rep (Slot_Size),
          NBSLOT => UInt4 (Number_Of_Slots - 1),
-         SLOTEN => Short (Enabled_Slots),
+         SLOTEN => UInt16 (Enabled_Slots),
          others => <>);
    end Configure_Block_Slot;
 

--- a/ARM/STM32/drivers/sai/stm32-sai.ads
+++ b/ARM/STM32/drivers/sai/stm32-sai.ads
@@ -52,7 +52,7 @@ package STM32.SAI is
    subtype SAI_Controller is STM32.Device.SAI_Port;
    type SAI_Block is (Block_A, Block_B);
 
-   subtype SAI_Audio_Frequency is Word;
+   subtype SAI_Audio_Frequency is UInt32;
 
    type SAI_Mono_Stereo_Mode is
      (Stereo,
@@ -237,7 +237,7 @@ package STM32.SAI is
 
    type Slots_Number is range 1 .. 16;
 
-   type SAI_Slots is new Short;
+   type SAI_Slots is new UInt16;
 
    Slot_0  : constant SAI_Slots := 2 ** 0;
    Slot_1  : constant SAI_Slots := 2 ** 1;

--- a/ARM/STM32/drivers/sd/sdio/stm32-sdmmc.ads
+++ b/ARM/STM32/drivers/sd/sdio/stm32-sdmmc.ads
@@ -63,14 +63,14 @@ package STM32.SDMMC is
       Data_Read_Access_Time_1          : Byte;
       Data_Read_Access_Time_2          : Byte; --  In CLK Cycles
       Max_Bus_Clock_Frequency          : Byte;
-      Card_Command_Class               : Short;
+      Card_Command_Class               : UInt16;
       Max_Read_Data_Block_Length       : Byte; -- ld (blocksize in bytes)
       Partial_Block_For_Read_Allowed   : Boolean;
       Write_Block_Missalignment        : Boolean;
       Read_Block_Missalignment         : Boolean;
       DSR_Implemented                  : Boolean;
       Reserved_2                       : Byte;
-      Device_Size                      : Word;
+      Device_Size                      : UInt32;
       Max_Read_Current_At_VDD_Min      : Byte;
       Max_Read_Current_At_VDD_Max      : Byte;
       Max_Write_Current_At_VDD_Min     : Byte;
@@ -126,7 +126,7 @@ package STM32.SDMMC is
       OEM_Application_ID    : String (1 .. 2);
       Product_Name          : String (1 .. 5);
       Product_Revision      : Card_Revision;
-      Product_Serial_Number : Word;
+      Product_Serial_Number : UInt32;
       Reserved_1            : Byte;
       Manufacturing_Date    : Manufacturing_Date_Type;
       CID_CRC               : Byte;
@@ -138,7 +138,7 @@ package STM32.SDMMC is
       SD_CID          : Card_Identification_Data_Register;
       Card_Capacity   : Unsigned_64;
       Card_Block_Size : Unsigned_32;
-      RCA             : Short; --  SD relative card address
+      RCA             : UInt16; --  SD relative card address
       Card_Type       : Supported_SD_Memory_Cards :=
                           STD_Capacity_SD_Card_V1_1;
    end record;
@@ -352,7 +352,7 @@ private
    SD_App_Change_Secure_Area          : constant SD_Specific_Command := 49;
    SD_App_Send_SCR                    : constant SD_Specific_Command := 51;
 
-   type Card_Data_Table is array (0 .. 3) of Word;
+   type Card_Data_Table is array (0 .. 3) of UInt32;
 
    type SDMMC_Controller
      (Periph : not null access STM32_SVD.SDIO.SDIO_Peripheral)
@@ -361,7 +361,7 @@ private
       CSD       : Card_Data_Table := (others => 0);
       Card_Type : Supported_SD_Memory_Cards :=
                     STD_Capacity_SD_Card_V1_1;
-      RCA       : Word := 0;
+      RCA       : UInt32 := 0;
       Operation : SDMMC_Operation := No_Operation;
    end record;
 

--- a/ARM/STM32/drivers/sd/sdmmc/stm32-sdmmc.ads
+++ b/ARM/STM32/drivers/sd/sdmmc/stm32-sdmmc.ads
@@ -62,14 +62,14 @@ package STM32.SDMMC is
       Data_Read_Access_Time_1          : Byte;
       Data_Read_Access_Time_2          : Byte; --  In CLK Cycles
       Max_Bus_Clock_Frequency          : Byte;
-      Card_Command_Class               : Short;
+      Card_Command_Class               : UInt16;
       Max_Read_Data_Block_Length       : Byte;
       Partial_Block_For_Read_Allowed   : Boolean;
       Write_Block_Missalignment        : Boolean;
       Read_Block_Missalignment         : Boolean;
       DSR_Implemented                  : Boolean;
       Reserved_2                       : Byte;
-      Device_Size                      : Word;
+      Device_Size                      : UInt32;
       Max_Read_Current_At_VDD_Min      : Byte;
       Max_Read_Current_At_VDD_Max      : Byte;
       Max_Write_Current_At_VDD_Min     : Byte;
@@ -125,7 +125,7 @@ package STM32.SDMMC is
       OEM_Application_ID    : String (1 .. 2);
       Product_Name          : String (1 .. 5);
       Product_Revision      : Card_Revision;
-      Product_Serial_Number : Word;
+      Product_Serial_Number : UInt32;
       Reserved_1            : Byte;
       Manufacturing_Date    : Manufacturing_Date_Type;
       CID_CRC               : Byte;
@@ -137,7 +137,7 @@ package STM32.SDMMC is
       SD_CID          : Card_Identification_Data_Register;
       Card_Capacity   : Unsigned_64;
       Card_Block_Size : Unsigned_32;
-      RCA             : Short; --  SD relative card address
+      RCA             : UInt16; --  SD relative card address
       Card_Type       : Supported_SD_Memory_Cards :=
                           STD_Capacity_SD_Card_V1_1;
    end record;
@@ -348,7 +348,7 @@ private
    SD_App_Change_Secure_Area          : constant SD_Specific_Command := 49;
    SD_App_Send_SCR                    : constant SD_Specific_Command := 51;
 
-   type Card_Data_Table is array (0 .. 3) of Word;
+   type Card_Data_Table is array (0 .. 3) of UInt32;
 
    type SDMMC_Controller (Periph : access STM32_SVD.SDMMC.SDMMC_Peripheral) is
    limited record
@@ -356,7 +356,7 @@ private
       CSD       : Card_Data_Table := (others => 0);
       Card_Type : Supported_SD_Memory_Cards :=
                     STD_Capacity_SD_Card_V1_1;
-      RCA       : Word := 0;
+      RCA       : UInt32 := 0;
       Operation : SDMMC_Operation := No_Operation;
    end record;
 

--- a/ARM/STM32/drivers/stm32-adc.adb
+++ b/ARM/STM32/drivers/stm32-adc.adb
@@ -101,7 +101,7 @@ package body STM32.ADC is
 
    function Conversion_Value
      (This : Analog_To_Digital_Converter)
-      return Short
+      return UInt16
    is
    begin
       return This.DR.DATA;
@@ -124,7 +124,7 @@ package body STM32.ADC is
    function Injected_Conversion_Value
      (This : Analog_To_Digital_Converter;
       Rank : Injected_Channel_Rank)
-      return Short
+      return UInt16
    is
    begin
       case Rank is
@@ -143,7 +143,7 @@ package body STM32.ADC is
    -- Multimode_Conversion_Value --
    --------------------------------
 
-   function Multimode_Conversion_Value return Word is
+   function Multimode_Conversion_Value return UInt32 is
      (C_ADC_Periph.CDR.Val);
 
    --------------------

--- a/ARM/STM32/drivers/stm32-adc.ads
+++ b/ARM/STM32/drivers/stm32-adc.ads
@@ -328,7 +328,7 @@ package STM32.ADC is
    --  part of starting.
 
    function Conversion_Value (This : Analog_To_Digital_Converter)
-      return Short with Inline;
+      return UInt16 with Inline;
    --  Returns the latest regular conversion result for the specified ADC unit
 
    function Data_Register_Address (This : Analog_To_Digital_Converter)
@@ -352,7 +352,7 @@ package STM32.ADC is
    function Injected_Conversion_Value
      (This : Analog_To_Digital_Converter;
       Rank : Injected_Channel_Rank)
-      return Short
+      return UInt16
      with Inline;
    --  Returns the latest conversion result for the analog input channel at
    --  the injected sequence position given by Rank on the specified ADC unit.
@@ -360,7 +360,7 @@ package STM32.ADC is
    --  Note that the offset corresponding to the specified Rank is subtracted
    --  automatically, so check the sign bit for a negative result.
 
-   function Multimode_Conversion_Value return Word with Inline;
+   function Multimode_Conversion_Value return UInt32 with Inline;
    --  Returns the latest ADC_1, ADC_2 and ADC_3 regular channel conversions'
    --  results based the selected multi ADC mode
 

--- a/ARM/STM32/drivers/stm32-dac.adb
+++ b/ARM/STM32/drivers/stm32-dac.adb
@@ -103,7 +103,7 @@ package body STM32.DAC is
    procedure Set_Output
      (This       : in out Digital_To_Analog_Converter;
       Channel    : DAC_Channel;
-      Value      : Word;
+      Value      : UInt32;
       Resolution : DAC_Resolution;
       Alignment  : Data_Alignment)
    is
@@ -167,14 +167,14 @@ package body STM32.DAC is
    function Converted_Output_Value
      (This    : Digital_To_Analog_Converter;
       Channel : DAC_Channel)
-      return Word
+      return UInt32
    is
    begin
       case Channel is
          when Channel_1 =>
-            return Word (This.DOR1.DACC1DOR);
+            return UInt32 (This.DOR1.DACC1DOR);
          when Channel_2 =>
-            return Word (This.DOR2.DACC2DOR);
+            return UInt32 (This.DOR2.DACC2DOR);
       end case;
    end Converted_Output_Value;
 
@@ -184,8 +184,8 @@ package body STM32.DAC is
 
    procedure Set_Dual_Output_Voltages
      (This            : in out Digital_To_Analog_Converter;
-      Channel_1_Value : Word;
-      Channel_2_Value : Word;
+      Channel_1_Value : UInt32;
+      Channel_2_Value : UInt32;
       Resolution      : DAC_Resolution;
       Alignment       : Data_Alignment)
    is
@@ -221,8 +221,8 @@ package body STM32.DAC is
    is
       Result : Dual_Channel_Output;
    begin
-      Result.Channel_1_Data := Short (This.DOR1.DACC1DOR);
-      Result.Channel_2_Data := Short (This.DOR2.DACC2DOR);
+      Result.Channel_1_Data := UInt16 (This.DOR1.DACC1DOR);
+      Result.Channel_2_Data := UInt16 (This.DOR2.DACC2DOR);
       return Result;
    end Converted_Dual_Output_Value;
 

--- a/ARM/STM32/drivers/stm32-dac.ads
+++ b/ARM/STM32/drivers/stm32-dac.ads
@@ -92,7 +92,7 @@ package STM32.DAC is
    procedure Set_Output
      (This       : in out Digital_To_Analog_Converter;
       Channel    : DAC_Channel;
-      Value      : Word;
+      Value      : UInt32;
       Resolution : DAC_Resolution;
       Alignment  : Data_Alignment);
    --  For the specified channel, writes the output Value to the data holding
@@ -119,19 +119,19 @@ package STM32.DAC is
    function Converted_Output_Value
      (This    : Digital_To_Analog_Converter;
       Channel : DAC_Channel)
-      return Word;
+      return UInt32;
    --  Returns the latest output value for the specified channel.
 
    procedure Set_Dual_Output_Voltages
      (This            : in out Digital_To_Analog_Converter;
-      Channel_1_Value : Word;
-      Channel_2_Value : Word;
+      Channel_1_Value : UInt32;
+      Channel_2_Value : UInt32;
       Resolution      : DAC_Resolution;
       Alignment       : Data_Alignment);
 
    type Dual_Channel_Output is record
-      Channel_1_Data : Short;
-      Channel_2_Data : Short;
+      Channel_1_Data : UInt16;
+      Channel_2_Data : UInt16;
    end record;
 
    function Converted_Dual_Output_Value (This : Digital_To_Analog_Converter)

--- a/ARM/STM32/drivers/stm32-dcmi.adb
+++ b/ARM/STM32/drivers/stm32-dcmi.adb
@@ -204,7 +204,7 @@ package body STM32.DCMI is
    -- Data --
    ----------
 
-   function Data return Word is (DCMI_Periph.DR.Val);
+   function Data return UInt32 is (DCMI_Periph.DR.Val);
 
    ----------
    -- Data --

--- a/ARM/STM32/drivers/stm32-dcmi.ads
+++ b/ARM/STM32/drivers/stm32-dcmi.ads
@@ -98,7 +98,7 @@ package STM32.DCMI is
    procedure Enable_Crop;
    procedure Disable_Crop;
 
-   function Data return Word;
+   function Data return UInt32;
    function Data return DR_Byte_Field_Array;
 
    function Data_Register_Address return System.Address;

--- a/ARM/STM32/drivers/stm32-device_id.ads
+++ b/ARM/STM32/drivers/stm32-device_id.ads
@@ -40,7 +40,7 @@ package STM32.Device_Id is
 
    function Unique_Id return Device_Id_Image;
 
-   type Device_Id_Tuple is array (1 .. 3) of Word
+   type Device_Id_Tuple is array (1 .. 3) of UInt32
      with Component_Size => 32;
 
    function Unique_Id return Device_Id_Tuple;

--- a/ARM/STM32/drivers/stm32-gpio.adb
+++ b/ARM/STM32/drivers/stm32-gpio.adb
@@ -48,7 +48,7 @@ with System.Machine_Code;
 
 package body STM32.GPIO is
 
-   procedure Lock_The_Pin (This : in out GPIO_Port;  Pin : Short);
+   procedure Lock_The_Pin (This : in out GPIO_Port;  Pin : UInt16);
    --  This is the routine that actually locks the pin for the port. It is an
    --  internal routine and has no preconditions. We use it to avoid redundant
    --  calls to the precondition that checks that the pin is not already
@@ -170,8 +170,8 @@ package body STM32.GPIO is
    -- Lock_The_Pin --
    ------------------
 
-   procedure Lock_The_Pin (This : in out GPIO_Port;  Pin : Short) is
-      Temp : Word;
+   procedure Lock_The_Pin (This : in out GPIO_Port;  Pin : UInt16) is
+      Temp : UInt32;
       pragma Volatile (Temp);
 
       use System.Machine_Code;
@@ -219,8 +219,8 @@ package body STM32.GPIO is
            "ldr  r3, [%1, #28]"   & LF & HT &
            "str  r3, %0"          & LF & HT,   -- temp <- lckr
            Inputs => (Address'Asm_Input ("r", This'Address), -- %1
-                     (Short'Asm_Input ("r", Pin))),            -- %2
-           Outputs => (Word'Asm_Output ("=m", Temp)),  -- %0
+                     (UInt16'Asm_Input ("r", Pin))),            -- %2
+           Outputs => (UInt32'Asm_Output ("=m", Temp)),  -- %0
            Volatile => True,
            Clobber  => ("r2, r3"));
    end Lock_The_Pin;

--- a/ARM/STM32/drivers/stm32-gpio.ads
+++ b/ARM/STM32/drivers/stm32-gpio.ads
@@ -246,7 +246,7 @@ private
 
    type GPIO_Port is new STM32_SVD.GPIO.GPIO_Peripheral;
 
-   LCCK : constant Word := 16#0001_0000#;
+   LCCK : constant UInt32 := 16#0001_0000#;
    --  As per the Reference Manual (RM0090; Doc ID 018909 Rev 6) pg 282,
    --  this is the "Lock Key" used to control the locking of port/pin
    --  configurations. It is bit 16 in the lock register (LCKR) of any

--- a/ARM/STM32/drivers/stm32-iwdg.adb
+++ b/ARM/STM32/drivers/stm32-iwdg.adb
@@ -36,9 +36,9 @@ package body STM32.IWDG is
 
    --  commands to the watchdog hardware
 
-   Reload_Counter : constant Short := 16#AAAA#;
-   Enable_Access  : constant Short := 16#5555#;
-   Start          : constant Short := 16#CCCC#;
+   Reload_Counter : constant UInt16 := 16#AAAA#;
+   Enable_Access  : constant UInt16 := 16#5555#;
+   Start          : constant UInt16 := 16#CCCC#;
 
    -------------------------
    -- Initialize_Watchdog --

--- a/ARM/STM32/drivers/stm32-pwm.ads
+++ b/ARM/STM32/drivers/stm32-pwm.ads
@@ -112,7 +112,7 @@ package STM32.PWM is
      with Inline,
           Pre => Attached (This) or else raise Not_Attached;
 
-   subtype Microseconds is Word;
+   subtype Microseconds is UInt32;
 
    procedure Set_Duty_Time
      (This  : in out PWM_Modulator;
@@ -153,8 +153,8 @@ private
      (Output_Timer : not null access STM32.Timers.Timer)
    is record
       Outputs      : PWM_Outputs;
-      Timer_Period : Word;
-      Frequency    : Word;
+      Timer_Period : UInt32;
+      Frequency    : UInt32;
    end record;
 
    type PWM_Modulator is record

--- a/ARM/STM32/drivers/stm32-rng.adb
+++ b/ARM/STM32/drivers/stm32-rng.adb
@@ -118,7 +118,7 @@ package body STM32.RNG is
    -- RNG_Data --
    --------------
 
-   function RNG_Data return Word
+   function RNG_Data return UInt32
      is (RNG_Periph.DR);
 
    --------------------

--- a/ARM/STM32/drivers/stm32-rng.ads
+++ b/ARM/STM32/drivers/stm32-rng.ads
@@ -63,7 +63,7 @@ package STM32.RNG is
 
    function RNG_Interrupt_Enabled return Boolean;
 
-   function RNG_Data return Word;
+   function RNG_Data return UInt32;
 
    function RNG_Data_Ready return Boolean;
 

--- a/ARM/STM32/drivers/stm32-spi.adb
+++ b/ARM/STM32/drivers/stm32-spi.adb
@@ -58,7 +58,7 @@ package body STM32.SPI is
       BRP_128 => 2#110#,
       BRP_256 => 2#111#);
 
-   type Half_Word_Pointer is access all Short
+   type Half_Word_Pointer is access all UInt16
      with Storage_Size => 0;
 
    function As_Half_Word_Pointer is new Ada.Unchecked_Conversion
@@ -144,7 +144,7 @@ package body STM32.SPI is
    -- Send --
    ----------
 
-   procedure Send (This : in out SPI_Port; Data : Short) is
+   procedure Send (This : in out SPI_Port; Data : UInt16) is
    begin
       This.Periph.DR.DR := Data;
    end Send;
@@ -153,7 +153,7 @@ package body STM32.SPI is
    -- Data --
    ----------
 
-   function Data (This : SPI_Port) return Short is
+   function Data (This : SPI_Port) return UInt16 is
    begin
       return This.Periph.DR.DR;
    end Data;
@@ -164,7 +164,7 @@ package body STM32.SPI is
 
    procedure Send (This : in out SPI_Port; Data : Byte) is
    begin
-      Send (This, Short (Data));
+      Send (This, UInt16 (Data));
    end Send;
 
    ----------
@@ -173,7 +173,7 @@ package body STM32.SPI is
 
    function Data (This : SPI_Port) return Byte is
    begin
-      return Byte (Short'(Data (This)));
+      return Byte (UInt16'(Data (This)));
    end Data;
 
    -------------
@@ -305,7 +305,7 @@ package body STM32.SPI is
    -------------------
 
    procedure Clear_Overrun (This : SPI_Port) is
-      Dummy1 : Short;
+      Dummy1 : UInt16;
       Dummy2 : SR_Register;
    begin
       Dummy1 := This.Periph.DR.DR;
@@ -464,7 +464,7 @@ package body STM32.SPI is
          Enable (This);
       end if;
 
-      This.Periph.DR.DR := Short (Outgoing);
+      This.Periph.DR.DR := UInt16 (Outgoing);
 
       while not Tx_Is_Empty (This) loop
          null;
@@ -580,7 +580,7 @@ package body STM32.SPI is
             null;
          end loop;
          Read_CRC : declare
-            Dummy : Short;
+            Dummy : UInt16;
          begin
             Dummy := This.Periph.DR.DR;
          end Read_CRC;
@@ -627,7 +627,7 @@ package body STM32.SPI is
             null;
          end loop;
          Read_CRC : declare
-            Dummy : Short;
+            Dummy : UInt16;
          begin
             Dummy := This.Periph.DR.DR;
          end Read_CRC;
@@ -664,7 +664,7 @@ package body STM32.SPI is
          raise Program_Error;
       end if;
 
-      This.Periph.DR.DR := Short (Outgoing);
+      This.Periph.DR.DR := UInt16 (Outgoing);
 
       --  enable CRC transmission
       if CRC_Enabled (This) then
@@ -685,7 +685,7 @@ package body STM32.SPI is
             null;
          end loop;
          Read_CRC : declare
-            Dummy : Short;
+            Dummy : UInt16;
          begin
             Dummy := This.Periph.DR.DR;
          end Read_CRC;
@@ -794,7 +794,7 @@ package body STM32.SPI is
       Incoming_Index : Natural := Incoming'First;
    begin
       if Current_Mode (This) = Slave or else Tx_Count = 1 then
-         This.Periph.DR.DR := Short (Outgoing (Outgoing_Index));
+         This.Periph.DR.DR := UInt16 (Outgoing (Outgoing_Index));
          Outgoing_Index := Outgoing_Index + 1;
          Tx_Count := Tx_Count - 1;
       end if;
@@ -823,7 +823,7 @@ package body STM32.SPI is
             null;
          end loop;
 
-         This.Periph.DR.DR := Short (Outgoing (Outgoing_Index));
+         This.Periph.DR.DR := UInt16 (Outgoing (Outgoing_Index));
          Outgoing_Index := Outgoing_Index + 1;
          Tx_Count := Tx_Count - 1;
 
@@ -899,7 +899,7 @@ package body STM32.SPI is
       Index    : Natural := Outgoing'First;
    begin
       if Current_Mode (This) = Slave or else Tx_Count = 1 then
-         This.Periph.DR.DR := Short (Outgoing (Index));
+         This.Periph.DR.DR := UInt16 (Outgoing (Index));
          Index := Index + 1;
          Tx_Count := Tx_Count - 1;
       end if;
@@ -910,7 +910,7 @@ package body STM32.SPI is
             null;
          end loop;
 
-         This.Periph.DR.DR := Short (Outgoing (Index));
+         This.Periph.DR.DR := UInt16 (Outgoing (Index));
          Index := Index + 1;
          Tx_Count := Tx_Count - 1;
       end loop;

--- a/ARM/STM32/drivers/stm32-spi.ads
+++ b/ARM/STM32/drivers/stm32-spi.ads
@@ -80,7 +80,7 @@ package STM32.SPI is
       Slave_Management    : SPI_Slave_Management;
       Baud_Rate_Prescaler : SPI_Baud_Rate_Prescaler;
       First_Bit           : SPI_First_Bit;
-      CRC_Poly            : Short;
+      CRC_Poly            : UInt16;
    end record;
 
    procedure Configure (This : in out SPI_Port; Conf : SPI_Configuration);
@@ -91,9 +91,9 @@ package STM32.SPI is
 
    function Enabled (This : SPI_Port) return Boolean;
 
-   procedure Send (This : in out SPI_Port; Data : Short);
+   procedure Send (This : in out SPI_Port; Data : UInt16);
 
-   function Data (This : SPI_Port) return Short
+   function Data (This : SPI_Port) return UInt16
      with Inline;
 
    procedure Send (This : in out SPI_Port; Data : Byte);

--- a/ARM/STM32/drivers/stm32-timers.adb
+++ b/ARM/STM32/drivers/stm32-timers.adb
@@ -47,8 +47,8 @@ package body STM32.Timers is
 
    procedure Configure
      (This      : in out Timer;
-      Prescaler : Short;
-      Period    : Word)
+      Prescaler : UInt16;
+      Period    : UInt32)
    is
    begin
       This.ARR := Period;
@@ -61,8 +61,8 @@ package body STM32.Timers is
 
    procedure Configure
      (This          : in out Timer;
-      Prescaler     : Short;
-      Period        : Word;
+      Prescaler     : UInt16;
+      Period        : UInt32;
       Clock_Divisor : Timer_Clock_Divisor;
       Counter_Mode  : Timer_Counter_Alignment_Mode)
    is
@@ -112,8 +112,8 @@ package body STM32.Timers is
 
    procedure Configure
      (This          : in out Timer;
-      Prescaler     : Short;
-      Period        : Word;
+      Prescaler     : UInt16;
+      Period        : UInt32;
       Clock_Divisor : Timer_Clock_Divisor;
       Counter_Mode  : Timer_Counter_Alignment_Mode;
       Repetitions   : Byte)
@@ -123,7 +123,7 @@ package body STM32.Timers is
       This.Prescaler := Prescaler;
       This.CR1.Clock_Division := Clock_Divisor;
       This.CR1.Mode_And_Dir := Counter_Mode;
-      This.RCR := Word (Repetitions);
+      This.RCR := UInt32 (Repetitions);
       This.EGR := Immediate'Enum_Rep;
    end Configure;
 
@@ -210,16 +210,16 @@ package body STM32.Timers is
    -- Set_Counter --
    -----------------
 
-   procedure Set_Counter (This : in out Timer;  Value : Short) is
+   procedure Set_Counter (This : in out Timer;  Value : UInt16) is
    begin
-      This.Counter := Word (Value);
+      This.Counter := UInt32 (Value);
    end Set_Counter;
 
    -----------------
    -- Set_Counter --
    -----------------
 
-   procedure Set_Counter (This : in out Timer;  Value : Word) is
+   procedure Set_Counter (This : in out Timer;  Value : UInt32) is
    begin
       This.Counter := Value;
    end Set_Counter;
@@ -228,7 +228,7 @@ package body STM32.Timers is
    -- Current_Counter --
    ---------------------
 
-   function Current_Counter (This : Timer) return Word is
+   function Current_Counter (This : Timer) return UInt32 is
    begin
       return This.Counter;
    end Current_Counter;
@@ -237,7 +237,7 @@ package body STM32.Timers is
    -- Set_Autoreload --
    --------------------
 
-   procedure Set_Autoreload (This : in out Timer;  Value : Word) is
+   procedure Set_Autoreload (This : in out Timer;  Value : UInt32) is
    begin
       This.ARR := Value;
    end Set_Autoreload;
@@ -246,7 +246,7 @@ package body STM32.Timers is
    -- Current_Autoreload --
    ------------------------
 
-   function Current_Autoreload (This : Timer) return Word is
+   function Current_Autoreload (This : Timer) return UInt32 is
    begin
       return This.ARR;
    end Current_Autoreload;
@@ -387,7 +387,7 @@ package body STM32.Timers is
 
    procedure Configure_Prescaler
      (This        : in out Timer;
-      Prescaler   : Short;
+      Prescaler   : UInt16;
       Reload_Mode : Timer_Prescaler_Reload_Mode)
    is
    begin
@@ -439,7 +439,7 @@ package body STM32.Timers is
    -- Current_Prescaler --
    -----------------------
 
-   function Current_Prescaler (This : Timer) return Short is
+   function Current_Prescaler (This : Timer) return UInt16 is
    begin
       return This.Prescaler;
    end Current_Prescaler;
@@ -516,7 +516,7 @@ package body STM32.Timers is
      (This   : in out Timer;
       Source : Timer_Event_Source)
    is
-      Temp_EGR : Word := This.EGR;
+      Temp_EGR : UInt32 := This.EGR;
    begin
       Temp_EGR := Temp_EGR or Source'Enum_Rep;
       This.EGR  := Temp_EGR;
@@ -677,7 +677,7 @@ package body STM32.Timers is
       Channel  : Timer_Channel;
       Mode     : Timer_Output_Compare_And_PWM_Mode;
       State    : Timer_Capture_Compare_State;
-      Pulse    : Word;
+      Pulse    : UInt32;
       Polarity : Timer_Output_Compare_Polarity)
    is
    begin
@@ -705,7 +705,7 @@ package body STM32.Timers is
       Channel                  : Timer_Channel;
       Mode                     : Timer_Output_Compare_And_PWM_Mode;
       State                    : Timer_Capture_Compare_State;
-      Pulse                    : Word;
+      Pulse                    : UInt32;
       Polarity                 : Timer_Output_Compare_Polarity;
       Idle_State               : Timer_Capture_Compare_State;
       Complementary_Polarity   : Timer_Output_Compare_Polarity;
@@ -1006,7 +1006,7 @@ package body STM32.Timers is
      (This    : in out Timer;
       Channel : Timer_Channel)
    is
-      Temp_EGR  : Word := This.EGR;
+      Temp_EGR  : UInt32 := This.EGR;
    begin
       This.CCER (Channel).CCxE := Enable;
 
@@ -1110,7 +1110,7 @@ package body STM32.Timers is
    procedure Set_Compare_Value
      (This       : in out Timer;
       Channel    : Timer_Channel;
-      Word_Value : Word)
+      Word_Value : UInt32)
    is
    begin
       This.CCR1_4 (Channel) := Word_Value;
@@ -1125,10 +1125,10 @@ package body STM32.Timers is
    procedure Set_Compare_Value
      (This    : in out Timer;
       Channel : Timer_Channel;
-      Value   : Short)
+      Value   : UInt16)
    is
    begin
-      This.CCR1_4 (Channel) := Word (Value);
+      This.CCR1_4 (Channel) := UInt32 (Value);
       --  These capture/compare registers are really only 15-bits wide, except
       --  for those of timers 2 and 5. For the sake of simplicity we represent
       --  all of them with full words, but only write word values when
@@ -1144,7 +1144,7 @@ package body STM32.Timers is
    function Current_Capture_Value
      (This    : Timer;
       Channel : Timer_Channel)
-      return Word
+      return UInt32
    is
    begin
       return This.CCR1_4 (Channel);
@@ -1157,10 +1157,10 @@ package body STM32.Timers is
    function Current_Capture_Value
      (This    : Timer;
       Channel : Timer_Channel)
-      return Short
+      return UInt16
    is
    begin
-      return Short (This.CCR1_4 (Channel));
+      return UInt16 (This.CCR1_4 (Channel));
    end Current_Capture_Value;
 
    -------------------------------------

--- a/ARM/STM32/drivers/stm32-timers.ads
+++ b/ARM/STM32/drivers/stm32-timers.ads
@@ -64,33 +64,33 @@ package STM32.Timers is
 
    procedure Configure
      (This      : in out Timer;
-      Prescaler : Short;
-      Period    : Word)
+      Prescaler : UInt16;
+      Period    : UInt32)
      with
-       Pre  => (if Period > Word (Short'Last) then Has_32bit_Counter (This)),
+       Pre  => (if Period > UInt32 (UInt16'Last) then Has_32bit_Counter (This)),
        Post => Current_Prescaler (This) = Prescaler and
                Current_Autoreload (This) = Period;
 
-   procedure Set_Counter (This : in out Timer;  Value : Short)
-     with Post => Current_Counter (This) = Word (Value);
+   procedure Set_Counter (This : in out Timer;  Value : UInt16)
+     with Post => Current_Counter (This) = UInt32 (Value);
 
-   procedure Set_Counter (This : in out Timer;  Value : Word)
+   procedure Set_Counter (This : in out Timer;  Value : UInt32)
      with
        Pre  => Has_32bit_Counter (This),
        Post => Current_Counter (This) = Value;
 
-   function Current_Counter (This : Timer) return Word;
+   function Current_Counter (This : Timer) return UInt32;
    --  For those timers that actually have a 32-bit counter this function will
    --  return the full word value. For the other timers, the upper half-word of
    --  the result will be all zeros so in effect the result will be a half-word
    --  value.
 
-   procedure Set_Autoreload (This : in out Timer;  Value : Word)
+   procedure Set_Autoreload (This : in out Timer;  Value : UInt32)
      with
-       Pre  => (if Value > Word (Short'Last) then Has_32bit_Counter (This)),
+       Pre  => (if Value > UInt32 (UInt16'Last) then Has_32bit_Counter (This)),
        Post => Current_Autoreload (This) = Value;
 
-   function Current_Autoreload (This : Timer) return Word;
+   function Current_Autoreload (This : Timer) return UInt32;
    --  Returns the value of the timer's Auto Reload Register (ARR)
 
    type Timer_Clock_Divisor is (Div1, Div2, Div4);
@@ -132,13 +132,13 @@ package STM32.Timers is
 
    procedure Configure
      (This          : in out Timer;
-      Prescaler     : Short;
-      Period        : Word;
+      Prescaler     : UInt16;
+      Period        : UInt32;
       Clock_Divisor : Timer_Clock_Divisor;
       Counter_Mode  : Timer_Counter_Alignment_Mode)
      with
        Pre  => not Basic_Timer (This) and
-               (if Period > Word (Short'Last) then Has_32bit_Counter (This)),
+               (if Period > UInt32 (UInt16'Last) then Has_32bit_Counter (This)),
        Post => Current_Prescaler (This) = Prescaler and
                Current_Clock_Division (This) = Clock_Divisor and
                Current_Counter_Mode (This) = Counter_Mode and
@@ -148,11 +148,11 @@ package STM32.Timers is
 
    procedure Configure_Prescaler
      (This        : in out Timer;
-      Prescaler   : Short;
+      Prescaler   : UInt16;
       Reload_Mode : Timer_Prescaler_Reload_Mode)
      with Post => Current_Prescaler (This) = Prescaler;
 
-   function Current_Prescaler (This : Timer) return Short;
+   function Current_Prescaler (This : Timer) return UInt16;
 
    procedure Set_UpdateDisable
      (This : in out Timer;
@@ -505,7 +505,7 @@ package STM32.Timers is
       Channel  : Timer_Channel;
       Mode     : Timer_Output_Compare_And_PWM_Mode;
       State    : Timer_Capture_Compare_State;
-      Pulse    : Word;
+      Pulse    : UInt32;
       Polarity : Timer_Output_Compare_Polarity)
      with
        Pre => (CC_Channel_Exists (This, Channel) and
@@ -518,7 +518,7 @@ package STM32.Timers is
    procedure Set_Compare_Value
      (This       : in out Timer;
       Channel    : Timer_Channel;
-      Word_Value : Word)
+      Word_Value : UInt32)
      with
        Pre  => Has_32bit_CC_Values (This),
        Post => Current_Capture_Value (This, Channel) = Word_Value;
@@ -526,7 +526,7 @@ package STM32.Timers is
    procedure Set_Compare_Value
      (This    : in out Timer;
       Channel : Timer_Channel;
-      Value   : Short)
+      Value   : UInt16)
      with
        Pre  => CC_Channel_Exists (This, Channel),
        Post => Current_Capture_Value (This, Channel) = Value;
@@ -680,7 +680,7 @@ package STM32.Timers is
    function Current_Capture_Value
      (This    : Timer;
       Channel : Timer_Channel)
-      return Word;
+      return UInt32;
    --  Reading the upper reserved area of the CCR register does no harm when
    --  the timer does not support 32-bit CC registers so we do not protect
    --  this function with a precondition.
@@ -688,7 +688,7 @@ package STM32.Timers is
    function Current_Capture_Value
      (This    : Timer;
       Channel : Timer_Channel)
-      return Short;
+      return UInt16;
 
    ----------------------------------------------------------------------------
 
@@ -711,14 +711,14 @@ package STM32.Timers is
 
    procedure Configure
      (This          : in out Timer;
-      Prescaler     : Short;
-      Period        : Word;
+      Prescaler     : UInt16;
+      Period        : UInt32;
       Clock_Divisor : Timer_Clock_Divisor;
       Counter_Mode  : Timer_Counter_Alignment_Mode;
       Repetitions   : Byte)
      with
        Pre  => Advanced_Timer (This) and
-               (if Period > Word (Short'Last) then Has_32bit_Counter (This)),
+               (if Period > UInt32 (UInt16'Last) then Has_32bit_Counter (This)),
        Post => Current_Prescaler (This) = Prescaler and
                Current_Autoreload (This) = Period;
 
@@ -727,7 +727,7 @@ package STM32.Timers is
       Channel                  : Timer_Channel;
       Mode                     : Timer_Output_Compare_And_PWM_Mode;
       State                    : Timer_Capture_Compare_State;
-      Pulse                    : Word;
+      Pulse                    : UInt32;
       Polarity                 : Timer_Output_Compare_Polarity;
       Idle_State               : Timer_Capture_Compare_State;
       Complementary_Polarity   : Timer_Output_Compare_Polarity;
@@ -1152,7 +1152,7 @@ private
    ------------------------  representation for CR2  --------------------------
 
    type TIMx_CR2 is record
-      Reserved0                                 : Short;
+      Reserved0                                 : UInt16;
       Reserved1                                 : Bit;
       Channel_4_Output_Idle_State               : Timer_Capture_Compare_State;
       Channel_3_Complementary_Output_Idle_State : Timer_Capture_Compare_State;
@@ -1190,7 +1190,7 @@ private
    ------------  representation for slave mode control register  --------------
 
    type TIMx_SMCR is record
-      Reserved0                  : Short;
+      Reserved0                  : UInt16;
       External_Trigger_Polarity  : Timer_External_Trigger_Polarity;
       External_Clock_Enable      : Boolean;
       External_Trigger_Prescaler : Timer_External_Trigger_Prescaler;
@@ -1329,7 +1329,7 @@ private
 
    type TIMx_CCMRx is record
       Descriptors : TIMx_CCMRx_Lower_Half;
-      Reserved    : Short;
+      Reserved    : UInt16;
    end record with Volatile_Full_Access, Size => 32;
 
    for TIMx_CCMRx use record
@@ -1396,13 +1396,13 @@ private
    --  all four values, indexed by the channel. Timers 2 and 5 actually use all
    --  32 bits of each, the other timers only use the lower half.
 
-   type Capture_Compare_Registers is array (Timer_Channel) of Word
+   type Capture_Compare_Registers is array (Timer_Channel) of UInt32
      with Volatile_Components, Component_Size => 32, Size => 128;
 
    ----------  representation for the Break and Dead Time Register - ----------
 
    type TIMx_BDTR is record
-      Reserved                      : Short;
+      Reserved                      : UInt16;
       Main_Output_Enabled           : Boolean;
       Automatic_Output_Enabled      : Boolean;
       Break_Polarity                : Timer_Break_Polarity;
@@ -1428,7 +1428,7 @@ private
    -----------  representation for the DMA Control Register type  -------------
 
    type TIMx_DCR is record
-      Reserved0    : Short;
+      Reserved0    : UInt16;
       Reserved1    : UInt3;
       Burst_Length : Timer_DMA_Burst_Length;
       Reserved2    : UInt3;
@@ -1446,7 +1446,7 @@ private
    -------  representation for Timer 2, 5, and 11 remapping options  ----------
 
    type TIMx_OR is record
-      Reserved0 : Short;
+      Reserved0 : UInt16;
       Reserved1 : UInt4;
       ITR1_RMP  : Timer_2_Remapping_Options;
       Reserved2 : UInt2;
@@ -1474,22 +1474,22 @@ private
       CR1                : TIMx_CR1;
       CR2                : TIMx_CR2;
       SMCR               : TIMx_SMCR;
-      DIER               : Word;
-      SR                 : Word;
-      EGR                : Word;
+      DIER               : UInt32;
+      SR                 : UInt32;
+      EGR                : UInt32;
       CCMR1_2            : TIMx_CCMR_Pair;
       CCER               : TIMx_CCER;
-      Reserved_CCER      : Short;
-      Counter            : Word with Atomic;
+      Reserved_CCER      : UInt16;
+      Counter            : UInt32 with Atomic;
       --  a full word for timers 2 and 5 only
-      Prescaler          : Short;
-      Reserved_Prescaler : Short;
-      ARR                : Word;
-      RCR                : Word;
+      Prescaler          : UInt16;
+      Reserved_Prescaler : UInt16;
+      ARR                : UInt32;
+      RCR                : UInt32;
       CCR1_4             : Capture_Compare_Registers;
       BDTR               : TIMx_BDTR;
       DCR                : TIMx_DCR;
-      DMAR               : Word;
+      DMAR               : UInt32;
       Options            : TIMx_OR;
    end record with Volatile, Size => 21 * 32;
 

--- a/ARM/STM32/drivers/uart_stm32f4/stm32-usarts.adb
+++ b/ARM/STM32/drivers/uart_stm32f4/stm32-usarts.adb
@@ -50,7 +50,7 @@ package body STM32.USARTs is
    -- APB_Clock --
    ---------------
 
-   function APB_Clock (This : USART) return Word is
+   function APB_Clock (This : USART) return UInt32 is
       Clocks : constant RCC_System_Clocks := System_Clock_Frequencies;
    begin
       if This.Periph.all'Address = USART1_Base
@@ -135,11 +135,11 @@ package body STM32.USARTs is
 
    procedure Set_Baud_Rate (This : in out USART; To : Baud_Rates)
    is
-      Clock        : constant Word := APB_Clock (This);
+      Clock        : constant UInt32 := APB_Clock (This);
       Over_By_8    : constant Boolean := This.Periph.CR1.OVER8;
-      Int_Scale    : constant Word := (if Over_By_8 then 2 else 4);
-      Int_Divider  : constant Word := (25 * Clock) / (Int_Scale * To);
-      Frac_Divider : constant Word := Int_Divider rem 100;
+      Int_Scale    : constant UInt32 := (if Over_By_8 then 2 else 4);
+      Int_Divider  : constant UInt32 := (25 * Clock) / (Int_Scale * To);
+      Frac_Divider : constant UInt32 := Int_Divider rem 100;
    begin
       --  the integer part of the divi
       if Over_By_8 then

--- a/ARM/STM32/drivers/uart_stm32f4/stm32-usarts.ads
+++ b/ARM/STM32/drivers/uart_stm32f4/stm32-usarts.ads
@@ -92,7 +92,7 @@ package STM32.USARTs is
 
    procedure Set_Parity (This : in out USART;  To : Parities);
 
-   subtype Baud_Rates is Word;
+   subtype Baud_Rates is UInt32;
 
    procedure Set_Baud_Rate (This : in out USART;  To : Baud_Rates);
 
@@ -254,7 +254,7 @@ package STM32.USARTs is
 
 private
 
-   function APB_Clock (This : USART) return Word with Inline;
+   function APB_Clock (This : USART) return UInt32 with Inline;
    --  Returns either APB1 or APB2 clock rate, in Hertz, depending on the
    --  USART. For the sake of not making this package board-specific, we assume
    --  that we are given a valid USART object at a valid address, AND that the

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-adc.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-adc.ads
@@ -530,14 +530,14 @@ package STM32_SVD.ADC is
       Reserved_22_31 at 0 range 22 .. 31;
    end record;
 
-   subtype JDR_JDATA_Field is HAL.Short;
+   subtype JDR_JDATA_Field is HAL.UInt16;
 
    --  injected data register x
    type JDR_Register is record
       --  Read-only. Injected data
       JDATA          : JDR_JDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -547,14 +547,14 @@ package STM32_SVD.ADC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DR_DATA_Field is HAL.Short;
+   subtype DR_DATA_Field is HAL.UInt16;
 
    --  regular data register
    type DR_Register is record
       --  Read-only. Regular data
       DATA           : DR_DATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -684,7 +684,7 @@ package STM32_SVD.ADC is
    end record;
 
    --  CDR_DATA array element
-   subtype CDR_DATA_Element is HAL.Short;
+   subtype CDR_DATA_Element is HAL.UInt16;
 
    --  CDR_DATA array
    type CDR_DATA_Field_Array is array (1 .. 2) of CDR_DATA_Element
@@ -697,7 +697,7 @@ package STM32_SVD.ADC is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : CDR_DATA_Field_Array;

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-can.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-can.ads
@@ -446,7 +446,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT0R_DLC_Field is HAL.UInt4;
-   subtype TDT0R_TIME_Field is HAL.Short;
+   subtype TDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT0R_Register is record
@@ -486,7 +486,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL0R_DATA_Field_Array;
@@ -514,7 +514,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH0R_DATA_Field_Array;
@@ -556,7 +556,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT1R_DLC_Field is HAL.UInt4;
-   subtype TDT1R_TIME_Field is HAL.Short;
+   subtype TDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT1R_Register is record
@@ -596,7 +596,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL1R_DATA_Field_Array;
@@ -624,7 +624,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH1R_DATA_Field_Array;
@@ -666,7 +666,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT2R_DLC_Field is HAL.UInt4;
-   subtype TDT2R_TIME_Field is HAL.Short;
+   subtype TDT2R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT2R_Register is record
@@ -706,7 +706,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL2R_DATA_Field_Array;
@@ -734,7 +734,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH2R_DATA_Field_Array;
@@ -777,7 +777,7 @@ package STM32_SVD.CAN is
 
    subtype RDT0R_DLC_Field is HAL.UInt4;
    subtype RDT0R_FMI_Field is HAL.Byte;
-   subtype RDT0R_TIME_Field is HAL.Short;
+   subtype RDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
    type RDT0R_Register is record
@@ -814,7 +814,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDL0R_DATA_Field_Array;
@@ -842,7 +842,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDH0R_DATA_Field_Array;
@@ -885,7 +885,7 @@ package STM32_SVD.CAN is
 
    subtype RDT1R_DLC_Field is HAL.UInt4;
    subtype RDT1R_FMI_Field is HAL.Byte;
-   subtype RDT1R_TIME_Field is HAL.Short;
+   subtype RDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
    type RDT1R_Register is record
@@ -922,7 +922,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDL1R_DATA_Field_Array;
@@ -950,7 +950,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDH1R_DATA_Field_Array;
@@ -1154,7 +1154,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F0R_FB_Field_Array;
@@ -1179,7 +1179,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F1R_FB_Field_Array;
@@ -1204,7 +1204,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F2R_FB_Field_Array;
@@ -1229,7 +1229,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F3R_FB_Field_Array;
@@ -1254,7 +1254,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F4R_FB_Field_Array;
@@ -1279,7 +1279,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F5R_FB_Field_Array;
@@ -1304,7 +1304,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F6R_FB_Field_Array;
@@ -1329,7 +1329,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F7R_FB_Field_Array;
@@ -1354,7 +1354,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F8R_FB_Field_Array;
@@ -1379,7 +1379,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F9R_FB_Field_Array;
@@ -1404,7 +1404,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F10R_FB_Field_Array;
@@ -1429,7 +1429,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F11R_FB_Field_Array;
@@ -1454,7 +1454,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F12R_FB_Field_Array;
@@ -1479,7 +1479,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F13R_FB_Field_Array;
@@ -1504,7 +1504,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F14R_FB_Field_Array;
@@ -1529,7 +1529,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F15R_FB_Field_Array;
@@ -1554,7 +1554,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F16R_FB_Field_Array;
@@ -1579,7 +1579,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F17R_FB_Field_Array;
@@ -1604,7 +1604,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F18R_FB_Field_Array;
@@ -1629,7 +1629,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F19R_FB_Field_Array;
@@ -1654,7 +1654,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F20R_FB_Field_Array;
@@ -1679,7 +1679,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F21R_FB_Field_Array;
@@ -1704,7 +1704,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F22R_FB_Field_Array;
@@ -1729,7 +1729,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F23R_FB_Field_Array;
@@ -1754,7 +1754,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F24R_FB_Field_Array;
@@ -1779,7 +1779,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F25R_FB_Field_Array;
@@ -1804,7 +1804,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F26R_FB_Field_Array;
@@ -1829,7 +1829,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F27R_FB_Field_Array;

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-crc.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-crc.ads
@@ -52,7 +52,7 @@ package STM32_SVD.CRC is
    --  Cryptographic processor
    type CRC_Peripheral is record
       --  Data register
-      DR  : HAL.Word;
+      DR  : HAL.UInt32;
       --  Independent Data register
       IDR : IDR_Register;
       --  Control register

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-dac.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-dac.ads
@@ -149,7 +149,7 @@ package STM32_SVD.DAC is
       --  DAC channel1 12-bit left-aligned data
       DACC1DHR       : DHR12L1_DACC1DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -203,7 +203,7 @@ package STM32_SVD.DAC is
       --  DAC channel2 12-bit left-aligned data
       DACC2DHR       : DHR12L2_DACC2DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -289,7 +289,7 @@ package STM32_SVD.DAC is
       --  DAC channel2 8-bit right-aligned data
       DACC2DHR       : DHR8RD_DACC2DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-dbg.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-dbg.ads
@@ -14,7 +14,7 @@ package STM32_SVD.DBG is
    ---------------
 
    subtype DBGMCU_IDCODE_DEV_ID_Field is HAL.UInt12;
-   subtype DBGMCU_IDCODE_REV_ID_Field is HAL.Short;
+   subtype DBGMCU_IDCODE_REV_ID_Field is HAL.UInt16;
 
    --  IDCODE
    type DBGMCU_IDCODE_Register is record

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-dcmi.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-dcmi.ads
@@ -307,7 +307,7 @@ package STM32_SVD.DCMI is
       case As_Array is
          when False =>
             --  Byte as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  Byte as an array
             Arr : DR_Byte_Field_Array;

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-dma.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-dma.ads
@@ -441,14 +441,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S0NDTR_NDT_Field is HAL.Short;
+   subtype S0NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S0NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S0NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -568,14 +568,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S1NDTR_NDT_Field is HAL.Short;
+   subtype S1NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S1NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S1NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -695,14 +695,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S2NDTR_NDT_Field is HAL.Short;
+   subtype S2NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S2NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S2NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -822,14 +822,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S3NDTR_NDT_Field is HAL.Short;
+   subtype S3NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S3NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S3NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -949,14 +949,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S4NDTR_NDT_Field is HAL.Short;
+   subtype S4NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S4NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S4NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1076,14 +1076,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S5NDTR_NDT_Field is HAL.Short;
+   subtype S5NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S5NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S5NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1203,14 +1203,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S6NDTR_NDT_Field is HAL.Short;
+   subtype S6NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S6NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S6NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1330,14 +1330,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S7NDTR_NDT_Field is HAL.Short;
+   subtype S7NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S7NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S7NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1396,11 +1396,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S0NDTR : S0NDTR_Register;
       --  stream x peripheral address register
-      S0PAR  : HAL.Word;
+      S0PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S0M0AR : HAL.Word;
+      S0M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S0M1AR : HAL.Word;
+      S0M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S0FCR  : S0FCR_Register;
       --  stream x configuration register
@@ -1408,11 +1408,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S1NDTR : S1NDTR_Register;
       --  stream x peripheral address register
-      S1PAR  : HAL.Word;
+      S1PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S1M0AR : HAL.Word;
+      S1M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S1M1AR : HAL.Word;
+      S1M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S1FCR  : S1FCR_Register;
       --  stream x configuration register
@@ -1420,11 +1420,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S2NDTR : S2NDTR_Register;
       --  stream x peripheral address register
-      S2PAR  : HAL.Word;
+      S2PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S2M0AR : HAL.Word;
+      S2M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S2M1AR : HAL.Word;
+      S2M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S2FCR  : S2FCR_Register;
       --  stream x configuration register
@@ -1432,11 +1432,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S3NDTR : S3NDTR_Register;
       --  stream x peripheral address register
-      S3PAR  : HAL.Word;
+      S3PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S3M0AR : HAL.Word;
+      S3M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S3M1AR : HAL.Word;
+      S3M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S3FCR  : S3FCR_Register;
       --  stream x configuration register
@@ -1444,11 +1444,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S4NDTR : S4NDTR_Register;
       --  stream x peripheral address register
-      S4PAR  : HAL.Word;
+      S4PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S4M0AR : HAL.Word;
+      S4M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S4M1AR : HAL.Word;
+      S4M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S4FCR  : S4FCR_Register;
       --  stream x configuration register
@@ -1456,11 +1456,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S5NDTR : S5NDTR_Register;
       --  stream x peripheral address register
-      S5PAR  : HAL.Word;
+      S5PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S5M0AR : HAL.Word;
+      S5M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S5M1AR : HAL.Word;
+      S5M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S5FCR  : S5FCR_Register;
       --  stream x configuration register
@@ -1468,11 +1468,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S6NDTR : S6NDTR_Register;
       --  stream x peripheral address register
-      S6PAR  : HAL.Word;
+      S6PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S6M0AR : HAL.Word;
+      S6M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S6M1AR : HAL.Word;
+      S6M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S6FCR  : S6FCR_Register;
       --  stream x configuration register
@@ -1480,11 +1480,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S7NDTR : S7NDTR_Register;
       --  stream x peripheral address register
-      S7PAR  : HAL.Word;
+      S7PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S7M0AR : HAL.Word;
+      S7M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S7M1AR : HAL.Word;
+      S7M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S7FCR  : S7FCR_Register;
    end record

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-ethernet.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-ethernet.ads
@@ -277,7 +277,7 @@ package STM32_SVD.Ethernet is
       Reserved_17_31 at 0 range 17 .. 31;
    end record;
 
-   subtype DMAMFBOCR_MFC_Field is HAL.Short;
+   subtype DMAMFBOCR_MFC_Field is HAL.UInt16;
    subtype DMAMFBOCR_MFA_Field is HAL.UInt11;
 
    --  Ethernet DMA missed frame and buffer overflow counter register
@@ -463,7 +463,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       PA             : MACMIIAR_PA_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -478,14 +478,14 @@ package STM32_SVD.Ethernet is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MACMIIDR_TD_Field is HAL.Short;
+   subtype MACMIIDR_TD_Field is HAL.UInt16;
 
    --  Ethernet MAC MII data register
    type MACMIIDR_Register is record
       --  no description available
       TD             : MACMIIDR_TD_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -496,7 +496,7 @@ package STM32_SVD.Ethernet is
    end record;
 
    subtype MACFCR_PLT_Field is HAL.UInt2;
-   subtype MACFCR_PT_Field is HAL.Short;
+   subtype MACFCR_PT_Field is HAL.UInt16;
 
    --  Ethernet MAC flow control register
    type MACFCR_Register is record
@@ -534,7 +534,7 @@ package STM32_SVD.Ethernet is
       PT            at 0 range 16 .. 31;
    end record;
 
-   subtype MACVLANTR_VLANTI_Field is HAL.Short;
+   subtype MACVLANTR_VLANTI_Field is HAL.UInt16;
 
    --  Ethernet MAC VLAN tag register
    type MACVLANTR_Register is record
@@ -680,7 +680,7 @@ package STM32_SVD.Ethernet is
       Reserved_10_31 at 0 range 10 .. 31;
    end record;
 
-   subtype MACA0HR_MACA0H_Field is HAL.Short;
+   subtype MACA0HR_MACA0H_Field is HAL.UInt16;
 
    --  Ethernet MAC address 0 high register
    type MACA0HR_Register is record
@@ -700,7 +700,7 @@ package STM32_SVD.Ethernet is
       MO             at 0 range 31 .. 31;
    end record;
 
-   subtype MACA1HR_MACA1H_Field is HAL.Short;
+   subtype MACA1HR_MACA1H_Field is HAL.UInt16;
    subtype MACA1HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 1 high register
@@ -727,7 +727,7 @@ package STM32_SVD.Ethernet is
       AE             at 0 range 31 .. 31;
    end record;
 
-   subtype MACA2HR_MAC2AH_Field is HAL.Short;
+   subtype MACA2HR_MAC2AH_Field is HAL.UInt16;
    subtype MACA2HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 2 high register
@@ -771,7 +771,7 @@ package STM32_SVD.Ethernet is
       Reserved_31_31 at 0 range 31 .. 31;
    end record;
 
-   subtype MACA3HR_MACA3H_Field is HAL.Short;
+   subtype MACA3HR_MACA3H_Field is HAL.UInt16;
    subtype MACA3HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 3 high register
@@ -1094,13 +1094,13 @@ package STM32_SVD.Ethernet is
       --  Ethernet DMA bus mode register
       DMABMR    : DMABMR_Register;
       --  Ethernet DMA transmit poll demand register
-      DMATPDR   : HAL.Word;
+      DMATPDR   : HAL.UInt32;
       --  EHERNET DMA receive poll demand register
-      DMARPDR   : HAL.Word;
+      DMARPDR   : HAL.UInt32;
       --  Ethernet DMA receive descriptor list address register
-      DMARDLAR  : HAL.Word;
+      DMARDLAR  : HAL.UInt32;
       --  Ethernet DMA transmit descriptor list address register
-      DMATDLAR  : HAL.Word;
+      DMATDLAR  : HAL.UInt32;
       --  Ethernet DMA status register
       DMASR     : DMASR_Register;
       --  Ethernet DMA operation mode register
@@ -1112,13 +1112,13 @@ package STM32_SVD.Ethernet is
       --  Ethernet DMA receive status watchdog timer register
       DMARSWTR  : DMARSWTR_Register;
       --  Ethernet DMA current host transmit descriptor register
-      DMACHTDR  : HAL.Word;
+      DMACHTDR  : HAL.UInt32;
       --  Ethernet DMA current host receive descriptor register
-      DMACHRDR  : HAL.Word;
+      DMACHRDR  : HAL.UInt32;
       --  Ethernet DMA current host transmit buffer address register
-      DMACHTBAR : HAL.Word;
+      DMACHTBAR : HAL.UInt32;
       --  Ethernet DMA current host receive buffer address register
-      DMACHRBAR : HAL.Word;
+      DMACHRBAR : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1150,9 +1150,9 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC frame filter register
       MACFFR    : MACFFR_Register;
       --  Ethernet MAC hash table high register
-      MACHTHR   : HAL.Word;
+      MACHTHR   : HAL.UInt32;
       --  Ethernet MAC hash table low register
-      MACHTLR   : HAL.Word;
+      MACHTLR   : HAL.UInt32;
       --  Ethernet MAC MII address register
       MACMIIAR  : MACMIIAR_Register;
       --  Ethernet MAC MII data register
@@ -1172,11 +1172,11 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC address 0 high register
       MACA0HR   : MACA0HR_Register;
       --  Ethernet MAC address 0 low register
-      MACA0LR   : HAL.Word;
+      MACA0LR   : HAL.UInt32;
       --  Ethernet MAC address 1 high register
       MACA1HR   : MACA1HR_Register;
       --  Ethernet MAC address1 low register
-      MACA1LR   : HAL.Word;
+      MACA1LR   : HAL.UInt32;
       --  Ethernet MAC address 2 high register
       MACA2HR   : MACA2HR_Register;
       --  Ethernet MAC address 2 low register
@@ -1184,7 +1184,7 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC address 3 high register
       MACA3HR   : MACA3HR_Register;
       --  Ethernet MAC address 3 low register
-      MACA3LR   : HAL.Word;
+      MACA3LR   : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1228,18 +1228,18 @@ package STM32_SVD.Ethernet is
       --  Ethernet MMC transmit interrupt mask register
       MMCTIMR     : MMCTIMR_Register;
       --  Ethernet MMC transmitted good frames after a single collision counter
-      MMCTGFSCCR  : HAL.Word;
+      MMCTGFSCCR  : HAL.UInt32;
       --  Ethernet MMC transmitted good frames after more than a single
       --  collision
-      MMCTGFMSCCR : HAL.Word;
+      MMCTGFMSCCR : HAL.UInt32;
       --  Ethernet MMC transmitted good frames counter register
-      MMCTGFCR    : HAL.Word;
+      MMCTGFCR    : HAL.UInt32;
       --  Ethernet MMC received frames with CRC error counter register
-      MMCRFCECR   : HAL.Word;
+      MMCRFCECR   : HAL.UInt32;
       --  Ethernet MMC received frames with alignment error counter register
-      MMCRFAECR   : HAL.Word;
+      MMCRFAECR   : HAL.UInt32;
       --  MMC received good unicast frames counter register
-      MMCRGUFCR   : HAL.Word;
+      MMCRGUFCR   : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1268,19 +1268,19 @@ package STM32_SVD.Ethernet is
       --  Ethernet PTP subsecond increment register
       PTPSSIR  : PTPSSIR_Register;
       --  Ethernet PTP time stamp high register
-      PTPTSHR  : HAL.Word;
+      PTPTSHR  : HAL.UInt32;
       --  Ethernet PTP time stamp low register
       PTPTSLR  : PTPTSLR_Register;
       --  Ethernet PTP time stamp high update register
-      PTPTSHUR : HAL.Word;
+      PTPTSHUR : HAL.UInt32;
       --  Ethernet PTP time stamp low update register
       PTPTSLUR : PTPTSLUR_Register;
       --  Ethernet PTP time stamp addend register
-      PTPTSAR  : HAL.Word;
+      PTPTSAR  : HAL.UInt32;
       --  Ethernet PTP target time high register
-      PTPTTHR  : HAL.Word;
+      PTPTTHR  : HAL.UInt32;
       --  Ethernet PTP target time low register
-      PTPTTLR  : HAL.Word;
+      PTPTTLR  : HAL.UInt32;
       --  Ethernet PTP time stamp status register
       PTPTSSR  : PTPTSSR_Register;
       --  Ethernet PTP PPS control register

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-flash.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-flash.ads
@@ -190,9 +190,9 @@ package STM32_SVD.FLASH is
       --  Flash access control register
       ACR     : ACR_Register;
       --  Flash key register
-      KEYR    : HAL.Word;
+      KEYR    : HAL.UInt32;
       --  Flash option key register
-      OPTKEYR : HAL.Word;
+      OPTKEYR : HAL.UInt32;
       --  Status register
       SR      : SR_Register;
       --  Control register

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-fsmc.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-fsmc.ads
@@ -409,7 +409,7 @@ package STM32_SVD.FSMC is
       --  Attribute memory space timing register 2
       PATT2 : PATT_Register;
       --  ECC result register 2
-      ECCR2 : HAL.Word;
+      ECCR2 : HAL.UInt32;
       --  PC Card/NAND Flash control register 3
       PCR3  : PCR_Register;
       --  FIFO status and interrupt register 3
@@ -419,7 +419,7 @@ package STM32_SVD.FSMC is
       --  Attribute memory space timing register 3
       PATT3 : PATT_Register;
       --  ECC result register 3
-      ECCR3 : HAL.Word;
+      ECCR3 : HAL.UInt32;
       --  PC Card/NAND Flash control register 4
       PCR4  : PCR_Register;
       --  FIFO status and interrupt register 4

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-gpio.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-gpio.ads
@@ -27,7 +27,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  MODER as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  MODER as an array
             Arr : MODER_Field_Array;
@@ -52,7 +52,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  OT as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  OT as an array
             Arr : OTYPER_OT_Field_Array;
@@ -70,7 +70,7 @@ package STM32_SVD.GPIO is
       --  Port x configuration bits (y = 0..15)
       OT             : OTYPER_OT_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -94,7 +94,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  OSPEEDR as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  OSPEEDR as an array
             Arr : OSPEEDR_Field_Array;
@@ -122,7 +122,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  PUPDR as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  PUPDR as an array
             Arr : PUPDR_Field_Array;
@@ -147,7 +147,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  IDR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  IDR as an array
             Arr : IDR_Field_Array;
@@ -165,7 +165,7 @@ package STM32_SVD.GPIO is
       --  Read-only. Port input data (y = 0..15)
       IDR            : IDR_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -186,7 +186,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  ODR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  ODR as an array
             Arr : ODR_Field_Array;
@@ -204,7 +204,7 @@ package STM32_SVD.GPIO is
       --  Port output data (y = 0..15)
       ODR            : ODR_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -225,7 +225,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  BS as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  BS as an array
             Arr : BSRR_BS_Field_Array;
@@ -249,7 +249,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  BR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  BR as an array
             Arr : BSRR_BR_Field_Array;
@@ -288,7 +288,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  LCK as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  LCK as an array
             Arr : LCKR_LCK_Field_Array;
@@ -333,7 +333,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  AFRL as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  AFRL as an array
             Arr : AFRL_Field_Array;
@@ -361,7 +361,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  AFRH as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  AFRH as an array
             Arr : AFRH_Field_Array;

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-i2c.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-i2c.ads
@@ -48,7 +48,7 @@ package STM32_SVD.I2C is
       --  Software reset
       SWRST          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -124,7 +124,7 @@ package STM32_SVD.I2C is
       --  Addressing mode (slave mode)
       ADDMODE        : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -210,7 +210,7 @@ package STM32_SVD.I2C is
       --  SMBus alert
       SMBALERT       : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -258,7 +258,7 @@ package STM32_SVD.I2C is
       --  Read-only. acket error checking register
       PEC            : SR2_PEC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -289,7 +289,7 @@ package STM32_SVD.I2C is
       --  I2C master mode selection
       F_S            : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-iwdg.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-iwdg.ads
@@ -13,14 +13,14 @@ package STM32_SVD.IWDG is
    -- Registers --
    ---------------
 
-   subtype KR_KEY_Field is HAL.Short;
+   subtype KR_KEY_Field is HAL.UInt16;
 
    --  Key register
    type KR_Register is record
       --  Write-only. Key value (write only, read 0000h)
       KEY            : KR_KEY_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-nvic.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-nvic.ads
@@ -44,7 +44,7 @@ package STM32_SVD.NVIC is
       case As_Array is
          when False =>
             --  IPR_N as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IPR_N as an array
             Arr : IPR_IPR_N_Field_Array;
@@ -84,35 +84,35 @@ package STM32_SVD.NVIC is
       --  Interrupt Controller Type Register
       ICTR  : ICTR_Register;
       --  Interrupt Set-Enable Register
-      ISER0 : HAL.Word;
+      ISER0 : HAL.UInt32;
       --  Interrupt Set-Enable Register
-      ISER1 : HAL.Word;
+      ISER1 : HAL.UInt32;
       --  Interrupt Set-Enable Register
-      ISER2 : HAL.Word;
+      ISER2 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER0 : HAL.Word;
+      ICER0 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER1 : HAL.Word;
+      ICER1 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER2 : HAL.Word;
+      ICER2 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR0 : HAL.Word;
+      ISPR0 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR1 : HAL.Word;
+      ISPR1 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR2 : HAL.Word;
+      ISPR2 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR0 : HAL.Word;
+      ICPR0 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR1 : HAL.Word;
+      ICPR1 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR2 : HAL.Word;
+      ICPR2 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR0 : HAL.Word;
+      IABR0 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR1 : HAL.Word;
+      IABR1 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR2 : HAL.Word;
+      IABR2 : HAL.UInt32;
       --  Interrupt Priority Register
       IPR0  : IPR_Register;
       --  Interrupt Priority Register

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-rng.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-rng.ads
@@ -75,7 +75,7 @@ package STM32_SVD.RNG is
       --  status register
       SR : SR_Register;
       --  data register
-      DR : HAL.Word;
+      DR : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-rtc.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-rtc.ads
@@ -267,14 +267,14 @@ package STM32_SVD.RTC is
       Reserved_23_31 at 0 range 23 .. 31;
    end record;
 
-   subtype WUTR_WUT_Field is HAL.Short;
+   subtype WUTR_WUT_Field is HAL.UInt16;
 
    --  wakeup timer register
    type WUTR_Register is record
       --  Wakeup auto-reload value bits
       WUT            : WUTR_WUT_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -444,14 +444,14 @@ package STM32_SVD.RTC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype SSR_SS_Field is HAL.Short;
+   subtype SSR_SS_Field is HAL.UInt16;
 
    --  sub second register
    type SSR_Register is record
       --  Read-only. Sub second value
       SS             : SSR_SS_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -468,7 +468,7 @@ package STM32_SVD.RTC is
       --  Write-only. Subtract a fraction of a second
       SUBFS          : SHIFTR_SUBFS_Field := 16#0#;
       --  unspecified
-      Reserved_15_30 : HAL.Short := 16#0#;
+      Reserved_15_30 : HAL.UInt16 := 16#0#;
       --  Write-only. Add one second
       ADD1S          : Boolean := False;
    end record
@@ -534,7 +534,7 @@ package STM32_SVD.RTC is
       --  Read-only. Week day units
       WDU            : TSDR_WDU_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -549,14 +549,14 @@ package STM32_SVD.RTC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype TSSSR_SS_Field is HAL.Short;
+   subtype TSSSR_SS_Field is HAL.UInt16;
 
    --  timestamp sub second register
    type TSSSR_Register is record
       --  Read-only. Sub second value
       SS             : TSSSR_SS_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -603,7 +603,7 @@ package STM32_SVD.RTC is
       --  Increase frequency of RTC by 488.5 ppm
       CALP           : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -767,45 +767,45 @@ package STM32_SVD.RTC is
       --  alarm B sub second register
       ALRMBSSR : ALRMBSSR_Register;
       --  backup register
-      BKP0R    : HAL.Word;
+      BKP0R    : HAL.UInt32;
       --  backup register
-      BKP1R    : HAL.Word;
+      BKP1R    : HAL.UInt32;
       --  backup register
-      BKP2R    : HAL.Word;
+      BKP2R    : HAL.UInt32;
       --  backup register
-      BKP3R    : HAL.Word;
+      BKP3R    : HAL.UInt32;
       --  backup register
-      BKP4R    : HAL.Word;
+      BKP4R    : HAL.UInt32;
       --  backup register
-      BKP5R    : HAL.Word;
+      BKP5R    : HAL.UInt32;
       --  backup register
-      BKP6R    : HAL.Word;
+      BKP6R    : HAL.UInt32;
       --  backup register
-      BKP7R    : HAL.Word;
+      BKP7R    : HAL.UInt32;
       --  backup register
-      BKP8R    : HAL.Word;
+      BKP8R    : HAL.UInt32;
       --  backup register
-      BKP9R    : HAL.Word;
+      BKP9R    : HAL.UInt32;
       --  backup register
-      BKP10R   : HAL.Word;
+      BKP10R   : HAL.UInt32;
       --  backup register
-      BKP11R   : HAL.Word;
+      BKP11R   : HAL.UInt32;
       --  backup register
-      BKP12R   : HAL.Word;
+      BKP12R   : HAL.UInt32;
       --  backup register
-      BKP13R   : HAL.Word;
+      BKP13R   : HAL.UInt32;
       --  backup register
-      BKP14R   : HAL.Word;
+      BKP14R   : HAL.UInt32;
       --  backup register
-      BKP15R   : HAL.Word;
+      BKP15R   : HAL.UInt32;
       --  backup register
-      BKP16R   : HAL.Word;
+      BKP16R   : HAL.UInt32;
       --  backup register
-      BKP17R   : HAL.Word;
+      BKP17R   : HAL.UInt32;
       --  backup register
-      BKP18R   : HAL.Word;
+      BKP18R   : HAL.UInt32;
       --  backup register
-      BKP19R   : HAL.Word;
+      BKP19R   : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-sdio.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-sdio.ads
@@ -455,21 +455,21 @@ package STM32_SVD.SDIO is
       --  SDI clock control register
       CLKCR   : CLKCR_Register;
       --  argument register
-      ARG     : HAL.Word;
+      ARG     : HAL.UInt32;
       --  command register
       CMD     : CMD_Register;
       --  command response register
       RESPCMD : RESPCMD_Register;
       --  response 1..4 register
-      RESP1   : HAL.Word;
+      RESP1   : HAL.UInt32;
       --  response 1..4 register
-      RESP2   : HAL.Word;
+      RESP2   : HAL.UInt32;
       --  response 1..4 register
-      RESP3   : HAL.Word;
+      RESP3   : HAL.UInt32;
       --  response 1..4 register
-      RESP4   : HAL.Word;
+      RESP4   : HAL.UInt32;
       --  data timer register
-      DTIMER  : HAL.Word;
+      DTIMER  : HAL.UInt32;
       --  data length register
       DLEN    : DLEN_Register;
       --  data control register
@@ -485,7 +485,7 @@ package STM32_SVD.SDIO is
       --  FIFO counter register
       FIFOCNT : FIFOCNT_Register;
       --  data FIFO register
-      FIFO    : HAL.Word;
+      FIFO    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-spi.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-spi.ads
@@ -46,7 +46,7 @@ package STM32_SVD.SPI is
       --  Bidirectional data mode enable
       BIDIMODE       : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -144,14 +144,14 @@ package STM32_SVD.SPI is
       Reserved_9_31 at 0 range 9 .. 31;
    end record;
 
-   subtype DR_DR_Field is HAL.Short;
+   subtype DR_DR_Field is HAL.UInt16;
 
    --  data register
    type DR_Register is record
       --  Data register
       DR             : DR_DR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -161,14 +161,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CRCPR_CRCPOLY_Field is HAL.Short;
+   subtype CRCPR_CRCPOLY_Field is HAL.UInt16;
 
    --  CRC polynomial register
    type CRCPR_Register is record
       --  CRC polynomial register
       CRCPOLY        : CRCPR_CRCPOLY_Field := 16#7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -178,14 +178,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype RXCRCR_RxCRC_Field is HAL.Short;
+   subtype RXCRCR_RxCRC_Field is HAL.UInt16;
 
    --  RX CRC register
    type RXCRCR_Register is record
       --  Read-only. Rx CRC register
       RxCRC          : RXCRCR_RxCRC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -195,14 +195,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype TXCRCR_TxCRC_Field is HAL.Short;
+   subtype TXCRCR_TxCRC_Field is HAL.UInt16;
 
    --  TX CRC register
    type TXCRCR_Register is record
       --  Read-only. Tx CRC register
       TxCRC          : TXCRCR_TxCRC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-syscfg.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-syscfg.ads
@@ -62,7 +62,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR1_EXTI_Field_Array;
@@ -81,7 +81,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR1_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -105,7 +105,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR2_EXTI_Field_Array;
@@ -124,7 +124,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR2_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -148,7 +148,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR3_EXTI_Field_Array;
@@ -167,7 +167,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR3_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -191,7 +191,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR4_EXTI_Field_Array;
@@ -210,7 +210,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR4_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-tim.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-tim.ads
@@ -129,7 +129,7 @@ package STM32_SVD.TIM is
       --  External trigger polarity
       ETP            : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -318,7 +318,7 @@ package STM32_SVD.TIM is
       --  Output Compare 2 clear enable
       OC2CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -359,7 +359,7 @@ package STM32_SVD.TIM is
       --  Input capture 2 filter
       IC2F           : CCMR1_Input_IC2F_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -402,7 +402,7 @@ package STM32_SVD.TIM is
       --  Output compare 4 clear enable
       OC4CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -443,7 +443,7 @@ package STM32_SVD.TIM is
       --  Input capture 4 filter
       IC4F           : CCMR2_Input_IC4F_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -512,14 +512,14 @@ package STM32_SVD.TIM is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype CNT_CNT_Field is HAL.Short;
+   subtype CNT_CNT_Field is HAL.UInt16;
 
    --  counter
    type CNT_Register is record
       --  counter value
       CNT            : CNT_CNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -529,14 +529,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype PSC_PSC_Field is HAL.Short;
+   subtype PSC_PSC_Field is HAL.UInt16;
 
    --  prescaler
    type PSC_Register is record
       --  Prescaler value
       PSC            : PSC_PSC_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -546,14 +546,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype ARR_ARR_Field is HAL.Short;
+   subtype ARR_ARR_Field is HAL.UInt16;
 
    --  auto-reload register
    type ARR_Register is record
       --  Auto-reload value
       ARR            : ARR_ARR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -580,14 +580,14 @@ package STM32_SVD.TIM is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype CCR1_CCR1_Field is HAL.Short;
+   subtype CCR1_CCR1_Field is HAL.UInt16;
 
    --  capture/compare register 1
    type CCR1_Register is record
       --  Capture/Compare 1 value
       CCR1           : CCR1_CCR1_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -597,14 +597,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR2_CCR2_Field is HAL.Short;
+   subtype CCR2_CCR2_Field is HAL.UInt16;
 
    --  capture/compare register 2
    type CCR2_Register is record
       --  Capture/Compare 2 value
       CCR2           : CCR2_CCR2_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -614,14 +614,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR3_CCR3_Field is HAL.Short;
+   subtype CCR3_CCR3_Field is HAL.UInt16;
 
    --  capture/compare register 3
    type CCR3_Register is record
       --  Capture/Compare value
       CCR3           : CCR3_CCR3_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -631,14 +631,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR4_CCR4_Field is HAL.Short;
+   subtype CCR4_CCR4_Field is HAL.UInt16;
 
    --  capture/compare register 4
    type CCR4_Register is record
       --  Capture/Compare value
       CCR4           : CCR4_CCR4_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -670,7 +670,7 @@ package STM32_SVD.TIM is
       --  Main output enable
       MOE            : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -711,14 +711,14 @@ package STM32_SVD.TIM is
       Reserved_13_31 at 0 range 13 .. 31;
    end record;
 
-   subtype DMAR_DMAB_Field is HAL.Short;
+   subtype DMAR_DMAB_Field is HAL.UInt16;
 
    --  DMA address for full transfer
    type DMAR_Register is record
       --  DMA register for burst accesses
       DMAB           : DMAR_DMAB_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -913,7 +913,7 @@ package STM32_SVD.TIM is
       --  O24CE
       O24CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -967,7 +967,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -992,8 +992,8 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CNT_CNT_L_Field is HAL.Short;
-   subtype CNT_CNT_H_Field is HAL.Short;
+   subtype CNT_CNT_L_Field is HAL.UInt16;
+   subtype CNT_CNT_H_Field is HAL.UInt16;
 
    --  counter
    type CNT_Register_1 is record
@@ -1010,8 +1010,8 @@ package STM32_SVD.TIM is
       CNT_H at 0 range 16 .. 31;
    end record;
 
-   subtype ARR_ARR_L_Field is HAL.Short;
-   subtype ARR_ARR_H_Field is HAL.Short;
+   subtype ARR_ARR_L_Field is HAL.UInt16;
+   subtype ARR_ARR_H_Field is HAL.UInt16;
 
    --  auto-reload register
    type ARR_Register_1 is record
@@ -1028,8 +1028,8 @@ package STM32_SVD.TIM is
       ARR_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR1_CCR1_L_Field is HAL.Short;
-   subtype CCR1_CCR1_H_Field is HAL.Short;
+   subtype CCR1_CCR1_L_Field is HAL.UInt16;
+   subtype CCR1_CCR1_H_Field is HAL.UInt16;
 
    --  capture/compare register 1
    type CCR1_Register_1 is record
@@ -1046,8 +1046,8 @@ package STM32_SVD.TIM is
       CCR1_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR2_CCR2_L_Field is HAL.Short;
-   subtype CCR2_CCR2_H_Field is HAL.Short;
+   subtype CCR2_CCR2_L_Field is HAL.UInt16;
+   subtype CCR2_CCR2_H_Field is HAL.UInt16;
 
    --  capture/compare register 2
    type CCR2_Register_1 is record
@@ -1064,8 +1064,8 @@ package STM32_SVD.TIM is
       CCR2_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR3_CCR3_L_Field is HAL.Short;
-   subtype CCR3_CCR3_H_Field is HAL.Short;
+   subtype CCR3_CCR3_L_Field is HAL.UInt16;
+   subtype CCR3_CCR3_H_Field is HAL.UInt16;
 
    --  capture/compare register 3
    type CCR3_Register_1 is record
@@ -1082,8 +1082,8 @@ package STM32_SVD.TIM is
       CCR3_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR4_CCR4_L_Field is HAL.Short;
-   subtype CCR4_CCR4_H_Field is HAL.Short;
+   subtype CCR4_CCR4_L_Field is HAL.UInt16;
+   subtype CCR4_CCR4_H_Field is HAL.UInt16;
 
    --  capture/compare register 4
    type CCR4_Register_1 is record

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-usart.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-usart.ads
@@ -79,7 +79,7 @@ package STM32_SVD.USART is
       --  mantissa of USARTDIV
       DIV_Mantissa   : BRR_DIV_Mantissa_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -125,7 +125,7 @@ package STM32_SVD.USART is
       --  Oversampling mode
       OVER8          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -370,7 +370,7 @@ package STM32_SVD.USART is
       --  Guard time value
       GT             : GTPR_GT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-usb_otg_fs.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-usb_otg_fs.ads
@@ -180,8 +180,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype FS_DAINT_IEPINT_Field is HAL.Short;
-   subtype FS_DAINT_OEPINT_Field is HAL.Short;
+   subtype FS_DAINT_IEPINT_Field is HAL.UInt16;
+   subtype FS_DAINT_OEPINT_Field is HAL.UInt16;
 
    --  OTG_FS device all endpoints interrupt register (OTG_FS_DAINT)
    type FS_DAINT_Register is record
@@ -198,8 +198,8 @@ package STM32_SVD.USB_OTG_FS is
       OEPINT at 0 range 16 .. 31;
    end record;
 
-   subtype FS_DAINTMSK_IEPM_Field is HAL.Short;
-   subtype FS_DAINTMSK_OEPM_Field is HAL.Short;
+   subtype FS_DAINTMSK_IEPM_Field is HAL.UInt16;
+   subtype FS_DAINTMSK_OEPM_Field is HAL.UInt16;
 
    --  OTG_FS all endpoints interrupt mask register (OTG_FS_DAINTMSK)
    type FS_DAINTMSK_Register is record
@@ -216,14 +216,14 @@ package STM32_SVD.USB_OTG_FS is
       OEPM at 0 range 16 .. 31;
    end record;
 
-   subtype DVBUSDIS_VBUSDT_Field is HAL.Short;
+   subtype DVBUSDIS_VBUSDT_Field is HAL.UInt16;
 
    --  OTG_FS device VBUS discharge time register
    type DVBUSDIS_Register is record
       --  Device VBUS discharge time
       VBUSDT         : DVBUSDIS_VBUSDT_Field := 16#17D7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -250,14 +250,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_12_31 at 0 range 12 .. 31;
    end record;
 
-   subtype DIEPEMPMSK_INEPTXFEM_Field is HAL.Short;
+   subtype DIEPEMPMSK_INEPTXFEM_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint FIFO empty interrupt mask register
    type DIEPEMPMSK_Register is record
       --  IN EP Tx FIFO empty interrupt mask bits
       INEPTXFEM      : DIEPEMPMSK_INEPTXFEM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -382,14 +382,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype DTXFSTS_INEPTFSAV_Field is HAL.Short;
+   subtype DTXFSTS_INEPTFSAV_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint transmit FIFO status register
    type DTXFSTS_Register is record
       --  Read-only. IN endpoint TxFIFO space available
       INEPTFSAV      : DTXFSTS_INEPTFSAV_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1196,14 +1196,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_25_31 at 0 range 25 .. 31;
    end record;
 
-   subtype FS_GRXFSIZ_RXFD_Field is HAL.Short;
+   subtype FS_GRXFSIZ_RXFD_Field is HAL.UInt16;
 
    --  OTG_FS Receive FIFO size register (OTG_FS_GRXFSIZ)
    type FS_GRXFSIZ_Register is record
       --  RxFIFO depth
       RXFD           : FS_GRXFSIZ_RXFD_Field := 16#200#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1213,8 +1213,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype FS_GNPTXFSIZ_Device_TX0FSA_Field is HAL.Short;
-   subtype FS_GNPTXFSIZ_Device_TX0FD_Field is HAL.Short;
+   subtype FS_GNPTXFSIZ_Device_TX0FSA_Field is HAL.UInt16;
+   subtype FS_GNPTXFSIZ_Device_TX0FD_Field is HAL.UInt16;
 
    --  OTG_FS non-periodic transmit FIFO size register (Device mode)
    type FS_GNPTXFSIZ_Device_Register is record
@@ -1231,8 +1231,8 @@ package STM32_SVD.USB_OTG_FS is
       TX0FD  at 0 range 16 .. 31;
    end record;
 
-   subtype FS_GNPTXFSIZ_Host_NPTXFSA_Field is HAL.Short;
-   subtype FS_GNPTXFSIZ_Host_NPTXFD_Field is HAL.Short;
+   subtype FS_GNPTXFSIZ_Host_NPTXFSA_Field is HAL.UInt16;
+   subtype FS_GNPTXFSIZ_Host_NPTXFD_Field is HAL.UInt16;
 
    --  OTG_FS non-periodic transmit FIFO size register (Host mode)
    type FS_GNPTXFSIZ_Host_Register is record
@@ -1249,7 +1249,7 @@ package STM32_SVD.USB_OTG_FS is
       NPTXFD  at 0 range 16 .. 31;
    end record;
 
-   subtype FS_GNPTXSTS_NPTXFSAV_Field is HAL.Short;
+   subtype FS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
    subtype FS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
    subtype FS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
@@ -1278,7 +1278,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS general core configuration register (OTG_FS_GCCFG)
    type FS_GCCFG_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  Power down
       PWRDWN         : Boolean := False;
       --  unspecified
@@ -1305,8 +1305,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype FS_HPTXFSIZ_PTXSA_Field is HAL.Short;
-   subtype FS_HPTXFSIZ_PTXFSIZ_Field is HAL.Short;
+   subtype FS_HPTXFSIZ_PTXSA_Field is HAL.UInt16;
+   subtype FS_HPTXFSIZ_PTXFSIZ_Field is HAL.UInt16;
 
    --  OTG_FS Host periodic transmit FIFO size register (OTG_FS_HPTXFSIZ)
    type FS_HPTXFSIZ_Register is record
@@ -1323,8 +1323,8 @@ package STM32_SVD.USB_OTG_FS is
       PTXFSIZ at 0 range 16 .. 31;
    end record;
 
-   subtype FS_DIEPTXF_INEPTXSA_Field is HAL.Short;
-   subtype FS_DIEPTXF_INEPTXFD_Field is HAL.Short;
+   subtype FS_DIEPTXF_INEPTXSA_Field is HAL.UInt16;
+   subtype FS_DIEPTXF_INEPTXFD_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint transmit FIFO size register (OTG_FS_DIEPTXF2)
    type FS_DIEPTXF_Register is record
@@ -1361,14 +1361,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype HFIR_FRIVL_Field is HAL.Short;
+   subtype HFIR_FRIVL_Field is HAL.UInt16;
 
    --  OTG_FS Host frame interval register
    type HFIR_Register is record
       --  Frame interval
       FRIVL          : HFIR_FRIVL_Field := 16#EA60#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1378,8 +1378,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype FS_HFNUM_FRNUM_Field is HAL.Short;
-   subtype FS_HFNUM_FTREM_Field is HAL.Short;
+   subtype FS_HFNUM_FRNUM_Field is HAL.UInt16;
+   subtype FS_HFNUM_FTREM_Field is HAL.UInt16;
 
    --  OTG_FS host frame number/frame time remaining register (OTG_FS_HFNUM)
    type FS_HFNUM_Register is record
@@ -1396,7 +1396,7 @@ package STM32_SVD.USB_OTG_FS is
       FTREM at 0 range 16 .. 31;
    end record;
 
-   subtype FS_HPTXSTS_PTXFSAVL_Field is HAL.Short;
+   subtype FS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
    subtype FS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
    subtype FS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
 
@@ -1419,14 +1419,14 @@ package STM32_SVD.USB_OTG_FS is
       PTXQTOP  at 0 range 24 .. 31;
    end record;
 
-   subtype HAINT_HAINT_Field is HAL.Short;
+   subtype HAINT_HAINT_Field is HAL.UInt16;
 
    --  OTG_FS Host all channels interrupt register
    type HAINT_Register is record
       --  Read-only. Channel interrupts
       HAINT          : HAINT_HAINT_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1436,14 +1436,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype HAINTMSK_HAINTM_Field is HAL.Short;
+   subtype HAINTMSK_HAINTM_Field is HAL.UInt16;
 
    --  OTG_FS host all channels interrupt mask register
    type HAINTMSK_Register is record
       --  Channel interrupt mask
       HAINTM         : HAINTMSK_HAINTM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1862,7 +1862,7 @@ package STM32_SVD.USB_OTG_FS is
       --  OTG_FS general core configuration register (OTG_FS_GCCFG)
       FS_GCCFG            : FS_GCCFG_Register;
       --  core ID register
-      FS_CID              : HAL.Word;
+      FS_CID              : HAL.UInt32;
       --  OTG_FS Host periodic transmit FIFO size register (OTG_FS_HPTXFSIZ)
       FS_HPTXFSIZ         : FS_HPTXFSIZ_Register;
       --  OTG_FS device IN endpoint transmit FIFO size register

--- a/ARM/STM32/svd/stm32f40x/stm32_svd-usb_otg_hs.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-usb_otg_hs.ads
@@ -209,8 +209,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_10_31 at 0 range 10 .. 31;
    end record;
 
-   subtype OTG_HS_DAINT_IEPINT_Field is HAL.Short;
-   subtype OTG_HS_DAINT_OEPINT_Field is HAL.Short;
+   subtype OTG_HS_DAINT_IEPINT_Field is HAL.UInt16;
+   subtype OTG_HS_DAINT_OEPINT_Field is HAL.UInt16;
 
    --  OTG_HS device all endpoints interrupt register
    type OTG_HS_DAINT_Register is record
@@ -227,8 +227,8 @@ package STM32_SVD.USB_OTG_HS is
       OEPINT at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DAINTMSK_IEPM_Field is HAL.Short;
-   subtype OTG_HS_DAINTMSK_OEPM_Field is HAL.Short;
+   subtype OTG_HS_DAINTMSK_IEPM_Field is HAL.UInt16;
+   subtype OTG_HS_DAINTMSK_OEPM_Field is HAL.UInt16;
 
    --  OTG_HS all endpoints interrupt mask register
    type OTG_HS_DAINTMSK_Register is record
@@ -245,14 +245,14 @@ package STM32_SVD.USB_OTG_HS is
       OEPM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DVBUSDIS_VBUSDT_Field is HAL.Short;
+   subtype OTG_HS_DVBUSDIS_VBUSDT_Field is HAL.UInt16;
 
    --  OTG_HS device VBUS discharge time register
    type OTG_HS_DVBUSDIS_Register is record
       --  Device VBUS discharge time
       VBUSDT         : OTG_HS_DVBUSDIS_VBUSDT_Field := 16#17D7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -318,14 +318,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype OTG_HS_DIEPEMPMSK_INEPTXFEM_Field is HAL.Short;
+   subtype OTG_HS_DIEPEMPMSK_INEPTXFEM_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint FIFO empty interrupt mask register
    type OTG_HS_DIEPEMPMSK_Register is record
       --  IN EP Tx FIFO empty interrupt mask bits
       INEPTXFEM      : OTG_HS_DIEPEMPMSK_INEPTXFEM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -621,14 +621,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype OTG_HS_DTXFSTS_INEPTFSAV_Field is HAL.Short;
+   subtype OTG_HS_DTXFSTS_INEPTFSAV_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint transmit FIFO status register
    type OTG_HS_DTXFSTS_Register is record
       --  Read-only. IN endpoint TxFIFO space avail
       INEPTFSAV      : OTG_HS_DTXFSTS_INEPTFSAV_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1435,14 +1435,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_25_31 at 0 range 25 .. 31;
    end record;
 
-   subtype OTG_HS_GRXFSIZ_RXFD_Field is HAL.Short;
+   subtype OTG_HS_GRXFSIZ_RXFD_Field is HAL.UInt16;
 
    --  OTG_HS Receive FIFO size register
    type OTG_HS_GRXFSIZ_Register is record
       --  RxFIFO depth
       RXFD           : OTG_HS_GRXFSIZ_RXFD_Field := 16#200#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1452,8 +1452,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_GNPTXFSIZ_Host_NPTXFSA_Field is HAL.Short;
-   subtype OTG_HS_GNPTXFSIZ_Host_NPTXFD_Field is HAL.Short;
+   subtype OTG_HS_GNPTXFSIZ_Host_NPTXFSA_Field is HAL.UInt16;
+   subtype OTG_HS_GNPTXFSIZ_Host_NPTXFD_Field is HAL.UInt16;
 
    --  OTG_HS nonperiodic transmit FIFO size register (host mode)
    type OTG_HS_GNPTXFSIZ_Host_Register is record
@@ -1470,8 +1470,8 @@ package STM32_SVD.USB_OTG_HS is
       NPTXFD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_TX0FSIZ_Peripheral_TX0FSA_Field is HAL.Short;
-   subtype OTG_HS_TX0FSIZ_Peripheral_TX0FD_Field is HAL.Short;
+   subtype OTG_HS_TX0FSIZ_Peripheral_TX0FSA_Field is HAL.UInt16;
+   subtype OTG_HS_TX0FSIZ_Peripheral_TX0FD_Field is HAL.UInt16;
 
    --  Endpoint 0 transmit FIFO size (peripheral mode)
    type OTG_HS_TX0FSIZ_Peripheral_Register is record
@@ -1488,7 +1488,7 @@ package STM32_SVD.USB_OTG_HS is
       TX0FD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.Short;
+   subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
    subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
    subtype OTG_HS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
@@ -1516,7 +1516,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS general core configuration register
    type OTG_HS_GCCFG_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  Power down
       PWRDWN         : Boolean := False;
       --  Enable I2C bus connection for the external I2C PHY interface
@@ -1546,8 +1546,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_22_31 at 0 range 22 .. 31;
    end record;
 
-   subtype OTG_HS_HPTXFSIZ_PTXSA_Field is HAL.Short;
-   subtype OTG_HS_HPTXFSIZ_PTXFD_Field is HAL.Short;
+   subtype OTG_HS_HPTXFSIZ_PTXSA_Field is HAL.UInt16;
+   subtype OTG_HS_HPTXFSIZ_PTXFD_Field is HAL.UInt16;
 
    --  OTG_HS Host periodic transmit FIFO size register
    type OTG_HS_HPTXFSIZ_Register is record
@@ -1564,8 +1564,8 @@ package STM32_SVD.USB_OTG_HS is
       PTXFD at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DIEPTXF_INEPTXSA_Field is HAL.Short;
-   subtype OTG_HS_DIEPTXF_INEPTXFD_Field is HAL.Short;
+   subtype OTG_HS_DIEPTXF_INEPTXSA_Field is HAL.UInt16;
+   subtype OTG_HS_DIEPTXF_INEPTXFD_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint transmit FIFO size register
    type OTG_HS_DIEPTXF_Register is record
@@ -1602,14 +1602,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype OTG_HS_HFIR_FRIVL_Field is HAL.Short;
+   subtype OTG_HS_HFIR_FRIVL_Field is HAL.UInt16;
 
    --  OTG_HS Host frame interval register
    type OTG_HS_HFIR_Register is record
       --  Frame interval
       FRIVL          : OTG_HS_HFIR_FRIVL_Field := 16#EA60#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1619,8 +1619,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HFNUM_FRNUM_Field is HAL.Short;
-   subtype OTG_HS_HFNUM_FTREM_Field is HAL.Short;
+   subtype OTG_HS_HFNUM_FRNUM_Field is HAL.UInt16;
+   subtype OTG_HS_HFNUM_FTREM_Field is HAL.UInt16;
 
    --  OTG_HS host frame number/frame time remaining register
    type OTG_HS_HFNUM_Register is record
@@ -1637,7 +1637,7 @@ package STM32_SVD.USB_OTG_HS is
       FTREM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.Short;
+   subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
    subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
    subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
 
@@ -1659,14 +1659,14 @@ package STM32_SVD.USB_OTG_HS is
       PTXQTOP  at 0 range 24 .. 31;
    end record;
 
-   subtype OTG_HS_HAINT_HAINT_Field is HAL.Short;
+   subtype OTG_HS_HAINT_HAINT_Field is HAL.UInt16;
 
    --  OTG_HS Host all channels interrupt register
    type OTG_HS_HAINT_Register is record
       --  Read-only. Channel interrupts
       HAINT          : OTG_HS_HAINT_HAINT_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1676,14 +1676,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HAINTMSK_HAINTM_Field is HAL.Short;
+   subtype OTG_HS_HAINTMSK_HAINTM_Field is HAL.UInt16;
 
    --  OTG_HS host all channels interrupt mask register
    type OTG_HS_HAINTMSK_Register is record
       --  Channel interrupt mask
       HAINTM         : OTG_HS_HAINTMSK_HAINTM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2012,7 +2012,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device IN endpoint 0 transfer size register
       OTG_HS_DIEPTSIZ0    : OTG_HS_DIEPTSIZ0_Register;
       --  OTG_HS device endpoint-1 DMA address register
-      OTG_HS_DIEPDMA1     : HAL.Word;
+      OTG_HS_DIEPDMA1     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS0     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-1 control register
@@ -2022,7 +2022,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ1    : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-2 DMA address register
-      OTG_HS_DIEPDMA2     : HAL.Word;
+      OTG_HS_DIEPDMA2     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS1     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-2 control register
@@ -2032,7 +2032,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ2    : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-3 DMA address register
-      OTG_HS_DIEPDMA3     : HAL.Word;
+      OTG_HS_DIEPDMA3     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS2     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-3 control register
@@ -2042,7 +2042,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ3    : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-4 DMA address register
-      OTG_HS_DIEPDMA4     : HAL.Word;
+      OTG_HS_DIEPDMA4     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS3     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-4 control register
@@ -2052,7 +2052,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ4    : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-5 DMA address register
-      OTG_HS_DIEPDMA5     : HAL.Word;
+      OTG_HS_DIEPDMA5     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS4     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-5 control register
@@ -2212,7 +2212,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS general core configuration register
       OTG_HS_GCCFG              : OTG_HS_GCCFG_Register;
       --  OTG_HS core ID register
-      OTG_HS_CID                : HAL.Word;
+      OTG_HS_CID                : HAL.UInt32;
       --  OTG_HS Host periodic transmit FIFO size register
       OTG_HS_HPTXFSIZ           : OTG_HS_HPTXFSIZ_Register;
       --  OTG_HS device IN endpoint transmit FIFO size register
@@ -2310,7 +2310,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-11 transfer size register
       OTG_HS_HCTSIZ0    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-0 DMA address register
-      OTG_HS_HCDMA0     : HAL.Word;
+      OTG_HS_HCDMA0     : HAL.UInt32;
       --  OTG_HS host channel-1 characteristics register
       OTG_HS_HCCHAR1    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-1 split control register
@@ -2322,7 +2322,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-1 transfer size register
       OTG_HS_HCTSIZ1    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-1 DMA address register
-      OTG_HS_HCDMA1     : HAL.Word;
+      OTG_HS_HCDMA1     : HAL.UInt32;
       --  OTG_HS host channel-2 characteristics register
       OTG_HS_HCCHAR2    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-2 split control register
@@ -2334,7 +2334,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-2 transfer size register
       OTG_HS_HCTSIZ2    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-2 DMA address register
-      OTG_HS_HCDMA2     : HAL.Word;
+      OTG_HS_HCDMA2     : HAL.UInt32;
       --  OTG_HS host channel-3 characteristics register
       OTG_HS_HCCHAR3    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-3 split control register
@@ -2346,7 +2346,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-3 transfer size register
       OTG_HS_HCTSIZ3    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-3 DMA address register
-      OTG_HS_HCDMA3     : HAL.Word;
+      OTG_HS_HCDMA3     : HAL.UInt32;
       --  OTG_HS host channel-4 characteristics register
       OTG_HS_HCCHAR4    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-4 split control register
@@ -2358,7 +2358,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-4 transfer size register
       OTG_HS_HCTSIZ4    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-4 DMA address register
-      OTG_HS_HCDMA4     : HAL.Word;
+      OTG_HS_HCDMA4     : HAL.UInt32;
       --  OTG_HS host channel-5 characteristics register
       OTG_HS_HCCHAR5    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-5 split control register
@@ -2370,7 +2370,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-5 transfer size register
       OTG_HS_HCTSIZ5    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-5 DMA address register
-      OTG_HS_HCDMA5     : HAL.Word;
+      OTG_HS_HCDMA5     : HAL.UInt32;
       --  OTG_HS host channel-6 characteristics register
       OTG_HS_HCCHAR6    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-6 split control register
@@ -2382,7 +2382,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-6 transfer size register
       OTG_HS_HCTSIZ6    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-6 DMA address register
-      OTG_HS_HCDMA6     : HAL.Word;
+      OTG_HS_HCDMA6     : HAL.UInt32;
       --  OTG_HS host channel-7 characteristics register
       OTG_HS_HCCHAR7    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-7 split control register
@@ -2394,7 +2394,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-7 transfer size register
       OTG_HS_HCTSIZ7    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-7 DMA address register
-      OTG_HS_HCDMA7     : HAL.Word;
+      OTG_HS_HCDMA7     : HAL.UInt32;
       --  OTG_HS host channel-8 characteristics register
       OTG_HS_HCCHAR8    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-8 split control register
@@ -2406,7 +2406,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-8 transfer size register
       OTG_HS_HCTSIZ8    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-8 DMA address register
-      OTG_HS_HCDMA8     : HAL.Word;
+      OTG_HS_HCDMA8     : HAL.UInt32;
       --  OTG_HS host channel-9 characteristics register
       OTG_HS_HCCHAR9    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-9 split control register
@@ -2418,7 +2418,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-9 transfer size register
       OTG_HS_HCTSIZ9    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-9 DMA address register
-      OTG_HS_HCDMA9     : HAL.Word;
+      OTG_HS_HCDMA9     : HAL.UInt32;
       --  OTG_HS host channel-10 characteristics register
       OTG_HS_HCCHAR10   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-10 split control register
@@ -2430,7 +2430,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-10 transfer size register
       OTG_HS_HCTSIZ10   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-10 DMA address register
-      OTG_HS_HCDMA10    : HAL.Word;
+      OTG_HS_HCDMA10    : HAL.UInt32;
       --  OTG_HS host channel-11 characteristics register
       OTG_HS_HCCHAR11   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-11 split control register
@@ -2442,7 +2442,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-11 transfer size register
       OTG_HS_HCTSIZ11   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-11 DMA address register
-      OTG_HS_HCDMA11    : HAL.Word;
+      OTG_HS_HCDMA11    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-adc.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-adc.ads
@@ -530,14 +530,14 @@ package STM32_SVD.ADC is
       Reserved_22_31 at 0 range 22 .. 31;
    end record;
 
-   subtype JDR_JDATA_Field is HAL.Short;
+   subtype JDR_JDATA_Field is HAL.UInt16;
 
    --  injected data register x
    type JDR_Register is record
       --  Read-only. Injected data
       JDATA          : JDR_JDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -547,14 +547,14 @@ package STM32_SVD.ADC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DR_DATA_Field is HAL.Short;
+   subtype DR_DATA_Field is HAL.UInt16;
 
    --  regular data register
    type DR_Register is record
       --  Read-only. Regular data
       DATA           : DR_DATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -684,7 +684,7 @@ package STM32_SVD.ADC is
    end record;
 
    --  CDR_DATA array element
-   subtype CDR_DATA_Element is HAL.Short;
+   subtype CDR_DATA_Element is HAL.UInt16;
 
    --  CDR_DATA array
    type CDR_DATA_Field_Array is array (1 .. 2) of CDR_DATA_Element
@@ -697,7 +697,7 @@ package STM32_SVD.ADC is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : CDR_DATA_Field_Array;

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-can.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-can.ads
@@ -446,7 +446,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT0R_DLC_Field is HAL.UInt4;
-   subtype TDT0R_TIME_Field is HAL.Short;
+   subtype TDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT0R_Register is record
@@ -486,7 +486,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL0R_DATA_Field_Array;
@@ -514,7 +514,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH0R_DATA_Field_Array;
@@ -556,7 +556,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT1R_DLC_Field is HAL.UInt4;
-   subtype TDT1R_TIME_Field is HAL.Short;
+   subtype TDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT1R_Register is record
@@ -596,7 +596,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL1R_DATA_Field_Array;
@@ -624,7 +624,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH1R_DATA_Field_Array;
@@ -666,7 +666,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT2R_DLC_Field is HAL.UInt4;
-   subtype TDT2R_TIME_Field is HAL.Short;
+   subtype TDT2R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT2R_Register is record
@@ -706,7 +706,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL2R_DATA_Field_Array;
@@ -734,7 +734,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH2R_DATA_Field_Array;
@@ -777,7 +777,7 @@ package STM32_SVD.CAN is
 
    subtype RDT0R_DLC_Field is HAL.UInt4;
    subtype RDT0R_FMI_Field is HAL.Byte;
-   subtype RDT0R_TIME_Field is HAL.Short;
+   subtype RDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
    type RDT0R_Register is record
@@ -814,7 +814,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDL0R_DATA_Field_Array;
@@ -842,7 +842,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDH0R_DATA_Field_Array;
@@ -885,7 +885,7 @@ package STM32_SVD.CAN is
 
    subtype RDT1R_DLC_Field is HAL.UInt4;
    subtype RDT1R_FMI_Field is HAL.Byte;
-   subtype RDT1R_TIME_Field is HAL.Short;
+   subtype RDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
    type RDT1R_Register is record
@@ -922,7 +922,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDL1R_DATA_Field_Array;
@@ -950,7 +950,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDH1R_DATA_Field_Array;
@@ -1154,7 +1154,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F0R_FB_Field_Array;
@@ -1179,7 +1179,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F1R_FB_Field_Array;
@@ -1204,7 +1204,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F2R_FB_Field_Array;
@@ -1229,7 +1229,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F3R_FB_Field_Array;
@@ -1254,7 +1254,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F4R_FB_Field_Array;
@@ -1279,7 +1279,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F5R_FB_Field_Array;
@@ -1304,7 +1304,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F6R_FB_Field_Array;
@@ -1329,7 +1329,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F7R_FB_Field_Array;
@@ -1354,7 +1354,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F8R_FB_Field_Array;
@@ -1379,7 +1379,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F9R_FB_Field_Array;
@@ -1404,7 +1404,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F10R_FB_Field_Array;
@@ -1429,7 +1429,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F11R_FB_Field_Array;
@@ -1454,7 +1454,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F12R_FB_Field_Array;
@@ -1479,7 +1479,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F13R_FB_Field_Array;
@@ -1504,7 +1504,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F14R_FB_Field_Array;
@@ -1529,7 +1529,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F15R_FB_Field_Array;
@@ -1554,7 +1554,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F16R_FB_Field_Array;
@@ -1579,7 +1579,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F17R_FB_Field_Array;
@@ -1604,7 +1604,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F18R_FB_Field_Array;
@@ -1629,7 +1629,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F19R_FB_Field_Array;
@@ -1654,7 +1654,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F20R_FB_Field_Array;
@@ -1679,7 +1679,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F21R_FB_Field_Array;
@@ -1704,7 +1704,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F22R_FB_Field_Array;
@@ -1729,7 +1729,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F23R_FB_Field_Array;
@@ -1754,7 +1754,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F24R_FB_Field_Array;
@@ -1779,7 +1779,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F25R_FB_Field_Array;
@@ -1804,7 +1804,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F26R_FB_Field_Array;
@@ -1829,7 +1829,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F27R_FB_Field_Array;

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-crc.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-crc.ads
@@ -52,7 +52,7 @@ package STM32_SVD.CRC is
    --  Cryptographic processor
    type CRC_Peripheral is record
       --  Data register
-      DR  : HAL.Word;
+      DR  : HAL.UInt32;
       --  Independent Data register
       IDR : IDR_Register;
       --  Control register

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-dac.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-dac.ads
@@ -149,7 +149,7 @@ package STM32_SVD.DAC is
       --  DAC channel1 12-bit left-aligned data
       DACC1DHR       : DHR12L1_DACC1DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -203,7 +203,7 @@ package STM32_SVD.DAC is
       --  DAC channel2 12-bit left-aligned data
       DACC2DHR       : DHR12L2_DACC2DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -289,7 +289,7 @@ package STM32_SVD.DAC is
       --  DAC channel2 8-bit right-aligned data
       DACC2DHR       : DHR8RD_DACC2DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-dbg.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-dbg.ads
@@ -14,7 +14,7 @@ package STM32_SVD.DBG is
    ---------------
 
    subtype DBGMCU_IDCODE_DEV_ID_Field is HAL.UInt12;
-   subtype DBGMCU_IDCODE_REV_ID_Field is HAL.Short;
+   subtype DBGMCU_IDCODE_REV_ID_Field is HAL.UInt16;
 
    --  IDCODE
    type DBGMCU_IDCODE_Register is record

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-dcmi.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-dcmi.ads
@@ -307,7 +307,7 @@ package STM32_SVD.DCMI is
       case As_Array is
          when False =>
             --  Byte as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  Byte as an array
             Arr : DR_Byte_Field_Array;

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-dma.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-dma.ads
@@ -441,14 +441,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S0NDTR_NDT_Field is HAL.Short;
+   subtype S0NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S0NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S0NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -568,14 +568,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S1NDTR_NDT_Field is HAL.Short;
+   subtype S1NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S1NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S1NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -695,14 +695,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S2NDTR_NDT_Field is HAL.Short;
+   subtype S2NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S2NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S2NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -822,14 +822,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S3NDTR_NDT_Field is HAL.Short;
+   subtype S3NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S3NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S3NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -949,14 +949,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S4NDTR_NDT_Field is HAL.Short;
+   subtype S4NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S4NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S4NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1076,14 +1076,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S5NDTR_NDT_Field is HAL.Short;
+   subtype S5NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S5NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S5NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1203,14 +1203,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S6NDTR_NDT_Field is HAL.Short;
+   subtype S6NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S6NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S6NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1330,14 +1330,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S7NDTR_NDT_Field is HAL.Short;
+   subtype S7NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S7NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S7NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1396,11 +1396,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S0NDTR : S0NDTR_Register;
       --  stream x peripheral address register
-      S0PAR  : HAL.Word;
+      S0PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S0M0AR : HAL.Word;
+      S0M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S0M1AR : HAL.Word;
+      S0M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S0FCR  : S0FCR_Register;
       --  stream x configuration register
@@ -1408,11 +1408,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S1NDTR : S1NDTR_Register;
       --  stream x peripheral address register
-      S1PAR  : HAL.Word;
+      S1PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S1M0AR : HAL.Word;
+      S1M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S1M1AR : HAL.Word;
+      S1M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S1FCR  : S1FCR_Register;
       --  stream x configuration register
@@ -1420,11 +1420,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S2NDTR : S2NDTR_Register;
       --  stream x peripheral address register
-      S2PAR  : HAL.Word;
+      S2PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S2M0AR : HAL.Word;
+      S2M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S2M1AR : HAL.Word;
+      S2M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S2FCR  : S2FCR_Register;
       --  stream x configuration register
@@ -1432,11 +1432,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S3NDTR : S3NDTR_Register;
       --  stream x peripheral address register
-      S3PAR  : HAL.Word;
+      S3PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S3M0AR : HAL.Word;
+      S3M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S3M1AR : HAL.Word;
+      S3M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S3FCR  : S3FCR_Register;
       --  stream x configuration register
@@ -1444,11 +1444,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S4NDTR : S4NDTR_Register;
       --  stream x peripheral address register
-      S4PAR  : HAL.Word;
+      S4PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S4M0AR : HAL.Word;
+      S4M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S4M1AR : HAL.Word;
+      S4M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S4FCR  : S4FCR_Register;
       --  stream x configuration register
@@ -1456,11 +1456,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S5NDTR : S5NDTR_Register;
       --  stream x peripheral address register
-      S5PAR  : HAL.Word;
+      S5PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S5M0AR : HAL.Word;
+      S5M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S5M1AR : HAL.Word;
+      S5M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S5FCR  : S5FCR_Register;
       --  stream x configuration register
@@ -1468,11 +1468,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S6NDTR : S6NDTR_Register;
       --  stream x peripheral address register
-      S6PAR  : HAL.Word;
+      S6PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S6M0AR : HAL.Word;
+      S6M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S6M1AR : HAL.Word;
+      S6M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S6FCR  : S6FCR_Register;
       --  stream x configuration register
@@ -1480,11 +1480,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S7NDTR : S7NDTR_Register;
       --  stream x peripheral address register
-      S7PAR  : HAL.Word;
+      S7PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S7M0AR : HAL.Word;
+      S7M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S7M1AR : HAL.Word;
+      S7M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S7FCR  : S7FCR_Register;
    end record

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-dma2d.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-dma2d.ads
@@ -343,7 +343,7 @@ package STM32_SVD.DMA2D is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype NLR_NL_Field is HAL.Short;
+   subtype NLR_NL_Field is HAL.UInt16;
    subtype NLR_PL_Field is HAL.UInt14;
 
    --  number of line register
@@ -364,14 +364,14 @@ package STM32_SVD.DMA2D is
       Reserved_30_31 at 0 range 30 .. 31;
    end record;
 
-   subtype LWR_LW_Field is HAL.Short;
+   subtype LWR_LW_Field is HAL.UInt16;
 
    --  line watermark register
    type LWR_Register is record
       --  Line watermark
       LW             : LWR_LW_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -392,7 +392,7 @@ package STM32_SVD.DMA2D is
       --  Dead Time
       DT             : AMTCR_DT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -469,11 +469,11 @@ package STM32_SVD.DMA2D is
       --  interrupt flag clear register
       IFCR    : IFCR_Register;
       --  foreground memory address register
-      FGMAR   : HAL.Word;
+      FGMAR   : HAL.UInt32;
       --  foreground offset register
       FGOR    : FGOR_Register;
       --  background memory address register
-      BGMAR   : HAL.Word;
+      BGMAR   : HAL.UInt32;
       --  background offset register
       BGOR    : BGOR_Register;
       --  foreground PFC control register
@@ -485,15 +485,15 @@ package STM32_SVD.DMA2D is
       --  background color register
       BGCOLR  : BGCOLR_Register;
       --  foreground CLUT memory address register
-      FGCMAR  : HAL.Word;
+      FGCMAR  : HAL.UInt32;
       --  background CLUT memory address register
-      BGCMAR  : HAL.Word;
+      BGCMAR  : HAL.UInt32;
       --  output PFC control register
       OPFCCR  : OPFCCR_Register;
       --  output color register
       OCOLR   : OCOLR_Register;
       --  output memory address register
-      OMAR    : HAL.Word;
+      OMAR    : HAL.UInt32;
       --  output offset register
       OOR     : OOR_Register;
       --  number of line register

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-ethernet.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-ethernet.ads
@@ -277,7 +277,7 @@ package STM32_SVD.Ethernet is
       Reserved_17_31 at 0 range 17 .. 31;
    end record;
 
-   subtype DMAMFBOCR_MFC_Field is HAL.Short;
+   subtype DMAMFBOCR_MFC_Field is HAL.UInt16;
    subtype DMAMFBOCR_MFA_Field is HAL.UInt11;
 
    --  Ethernet DMA missed frame and buffer overflow counter register
@@ -463,7 +463,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       PA             : MACMIIAR_PA_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -478,14 +478,14 @@ package STM32_SVD.Ethernet is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MACMIIDR_TD_Field is HAL.Short;
+   subtype MACMIIDR_TD_Field is HAL.UInt16;
 
    --  Ethernet MAC MII data register
    type MACMIIDR_Register is record
       --  no description available
       TD             : MACMIIDR_TD_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -496,7 +496,7 @@ package STM32_SVD.Ethernet is
    end record;
 
    subtype MACFCR_PLT_Field is HAL.UInt2;
-   subtype MACFCR_PT_Field is HAL.Short;
+   subtype MACFCR_PT_Field is HAL.UInt16;
 
    --  Ethernet MAC flow control register
    type MACFCR_Register is record
@@ -534,7 +534,7 @@ package STM32_SVD.Ethernet is
       PT            at 0 range 16 .. 31;
    end record;
 
-   subtype MACVLANTR_VLANTI_Field is HAL.Short;
+   subtype MACVLANTR_VLANTI_Field is HAL.UInt16;
 
    --  Ethernet MAC VLAN tag register
    type MACVLANTR_Register is record
@@ -680,7 +680,7 @@ package STM32_SVD.Ethernet is
       Reserved_10_31 at 0 range 10 .. 31;
    end record;
 
-   subtype MACA0HR_MACA0H_Field is HAL.Short;
+   subtype MACA0HR_MACA0H_Field is HAL.UInt16;
 
    --  Ethernet MAC address 0 high register
    type MACA0HR_Register is record
@@ -700,7 +700,7 @@ package STM32_SVD.Ethernet is
       MO             at 0 range 31 .. 31;
    end record;
 
-   subtype MACA1HR_MACA1H_Field is HAL.Short;
+   subtype MACA1HR_MACA1H_Field is HAL.UInt16;
    subtype MACA1HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 1 high register
@@ -727,7 +727,7 @@ package STM32_SVD.Ethernet is
       AE             at 0 range 31 .. 31;
    end record;
 
-   subtype MACA2HR_MAC2AH_Field is HAL.Short;
+   subtype MACA2HR_MAC2AH_Field is HAL.UInt16;
    subtype MACA2HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 2 high register
@@ -771,7 +771,7 @@ package STM32_SVD.Ethernet is
       Reserved_31_31 at 0 range 31 .. 31;
    end record;
 
-   subtype MACA3HR_MACA3H_Field is HAL.Short;
+   subtype MACA3HR_MACA3H_Field is HAL.UInt16;
    subtype MACA3HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 3 high register
@@ -1094,13 +1094,13 @@ package STM32_SVD.Ethernet is
       --  Ethernet DMA bus mode register
       DMABMR    : DMABMR_Register;
       --  Ethernet DMA transmit poll demand register
-      DMATPDR   : HAL.Word;
+      DMATPDR   : HAL.UInt32;
       --  EHERNET DMA receive poll demand register
-      DMARPDR   : HAL.Word;
+      DMARPDR   : HAL.UInt32;
       --  Ethernet DMA receive descriptor list address register
-      DMARDLAR  : HAL.Word;
+      DMARDLAR  : HAL.UInt32;
       --  Ethernet DMA transmit descriptor list address register
-      DMATDLAR  : HAL.Word;
+      DMATDLAR  : HAL.UInt32;
       --  Ethernet DMA status register
       DMASR     : DMASR_Register;
       --  Ethernet DMA operation mode register
@@ -1112,13 +1112,13 @@ package STM32_SVD.Ethernet is
       --  Ethernet DMA receive status watchdog timer register
       DMARSWTR  : DMARSWTR_Register;
       --  Ethernet DMA current host transmit descriptor register
-      DMACHTDR  : HAL.Word;
+      DMACHTDR  : HAL.UInt32;
       --  Ethernet DMA current host receive descriptor register
-      DMACHRDR  : HAL.Word;
+      DMACHRDR  : HAL.UInt32;
       --  Ethernet DMA current host transmit buffer address register
-      DMACHTBAR : HAL.Word;
+      DMACHTBAR : HAL.UInt32;
       --  Ethernet DMA current host receive buffer address register
-      DMACHRBAR : HAL.Word;
+      DMACHRBAR : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1150,9 +1150,9 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC frame filter register
       MACFFR    : MACFFR_Register;
       --  Ethernet MAC hash table high register
-      MACHTHR   : HAL.Word;
+      MACHTHR   : HAL.UInt32;
       --  Ethernet MAC hash table low register
-      MACHTLR   : HAL.Word;
+      MACHTLR   : HAL.UInt32;
       --  Ethernet MAC MII address register
       MACMIIAR  : MACMIIAR_Register;
       --  Ethernet MAC MII data register
@@ -1172,11 +1172,11 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC address 0 high register
       MACA0HR   : MACA0HR_Register;
       --  Ethernet MAC address 0 low register
-      MACA0LR   : HAL.Word;
+      MACA0LR   : HAL.UInt32;
       --  Ethernet MAC address 1 high register
       MACA1HR   : MACA1HR_Register;
       --  Ethernet MAC address1 low register
-      MACA1LR   : HAL.Word;
+      MACA1LR   : HAL.UInt32;
       --  Ethernet MAC address 2 high register
       MACA2HR   : MACA2HR_Register;
       --  Ethernet MAC address 2 low register
@@ -1184,7 +1184,7 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC address 3 high register
       MACA3HR   : MACA3HR_Register;
       --  Ethernet MAC address 3 low register
-      MACA3LR   : HAL.Word;
+      MACA3LR   : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1228,18 +1228,18 @@ package STM32_SVD.Ethernet is
       --  Ethernet MMC transmit interrupt mask register
       MMCTIMR     : MMCTIMR_Register;
       --  Ethernet MMC transmitted good frames after a single collision counter
-      MMCTGFSCCR  : HAL.Word;
+      MMCTGFSCCR  : HAL.UInt32;
       --  Ethernet MMC transmitted good frames after more than a single
       --  collision
-      MMCTGFMSCCR : HAL.Word;
+      MMCTGFMSCCR : HAL.UInt32;
       --  Ethernet MMC transmitted good frames counter register
-      MMCTGFCR    : HAL.Word;
+      MMCTGFCR    : HAL.UInt32;
       --  Ethernet MMC received frames with CRC error counter register
-      MMCRFCECR   : HAL.Word;
+      MMCRFCECR   : HAL.UInt32;
       --  Ethernet MMC received frames with alignment error counter register
-      MMCRFAECR   : HAL.Word;
+      MMCRFAECR   : HAL.UInt32;
       --  MMC received good unicast frames counter register
-      MMCRGUFCR   : HAL.Word;
+      MMCRGUFCR   : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1268,19 +1268,19 @@ package STM32_SVD.Ethernet is
       --  Ethernet PTP subsecond increment register
       PTPSSIR  : PTPSSIR_Register;
       --  Ethernet PTP time stamp high register
-      PTPTSHR  : HAL.Word;
+      PTPTSHR  : HAL.UInt32;
       --  Ethernet PTP time stamp low register
       PTPTSLR  : PTPTSLR_Register;
       --  Ethernet PTP time stamp high update register
-      PTPTSHUR : HAL.Word;
+      PTPTSHUR : HAL.UInt32;
       --  Ethernet PTP time stamp low update register
       PTPTSLUR : PTPTSLUR_Register;
       --  Ethernet PTP time stamp addend register
-      PTPTSAR  : HAL.Word;
+      PTPTSAR  : HAL.UInt32;
       --  Ethernet PTP target time high register
-      PTPTTHR  : HAL.Word;
+      PTPTTHR  : HAL.UInt32;
       --  Ethernet PTP target time low register
-      PTPTTLR  : HAL.Word;
+      PTPTTLR  : HAL.UInt32;
       --  Ethernet PTP time stamp status register
       PTPTSSR  : PTPTSSR_Register;
       --  Ethernet PTP PPS control register

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-flash.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-flash.ads
@@ -186,7 +186,7 @@ package STM32_SVD.FLASH is
    --  Flash option control register 1
    type OPTCR1_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  Not write protect
       nWRP           : OPTCR1_nWRP_Field := 16#FFF#;
       --  unspecified
@@ -210,9 +210,9 @@ package STM32_SVD.FLASH is
       --  Flash access control register
       ACR     : ACR_Register;
       --  Flash key register
-      KEYR    : HAL.Word;
+      KEYR    : HAL.UInt32;
       --  Flash option key register
-      OPTKEYR : HAL.Word;
+      OPTKEYR : HAL.UInt32;
       --  Status register
       SR      : SR_Register;
       --  Control register

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-fsmc.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-fsmc.ads
@@ -623,7 +623,7 @@ package STM32_SVD.FSMC is
       --  Attribute memory space timing register 2
       PATT2 : PATT_Register;
       --  ECC result register 2
-      ECCR2 : HAL.Word;
+      ECCR2 : HAL.UInt32;
       --  PC Card/NAND Flash control register 3
       PCR3  : PCR_Register;
       --  FIFO status and interrupt register 3
@@ -633,7 +633,7 @@ package STM32_SVD.FSMC is
       --  Attribute memory space timing register 3
       PATT3 : PATT_Register;
       --  ECC result register 3
-      ECCR3 : HAL.Word;
+      ECCR3 : HAL.UInt32;
       --  PC Card/NAND Flash control register 4
       PCR4  : PCR_Register;
       --  FIFO status and interrupt register 4

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-gpio.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-gpio.ads
@@ -27,7 +27,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  MODER as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  MODER as an array
             Arr : MODER_Field_Array;
@@ -52,7 +52,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  OT as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  OT as an array
             Arr : OTYPER_OT_Field_Array;
@@ -70,7 +70,7 @@ package STM32_SVD.GPIO is
       --  Port x configuration bits (y = 0..15)
       OT             : OTYPER_OT_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -94,7 +94,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  OSPEEDR as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  OSPEEDR as an array
             Arr : OSPEEDR_Field_Array;
@@ -122,7 +122,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  PUPDR as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  PUPDR as an array
             Arr : PUPDR_Field_Array;
@@ -147,7 +147,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  IDR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  IDR as an array
             Arr : IDR_Field_Array;
@@ -165,7 +165,7 @@ package STM32_SVD.GPIO is
       --  Read-only. Port input data (y = 0..15)
       IDR            : IDR_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -186,7 +186,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  ODR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  ODR as an array
             Arr : ODR_Field_Array;
@@ -204,7 +204,7 @@ package STM32_SVD.GPIO is
       --  Port output data (y = 0..15)
       ODR            : ODR_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -225,7 +225,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  BS as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  BS as an array
             Arr : BSRR_BS_Field_Array;
@@ -249,7 +249,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  BR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  BR as an array
             Arr : BSRR_BR_Field_Array;
@@ -288,7 +288,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  LCK as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  LCK as an array
             Arr : LCKR_LCK_Field_Array;
@@ -333,7 +333,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  AFRL as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  AFRL as an array
             Arr : AFRL_Field_Array;
@@ -361,7 +361,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  AFRH as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  AFRH as an array
             Arr : AFRH_Field_Array;

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-i2c.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-i2c.ads
@@ -48,7 +48,7 @@ package STM32_SVD.I2C is
       --  Software reset
       SWRST          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -124,7 +124,7 @@ package STM32_SVD.I2C is
       --  Addressing mode (slave mode)
       ADDMODE        : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -210,7 +210,7 @@ package STM32_SVD.I2C is
       --  SMBus alert
       SMBALERT       : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -258,7 +258,7 @@ package STM32_SVD.I2C is
       --  Read-only. acket error checking register
       PEC            : SR2_PEC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -289,7 +289,7 @@ package STM32_SVD.I2C is
       --  I2C master mode selection
       F_S            : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-iwdg.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-iwdg.ads
@@ -13,14 +13,14 @@ package STM32_SVD.IWDG is
    -- Registers --
    ---------------
 
-   subtype KR_KEY_Field is HAL.Short;
+   subtype KR_KEY_Field is HAL.UInt16;
 
    --  Key register
    type KR_Register is record
       --  Write-only. Key value (write only, read 0000h)
       KEY            : KR_KEY_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-ltdc.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-ltdc.ads
@@ -288,8 +288,8 @@ package STM32_SVD.LTDC is
       Reserved_11_31 at 0 range 11 .. 31;
    end record;
 
-   subtype CPSR_CYPOS_Field is HAL.Short;
-   subtype CPSR_CXPOS_Field is HAL.Short;
+   subtype CPSR_CYPOS_Field is HAL.UInt16;
+   subtype CPSR_CXPOS_Field is HAL.UInt16;
 
    --  Current Position Status Register
    type CPSR_Register is record
@@ -875,7 +875,7 @@ package STM32_SVD.LTDC is
       --  Layerx Blending Factors Configuration Register
       L1BFCR   : L1BFCR_Register;
       --  Layerx Color Frame Buffer Address Register
-      L1CFBAR  : HAL.Word;
+      L1CFBAR  : HAL.UInt32;
       --  Layerx Color Frame Buffer Length Register
       L1CFBLR  : L1CFBLR_Register;
       --  Layerx ColorFrame Buffer Line Number Register
@@ -899,7 +899,7 @@ package STM32_SVD.LTDC is
       --  Layerx Blending Factors Configuration Register
       L2BFCR   : L2BFCR_Register;
       --  Layerx Color Frame Buffer Address Register
-      L2CFBAR  : HAL.Word;
+      L2CFBAR  : HAL.UInt32;
       --  Layerx Color Frame Buffer Length Register
       L2CFBLR  : L2CFBLR_Register;
       --  Layerx ColorFrame Buffer Line Number Register

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-nvic.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-nvic.ads
@@ -44,7 +44,7 @@ package STM32_SVD.NVIC is
       case As_Array is
          when False =>
             --  IPR_N as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IPR_N as an array
             Arr : IPR_IPR_N_Field_Array;
@@ -84,35 +84,35 @@ package STM32_SVD.NVIC is
       --  Interrupt Controller Type Register
       ICTR  : ICTR_Register;
       --  Interrupt Set-Enable Register
-      ISER0 : HAL.Word;
+      ISER0 : HAL.UInt32;
       --  Interrupt Set-Enable Register
-      ISER1 : HAL.Word;
+      ISER1 : HAL.UInt32;
       --  Interrupt Set-Enable Register
-      ISER2 : HAL.Word;
+      ISER2 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER0 : HAL.Word;
+      ICER0 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER1 : HAL.Word;
+      ICER1 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER2 : HAL.Word;
+      ICER2 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR0 : HAL.Word;
+      ISPR0 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR1 : HAL.Word;
+      ISPR1 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR2 : HAL.Word;
+      ISPR2 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR0 : HAL.Word;
+      ICPR0 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR1 : HAL.Word;
+      ICPR1 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR2 : HAL.Word;
+      ICPR2 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR0 : HAL.Word;
+      IABR0 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR1 : HAL.Word;
+      IABR1 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR2 : HAL.Word;
+      IABR2 : HAL.UInt32;
       --  Interrupt Priority Register
       IPR0  : IPR_Register;
       --  Interrupt Priority Register

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-rng.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-rng.ads
@@ -75,7 +75,7 @@ package STM32_SVD.RNG is
       --  status register
       SR : SR_Register;
       --  data register
-      DR : HAL.Word;
+      DR : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-rtc.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-rtc.ads
@@ -267,14 +267,14 @@ package STM32_SVD.RTC is
       Reserved_23_31 at 0 range 23 .. 31;
    end record;
 
-   subtype WUTR_WUT_Field is HAL.Short;
+   subtype WUTR_WUT_Field is HAL.UInt16;
 
    --  wakeup timer register
    type WUTR_Register is record
       --  Wakeup auto-reload value bits
       WUT            : WUTR_WUT_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -444,14 +444,14 @@ package STM32_SVD.RTC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype SSR_SS_Field is HAL.Short;
+   subtype SSR_SS_Field is HAL.UInt16;
 
    --  sub second register
    type SSR_Register is record
       --  Read-only. Sub second value
       SS             : SSR_SS_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -468,7 +468,7 @@ package STM32_SVD.RTC is
       --  Write-only. Subtract a fraction of a second
       SUBFS          : SHIFTR_SUBFS_Field := 16#0#;
       --  unspecified
-      Reserved_15_30 : HAL.Short := 16#0#;
+      Reserved_15_30 : HAL.UInt16 := 16#0#;
       --  Write-only. Add one second
       ADD1S          : Boolean := False;
    end record
@@ -534,7 +534,7 @@ package STM32_SVD.RTC is
       --  Read-only. Week day units
       WDU            : TSDR_WDU_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -549,14 +549,14 @@ package STM32_SVD.RTC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype TSSSR_SS_Field is HAL.Short;
+   subtype TSSSR_SS_Field is HAL.UInt16;
 
    --  timestamp sub second register
    type TSSSR_Register is record
       --  Read-only. Sub second value
       SS             : TSSSR_SS_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -603,7 +603,7 @@ package STM32_SVD.RTC is
       --  Increase frequency of RTC by 488.5 ppm
       CALP           : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -767,45 +767,45 @@ package STM32_SVD.RTC is
       --  alarm B sub second register
       ALRMBSSR : ALRMBSSR_Register;
       --  backup register
-      BKP0R    : HAL.Word;
+      BKP0R    : HAL.UInt32;
       --  backup register
-      BKP1R    : HAL.Word;
+      BKP1R    : HAL.UInt32;
       --  backup register
-      BKP2R    : HAL.Word;
+      BKP2R    : HAL.UInt32;
       --  backup register
-      BKP3R    : HAL.Word;
+      BKP3R    : HAL.UInt32;
       --  backup register
-      BKP4R    : HAL.Word;
+      BKP4R    : HAL.UInt32;
       --  backup register
-      BKP5R    : HAL.Word;
+      BKP5R    : HAL.UInt32;
       --  backup register
-      BKP6R    : HAL.Word;
+      BKP6R    : HAL.UInt32;
       --  backup register
-      BKP7R    : HAL.Word;
+      BKP7R    : HAL.UInt32;
       --  backup register
-      BKP8R    : HAL.Word;
+      BKP8R    : HAL.UInt32;
       --  backup register
-      BKP9R    : HAL.Word;
+      BKP9R    : HAL.UInt32;
       --  backup register
-      BKP10R   : HAL.Word;
+      BKP10R   : HAL.UInt32;
       --  backup register
-      BKP11R   : HAL.Word;
+      BKP11R   : HAL.UInt32;
       --  backup register
-      BKP12R   : HAL.Word;
+      BKP12R   : HAL.UInt32;
       --  backup register
-      BKP13R   : HAL.Word;
+      BKP13R   : HAL.UInt32;
       --  backup register
-      BKP14R   : HAL.Word;
+      BKP14R   : HAL.UInt32;
       --  backup register
-      BKP15R   : HAL.Word;
+      BKP15R   : HAL.UInt32;
       --  backup register
-      BKP16R   : HAL.Word;
+      BKP16R   : HAL.UInt32;
       --  backup register
-      BKP17R   : HAL.Word;
+      BKP17R   : HAL.UInt32;
       --  backup register
-      BKP18R   : HAL.Word;
+      BKP18R   : HAL.UInt32;
       --  backup register
-      BKP19R   : HAL.Word;
+      BKP19R   : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-sai.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-sai.ads
@@ -99,7 +99,7 @@ package STM32_SVD.SAI is
       --  Companding mode
       COMP           : ACR2_COMP_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -152,7 +152,7 @@ package STM32_SVD.SAI is
    subtype ASLOTR_FBOFF_Field is HAL.UInt5;
    subtype ASLOTR_SLOTSZ_Field is HAL.UInt2;
    subtype ASLOTR_NBSLOT_Field is HAL.UInt4;
-   subtype ASLOTR_SLOTEN_Field is HAL.Short;
+   subtype ASLOTR_SLOTEN_Field is HAL.UInt16;
 
    --  ASlot register
    type ASLOTR_Register is record
@@ -374,7 +374,7 @@ package STM32_SVD.SAI is
       --  Companding mode
       COMP           : BCR2_COMP_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -427,7 +427,7 @@ package STM32_SVD.SAI is
    subtype BSLOTR_FBOFF_Field is HAL.UInt5;
    subtype BSLOTR_SLOTSZ_Field is HAL.UInt2;
    subtype BSLOTR_NBSLOT_Field is HAL.UInt4;
-   subtype BSLOTR_SLOTEN_Field is HAL.Short;
+   subtype BSLOTR_SLOTEN_Field is HAL.UInt16;
 
    --  BSlot register
    type BSLOTR_Register is record
@@ -584,7 +584,7 @@ package STM32_SVD.SAI is
       --  AClear flag register
       ACLRFR : ACLRFR_Register;
       --  AData register
-      ADR    : HAL.Word;
+      ADR    : HAL.UInt32;
       --  BConfiguration register 1
       BCR1   : BCR1_Register;
       --  BConfiguration register 2
@@ -600,7 +600,7 @@ package STM32_SVD.SAI is
       --  BClear flag register
       BCLRFR : BCLRFR_Register;
       --  BData register
-      BDR    : HAL.Word;
+      BDR    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-sdio.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-sdio.ads
@@ -455,21 +455,21 @@ package STM32_SVD.SDIO is
       --  SDI clock control register
       CLKCR   : CLKCR_Register;
       --  argument register
-      ARG     : HAL.Word;
+      ARG     : HAL.UInt32;
       --  command register
       CMD     : CMD_Register;
       --  command response register
       RESPCMD : RESPCMD_Register;
       --  response 1..4 register
-      RESP1   : HAL.Word;
+      RESP1   : HAL.UInt32;
       --  response 1..4 register
-      RESP2   : HAL.Word;
+      RESP2   : HAL.UInt32;
       --  response 1..4 register
-      RESP3   : HAL.Word;
+      RESP3   : HAL.UInt32;
       --  response 1..4 register
-      RESP4   : HAL.Word;
+      RESP4   : HAL.UInt32;
       --  data timer register
-      DTIMER  : HAL.Word;
+      DTIMER  : HAL.UInt32;
       --  data length register
       DLEN    : DLEN_Register;
       --  data control register
@@ -485,7 +485,7 @@ package STM32_SVD.SDIO is
       --  FIFO counter register
       FIFOCNT : FIFOCNT_Register;
       --  data FIFO register
-      FIFO    : HAL.Word;
+      FIFO    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-spi.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-spi.ads
@@ -46,7 +46,7 @@ package STM32_SVD.SPI is
       --  Bidirectional data mode enable
       BIDIMODE       : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -144,14 +144,14 @@ package STM32_SVD.SPI is
       Reserved_9_31 at 0 range 9 .. 31;
    end record;
 
-   subtype DR_DR_Field is HAL.Short;
+   subtype DR_DR_Field is HAL.UInt16;
 
    --  data register
    type DR_Register is record
       --  Data register
       DR             : DR_DR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -161,14 +161,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CRCPR_CRCPOLY_Field is HAL.Short;
+   subtype CRCPR_CRCPOLY_Field is HAL.UInt16;
 
    --  CRC polynomial register
    type CRCPR_Register is record
       --  CRC polynomial register
       CRCPOLY        : CRCPR_CRCPOLY_Field := 16#7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -178,14 +178,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype RXCRCR_RxCRC_Field is HAL.Short;
+   subtype RXCRCR_RxCRC_Field is HAL.UInt16;
 
    --  RX CRC register
    type RXCRCR_Register is record
       --  Read-only. Rx CRC register
       RxCRC          : RXCRCR_RxCRC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -195,14 +195,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype TXCRCR_TxCRC_Field is HAL.Short;
+   subtype TXCRCR_TxCRC_Field is HAL.UInt16;
 
    --  TX CRC register
    type TXCRCR_Register is record
       --  Read-only. Tx CRC register
       TxCRC          : TXCRCR_TxCRC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-syscfg.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-syscfg.ads
@@ -46,7 +46,7 @@ package STM32_SVD.SYSCFG is
    --  peripheral mode configuration register
    type PMC_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  ADC1DC2
       ADC1DC2        : Boolean := False;
       --  ADC2DC2
@@ -87,7 +87,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR1_EXTI_Field_Array;
@@ -106,7 +106,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR1_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -130,7 +130,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR2_EXTI_Field_Array;
@@ -149,7 +149,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR2_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -173,7 +173,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR3_EXTI_Field_Array;
@@ -192,7 +192,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR3_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -216,7 +216,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR4_EXTI_Field_Array;
@@ -235,7 +235,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR4_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-tim.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-tim.ads
@@ -129,7 +129,7 @@ package STM32_SVD.TIM is
       --  External trigger polarity
       ETP            : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -318,7 +318,7 @@ package STM32_SVD.TIM is
       --  Output Compare 2 clear enable
       OC2CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -359,7 +359,7 @@ package STM32_SVD.TIM is
       --  Input capture 2 filter
       IC2F           : CCMR1_Input_IC2F_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -402,7 +402,7 @@ package STM32_SVD.TIM is
       --  Output compare 4 clear enable
       OC4CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -443,7 +443,7 @@ package STM32_SVD.TIM is
       --  Input capture 4 filter
       IC4F           : CCMR2_Input_IC4F_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -512,14 +512,14 @@ package STM32_SVD.TIM is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype CNT_CNT_Field is HAL.Short;
+   subtype CNT_CNT_Field is HAL.UInt16;
 
    --  counter
    type CNT_Register is record
       --  counter value
       CNT            : CNT_CNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -529,14 +529,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype PSC_PSC_Field is HAL.Short;
+   subtype PSC_PSC_Field is HAL.UInt16;
 
    --  prescaler
    type PSC_Register is record
       --  Prescaler value
       PSC            : PSC_PSC_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -546,14 +546,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype ARR_ARR_Field is HAL.Short;
+   subtype ARR_ARR_Field is HAL.UInt16;
 
    --  auto-reload register
    type ARR_Register is record
       --  Auto-reload value
       ARR            : ARR_ARR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -580,14 +580,14 @@ package STM32_SVD.TIM is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype CCR1_CCR1_Field is HAL.Short;
+   subtype CCR1_CCR1_Field is HAL.UInt16;
 
    --  capture/compare register 1
    type CCR1_Register is record
       --  Capture/Compare 1 value
       CCR1           : CCR1_CCR1_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -597,14 +597,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR2_CCR2_Field is HAL.Short;
+   subtype CCR2_CCR2_Field is HAL.UInt16;
 
    --  capture/compare register 2
    type CCR2_Register is record
       --  Capture/Compare 2 value
       CCR2           : CCR2_CCR2_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -614,14 +614,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR3_CCR3_Field is HAL.Short;
+   subtype CCR3_CCR3_Field is HAL.UInt16;
 
    --  capture/compare register 3
    type CCR3_Register is record
       --  Capture/Compare value
       CCR3           : CCR3_CCR3_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -631,14 +631,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR4_CCR4_Field is HAL.Short;
+   subtype CCR4_CCR4_Field is HAL.UInt16;
 
    --  capture/compare register 4
    type CCR4_Register is record
       --  Capture/Compare value
       CCR4           : CCR4_CCR4_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -670,7 +670,7 @@ package STM32_SVD.TIM is
       --  Main output enable
       MOE            : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -711,14 +711,14 @@ package STM32_SVD.TIM is
       Reserved_13_31 at 0 range 13 .. 31;
    end record;
 
-   subtype DMAR_DMAB_Field is HAL.Short;
+   subtype DMAR_DMAB_Field is HAL.UInt16;
 
    --  DMA address for full transfer
    type DMAR_Register is record
       --  DMA register for burst accesses
       DMAB           : DMAR_DMAB_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -913,7 +913,7 @@ package STM32_SVD.TIM is
       --  O24CE
       O24CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -967,7 +967,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -992,8 +992,8 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CNT_CNT_L_Field is HAL.Short;
-   subtype CNT_CNT_H_Field is HAL.Short;
+   subtype CNT_CNT_L_Field is HAL.UInt16;
+   subtype CNT_CNT_H_Field is HAL.UInt16;
 
    --  counter
    type CNT_Register_1 is record
@@ -1010,8 +1010,8 @@ package STM32_SVD.TIM is
       CNT_H at 0 range 16 .. 31;
    end record;
 
-   subtype ARR_ARR_L_Field is HAL.Short;
-   subtype ARR_ARR_H_Field is HAL.Short;
+   subtype ARR_ARR_L_Field is HAL.UInt16;
+   subtype ARR_ARR_H_Field is HAL.UInt16;
 
    --  auto-reload register
    type ARR_Register_1 is record
@@ -1028,8 +1028,8 @@ package STM32_SVD.TIM is
       ARR_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR1_CCR1_L_Field is HAL.Short;
-   subtype CCR1_CCR1_H_Field is HAL.Short;
+   subtype CCR1_CCR1_L_Field is HAL.UInt16;
+   subtype CCR1_CCR1_H_Field is HAL.UInt16;
 
    --  capture/compare register 1
    type CCR1_Register_1 is record
@@ -1046,8 +1046,8 @@ package STM32_SVD.TIM is
       CCR1_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR2_CCR2_L_Field is HAL.Short;
-   subtype CCR2_CCR2_H_Field is HAL.Short;
+   subtype CCR2_CCR2_L_Field is HAL.UInt16;
+   subtype CCR2_CCR2_H_Field is HAL.UInt16;
 
    --  capture/compare register 2
    type CCR2_Register_1 is record
@@ -1064,8 +1064,8 @@ package STM32_SVD.TIM is
       CCR2_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR3_CCR3_L_Field is HAL.Short;
-   subtype CCR3_CCR3_H_Field is HAL.Short;
+   subtype CCR3_CCR3_L_Field is HAL.UInt16;
+   subtype CCR3_CCR3_H_Field is HAL.UInt16;
 
    --  capture/compare register 3
    type CCR3_Register_1 is record
@@ -1082,8 +1082,8 @@ package STM32_SVD.TIM is
       CCR3_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR4_CCR4_L_Field is HAL.Short;
-   subtype CCR4_CCR4_H_Field is HAL.Short;
+   subtype CCR4_CCR4_L_Field is HAL.UInt16;
+   subtype CCR4_CCR4_H_Field is HAL.UInt16;
 
    --  capture/compare register 4
    type CCR4_Register_1 is record

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-usart.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-usart.ads
@@ -79,7 +79,7 @@ package STM32_SVD.USART is
       --  mantissa of USARTDIV
       DIV_Mantissa   : BRR_DIV_Mantissa_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -125,7 +125,7 @@ package STM32_SVD.USART is
       --  Oversampling mode
       OVER8          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -370,7 +370,7 @@ package STM32_SVD.USART is
       --  Guard time value
       GT             : GTPR_GT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-usb_otg_fs.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-usb_otg_fs.ads
@@ -180,8 +180,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype FS_DAINT_IEPINT_Field is HAL.Short;
-   subtype FS_DAINT_OEPINT_Field is HAL.Short;
+   subtype FS_DAINT_IEPINT_Field is HAL.UInt16;
+   subtype FS_DAINT_OEPINT_Field is HAL.UInt16;
 
    --  OTG_FS device all endpoints interrupt register (OTG_FS_DAINT)
    type FS_DAINT_Register is record
@@ -198,8 +198,8 @@ package STM32_SVD.USB_OTG_FS is
       OEPINT at 0 range 16 .. 31;
    end record;
 
-   subtype FS_DAINTMSK_IEPM_Field is HAL.Short;
-   subtype FS_DAINTMSK_OEPM_Field is HAL.Short;
+   subtype FS_DAINTMSK_IEPM_Field is HAL.UInt16;
+   subtype FS_DAINTMSK_OEPM_Field is HAL.UInt16;
 
    --  OTG_FS all endpoints interrupt mask register (OTG_FS_DAINTMSK)
    type FS_DAINTMSK_Register is record
@@ -216,14 +216,14 @@ package STM32_SVD.USB_OTG_FS is
       OEPM at 0 range 16 .. 31;
    end record;
 
-   subtype DVBUSDIS_VBUSDT_Field is HAL.Short;
+   subtype DVBUSDIS_VBUSDT_Field is HAL.UInt16;
 
    --  OTG_FS device VBUS discharge time register
    type DVBUSDIS_Register is record
       --  Device VBUS discharge time
       VBUSDT         : DVBUSDIS_VBUSDT_Field := 16#17D7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -250,14 +250,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_12_31 at 0 range 12 .. 31;
    end record;
 
-   subtype DIEPEMPMSK_INEPTXFEM_Field is HAL.Short;
+   subtype DIEPEMPMSK_INEPTXFEM_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint FIFO empty interrupt mask register
    type DIEPEMPMSK_Register is record
       --  IN EP Tx FIFO empty interrupt mask bits
       INEPTXFEM      : DIEPEMPMSK_INEPTXFEM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -382,14 +382,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype DTXFSTS_INEPTFSAV_Field is HAL.Short;
+   subtype DTXFSTS_INEPTFSAV_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint transmit FIFO status register
    type DTXFSTS_Register is record
       --  Read-only. IN endpoint TxFIFO space available
       INEPTFSAV      : DTXFSTS_INEPTFSAV_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1196,14 +1196,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_25_31 at 0 range 25 .. 31;
    end record;
 
-   subtype FS_GRXFSIZ_RXFD_Field is HAL.Short;
+   subtype FS_GRXFSIZ_RXFD_Field is HAL.UInt16;
 
    --  OTG_FS Receive FIFO size register (OTG_FS_GRXFSIZ)
    type FS_GRXFSIZ_Register is record
       --  RxFIFO depth
       RXFD           : FS_GRXFSIZ_RXFD_Field := 16#200#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1213,8 +1213,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype FS_GNPTXFSIZ_Device_TX0FSA_Field is HAL.Short;
-   subtype FS_GNPTXFSIZ_Device_TX0FD_Field is HAL.Short;
+   subtype FS_GNPTXFSIZ_Device_TX0FSA_Field is HAL.UInt16;
+   subtype FS_GNPTXFSIZ_Device_TX0FD_Field is HAL.UInt16;
 
    --  OTG_FS non-periodic transmit FIFO size register (Device mode)
    type FS_GNPTXFSIZ_Device_Register is record
@@ -1231,8 +1231,8 @@ package STM32_SVD.USB_OTG_FS is
       TX0FD  at 0 range 16 .. 31;
    end record;
 
-   subtype FS_GNPTXFSIZ_Host_NPTXFSA_Field is HAL.Short;
-   subtype FS_GNPTXFSIZ_Host_NPTXFD_Field is HAL.Short;
+   subtype FS_GNPTXFSIZ_Host_NPTXFSA_Field is HAL.UInt16;
+   subtype FS_GNPTXFSIZ_Host_NPTXFD_Field is HAL.UInt16;
 
    --  OTG_FS non-periodic transmit FIFO size register (Host mode)
    type FS_GNPTXFSIZ_Host_Register is record
@@ -1249,7 +1249,7 @@ package STM32_SVD.USB_OTG_FS is
       NPTXFD  at 0 range 16 .. 31;
    end record;
 
-   subtype FS_GNPTXSTS_NPTXFSAV_Field is HAL.Short;
+   subtype FS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
    subtype FS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
    subtype FS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
@@ -1278,7 +1278,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS general core configuration register (OTG_FS_GCCFG)
    type FS_GCCFG_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  Power down
       PWRDWN         : Boolean := False;
       --  unspecified
@@ -1305,8 +1305,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype FS_HPTXFSIZ_PTXSA_Field is HAL.Short;
-   subtype FS_HPTXFSIZ_PTXFSIZ_Field is HAL.Short;
+   subtype FS_HPTXFSIZ_PTXSA_Field is HAL.UInt16;
+   subtype FS_HPTXFSIZ_PTXFSIZ_Field is HAL.UInt16;
 
    --  OTG_FS Host periodic transmit FIFO size register (OTG_FS_HPTXFSIZ)
    type FS_HPTXFSIZ_Register is record
@@ -1323,8 +1323,8 @@ package STM32_SVD.USB_OTG_FS is
       PTXFSIZ at 0 range 16 .. 31;
    end record;
 
-   subtype FS_DIEPTXF_INEPTXSA_Field is HAL.Short;
-   subtype FS_DIEPTXF_INEPTXFD_Field is HAL.Short;
+   subtype FS_DIEPTXF_INEPTXSA_Field is HAL.UInt16;
+   subtype FS_DIEPTXF_INEPTXFD_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint transmit FIFO size register (OTG_FS_DIEPTXF2)
    type FS_DIEPTXF_Register is record
@@ -1361,14 +1361,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype HFIR_FRIVL_Field is HAL.Short;
+   subtype HFIR_FRIVL_Field is HAL.UInt16;
 
    --  OTG_FS Host frame interval register
    type HFIR_Register is record
       --  Frame interval
       FRIVL          : HFIR_FRIVL_Field := 16#EA60#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1378,8 +1378,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype FS_HFNUM_FRNUM_Field is HAL.Short;
-   subtype FS_HFNUM_FTREM_Field is HAL.Short;
+   subtype FS_HFNUM_FRNUM_Field is HAL.UInt16;
+   subtype FS_HFNUM_FTREM_Field is HAL.UInt16;
 
    --  OTG_FS host frame number/frame time remaining register (OTG_FS_HFNUM)
    type FS_HFNUM_Register is record
@@ -1396,7 +1396,7 @@ package STM32_SVD.USB_OTG_FS is
       FTREM at 0 range 16 .. 31;
    end record;
 
-   subtype FS_HPTXSTS_PTXFSAVL_Field is HAL.Short;
+   subtype FS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
    subtype FS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
    subtype FS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
 
@@ -1419,14 +1419,14 @@ package STM32_SVD.USB_OTG_FS is
       PTXQTOP  at 0 range 24 .. 31;
    end record;
 
-   subtype HAINT_HAINT_Field is HAL.Short;
+   subtype HAINT_HAINT_Field is HAL.UInt16;
 
    --  OTG_FS Host all channels interrupt register
    type HAINT_Register is record
       --  Read-only. Channel interrupts
       HAINT          : HAINT_HAINT_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1436,14 +1436,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype HAINTMSK_HAINTM_Field is HAL.Short;
+   subtype HAINTMSK_HAINTM_Field is HAL.UInt16;
 
    --  OTG_FS host all channels interrupt mask register
    type HAINTMSK_Register is record
       --  Channel interrupt mask
       HAINTM         : HAINTMSK_HAINTM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1862,7 +1862,7 @@ package STM32_SVD.USB_OTG_FS is
       --  OTG_FS general core configuration register (OTG_FS_GCCFG)
       FS_GCCFG            : FS_GCCFG_Register;
       --  core ID register
-      FS_CID              : HAL.Word;
+      FS_CID              : HAL.UInt32;
       --  OTG_FS Host periodic transmit FIFO size register (OTG_FS_HPTXFSIZ)
       FS_HPTXFSIZ         : FS_HPTXFSIZ_Register;
       --  OTG_FS device IN endpoint transmit FIFO size register

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-usb_otg_hs.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-usb_otg_hs.ads
@@ -209,8 +209,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_10_31 at 0 range 10 .. 31;
    end record;
 
-   subtype OTG_HS_DAINT_IEPINT_Field is HAL.Short;
-   subtype OTG_HS_DAINT_OEPINT_Field is HAL.Short;
+   subtype OTG_HS_DAINT_IEPINT_Field is HAL.UInt16;
+   subtype OTG_HS_DAINT_OEPINT_Field is HAL.UInt16;
 
    --  OTG_HS device all endpoints interrupt register
    type OTG_HS_DAINT_Register is record
@@ -227,8 +227,8 @@ package STM32_SVD.USB_OTG_HS is
       OEPINT at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DAINTMSK_IEPM_Field is HAL.Short;
-   subtype OTG_HS_DAINTMSK_OEPM_Field is HAL.Short;
+   subtype OTG_HS_DAINTMSK_IEPM_Field is HAL.UInt16;
+   subtype OTG_HS_DAINTMSK_OEPM_Field is HAL.UInt16;
 
    --  OTG_HS all endpoints interrupt mask register
    type OTG_HS_DAINTMSK_Register is record
@@ -245,14 +245,14 @@ package STM32_SVD.USB_OTG_HS is
       OEPM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DVBUSDIS_VBUSDT_Field is HAL.Short;
+   subtype OTG_HS_DVBUSDIS_VBUSDT_Field is HAL.UInt16;
 
    --  OTG_HS device VBUS discharge time register
    type OTG_HS_DVBUSDIS_Register is record
       --  Device VBUS discharge time
       VBUSDT         : OTG_HS_DVBUSDIS_VBUSDT_Field := 16#17D7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -318,14 +318,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype OTG_HS_DIEPEMPMSK_INEPTXFEM_Field is HAL.Short;
+   subtype OTG_HS_DIEPEMPMSK_INEPTXFEM_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint FIFO empty interrupt mask register
    type OTG_HS_DIEPEMPMSK_Register is record
       --  IN EP Tx FIFO empty interrupt mask bits
       INEPTXFEM      : OTG_HS_DIEPEMPMSK_INEPTXFEM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -621,14 +621,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype OTG_HS_DTXFSTS_INEPTFSAV_Field is HAL.Short;
+   subtype OTG_HS_DTXFSTS_INEPTFSAV_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint transmit FIFO status register
    type OTG_HS_DTXFSTS_Register is record
       --  Read-only. IN endpoint TxFIFO space avail
       INEPTFSAV      : OTG_HS_DTXFSTS_INEPTFSAV_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1435,14 +1435,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_25_31 at 0 range 25 .. 31;
    end record;
 
-   subtype OTG_HS_GRXFSIZ_RXFD_Field is HAL.Short;
+   subtype OTG_HS_GRXFSIZ_RXFD_Field is HAL.UInt16;
 
    --  OTG_HS Receive FIFO size register
    type OTG_HS_GRXFSIZ_Register is record
       --  RxFIFO depth
       RXFD           : OTG_HS_GRXFSIZ_RXFD_Field := 16#200#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1452,8 +1452,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_GNPTXFSIZ_Host_NPTXFSA_Field is HAL.Short;
-   subtype OTG_HS_GNPTXFSIZ_Host_NPTXFD_Field is HAL.Short;
+   subtype OTG_HS_GNPTXFSIZ_Host_NPTXFSA_Field is HAL.UInt16;
+   subtype OTG_HS_GNPTXFSIZ_Host_NPTXFD_Field is HAL.UInt16;
 
    --  OTG_HS nonperiodic transmit FIFO size register (host mode)
    type OTG_HS_GNPTXFSIZ_Host_Register is record
@@ -1470,8 +1470,8 @@ package STM32_SVD.USB_OTG_HS is
       NPTXFD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_TX0FSIZ_Peripheral_TX0FSA_Field is HAL.Short;
-   subtype OTG_HS_TX0FSIZ_Peripheral_TX0FD_Field is HAL.Short;
+   subtype OTG_HS_TX0FSIZ_Peripheral_TX0FSA_Field is HAL.UInt16;
+   subtype OTG_HS_TX0FSIZ_Peripheral_TX0FD_Field is HAL.UInt16;
 
    --  Endpoint 0 transmit FIFO size (peripheral mode)
    type OTG_HS_TX0FSIZ_Peripheral_Register is record
@@ -1488,7 +1488,7 @@ package STM32_SVD.USB_OTG_HS is
       TX0FD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.Short;
+   subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
    subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
    subtype OTG_HS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
@@ -1516,7 +1516,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS general core configuration register
    type OTG_HS_GCCFG_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  Power down
       PWRDWN         : Boolean := False;
       --  Enable I2C bus connection for the external I2C PHY interface
@@ -1546,8 +1546,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_22_31 at 0 range 22 .. 31;
    end record;
 
-   subtype OTG_HS_HPTXFSIZ_PTXSA_Field is HAL.Short;
-   subtype OTG_HS_HPTXFSIZ_PTXFD_Field is HAL.Short;
+   subtype OTG_HS_HPTXFSIZ_PTXSA_Field is HAL.UInt16;
+   subtype OTG_HS_HPTXFSIZ_PTXFD_Field is HAL.UInt16;
 
    --  OTG_HS Host periodic transmit FIFO size register
    type OTG_HS_HPTXFSIZ_Register is record
@@ -1564,8 +1564,8 @@ package STM32_SVD.USB_OTG_HS is
       PTXFD at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DIEPTXF_INEPTXSA_Field is HAL.Short;
-   subtype OTG_HS_DIEPTXF_INEPTXFD_Field is HAL.Short;
+   subtype OTG_HS_DIEPTXF_INEPTXSA_Field is HAL.UInt16;
+   subtype OTG_HS_DIEPTXF_INEPTXFD_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint transmit FIFO size register
    type OTG_HS_DIEPTXF_Register is record
@@ -1602,14 +1602,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype OTG_HS_HFIR_FRIVL_Field is HAL.Short;
+   subtype OTG_HS_HFIR_FRIVL_Field is HAL.UInt16;
 
    --  OTG_HS Host frame interval register
    type OTG_HS_HFIR_Register is record
       --  Frame interval
       FRIVL          : OTG_HS_HFIR_FRIVL_Field := 16#EA60#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1619,8 +1619,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HFNUM_FRNUM_Field is HAL.Short;
-   subtype OTG_HS_HFNUM_FTREM_Field is HAL.Short;
+   subtype OTG_HS_HFNUM_FRNUM_Field is HAL.UInt16;
+   subtype OTG_HS_HFNUM_FTREM_Field is HAL.UInt16;
 
    --  OTG_HS host frame number/frame time remaining register
    type OTG_HS_HFNUM_Register is record
@@ -1637,7 +1637,7 @@ package STM32_SVD.USB_OTG_HS is
       FTREM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.Short;
+   subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
    subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
    subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
 
@@ -1659,14 +1659,14 @@ package STM32_SVD.USB_OTG_HS is
       PTXQTOP  at 0 range 24 .. 31;
    end record;
 
-   subtype OTG_HS_HAINT_HAINT_Field is HAL.Short;
+   subtype OTG_HS_HAINT_HAINT_Field is HAL.UInt16;
 
    --  OTG_HS Host all channels interrupt register
    type OTG_HS_HAINT_Register is record
       --  Read-only. Channel interrupts
       HAINT          : OTG_HS_HAINT_HAINT_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1676,14 +1676,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HAINTMSK_HAINTM_Field is HAL.Short;
+   subtype OTG_HS_HAINTMSK_HAINTM_Field is HAL.UInt16;
 
    --  OTG_HS host all channels interrupt mask register
    type OTG_HS_HAINTMSK_Register is record
       --  Channel interrupt mask
       HAINTM         : OTG_HS_HAINTMSK_HAINTM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2012,7 +2012,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device IN endpoint 0 transfer size register
       OTG_HS_DIEPTSIZ0    : OTG_HS_DIEPTSIZ0_Register;
       --  OTG_HS device endpoint-1 DMA address register
-      OTG_HS_DIEPDMA1     : HAL.Word;
+      OTG_HS_DIEPDMA1     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS0     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-1 control register
@@ -2022,7 +2022,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ1    : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-2 DMA address register
-      OTG_HS_DIEPDMA2     : HAL.Word;
+      OTG_HS_DIEPDMA2     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS1     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-2 control register
@@ -2032,7 +2032,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ2    : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-3 DMA address register
-      OTG_HS_DIEPDMA3     : HAL.Word;
+      OTG_HS_DIEPDMA3     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS2     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-3 control register
@@ -2042,7 +2042,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ3    : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-4 DMA address register
-      OTG_HS_DIEPDMA4     : HAL.Word;
+      OTG_HS_DIEPDMA4     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS3     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-4 control register
@@ -2052,7 +2052,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ4    : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-5 DMA address register
-      OTG_HS_DIEPDMA5     : HAL.Word;
+      OTG_HS_DIEPDMA5     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS4     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-5 control register
@@ -2212,7 +2212,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS general core configuration register
       OTG_HS_GCCFG              : OTG_HS_GCCFG_Register;
       --  OTG_HS core ID register
-      OTG_HS_CID                : HAL.Word;
+      OTG_HS_CID                : HAL.UInt32;
       --  OTG_HS Host periodic transmit FIFO size register
       OTG_HS_HPTXFSIZ           : OTG_HS_HPTXFSIZ_Register;
       --  OTG_HS device IN endpoint transmit FIFO size register
@@ -2310,7 +2310,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-11 transfer size register
       OTG_HS_HCTSIZ0    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-0 DMA address register
-      OTG_HS_HCDMA0     : HAL.Word;
+      OTG_HS_HCDMA0     : HAL.UInt32;
       --  OTG_HS host channel-1 characteristics register
       OTG_HS_HCCHAR1    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-1 split control register
@@ -2322,7 +2322,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-1 transfer size register
       OTG_HS_HCTSIZ1    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-1 DMA address register
-      OTG_HS_HCDMA1     : HAL.Word;
+      OTG_HS_HCDMA1     : HAL.UInt32;
       --  OTG_HS host channel-2 characteristics register
       OTG_HS_HCCHAR2    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-2 split control register
@@ -2334,7 +2334,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-2 transfer size register
       OTG_HS_HCTSIZ2    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-2 DMA address register
-      OTG_HS_HCDMA2     : HAL.Word;
+      OTG_HS_HCDMA2     : HAL.UInt32;
       --  OTG_HS host channel-3 characteristics register
       OTG_HS_HCCHAR3    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-3 split control register
@@ -2346,7 +2346,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-3 transfer size register
       OTG_HS_HCTSIZ3    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-3 DMA address register
-      OTG_HS_HCDMA3     : HAL.Word;
+      OTG_HS_HCDMA3     : HAL.UInt32;
       --  OTG_HS host channel-4 characteristics register
       OTG_HS_HCCHAR4    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-4 split control register
@@ -2358,7 +2358,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-4 transfer size register
       OTG_HS_HCTSIZ4    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-4 DMA address register
-      OTG_HS_HCDMA4     : HAL.Word;
+      OTG_HS_HCDMA4     : HAL.UInt32;
       --  OTG_HS host channel-5 characteristics register
       OTG_HS_HCCHAR5    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-5 split control register
@@ -2370,7 +2370,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-5 transfer size register
       OTG_HS_HCTSIZ5    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-5 DMA address register
-      OTG_HS_HCDMA5     : HAL.Word;
+      OTG_HS_HCDMA5     : HAL.UInt32;
       --  OTG_HS host channel-6 characteristics register
       OTG_HS_HCCHAR6    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-6 split control register
@@ -2382,7 +2382,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-6 transfer size register
       OTG_HS_HCTSIZ6    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-6 DMA address register
-      OTG_HS_HCDMA6     : HAL.Word;
+      OTG_HS_HCDMA6     : HAL.UInt32;
       --  OTG_HS host channel-7 characteristics register
       OTG_HS_HCCHAR7    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-7 split control register
@@ -2394,7 +2394,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-7 transfer size register
       OTG_HS_HCTSIZ7    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-7 DMA address register
-      OTG_HS_HCDMA7     : HAL.Word;
+      OTG_HS_HCDMA7     : HAL.UInt32;
       --  OTG_HS host channel-8 characteristics register
       OTG_HS_HCCHAR8    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-8 split control register
@@ -2406,7 +2406,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-8 transfer size register
       OTG_HS_HCTSIZ8    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-8 DMA address register
-      OTG_HS_HCDMA8     : HAL.Word;
+      OTG_HS_HCDMA8     : HAL.UInt32;
       --  OTG_HS host channel-9 characteristics register
       OTG_HS_HCCHAR9    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-9 split control register
@@ -2418,7 +2418,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-9 transfer size register
       OTG_HS_HCTSIZ9    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-9 DMA address register
-      OTG_HS_HCDMA9     : HAL.Word;
+      OTG_HS_HCDMA9     : HAL.UInt32;
       --  OTG_HS host channel-10 characteristics register
       OTG_HS_HCCHAR10   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-10 split control register
@@ -2430,7 +2430,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-10 transfer size register
       OTG_HS_HCTSIZ10   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-10 DMA address register
-      OTG_HS_HCDMA10    : HAL.Word;
+      OTG_HS_HCDMA10    : HAL.UInt32;
       --  OTG_HS host channel-11 characteristics register
       OTG_HS_HCCHAR11   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-11 split control register
@@ -2442,7 +2442,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-11 transfer size register
       OTG_HS_HCTSIZ11   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-11 DMA address register
-      OTG_HS_HCDMA11    : HAL.Word;
+      OTG_HS_HCDMA11    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-adc.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-adc.ads
@@ -530,14 +530,14 @@ package STM32_SVD.ADC is
       Reserved_22_31 at 0 range 22 .. 31;
    end record;
 
-   subtype JDR_JDATA_Field is HAL.Short;
+   subtype JDR_JDATA_Field is HAL.UInt16;
 
    --  injected data register x
    type JDR_Register is record
       --  Read-only. Injected data
       JDATA          : JDR_JDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -547,14 +547,14 @@ package STM32_SVD.ADC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DR_DATA_Field is HAL.Short;
+   subtype DR_DATA_Field is HAL.UInt16;
 
    --  regular data register
    type DR_Register is record
       --  Read-only. Regular data
       DATA           : DR_DATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -684,7 +684,7 @@ package STM32_SVD.ADC is
    end record;
 
    --  CDR_DATA array element
-   subtype CDR_DATA_Element is HAL.Short;
+   subtype CDR_DATA_Element is HAL.UInt16;
 
    --  CDR_DATA array
    type CDR_DATA_Field_Array is array (1 .. 2) of CDR_DATA_Element
@@ -697,7 +697,7 @@ package STM32_SVD.ADC is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : CDR_DATA_Field_Array;

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-can.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-can.ads
@@ -446,7 +446,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT0R_DLC_Field is HAL.UInt4;
-   subtype TDT0R_TIME_Field is HAL.Short;
+   subtype TDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT0R_Register is record
@@ -486,7 +486,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL0R_DATA_Field_Array;
@@ -514,7 +514,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH0R_DATA_Field_Array;
@@ -556,7 +556,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT1R_DLC_Field is HAL.UInt4;
-   subtype TDT1R_TIME_Field is HAL.Short;
+   subtype TDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT1R_Register is record
@@ -596,7 +596,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL1R_DATA_Field_Array;
@@ -624,7 +624,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH1R_DATA_Field_Array;
@@ -666,7 +666,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT2R_DLC_Field is HAL.UInt4;
-   subtype TDT2R_TIME_Field is HAL.Short;
+   subtype TDT2R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT2R_Register is record
@@ -706,7 +706,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL2R_DATA_Field_Array;
@@ -734,7 +734,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH2R_DATA_Field_Array;
@@ -777,7 +777,7 @@ package STM32_SVD.CAN is
 
    subtype RDT0R_DLC_Field is HAL.UInt4;
    subtype RDT0R_FMI_Field is HAL.Byte;
-   subtype RDT0R_TIME_Field is HAL.Short;
+   subtype RDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
    type RDT0R_Register is record
@@ -814,7 +814,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDL0R_DATA_Field_Array;
@@ -842,7 +842,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDH0R_DATA_Field_Array;
@@ -885,7 +885,7 @@ package STM32_SVD.CAN is
 
    subtype RDT1R_DLC_Field is HAL.UInt4;
    subtype RDT1R_FMI_Field is HAL.Byte;
-   subtype RDT1R_TIME_Field is HAL.Short;
+   subtype RDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
    type RDT1R_Register is record
@@ -922,7 +922,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDL1R_DATA_Field_Array;
@@ -950,7 +950,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDH1R_DATA_Field_Array;
@@ -1154,7 +1154,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F0R_FB_Field_Array;
@@ -1179,7 +1179,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F1R_FB_Field_Array;
@@ -1204,7 +1204,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F2R_FB_Field_Array;
@@ -1229,7 +1229,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F3R_FB_Field_Array;
@@ -1254,7 +1254,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F4R_FB_Field_Array;
@@ -1279,7 +1279,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F5R_FB_Field_Array;
@@ -1304,7 +1304,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F6R_FB_Field_Array;
@@ -1329,7 +1329,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F7R_FB_Field_Array;
@@ -1354,7 +1354,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F8R_FB_Field_Array;
@@ -1379,7 +1379,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F9R_FB_Field_Array;
@@ -1404,7 +1404,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F10R_FB_Field_Array;
@@ -1429,7 +1429,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F11R_FB_Field_Array;
@@ -1454,7 +1454,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F12R_FB_Field_Array;
@@ -1479,7 +1479,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F13R_FB_Field_Array;
@@ -1504,7 +1504,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F14R_FB_Field_Array;
@@ -1529,7 +1529,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F15R_FB_Field_Array;
@@ -1554,7 +1554,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F16R_FB_Field_Array;
@@ -1579,7 +1579,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F17R_FB_Field_Array;
@@ -1604,7 +1604,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F18R_FB_Field_Array;
@@ -1629,7 +1629,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F19R_FB_Field_Array;
@@ -1654,7 +1654,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F20R_FB_Field_Array;
@@ -1679,7 +1679,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F21R_FB_Field_Array;
@@ -1704,7 +1704,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F22R_FB_Field_Array;
@@ -1729,7 +1729,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F23R_FB_Field_Array;
@@ -1754,7 +1754,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F24R_FB_Field_Array;
@@ -1779,7 +1779,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F25R_FB_Field_Array;
@@ -1804,7 +1804,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F26R_FB_Field_Array;
@@ -1829,7 +1829,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F27R_FB_Field_Array;

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-crc.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-crc.ads
@@ -52,7 +52,7 @@ package STM32_SVD.CRC is
    --  Cryptographic processor
    type CRC_Peripheral is record
       --  Data register
-      DR  : HAL.Word;
+      DR  : HAL.UInt32;
       --  Independent Data register
       IDR : IDR_Register;
       --  Control register

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-cryp.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-cryp.ads
@@ -173,7 +173,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K0LR_b_Field_Array;
@@ -198,7 +198,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K0RR_b_Field_Array;
@@ -223,7 +223,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K1LR_b_Field_Array;
@@ -248,7 +248,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K1RR_b_Field_Array;
@@ -273,7 +273,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K2LR_b_Field_Array;
@@ -298,7 +298,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K2RR_b_Field_Array;
@@ -323,7 +323,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K3LR_b_Field_Array;
@@ -348,7 +348,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K3RR_b_Field_Array;
@@ -373,7 +373,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  IV as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IV as an array
             Arr : IV0LR_IV_Field_Array;
@@ -398,7 +398,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  IV as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IV as an array
             Arr : IV0RR_IV_Field_Array;
@@ -423,7 +423,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  IV as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IV as an array
             Arr : IV1LR_IV_Field_Array;
@@ -448,7 +448,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  IV as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IV as an array
             Arr : IV1RR_IV_Field_Array;
@@ -473,9 +473,9 @@ package STM32_SVD.CRYP is
       --  status register
       SR         : SR_Register;
       --  data input register
-      DIN        : HAL.Word;
+      DIN        : HAL.UInt32;
       --  data output register
-      DOUT       : HAL.Word;
+      DOUT       : HAL.UInt32;
       --  DMA control register
       DMACR      : DMACR_Register;
       --  interrupt mask set/clear register
@@ -509,37 +509,37 @@ package STM32_SVD.CRYP is
       --  initialization vector registers
       IV1RR      : IV1RR_Register;
       --  context swap register
-      CSGCMCCM0R : HAL.Word;
+      CSGCMCCM0R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM1R : HAL.Word;
+      CSGCMCCM1R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM2R : HAL.Word;
+      CSGCMCCM2R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM3R : HAL.Word;
+      CSGCMCCM3R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM4R : HAL.Word;
+      CSGCMCCM4R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM5R : HAL.Word;
+      CSGCMCCM5R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM6R : HAL.Word;
+      CSGCMCCM6R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM7R : HAL.Word;
+      CSGCMCCM7R : HAL.UInt32;
       --  context swap register
-      CSGCM0R    : HAL.Word;
+      CSGCM0R    : HAL.UInt32;
       --  context swap register
-      CSGCM1R    : HAL.Word;
+      CSGCM1R    : HAL.UInt32;
       --  context swap register
-      CSGCM2R    : HAL.Word;
+      CSGCM2R    : HAL.UInt32;
       --  context swap register
-      CSGCM3R    : HAL.Word;
+      CSGCM3R    : HAL.UInt32;
       --  context swap register
-      CSGCM4R    : HAL.Word;
+      CSGCM4R    : HAL.UInt32;
       --  context swap register
-      CSGCM5R    : HAL.Word;
+      CSGCM5R    : HAL.UInt32;
       --  context swap register
-      CSGCM6R    : HAL.Word;
+      CSGCM6R    : HAL.UInt32;
       --  context swap register
-      CSGCM7R    : HAL.Word;
+      CSGCM7R    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-dac.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-dac.ads
@@ -149,7 +149,7 @@ package STM32_SVD.DAC is
       --  DAC channel1 12-bit left-aligned data
       DACC1DHR       : DHR12L1_DACC1DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -203,7 +203,7 @@ package STM32_SVD.DAC is
       --  DAC channel2 12-bit left-aligned data
       DACC2DHR       : DHR12L2_DACC2DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -289,7 +289,7 @@ package STM32_SVD.DAC is
       --  DAC channel2 8-bit right-aligned data
       DACC2DHR       : DHR8RD_DACC2DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-dbg.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-dbg.ads
@@ -14,7 +14,7 @@ package STM32_SVD.DBG is
    ---------------
 
    subtype DBGMCU_IDCODE_DEV_ID_Field is HAL.UInt12;
-   subtype DBGMCU_IDCODE_REV_ID_Field is HAL.Short;
+   subtype DBGMCU_IDCODE_REV_ID_Field is HAL.UInt16;
 
    --  IDCODE
    type DBGMCU_IDCODE_Register is record

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-dcmi.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-dcmi.ads
@@ -307,7 +307,7 @@ package STM32_SVD.DCMI is
       case As_Array is
          when False =>
             --  Byte as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  Byte as an array
             Arr : DR_Byte_Field_Array;

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-dma.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-dma.ads
@@ -441,14 +441,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S0NDTR_NDT_Field is HAL.Short;
+   subtype S0NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S0NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S0NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -568,14 +568,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S1NDTR_NDT_Field is HAL.Short;
+   subtype S1NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S1NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S1NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -695,14 +695,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S2NDTR_NDT_Field is HAL.Short;
+   subtype S2NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S2NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S2NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -822,14 +822,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S3NDTR_NDT_Field is HAL.Short;
+   subtype S3NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S3NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S3NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -949,14 +949,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S4NDTR_NDT_Field is HAL.Short;
+   subtype S4NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S4NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S4NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1076,14 +1076,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S5NDTR_NDT_Field is HAL.Short;
+   subtype S5NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S5NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S5NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1203,14 +1203,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S6NDTR_NDT_Field is HAL.Short;
+   subtype S6NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S6NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S6NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1330,14 +1330,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S7NDTR_NDT_Field is HAL.Short;
+   subtype S7NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S7NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S7NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1396,11 +1396,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S0NDTR : S0NDTR_Register;
       --  stream x peripheral address register
-      S0PAR  : HAL.Word;
+      S0PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S0M0AR : HAL.Word;
+      S0M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S0M1AR : HAL.Word;
+      S0M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S0FCR  : S0FCR_Register;
       --  stream x configuration register
@@ -1408,11 +1408,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S1NDTR : S1NDTR_Register;
       --  stream x peripheral address register
-      S1PAR  : HAL.Word;
+      S1PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S1M0AR : HAL.Word;
+      S1M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S1M1AR : HAL.Word;
+      S1M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S1FCR  : S1FCR_Register;
       --  stream x configuration register
@@ -1420,11 +1420,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S2NDTR : S2NDTR_Register;
       --  stream x peripheral address register
-      S2PAR  : HAL.Word;
+      S2PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S2M0AR : HAL.Word;
+      S2M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S2M1AR : HAL.Word;
+      S2M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S2FCR  : S2FCR_Register;
       --  stream x configuration register
@@ -1432,11 +1432,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S3NDTR : S3NDTR_Register;
       --  stream x peripheral address register
-      S3PAR  : HAL.Word;
+      S3PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S3M0AR : HAL.Word;
+      S3M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S3M1AR : HAL.Word;
+      S3M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S3FCR  : S3FCR_Register;
       --  stream x configuration register
@@ -1444,11 +1444,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S4NDTR : S4NDTR_Register;
       --  stream x peripheral address register
-      S4PAR  : HAL.Word;
+      S4PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S4M0AR : HAL.Word;
+      S4M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S4M1AR : HAL.Word;
+      S4M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S4FCR  : S4FCR_Register;
       --  stream x configuration register
@@ -1456,11 +1456,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S5NDTR : S5NDTR_Register;
       --  stream x peripheral address register
-      S5PAR  : HAL.Word;
+      S5PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S5M0AR : HAL.Word;
+      S5M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S5M1AR : HAL.Word;
+      S5M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S5FCR  : S5FCR_Register;
       --  stream x configuration register
@@ -1468,11 +1468,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S6NDTR : S6NDTR_Register;
       --  stream x peripheral address register
-      S6PAR  : HAL.Word;
+      S6PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S6M0AR : HAL.Word;
+      S6M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S6M1AR : HAL.Word;
+      S6M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S6FCR  : S6FCR_Register;
       --  stream x configuration register
@@ -1480,11 +1480,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S7NDTR : S7NDTR_Register;
       --  stream x peripheral address register
-      S7PAR  : HAL.Word;
+      S7PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S7M0AR : HAL.Word;
+      S7M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S7M1AR : HAL.Word;
+      S7M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S7FCR  : S7FCR_Register;
    end record

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-dma2d.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-dma2d.ads
@@ -343,7 +343,7 @@ package STM32_SVD.DMA2D is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype NLR_NL_Field is HAL.Short;
+   subtype NLR_NL_Field is HAL.UInt16;
    subtype NLR_PL_Field is HAL.UInt14;
 
    --  number of line register
@@ -364,14 +364,14 @@ package STM32_SVD.DMA2D is
       Reserved_30_31 at 0 range 30 .. 31;
    end record;
 
-   subtype LWR_LW_Field is HAL.Short;
+   subtype LWR_LW_Field is HAL.UInt16;
 
    --  line watermark register
    type LWR_Register is record
       --  Line watermark
       LW             : LWR_LW_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -392,7 +392,7 @@ package STM32_SVD.DMA2D is
       --  Dead Time
       DT             : AMTCR_DT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -469,11 +469,11 @@ package STM32_SVD.DMA2D is
       --  interrupt flag clear register
       IFCR    : IFCR_Register;
       --  foreground memory address register
-      FGMAR   : HAL.Word;
+      FGMAR   : HAL.UInt32;
       --  foreground offset register
       FGOR    : FGOR_Register;
       --  background memory address register
-      BGMAR   : HAL.Word;
+      BGMAR   : HAL.UInt32;
       --  background offset register
       BGOR    : BGOR_Register;
       --  foreground PFC control register
@@ -485,15 +485,15 @@ package STM32_SVD.DMA2D is
       --  background color register
       BGCOLR  : BGCOLR_Register;
       --  foreground CLUT memory address register
-      FGCMAR  : HAL.Word;
+      FGCMAR  : HAL.UInt32;
       --  background CLUT memory address register
-      BGCMAR  : HAL.Word;
+      BGCMAR  : HAL.UInt32;
       --  output PFC control register
       OPFCCR  : OPFCCR_Register;
       --  output color register
       OCOLR   : OCOLR_Register;
       --  output memory address register
-      OMAR    : HAL.Word;
+      OMAR    : HAL.UInt32;
       --  output offset register
       OOR     : OOR_Register;
       --  number of line register

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-dsi.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-dsi.ads
@@ -38,7 +38,7 @@ package STM32_SVD.DSI is
       --  Timeout Clock Division
       TOCKDIV        : DSI_CCR_TOCKDIV_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -422,14 +422,14 @@ package STM32_SVD.DSI is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype DSI_LCCR_CMDSIZE_Field is HAL.Short;
+   subtype DSI_LCCR_CMDSIZE_Field is HAL.UInt16;
 
    --  DSI Host LTDC Command Configuration Register
    type DSI_LCCR_Register is record
       --  Command Size
       CMDSIZE        : DSI_LCCR_CMDSIZE_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -545,7 +545,7 @@ package STM32_SVD.DSI is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : DSI_GPDR_DATA_Field_Array;
@@ -592,8 +592,8 @@ package STM32_SVD.DSI is
       Reserved_7_31 at 0 range 7 .. 31;
    end record;
 
-   subtype DSI_TCCR0_LPRX_TOCNT_Field is HAL.Short;
-   subtype DSI_TCCR0_HSTX_TOCNT_Field is HAL.Short;
+   subtype DSI_TCCR0_LPRX_TOCNT_Field is HAL.UInt16;
+   subtype DSI_TCCR0_HSTX_TOCNT_Field is HAL.UInt16;
 
    --  DSI Host Timeout Counter Configuration Register 0
    type DSI_TCCR0_Register is record
@@ -610,14 +610,14 @@ package STM32_SVD.DSI is
       HSTX_TOCNT at 0 range 16 .. 31;
    end record;
 
-   subtype DSI_TCCR1_HSRD_TOCNT_Field is HAL.Short;
+   subtype DSI_TCCR1_HSRD_TOCNT_Field is HAL.UInt16;
 
    --  DSI Host Timeout Counter Configuration Register 1
    type DSI_TCCR1_Register is record
       --  High-Speed Read Timeout Counter
       HSRD_TOCNT     : DSI_TCCR1_HSRD_TOCNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -627,14 +627,14 @@ package STM32_SVD.DSI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DSI_TCCR2_LPRD_TOCNT_Field is HAL.Short;
+   subtype DSI_TCCR2_LPRD_TOCNT_Field is HAL.UInt16;
 
    --  DSI Host Timeout Counter Configuration Register 2
    type DSI_TCCR2_Register is record
       --  Low-Power Read Timeout Counter
       LPRD_TOCNT     : DSI_TCCR2_LPRD_TOCNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -644,7 +644,7 @@ package STM32_SVD.DSI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DSI_TCCR3_HSWR_TOCNT_Field is HAL.Short;
+   subtype DSI_TCCR3_HSWR_TOCNT_Field is HAL.UInt16;
 
    --  DSI Host Timeout Counter Configuration Register 3
    type DSI_TCCR3_Register is record
@@ -667,14 +667,14 @@ package STM32_SVD.DSI is
       Reserved_25_31 at 0 range 25 .. 31;
    end record;
 
-   subtype DSI_TCCR4_LSWR_TOCNT_Field is HAL.Short;
+   subtype DSI_TCCR4_LSWR_TOCNT_Field is HAL.UInt16;
 
    --  DSI Host Timeout Counter Configuration Register 4
    type DSI_TCCR4_Register is record
       --  Low-Power Write Timeout Counter
       LSWR_TOCNT     : DSI_TCCR4_LSWR_TOCNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -684,14 +684,14 @@ package STM32_SVD.DSI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DSI_TCCR5_BTA_TOCNT_Field is HAL.Short;
+   subtype DSI_TCCR5_BTA_TOCNT_Field is HAL.UInt16;
 
    --  DSI Host Timeout Counter Configuration Register 5
    type DSI_TCCR5_Register is record
       --  Bus-Turn-Around Timeout Counter
       BTA_TOCNT      : DSI_TCCR5_BTA_TOCNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -801,7 +801,7 @@ package STM32_SVD.DSI is
       --  SW_TIME
       SW_TIME        : DSI_PCONFR_SW_TIME_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -904,7 +904,7 @@ package STM32_SVD.DSI is
       case As_Array is
          when False =>
             --  AE as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  AE as an array
             Arr : DSI_ISR0_AE_Field_Array;
@@ -1147,7 +1147,7 @@ package STM32_SVD.DSI is
       case As_Array is
          when False =>
             --  FAE as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  FAE as an array
             Arr : DSI_FIR0_FAE_Field_Array;
@@ -2023,7 +2023,7 @@ package STM32_SVD.DSI is
    --  DSI Host
    type DSI_Peripheral is record
       --  DSI Host Version Register
-      DSI_VR      : HAL.Word;
+      DSI_VR      : HAL.UInt32;
       --  DSI Host Control Register
       DSI_CR      : DSI_CR_Register;
       --  DSI HOST Clock Control Register

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-ethernet.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-ethernet.ads
@@ -277,7 +277,7 @@ package STM32_SVD.Ethernet is
       Reserved_17_31 at 0 range 17 .. 31;
    end record;
 
-   subtype DMAMFBOCR_MFC_Field is HAL.Short;
+   subtype DMAMFBOCR_MFC_Field is HAL.UInt16;
    subtype DMAMFBOCR_MFA_Field is HAL.UInt11;
 
    --  Ethernet DMA missed frame and buffer overflow counter register
@@ -463,7 +463,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       PA             : MACMIIAR_PA_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -478,14 +478,14 @@ package STM32_SVD.Ethernet is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MACMIIDR_TD_Field is HAL.Short;
+   subtype MACMIIDR_TD_Field is HAL.UInt16;
 
    --  Ethernet MAC MII data register
    type MACMIIDR_Register is record
       --  no description available
       TD             : MACMIIDR_TD_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -496,7 +496,7 @@ package STM32_SVD.Ethernet is
    end record;
 
    subtype MACFCR_PLT_Field is HAL.UInt2;
-   subtype MACFCR_PT_Field is HAL.Short;
+   subtype MACFCR_PT_Field is HAL.UInt16;
 
    --  Ethernet MAC flow control register
    type MACFCR_Register is record
@@ -534,7 +534,7 @@ package STM32_SVD.Ethernet is
       PT            at 0 range 16 .. 31;
    end record;
 
-   subtype MACVLANTR_VLANTI_Field is HAL.Short;
+   subtype MACVLANTR_VLANTI_Field is HAL.UInt16;
 
    --  Ethernet MAC VLAN tag register
    type MACVLANTR_Register is record
@@ -680,7 +680,7 @@ package STM32_SVD.Ethernet is
       Reserved_10_31 at 0 range 10 .. 31;
    end record;
 
-   subtype MACA0HR_MACA0H_Field is HAL.Short;
+   subtype MACA0HR_MACA0H_Field is HAL.UInt16;
 
    --  Ethernet MAC address 0 high register
    type MACA0HR_Register is record
@@ -700,7 +700,7 @@ package STM32_SVD.Ethernet is
       MO             at 0 range 31 .. 31;
    end record;
 
-   subtype MACA1HR_MACA1H_Field is HAL.Short;
+   subtype MACA1HR_MACA1H_Field is HAL.UInt16;
    subtype MACA1HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 1 high register
@@ -727,7 +727,7 @@ package STM32_SVD.Ethernet is
       AE             at 0 range 31 .. 31;
    end record;
 
-   subtype MACA2HR_MAC2AH_Field is HAL.Short;
+   subtype MACA2HR_MAC2AH_Field is HAL.UInt16;
    subtype MACA2HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 2 high register
@@ -771,7 +771,7 @@ package STM32_SVD.Ethernet is
       Reserved_31_31 at 0 range 31 .. 31;
    end record;
 
-   subtype MACA3HR_MACA3H_Field is HAL.Short;
+   subtype MACA3HR_MACA3H_Field is HAL.UInt16;
    subtype MACA3HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 3 high register
@@ -1094,13 +1094,13 @@ package STM32_SVD.Ethernet is
       --  Ethernet DMA bus mode register
       DMABMR    : DMABMR_Register;
       --  Ethernet DMA transmit poll demand register
-      DMATPDR   : HAL.Word;
+      DMATPDR   : HAL.UInt32;
       --  EHERNET DMA receive poll demand register
-      DMARPDR   : HAL.Word;
+      DMARPDR   : HAL.UInt32;
       --  Ethernet DMA receive descriptor list address register
-      DMARDLAR  : HAL.Word;
+      DMARDLAR  : HAL.UInt32;
       --  Ethernet DMA transmit descriptor list address register
-      DMATDLAR  : HAL.Word;
+      DMATDLAR  : HAL.UInt32;
       --  Ethernet DMA status register
       DMASR     : DMASR_Register;
       --  Ethernet DMA operation mode register
@@ -1112,13 +1112,13 @@ package STM32_SVD.Ethernet is
       --  Ethernet DMA receive status watchdog timer register
       DMARSWTR  : DMARSWTR_Register;
       --  Ethernet DMA current host transmit descriptor register
-      DMACHTDR  : HAL.Word;
+      DMACHTDR  : HAL.UInt32;
       --  Ethernet DMA current host receive descriptor register
-      DMACHRDR  : HAL.Word;
+      DMACHRDR  : HAL.UInt32;
       --  Ethernet DMA current host transmit buffer address register
-      DMACHTBAR : HAL.Word;
+      DMACHTBAR : HAL.UInt32;
       --  Ethernet DMA current host receive buffer address register
-      DMACHRBAR : HAL.Word;
+      DMACHRBAR : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1150,9 +1150,9 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC frame filter register
       MACFFR    : MACFFR_Register;
       --  Ethernet MAC hash table high register
-      MACHTHR   : HAL.Word;
+      MACHTHR   : HAL.UInt32;
       --  Ethernet MAC hash table low register
-      MACHTLR   : HAL.Word;
+      MACHTLR   : HAL.UInt32;
       --  Ethernet MAC MII address register
       MACMIIAR  : MACMIIAR_Register;
       --  Ethernet MAC MII data register
@@ -1172,11 +1172,11 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC address 0 high register
       MACA0HR   : MACA0HR_Register;
       --  Ethernet MAC address 0 low register
-      MACA0LR   : HAL.Word;
+      MACA0LR   : HAL.UInt32;
       --  Ethernet MAC address 1 high register
       MACA1HR   : MACA1HR_Register;
       --  Ethernet MAC address1 low register
-      MACA1LR   : HAL.Word;
+      MACA1LR   : HAL.UInt32;
       --  Ethernet MAC address 2 high register
       MACA2HR   : MACA2HR_Register;
       --  Ethernet MAC address 2 low register
@@ -1184,7 +1184,7 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC address 3 high register
       MACA3HR   : MACA3HR_Register;
       --  Ethernet MAC address 3 low register
-      MACA3LR   : HAL.Word;
+      MACA3LR   : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1228,18 +1228,18 @@ package STM32_SVD.Ethernet is
       --  Ethernet MMC transmit interrupt mask register
       MMCTIMR     : MMCTIMR_Register;
       --  Ethernet MMC transmitted good frames after a single collision counter
-      MMCTGFSCCR  : HAL.Word;
+      MMCTGFSCCR  : HAL.UInt32;
       --  Ethernet MMC transmitted good frames after more than a single
       --  collision
-      MMCTGFMSCCR : HAL.Word;
+      MMCTGFMSCCR : HAL.UInt32;
       --  Ethernet MMC transmitted good frames counter register
-      MMCTGFCR    : HAL.Word;
+      MMCTGFCR    : HAL.UInt32;
       --  Ethernet MMC received frames with CRC error counter register
-      MMCRFCECR   : HAL.Word;
+      MMCRFCECR   : HAL.UInt32;
       --  Ethernet MMC received frames with alignment error counter register
-      MMCRFAECR   : HAL.Word;
+      MMCRFAECR   : HAL.UInt32;
       --  MMC received good unicast frames counter register
-      MMCRGUFCR   : HAL.Word;
+      MMCRGUFCR   : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1268,19 +1268,19 @@ package STM32_SVD.Ethernet is
       --  Ethernet PTP subsecond increment register
       PTPSSIR  : PTPSSIR_Register;
       --  Ethernet PTP time stamp high register
-      PTPTSHR  : HAL.Word;
+      PTPTSHR  : HAL.UInt32;
       --  Ethernet PTP time stamp low register
       PTPTSLR  : PTPTSLR_Register;
       --  Ethernet PTP time stamp high update register
-      PTPTSHUR : HAL.Word;
+      PTPTSHUR : HAL.UInt32;
       --  Ethernet PTP time stamp low update register
       PTPTSLUR : PTPTSLUR_Register;
       --  Ethernet PTP time stamp addend register
-      PTPTSAR  : HAL.Word;
+      PTPTSAR  : HAL.UInt32;
       --  Ethernet PTP target time high register
-      PTPTTHR  : HAL.Word;
+      PTPTTHR  : HAL.UInt32;
       --  Ethernet PTP target time low register
-      PTPTTLR  : HAL.Word;
+      PTPTTLR  : HAL.UInt32;
       --  Ethernet PTP time stamp status register
       PTPTSSR  : PTPTSSR_Register;
       --  Ethernet PTP PPS control register

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-flash.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-flash.ads
@@ -195,7 +195,7 @@ package STM32_SVD.FLASH is
    --  Flash option control register 1
    type OPTCR1_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  Not write protect
       nWRP           : OPTCR1_nWRP_Field := 16#FFF#;
       --  unspecified
@@ -219,9 +219,9 @@ package STM32_SVD.FLASH is
       --  Flash access control register
       ACR     : ACR_Register;
       --  Flash key register
-      KEYR    : HAL.Word;
+      KEYR    : HAL.UInt32;
       --  Flash option key register
-      OPTKEYR : HAL.Word;
+      OPTKEYR : HAL.UInt32;
       --  Status register
       SR      : SR_Register;
       --  Control register

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-fsmc.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-fsmc.ads
@@ -597,7 +597,7 @@ package STM32_SVD.FSMC is
       --  Attribute memory space timing register 3
       PATT  : PATT_Register;
       --  ECC result register 3
-      ECCR  : HAL.Word;
+      ECCR  : HAL.UInt32;
       --  SRAM/NOR-Flash write timing registers 1
       BWTR1 : BWTR_Register;
       --  SRAM/NOR-Flash write timing registers 2

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-gpio.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-gpio.ads
@@ -27,7 +27,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  MODER as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  MODER as an array
             Arr : MODER_Field_Array;
@@ -52,7 +52,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  OT as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  OT as an array
             Arr : OTYPER_OT_Field_Array;
@@ -70,7 +70,7 @@ package STM32_SVD.GPIO is
       --  Port x configuration bits (y = 0..15)
       OT             : OTYPER_OT_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -94,7 +94,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  OSPEEDR as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  OSPEEDR as an array
             Arr : OSPEEDR_Field_Array;
@@ -122,7 +122,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  PUPDR as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  PUPDR as an array
             Arr : PUPDR_Field_Array;
@@ -147,7 +147,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  IDR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  IDR as an array
             Arr : IDR_Field_Array;
@@ -165,7 +165,7 @@ package STM32_SVD.GPIO is
       --  Read-only. Port input data (y = 0..15)
       IDR            : IDR_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -186,7 +186,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  ODR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  ODR as an array
             Arr : ODR_Field_Array;
@@ -204,7 +204,7 @@ package STM32_SVD.GPIO is
       --  Port output data (y = 0..15)
       ODR            : ODR_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -225,7 +225,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  BS as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  BS as an array
             Arr : BSRR_BS_Field_Array;
@@ -249,7 +249,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  BR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  BR as an array
             Arr : BSRR_BR_Field_Array;
@@ -288,7 +288,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  LCK as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  LCK as an array
             Arr : LCKR_LCK_Field_Array;
@@ -333,7 +333,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  AFRL as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  AFRL as an array
             Arr : AFRL_Field_Array;
@@ -361,7 +361,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  AFRH as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  AFRH as an array
             Arr : AFRH_Field_Array;

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-hash.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-hash.ads
@@ -141,147 +141,147 @@ package STM32_SVD.HASH is
       --  control register
       CR       : CR_Register;
       --  data input register
-      DIN      : HAL.Word;
+      DIN      : HAL.UInt32;
       --  start register
       STR      : STR_Register;
       --  digest registers
-      HR0      : HAL.Word;
+      HR0      : HAL.UInt32;
       --  digest registers
-      HR1      : HAL.Word;
+      HR1      : HAL.UInt32;
       --  digest registers
-      HR2      : HAL.Word;
+      HR2      : HAL.UInt32;
       --  digest registers
-      HR3      : HAL.Word;
+      HR3      : HAL.UInt32;
       --  digest registers
-      HR4      : HAL.Word;
+      HR4      : HAL.UInt32;
       --  interrupt enable register
       IMR      : IMR_Register;
       --  status register
       SR       : SR_Register;
       --  context swap registers
-      CSR0     : HAL.Word;
+      CSR0     : HAL.UInt32;
       --  context swap registers
-      CSR1     : HAL.Word;
+      CSR1     : HAL.UInt32;
       --  context swap registers
-      CSR2     : HAL.Word;
+      CSR2     : HAL.UInt32;
       --  context swap registers
-      CSR3     : HAL.Word;
+      CSR3     : HAL.UInt32;
       --  context swap registers
-      CSR4     : HAL.Word;
+      CSR4     : HAL.UInt32;
       --  context swap registers
-      CSR5     : HAL.Word;
+      CSR5     : HAL.UInt32;
       --  context swap registers
-      CSR6     : HAL.Word;
+      CSR6     : HAL.UInt32;
       --  context swap registers
-      CSR7     : HAL.Word;
+      CSR7     : HAL.UInt32;
       --  context swap registers
-      CSR8     : HAL.Word;
+      CSR8     : HAL.UInt32;
       --  context swap registers
-      CSR9     : HAL.Word;
+      CSR9     : HAL.UInt32;
       --  context swap registers
-      CSR10    : HAL.Word;
+      CSR10    : HAL.UInt32;
       --  context swap registers
-      CSR11    : HAL.Word;
+      CSR11    : HAL.UInt32;
       --  context swap registers
-      CSR12    : HAL.Word;
+      CSR12    : HAL.UInt32;
       --  context swap registers
-      CSR13    : HAL.Word;
+      CSR13    : HAL.UInt32;
       --  context swap registers
-      CSR14    : HAL.Word;
+      CSR14    : HAL.UInt32;
       --  context swap registers
-      CSR15    : HAL.Word;
+      CSR15    : HAL.UInt32;
       --  context swap registers
-      CSR16    : HAL.Word;
+      CSR16    : HAL.UInt32;
       --  context swap registers
-      CSR17    : HAL.Word;
+      CSR17    : HAL.UInt32;
       --  context swap registers
-      CSR18    : HAL.Word;
+      CSR18    : HAL.UInt32;
       --  context swap registers
-      CSR19    : HAL.Word;
+      CSR19    : HAL.UInt32;
       --  context swap registers
-      CSR20    : HAL.Word;
+      CSR20    : HAL.UInt32;
       --  context swap registers
-      CSR21    : HAL.Word;
+      CSR21    : HAL.UInt32;
       --  context swap registers
-      CSR22    : HAL.Word;
+      CSR22    : HAL.UInt32;
       --  context swap registers
-      CSR23    : HAL.Word;
+      CSR23    : HAL.UInt32;
       --  context swap registers
-      CSR24    : HAL.Word;
+      CSR24    : HAL.UInt32;
       --  context swap registers
-      CSR25    : HAL.Word;
+      CSR25    : HAL.UInt32;
       --  context swap registers
-      CSR26    : HAL.Word;
+      CSR26    : HAL.UInt32;
       --  context swap registers
-      CSR27    : HAL.Word;
+      CSR27    : HAL.UInt32;
       --  context swap registers
-      CSR28    : HAL.Word;
+      CSR28    : HAL.UInt32;
       --  context swap registers
-      CSR29    : HAL.Word;
+      CSR29    : HAL.UInt32;
       --  context swap registers
-      CSR30    : HAL.Word;
+      CSR30    : HAL.UInt32;
       --  context swap registers
-      CSR31    : HAL.Word;
+      CSR31    : HAL.UInt32;
       --  context swap registers
-      CSR32    : HAL.Word;
+      CSR32    : HAL.UInt32;
       --  context swap registers
-      CSR33    : HAL.Word;
+      CSR33    : HAL.UInt32;
       --  context swap registers
-      CSR34    : HAL.Word;
+      CSR34    : HAL.UInt32;
       --  context swap registers
-      CSR35    : HAL.Word;
+      CSR35    : HAL.UInt32;
       --  context swap registers
-      CSR36    : HAL.Word;
+      CSR36    : HAL.UInt32;
       --  context swap registers
-      CSR37    : HAL.Word;
+      CSR37    : HAL.UInt32;
       --  context swap registers
-      CSR38    : HAL.Word;
+      CSR38    : HAL.UInt32;
       --  context swap registers
-      CSR39    : HAL.Word;
+      CSR39    : HAL.UInt32;
       --  context swap registers
-      CSR40    : HAL.Word;
+      CSR40    : HAL.UInt32;
       --  context swap registers
-      CSR41    : HAL.Word;
+      CSR41    : HAL.UInt32;
       --  context swap registers
-      CSR42    : HAL.Word;
+      CSR42    : HAL.UInt32;
       --  context swap registers
-      CSR43    : HAL.Word;
+      CSR43    : HAL.UInt32;
       --  context swap registers
-      CSR44    : HAL.Word;
+      CSR44    : HAL.UInt32;
       --  context swap registers
-      CSR45    : HAL.Word;
+      CSR45    : HAL.UInt32;
       --  context swap registers
-      CSR46    : HAL.Word;
+      CSR46    : HAL.UInt32;
       --  context swap registers
-      CSR47    : HAL.Word;
+      CSR47    : HAL.UInt32;
       --  context swap registers
-      CSR48    : HAL.Word;
+      CSR48    : HAL.UInt32;
       --  context swap registers
-      CSR49    : HAL.Word;
+      CSR49    : HAL.UInt32;
       --  context swap registers
-      CSR50    : HAL.Word;
+      CSR50    : HAL.UInt32;
       --  context swap registers
-      CSR51    : HAL.Word;
+      CSR51    : HAL.UInt32;
       --  context swap registers
-      CSR52    : HAL.Word;
+      CSR52    : HAL.UInt32;
       --  context swap registers
-      CSR53    : HAL.Word;
+      CSR53    : HAL.UInt32;
       --  HASH digest register
-      HASH_HR0 : HAL.Word;
+      HASH_HR0 : HAL.UInt32;
       --  read-only
-      HASH_HR1 : HAL.Word;
+      HASH_HR1 : HAL.UInt32;
       --  read-only
-      HASH_HR2 : HAL.Word;
+      HASH_HR2 : HAL.UInt32;
       --  read-only
-      HASH_HR3 : HAL.Word;
+      HASH_HR3 : HAL.UInt32;
       --  read-only
-      HASH_HR4 : HAL.Word;
+      HASH_HR4 : HAL.UInt32;
       --  read-only
-      HASH_HR5 : HAL.Word;
+      HASH_HR5 : HAL.UInt32;
       --  read-only
-      HASH_HR6 : HAL.Word;
+      HASH_HR6 : HAL.UInt32;
       --  read-only
-      HASH_HR7 : HAL.Word;
+      HASH_HR7 : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-i2c.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-i2c.ads
@@ -48,7 +48,7 @@ package STM32_SVD.I2C is
       --  Software reset
       SWRST          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -124,7 +124,7 @@ package STM32_SVD.I2C is
       --  Addressing mode (slave mode)
       ADDMODE        : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -210,7 +210,7 @@ package STM32_SVD.I2C is
       --  SMBus alert
       SMBALERT       : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -258,7 +258,7 @@ package STM32_SVD.I2C is
       --  Read-only. acket error checking register
       PEC            : SR2_PEC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -289,7 +289,7 @@ package STM32_SVD.I2C is
       --  I2C master mode selection
       F_S            : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-iwdg.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-iwdg.ads
@@ -13,14 +13,14 @@ package STM32_SVD.IWDG is
    -- Registers --
    ---------------
 
-   subtype KR_KEY_Field is HAL.Short;
+   subtype KR_KEY_Field is HAL.UInt16;
 
    --  Key register
    type KR_Register is record
       --  Write-only. Key value (write only, read 0000h)
       KEY            : KR_KEY_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-ltdc.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-ltdc.ads
@@ -288,8 +288,8 @@ package STM32_SVD.LTDC is
       Reserved_11_31 at 0 range 11 .. 31;
    end record;
 
-   subtype CPSR_CYPOS_Field is HAL.Short;
-   subtype CPSR_CXPOS_Field is HAL.Short;
+   subtype CPSR_CYPOS_Field is HAL.UInt16;
+   subtype CPSR_CXPOS_Field is HAL.UInt16;
 
    --  Current Position Status Register
    type CPSR_Register is record
@@ -875,7 +875,7 @@ package STM32_SVD.LTDC is
       --  Layerx Blending Factors Configuration Register
       L1BFCR   : L1BFCR_Register;
       --  Layerx Color Frame Buffer Address Register
-      L1CFBAR  : HAL.Word;
+      L1CFBAR  : HAL.UInt32;
       --  Layerx Color Frame Buffer Length Register
       L1CFBLR  : L1CFBLR_Register;
       --  Layerx ColorFrame Buffer Line Number Register
@@ -899,7 +899,7 @@ package STM32_SVD.LTDC is
       --  Layerx Blending Factors Configuration Register
       L2BFCR   : L2BFCR_Register;
       --  Layerx Color Frame Buffer Address Register
-      L2CFBAR  : HAL.Word;
+      L2CFBAR  : HAL.UInt32;
       --  Layerx Color Frame Buffer Length Register
       L2CFBLR  : L2CFBLR_Register;
       --  Layerx ColorFrame Buffer Line Number Register

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-nvic.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-nvic.ads
@@ -44,7 +44,7 @@ package STM32_SVD.NVIC is
       case As_Array is
          when False =>
             --  IPR_N as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IPR_N as an array
             Arr : IPR_IPR_N_Field_Array;
@@ -84,35 +84,35 @@ package STM32_SVD.NVIC is
       --  Interrupt Controller Type Register
       ICTR  : ICTR_Register;
       --  Interrupt Set-Enable Register
-      ISER0 : HAL.Word;
+      ISER0 : HAL.UInt32;
       --  Interrupt Set-Enable Register
-      ISER1 : HAL.Word;
+      ISER1 : HAL.UInt32;
       --  Interrupt Set-Enable Register
-      ISER2 : HAL.Word;
+      ISER2 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER0 : HAL.Word;
+      ICER0 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER1 : HAL.Word;
+      ICER1 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER2 : HAL.Word;
+      ICER2 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR0 : HAL.Word;
+      ISPR0 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR1 : HAL.Word;
+      ISPR1 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR2 : HAL.Word;
+      ISPR2 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR0 : HAL.Word;
+      ICPR0 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR1 : HAL.Word;
+      ICPR1 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR2 : HAL.Word;
+      ICPR2 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR0 : HAL.Word;
+      IABR0 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR1 : HAL.Word;
+      IABR1 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR2 : HAL.Word;
+      IABR2 : HAL.UInt32;
       --  Interrupt Priority Register
       IPR0  : IPR_Register;
       --  Interrupt Priority Register

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-quadspi.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-quadspi.ads
@@ -238,14 +238,14 @@ package STM32_SVD.QUADSPI is
       DDRM           at 0 range 31 .. 31;
    end record;
 
-   subtype PIR_INTERVAL_Field is HAL.Short;
+   subtype PIR_INTERVAL_Field is HAL.UInt16;
 
    --  polling interval register
    type PIR_Register is record
       --  Polling interval
       INTERVAL       : PIR_INTERVAL_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -255,14 +255,14 @@ package STM32_SVD.QUADSPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype LPTR_TIMEOUT_Field is HAL.Short;
+   subtype LPTR_TIMEOUT_Field is HAL.UInt16;
 
    --  low-power timeout register
    type LPTR_Register is record
       --  Timeout period
       TIMEOUT        : LPTR_TIMEOUT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -287,19 +287,19 @@ package STM32_SVD.QUADSPI is
       --  flag clear register
       FCR   : FCR_Register;
       --  data length register
-      DLR   : HAL.Word;
+      DLR   : HAL.UInt32;
       --  communication configuration register
       CCR   : CCR_Register;
       --  address register
-      AR    : HAL.Word;
+      AR    : HAL.UInt32;
       --  ABR
-      ABR   : HAL.Word;
+      ABR   : HAL.UInt32;
       --  data register
-      DR    : HAL.Word;
+      DR    : HAL.UInt32;
       --  polling status mask register
-      PSMKR : HAL.Word;
+      PSMKR : HAL.UInt32;
       --  polling status match register
-      PSMAR : HAL.Word;
+      PSMAR : HAL.UInt32;
       --  polling interval register
       PIR   : PIR_Register;
       --  low-power timeout register

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-rng.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-rng.ads
@@ -75,7 +75,7 @@ package STM32_SVD.RNG is
       --  status register
       SR : SR_Register;
       --  data register
-      DR : HAL.Word;
+      DR : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-rtc.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-rtc.ads
@@ -267,14 +267,14 @@ package STM32_SVD.RTC is
       Reserved_23_31 at 0 range 23 .. 31;
    end record;
 
-   subtype WUTR_WUT_Field is HAL.Short;
+   subtype WUTR_WUT_Field is HAL.UInt16;
 
    --  wakeup timer register
    type WUTR_Register is record
       --  Wakeup auto-reload value bits
       WUT            : WUTR_WUT_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -444,14 +444,14 @@ package STM32_SVD.RTC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype SSR_SS_Field is HAL.Short;
+   subtype SSR_SS_Field is HAL.UInt16;
 
    --  sub second register
    type SSR_Register is record
       --  Read-only. Sub second value
       SS             : SSR_SS_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -468,7 +468,7 @@ package STM32_SVD.RTC is
       --  Write-only. Subtract a fraction of a second
       SUBFS          : SHIFTR_SUBFS_Field := 16#0#;
       --  unspecified
-      Reserved_15_30 : HAL.Short := 16#0#;
+      Reserved_15_30 : HAL.UInt16 := 16#0#;
       --  Write-only. Add one second
       ADD1S          : Boolean := False;
    end record
@@ -534,7 +534,7 @@ package STM32_SVD.RTC is
       --  Read-only. Week day units
       WDU            : TSDR_WDU_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -549,14 +549,14 @@ package STM32_SVD.RTC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype TSSSR_SS_Field is HAL.Short;
+   subtype TSSSR_SS_Field is HAL.UInt16;
 
    --  timestamp sub second register
    type TSSSR_Register is record
       --  Read-only. Sub second value
       SS             : TSSSR_SS_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -603,7 +603,7 @@ package STM32_SVD.RTC is
       --  Increase frequency of RTC by 488.5 ppm
       CALP           : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -767,45 +767,45 @@ package STM32_SVD.RTC is
       --  alarm B sub second register
       ALRMBSSR : ALRMBSSR_Register;
       --  backup register
-      BKP0R    : HAL.Word;
+      BKP0R    : HAL.UInt32;
       --  backup register
-      BKP1R    : HAL.Word;
+      BKP1R    : HAL.UInt32;
       --  backup register
-      BKP2R    : HAL.Word;
+      BKP2R    : HAL.UInt32;
       --  backup register
-      BKP3R    : HAL.Word;
+      BKP3R    : HAL.UInt32;
       --  backup register
-      BKP4R    : HAL.Word;
+      BKP4R    : HAL.UInt32;
       --  backup register
-      BKP5R    : HAL.Word;
+      BKP5R    : HAL.UInt32;
       --  backup register
-      BKP6R    : HAL.Word;
+      BKP6R    : HAL.UInt32;
       --  backup register
-      BKP7R    : HAL.Word;
+      BKP7R    : HAL.UInt32;
       --  backup register
-      BKP8R    : HAL.Word;
+      BKP8R    : HAL.UInt32;
       --  backup register
-      BKP9R    : HAL.Word;
+      BKP9R    : HAL.UInt32;
       --  backup register
-      BKP10R   : HAL.Word;
+      BKP10R   : HAL.UInt32;
       --  backup register
-      BKP11R   : HAL.Word;
+      BKP11R   : HAL.UInt32;
       --  backup register
-      BKP12R   : HAL.Word;
+      BKP12R   : HAL.UInt32;
       --  backup register
-      BKP13R   : HAL.Word;
+      BKP13R   : HAL.UInt32;
       --  backup register
-      BKP14R   : HAL.Word;
+      BKP14R   : HAL.UInt32;
       --  backup register
-      BKP15R   : HAL.Word;
+      BKP15R   : HAL.UInt32;
       --  backup register
-      BKP16R   : HAL.Word;
+      BKP16R   : HAL.UInt32;
       --  backup register
-      BKP17R   : HAL.Word;
+      BKP17R   : HAL.UInt32;
       --  backup register
-      BKP18R   : HAL.Word;
+      BKP18R   : HAL.UInt32;
       --  backup register
-      BKP19R   : HAL.Word;
+      BKP19R   : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-sai.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-sai.ads
@@ -116,7 +116,7 @@ package STM32_SVD.SAI is
       --  Companding mode
       COMP           : ACR2_COMP_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -169,7 +169,7 @@ package STM32_SVD.SAI is
    subtype ASLOTR_FBOFF_Field is HAL.UInt5;
    subtype ASLOTR_SLOTSZ_Field is HAL.UInt2;
    subtype ASLOTR_NBSLOT_Field is HAL.UInt4;
-   subtype ASLOTR_SLOTEN_Field is HAL.Short;
+   subtype ASLOTR_SLOTEN_Field is HAL.UInt16;
 
    --  ASlot register
    type ASLOTR_Register is record
@@ -391,7 +391,7 @@ package STM32_SVD.SAI is
       --  Companding mode
       COMP           : BCR2_COMP_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -444,7 +444,7 @@ package STM32_SVD.SAI is
    subtype BSLOTR_FBOFF_Field is HAL.UInt5;
    subtype BSLOTR_SLOTSZ_Field is HAL.UInt2;
    subtype BSLOTR_NBSLOT_Field is HAL.UInt4;
-   subtype BSLOTR_SLOTEN_Field is HAL.Short;
+   subtype BSLOTR_SLOTEN_Field is HAL.UInt16;
 
    --  BSlot register
    type BSLOTR_Register is record
@@ -603,7 +603,7 @@ package STM32_SVD.SAI is
       --  AClear flag register
       ACLRFR : ACLRFR_Register;
       --  AData register
-      ADR    : HAL.Word;
+      ADR    : HAL.UInt32;
       --  BConfiguration register 1
       BCR1   : BCR1_Register;
       --  BConfiguration register 2
@@ -619,7 +619,7 @@ package STM32_SVD.SAI is
       --  BClear flag register
       BCLRFR : BCLRFR_Register;
       --  BData register
-      BDR    : HAL.Word;
+      BDR    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-sdio.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-sdio.ads
@@ -579,21 +579,21 @@ package STM32_SVD.SDIO is
       --  SDI clock control register
       CLKCR   : CLKCR_Register;
       --  argument register
-      ARG     : HAL.Word;
+      ARG     : HAL.UInt32;
       --  command register
       CMD     : CMD_Register;
       --  command response register
       RESPCMD : RESPCMD_Register;
       --  response 1..4 register
-      RESP1   : HAL.Word;
+      RESP1   : HAL.UInt32;
       --  response 1..4 register
-      RESP2   : HAL.Word;
+      RESP2   : HAL.UInt32;
       --  response 1..4 register
-      RESP3   : HAL.Word;
+      RESP3   : HAL.UInt32;
       --  response 1..4 register
-      RESP4   : HAL.Word;
+      RESP4   : HAL.UInt32;
       --  data timer register
-      DTIMER  : HAL.Word;
+      DTIMER  : HAL.UInt32;
       --  data length register
       DLEN    : DLEN_Register;
       --  data control register
@@ -609,7 +609,7 @@ package STM32_SVD.SDIO is
       --  FIFO counter register
       FIFOCNT : FIFOCNT_Register;
       --  data FIFO register
-      FIFO    : HAL.Word;
+      FIFO    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-spi.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-spi.ads
@@ -46,7 +46,7 @@ package STM32_SVD.SPI is
       --  Bidirectional data mode enable
       BIDIMODE       : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -144,14 +144,14 @@ package STM32_SVD.SPI is
       Reserved_9_31 at 0 range 9 .. 31;
    end record;
 
-   subtype DR_DR_Field is HAL.Short;
+   subtype DR_DR_Field is HAL.UInt16;
 
    --  data register
    type DR_Register is record
       --  Data register
       DR             : DR_DR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -161,14 +161,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CRCPR_CRCPOLY_Field is HAL.Short;
+   subtype CRCPR_CRCPOLY_Field is HAL.UInt16;
 
    --  CRC polynomial register
    type CRCPR_Register is record
       --  CRC polynomial register
       CRCPOLY        : CRCPR_CRCPOLY_Field := 16#7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -178,14 +178,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype RXCRCR_RxCRC_Field is HAL.Short;
+   subtype RXCRCR_RxCRC_Field is HAL.UInt16;
 
    --  RX CRC register
    type RXCRCR_Register is record
       --  Read-only. Rx CRC register
       RxCRC          : RXCRCR_RxCRC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -195,14 +195,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype TXCRCR_TxCRC_Field is HAL.Short;
+   subtype TXCRCR_TxCRC_Field is HAL.UInt16;
 
    --  TX CRC register
    type TXCRCR_Register is record
       --  Read-only. Tx CRC register
       TxCRC          : TXCRCR_TxCRC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-syscfg.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-syscfg.ads
@@ -46,7 +46,7 @@ package STM32_SVD.SYSCFG is
    --  peripheral mode configuration register
    type PMC_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  ADC1DC2
       ADC1DC2        : Boolean := False;
       --  ADC2DC2
@@ -87,7 +87,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR1_EXTI_Field_Array;
@@ -106,7 +106,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR1_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -130,7 +130,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR2_EXTI_Field_Array;
@@ -149,7 +149,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR2_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -173,7 +173,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR3_EXTI_Field_Array;
@@ -192,7 +192,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR3_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -216,7 +216,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR4_EXTI_Field_Array;
@@ -235,7 +235,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR4_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-tim.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-tim.ads
@@ -129,7 +129,7 @@ package STM32_SVD.TIM is
       --  External trigger polarity
       ETP            : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -318,7 +318,7 @@ package STM32_SVD.TIM is
       --  Output Compare 2 clear enable
       OC2CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -359,7 +359,7 @@ package STM32_SVD.TIM is
       --  Input capture 2 filter
       IC2F           : CCMR1_Input_IC2F_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -402,7 +402,7 @@ package STM32_SVD.TIM is
       --  Output compare 4 clear enable
       OC4CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -443,7 +443,7 @@ package STM32_SVD.TIM is
       --  Input capture 4 filter
       IC4F           : CCMR2_Input_IC4F_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -512,14 +512,14 @@ package STM32_SVD.TIM is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype CNT_CNT_Field is HAL.Short;
+   subtype CNT_CNT_Field is HAL.UInt16;
 
    --  counter
    type CNT_Register is record
       --  counter value
       CNT            : CNT_CNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -529,14 +529,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype PSC_PSC_Field is HAL.Short;
+   subtype PSC_PSC_Field is HAL.UInt16;
 
    --  prescaler
    type PSC_Register is record
       --  Prescaler value
       PSC            : PSC_PSC_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -546,14 +546,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype ARR_ARR_Field is HAL.Short;
+   subtype ARR_ARR_Field is HAL.UInt16;
 
    --  auto-reload register
    type ARR_Register is record
       --  Auto-reload value
       ARR            : ARR_ARR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -580,14 +580,14 @@ package STM32_SVD.TIM is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype CCR1_CCR1_Field is HAL.Short;
+   subtype CCR1_CCR1_Field is HAL.UInt16;
 
    --  capture/compare register 1
    type CCR1_Register is record
       --  Capture/Compare 1 value
       CCR1           : CCR1_CCR1_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -597,14 +597,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR2_CCR2_Field is HAL.Short;
+   subtype CCR2_CCR2_Field is HAL.UInt16;
 
    --  capture/compare register 2
    type CCR2_Register is record
       --  Capture/Compare 2 value
       CCR2           : CCR2_CCR2_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -614,14 +614,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR3_CCR3_Field is HAL.Short;
+   subtype CCR3_CCR3_Field is HAL.UInt16;
 
    --  capture/compare register 3
    type CCR3_Register is record
       --  Capture/Compare value
       CCR3           : CCR3_CCR3_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -631,14 +631,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR4_CCR4_Field is HAL.Short;
+   subtype CCR4_CCR4_Field is HAL.UInt16;
 
    --  capture/compare register 4
    type CCR4_Register is record
       --  Capture/Compare value
       CCR4           : CCR4_CCR4_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -670,7 +670,7 @@ package STM32_SVD.TIM is
       --  Main output enable
       MOE            : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -711,14 +711,14 @@ package STM32_SVD.TIM is
       Reserved_13_31 at 0 range 13 .. 31;
    end record;
 
-   subtype DMAR_DMAB_Field is HAL.Short;
+   subtype DMAR_DMAB_Field is HAL.UInt16;
 
    --  DMA address for full transfer
    type DMAR_Register is record
       --  DMA register for burst accesses
       DMAB           : DMAR_DMAB_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -913,7 +913,7 @@ package STM32_SVD.TIM is
       --  O24CE
       O24CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -967,7 +967,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -992,8 +992,8 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CNT_CNT_L_Field is HAL.Short;
-   subtype CNT_CNT_H_Field is HAL.Short;
+   subtype CNT_CNT_L_Field is HAL.UInt16;
+   subtype CNT_CNT_H_Field is HAL.UInt16;
 
    --  counter
    type CNT_Register_1 is record
@@ -1010,8 +1010,8 @@ package STM32_SVD.TIM is
       CNT_H at 0 range 16 .. 31;
    end record;
 
-   subtype ARR_ARR_L_Field is HAL.Short;
-   subtype ARR_ARR_H_Field is HAL.Short;
+   subtype ARR_ARR_L_Field is HAL.UInt16;
+   subtype ARR_ARR_H_Field is HAL.UInt16;
 
    --  auto-reload register
    type ARR_Register_1 is record
@@ -1028,8 +1028,8 @@ package STM32_SVD.TIM is
       ARR_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR1_CCR1_L_Field is HAL.Short;
-   subtype CCR1_CCR1_H_Field is HAL.Short;
+   subtype CCR1_CCR1_L_Field is HAL.UInt16;
+   subtype CCR1_CCR1_H_Field is HAL.UInt16;
 
    --  capture/compare register 1
    type CCR1_Register_1 is record
@@ -1046,8 +1046,8 @@ package STM32_SVD.TIM is
       CCR1_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR2_CCR2_L_Field is HAL.Short;
-   subtype CCR2_CCR2_H_Field is HAL.Short;
+   subtype CCR2_CCR2_L_Field is HAL.UInt16;
+   subtype CCR2_CCR2_H_Field is HAL.UInt16;
 
    --  capture/compare register 2
    type CCR2_Register_1 is record
@@ -1064,8 +1064,8 @@ package STM32_SVD.TIM is
       CCR2_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR3_CCR3_L_Field is HAL.Short;
-   subtype CCR3_CCR3_H_Field is HAL.Short;
+   subtype CCR3_CCR3_L_Field is HAL.UInt16;
+   subtype CCR3_CCR3_H_Field is HAL.UInt16;
 
    --  capture/compare register 3
    type CCR3_Register_1 is record
@@ -1082,8 +1082,8 @@ package STM32_SVD.TIM is
       CCR3_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR4_CCR4_L_Field is HAL.Short;
-   subtype CCR4_CCR4_H_Field is HAL.Short;
+   subtype CCR4_CCR4_L_Field is HAL.UInt16;
+   subtype CCR4_CCR4_H_Field is HAL.UInt16;
 
    --  capture/compare register 4
    type CCR4_Register_1 is record

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-usart.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-usart.ads
@@ -79,7 +79,7 @@ package STM32_SVD.USART is
       --  mantissa of USARTDIV
       DIV_Mantissa   : BRR_DIV_Mantissa_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -125,7 +125,7 @@ package STM32_SVD.USART is
       --  Oversampling mode
       OVER8          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -370,7 +370,7 @@ package STM32_SVD.USART is
       --  Guard time value
       GT             : GTPR_GT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-usb_otg_fs.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-usb_otg_fs.ads
@@ -180,8 +180,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype FS_DAINT_IEPINT_Field is HAL.Short;
-   subtype FS_DAINT_OEPINT_Field is HAL.Short;
+   subtype FS_DAINT_IEPINT_Field is HAL.UInt16;
+   subtype FS_DAINT_OEPINT_Field is HAL.UInt16;
 
    --  OTG_FS device all endpoints interrupt register (OTG_FS_DAINT)
    type FS_DAINT_Register is record
@@ -198,8 +198,8 @@ package STM32_SVD.USB_OTG_FS is
       OEPINT at 0 range 16 .. 31;
    end record;
 
-   subtype FS_DAINTMSK_IEPM_Field is HAL.Short;
-   subtype FS_DAINTMSK_OEPM_Field is HAL.Short;
+   subtype FS_DAINTMSK_IEPM_Field is HAL.UInt16;
+   subtype FS_DAINTMSK_OEPM_Field is HAL.UInt16;
 
    --  OTG_FS all endpoints interrupt mask register (OTG_FS_DAINTMSK)
    type FS_DAINTMSK_Register is record
@@ -216,14 +216,14 @@ package STM32_SVD.USB_OTG_FS is
       OEPM at 0 range 16 .. 31;
    end record;
 
-   subtype DVBUSDIS_VBUSDT_Field is HAL.Short;
+   subtype DVBUSDIS_VBUSDT_Field is HAL.UInt16;
 
    --  OTG_FS device VBUS discharge time register
    type DVBUSDIS_Register is record
       --  Device VBUS discharge time
       VBUSDT         : DVBUSDIS_VBUSDT_Field := 16#17D7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -250,14 +250,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_12_31 at 0 range 12 .. 31;
    end record;
 
-   subtype DIEPEMPMSK_INEPTXFEM_Field is HAL.Short;
+   subtype DIEPEMPMSK_INEPTXFEM_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint FIFO empty interrupt mask register
    type DIEPEMPMSK_Register is record
       --  IN EP Tx FIFO empty interrupt mask bits
       INEPTXFEM      : DIEPEMPMSK_INEPTXFEM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -382,14 +382,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype DTXFSTS_INEPTFSAV_Field is HAL.Short;
+   subtype DTXFSTS_INEPTFSAV_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint transmit FIFO status register
    type DTXFSTS_Register is record
       --  Read-only. IN endpoint TxFIFO space available
       INEPTFSAV      : DTXFSTS_INEPTFSAV_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1196,14 +1196,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_25_31 at 0 range 25 .. 31;
    end record;
 
-   subtype FS_GRXFSIZ_RXFD_Field is HAL.Short;
+   subtype FS_GRXFSIZ_RXFD_Field is HAL.UInt16;
 
    --  OTG_FS Receive FIFO size register (OTG_FS_GRXFSIZ)
    type FS_GRXFSIZ_Register is record
       --  RxFIFO depth
       RXFD           : FS_GRXFSIZ_RXFD_Field := 16#200#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1213,8 +1213,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype FS_GNPTXFSIZ_Device_TX0FSA_Field is HAL.Short;
-   subtype FS_GNPTXFSIZ_Device_TX0FD_Field is HAL.Short;
+   subtype FS_GNPTXFSIZ_Device_TX0FSA_Field is HAL.UInt16;
+   subtype FS_GNPTXFSIZ_Device_TX0FD_Field is HAL.UInt16;
 
    --  OTG_FS non-periodic transmit FIFO size register (Device mode)
    type FS_GNPTXFSIZ_Device_Register is record
@@ -1231,8 +1231,8 @@ package STM32_SVD.USB_OTG_FS is
       TX0FD  at 0 range 16 .. 31;
    end record;
 
-   subtype FS_GNPTXFSIZ_Host_NPTXFSA_Field is HAL.Short;
-   subtype FS_GNPTXFSIZ_Host_NPTXFD_Field is HAL.Short;
+   subtype FS_GNPTXFSIZ_Host_NPTXFSA_Field is HAL.UInt16;
+   subtype FS_GNPTXFSIZ_Host_NPTXFD_Field is HAL.UInt16;
 
    --  OTG_FS non-periodic transmit FIFO size register (Host mode)
    type FS_GNPTXFSIZ_Host_Register is record
@@ -1249,7 +1249,7 @@ package STM32_SVD.USB_OTG_FS is
       NPTXFD  at 0 range 16 .. 31;
    end record;
 
-   subtype FS_GNPTXSTS_NPTXFSAV_Field is HAL.Short;
+   subtype FS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
    subtype FS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
    subtype FS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
@@ -1278,7 +1278,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS general core configuration register (OTG_FS_GCCFG)
    type FS_GCCFG_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  Power down
       PWRDWN         : Boolean := False;
       --  unspecified
@@ -1305,8 +1305,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype FS_HPTXFSIZ_PTXSA_Field is HAL.Short;
-   subtype FS_HPTXFSIZ_PTXFSIZ_Field is HAL.Short;
+   subtype FS_HPTXFSIZ_PTXSA_Field is HAL.UInt16;
+   subtype FS_HPTXFSIZ_PTXFSIZ_Field is HAL.UInt16;
 
    --  OTG_FS Host periodic transmit FIFO size register (OTG_FS_HPTXFSIZ)
    type FS_HPTXFSIZ_Register is record
@@ -1323,8 +1323,8 @@ package STM32_SVD.USB_OTG_FS is
       PTXFSIZ at 0 range 16 .. 31;
    end record;
 
-   subtype FS_DIEPTXF_INEPTXSA_Field is HAL.Short;
-   subtype FS_DIEPTXF_INEPTXFD_Field is HAL.Short;
+   subtype FS_DIEPTXF_INEPTXSA_Field is HAL.UInt16;
+   subtype FS_DIEPTXF_INEPTXFD_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint transmit FIFO size register (OTG_FS_DIEPTXF1)
    type FS_DIEPTXF_Register is record
@@ -1361,14 +1361,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype HFIR_FRIVL_Field is HAL.Short;
+   subtype HFIR_FRIVL_Field is HAL.UInt16;
 
    --  OTG_FS Host frame interval register
    type HFIR_Register is record
       --  Frame interval
       FRIVL          : HFIR_FRIVL_Field := 16#EA60#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1378,8 +1378,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype FS_HFNUM_FRNUM_Field is HAL.Short;
-   subtype FS_HFNUM_FTREM_Field is HAL.Short;
+   subtype FS_HFNUM_FRNUM_Field is HAL.UInt16;
+   subtype FS_HFNUM_FTREM_Field is HAL.UInt16;
 
    --  OTG_FS host frame number/frame time remaining register (OTG_FS_HFNUM)
    type FS_HFNUM_Register is record
@@ -1396,7 +1396,7 @@ package STM32_SVD.USB_OTG_FS is
       FTREM at 0 range 16 .. 31;
    end record;
 
-   subtype FS_HPTXSTS_PTXFSAVL_Field is HAL.Short;
+   subtype FS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
    subtype FS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
    subtype FS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
 
@@ -1419,14 +1419,14 @@ package STM32_SVD.USB_OTG_FS is
       PTXQTOP  at 0 range 24 .. 31;
    end record;
 
-   subtype HAINT_HAINT_Field is HAL.Short;
+   subtype HAINT_HAINT_Field is HAL.UInt16;
 
    --  OTG_FS Host all channels interrupt register
    type HAINT_Register is record
       --  Read-only. Channel interrupts
       HAINT          : HAINT_HAINT_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1436,14 +1436,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype HAINTMSK_HAINTM_Field is HAL.Short;
+   subtype HAINTMSK_HAINTM_Field is HAL.UInt16;
 
    --  OTG_FS host all channels interrupt mask register
    type HAINTMSK_Register is record
       --  Channel interrupt mask
       HAINTM         : HAINTMSK_HAINTM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1862,7 +1862,7 @@ package STM32_SVD.USB_OTG_FS is
       --  OTG_FS general core configuration register (OTG_FS_GCCFG)
       FS_GCCFG            : FS_GCCFG_Register;
       --  core ID register
-      FS_CID              : HAL.Word;
+      FS_CID              : HAL.UInt32;
       --  OTG_FS Host periodic transmit FIFO size register (OTG_FS_HPTXFSIZ)
       FS_HPTXFSIZ         : FS_HPTXFSIZ_Register;
       --  OTG_FS device IN endpoint transmit FIFO size register
@@ -1876,10 +1876,10 @@ package STM32_SVD.USB_OTG_FS is
       FS_DIEPTXF3         : FS_DIEPTXF_Register;
       --  OTG_FS device IN endpoint transmit FIFO size register
       --  (OTG_FS_DIEPTXF4)
-      FS_DIEPTXF4         : HAL.Word;
+      FS_DIEPTXF4         : HAL.UInt32;
       --  OTG_FS device IN endpoint transmit FIFO size register
       --  (OTG_FS_DIEPTXF5)
-      FS_DIEPTXF5         : HAL.Word;
+      FS_DIEPTXF5         : HAL.UInt32;
       case Discriminent is
          when Device =>
             --  OTG_FS Receive status debug read(Device mode)

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-usb_otg_hs.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-usb_otg_hs.ads
@@ -209,8 +209,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_10_31 at 0 range 10 .. 31;
    end record;
 
-   subtype OTG_HS_DAINT_IEPINT_Field is HAL.Short;
-   subtype OTG_HS_DAINT_OEPINT_Field is HAL.Short;
+   subtype OTG_HS_DAINT_IEPINT_Field is HAL.UInt16;
+   subtype OTG_HS_DAINT_OEPINT_Field is HAL.UInt16;
 
    --  OTG_HS device all endpoints interrupt register
    type OTG_HS_DAINT_Register is record
@@ -227,8 +227,8 @@ package STM32_SVD.USB_OTG_HS is
       OEPINT at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DAINTMSK_IEPM_Field is HAL.Short;
-   subtype OTG_HS_DAINTMSK_OEPM_Field is HAL.Short;
+   subtype OTG_HS_DAINTMSK_IEPM_Field is HAL.UInt16;
+   subtype OTG_HS_DAINTMSK_OEPM_Field is HAL.UInt16;
 
    --  OTG_HS all endpoints interrupt mask register
    type OTG_HS_DAINTMSK_Register is record
@@ -245,14 +245,14 @@ package STM32_SVD.USB_OTG_HS is
       OEPM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DVBUSDIS_VBUSDT_Field is HAL.Short;
+   subtype OTG_HS_DVBUSDIS_VBUSDT_Field is HAL.UInt16;
 
    --  OTG_HS device VBUS discharge time register
    type OTG_HS_DVBUSDIS_Register is record
       --  Device VBUS discharge time
       VBUSDT         : OTG_HS_DVBUSDIS_VBUSDT_Field := 16#17D7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -318,14 +318,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype OTG_HS_DIEPEMPMSK_INEPTXFEM_Field is HAL.Short;
+   subtype OTG_HS_DIEPEMPMSK_INEPTXFEM_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint FIFO empty interrupt mask register
    type OTG_HS_DIEPEMPMSK_Register is record
       --  IN EP Tx FIFO empty interrupt mask bits
       INEPTXFEM      : OTG_HS_DIEPEMPMSK_INEPTXFEM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -621,14 +621,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype OTG_HS_DTXFSTS_INEPTFSAV_Field is HAL.Short;
+   subtype OTG_HS_DTXFSTS_INEPTFSAV_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint transmit FIFO status register
    type OTG_HS_DTXFSTS_Register is record
       --  Read-only. IN endpoint TxFIFO space avail
       INEPTFSAV      : OTG_HS_DTXFSTS_INEPTFSAV_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1435,14 +1435,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_25_31 at 0 range 25 .. 31;
    end record;
 
-   subtype OTG_HS_GRXFSIZ_RXFD_Field is HAL.Short;
+   subtype OTG_HS_GRXFSIZ_RXFD_Field is HAL.UInt16;
 
    --  OTG_HS Receive FIFO size register
    type OTG_HS_GRXFSIZ_Register is record
       --  RxFIFO depth
       RXFD           : OTG_HS_GRXFSIZ_RXFD_Field := 16#200#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1452,8 +1452,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_GNPTXFSIZ_Host_NPTXFSA_Field is HAL.Short;
-   subtype OTG_HS_GNPTXFSIZ_Host_NPTXFD_Field is HAL.Short;
+   subtype OTG_HS_GNPTXFSIZ_Host_NPTXFSA_Field is HAL.UInt16;
+   subtype OTG_HS_GNPTXFSIZ_Host_NPTXFD_Field is HAL.UInt16;
 
    --  OTG_HS nonperiodic transmit FIFO size register (host mode)
    type OTG_HS_GNPTXFSIZ_Host_Register is record
@@ -1470,8 +1470,8 @@ package STM32_SVD.USB_OTG_HS is
       NPTXFD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_TX0FSIZ_Peripheral_TX0FSA_Field is HAL.Short;
-   subtype OTG_HS_TX0FSIZ_Peripheral_TX0FD_Field is HAL.Short;
+   subtype OTG_HS_TX0FSIZ_Peripheral_TX0FSA_Field is HAL.UInt16;
+   subtype OTG_HS_TX0FSIZ_Peripheral_TX0FD_Field is HAL.UInt16;
 
    --  Endpoint 0 transmit FIFO size (peripheral mode)
    type OTG_HS_TX0FSIZ_Peripheral_Register is record
@@ -1488,7 +1488,7 @@ package STM32_SVD.USB_OTG_HS is
       TX0FD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.Short;
+   subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
    subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
    subtype OTG_HS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
@@ -1516,7 +1516,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS general core configuration register
    type OTG_HS_GCCFG_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  Power down
       PWRDWN         : Boolean := False;
       --  Enable I2C bus connection for the external I2C PHY interface
@@ -1546,8 +1546,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_22_31 at 0 range 22 .. 31;
    end record;
 
-   subtype OTG_HS_HPTXFSIZ_PTXSA_Field is HAL.Short;
-   subtype OTG_HS_HPTXFSIZ_PTXFD_Field is HAL.Short;
+   subtype OTG_HS_HPTXFSIZ_PTXSA_Field is HAL.UInt16;
+   subtype OTG_HS_HPTXFSIZ_PTXFD_Field is HAL.UInt16;
 
    --  OTG_HS Host periodic transmit FIFO size register
    type OTG_HS_HPTXFSIZ_Register is record
@@ -1564,8 +1564,8 @@ package STM32_SVD.USB_OTG_HS is
       PTXFD at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DIEPTXF_INEPTXSA_Field is HAL.Short;
-   subtype OTG_HS_DIEPTXF_INEPTXFD_Field is HAL.Short;
+   subtype OTG_HS_DIEPTXF_INEPTXSA_Field is HAL.UInt16;
+   subtype OTG_HS_DIEPTXF_INEPTXFD_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint transmit FIFO size register
    type OTG_HS_DIEPTXF_Register is record
@@ -1602,14 +1602,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype OTG_HS_HFIR_FRIVL_Field is HAL.Short;
+   subtype OTG_HS_HFIR_FRIVL_Field is HAL.UInt16;
 
    --  OTG_HS Host frame interval register
    type OTG_HS_HFIR_Register is record
       --  Frame interval
       FRIVL          : OTG_HS_HFIR_FRIVL_Field := 16#EA60#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1619,8 +1619,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HFNUM_FRNUM_Field is HAL.Short;
-   subtype OTG_HS_HFNUM_FTREM_Field is HAL.Short;
+   subtype OTG_HS_HFNUM_FRNUM_Field is HAL.UInt16;
+   subtype OTG_HS_HFNUM_FTREM_Field is HAL.UInt16;
 
    --  OTG_HS host frame number/frame time remaining register
    type OTG_HS_HFNUM_Register is record
@@ -1637,7 +1637,7 @@ package STM32_SVD.USB_OTG_HS is
       FTREM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.Short;
+   subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
    subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
    subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
 
@@ -1659,14 +1659,14 @@ package STM32_SVD.USB_OTG_HS is
       PTXQTOP  at 0 range 24 .. 31;
    end record;
 
-   subtype OTG_HS_HAINT_HAINT_Field is HAL.Short;
+   subtype OTG_HS_HAINT_HAINT_Field is HAL.UInt16;
 
    --  OTG_HS Host all channels interrupt register
    type OTG_HS_HAINT_Register is record
       --  Read-only. Channel interrupts
       HAINT          : OTG_HS_HAINT_HAINT_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1676,14 +1676,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HAINTMSK_HAINTM_Field is HAL.Short;
+   subtype OTG_HS_HAINTMSK_HAINTM_Field is HAL.UInt16;
 
    --  OTG_HS host all channels interrupt mask register
    type OTG_HS_HAINTMSK_Register is record
       --  Channel interrupt mask
       HAINTM         : OTG_HS_HAINTMSK_HAINTM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2012,7 +2012,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device IN endpoint 0 transfer size register
       OTG_HS_DIEPTSIZ0    : OTG_HS_DIEPTSIZ0_Register;
       --  OTG_HS device endpoint-1 DMA address register
-      OTG_HS_DIEPDMA1     : HAL.Word;
+      OTG_HS_DIEPDMA1     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS0     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-1 control register
@@ -2022,7 +2022,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ1    : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-2 DMA address register
-      OTG_HS_DIEPDMA2     : HAL.Word;
+      OTG_HS_DIEPDMA2     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS1     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-2 control register
@@ -2032,7 +2032,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ2    : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-3 DMA address register
-      OTG_HS_DIEPDMA3     : HAL.Word;
+      OTG_HS_DIEPDMA3     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS2     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-3 control register
@@ -2042,7 +2042,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ3    : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-4 DMA address register
-      OTG_HS_DIEPDMA4     : HAL.Word;
+      OTG_HS_DIEPDMA4     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS3     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-4 control register
@@ -2052,7 +2052,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ4    : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-5 DMA address register
-      OTG_HS_DIEPDMA5     : HAL.Word;
+      OTG_HS_DIEPDMA5     : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS4     : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-5 control register
@@ -2212,7 +2212,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS general core configuration register
       OTG_HS_GCCFG              : OTG_HS_GCCFG_Register;
       --  OTG_HS core ID register
-      OTG_HS_CID                : HAL.Word;
+      OTG_HS_CID                : HAL.UInt32;
       --  OTG_HS Host periodic transmit FIFO size register
       OTG_HS_HPTXFSIZ           : OTG_HS_HPTXFSIZ_Register;
       --  OTG_HS device IN endpoint transmit FIFO size register
@@ -2310,7 +2310,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-11 transfer size register
       OTG_HS_HCTSIZ0    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-0 DMA address register
-      OTG_HS_HCDMA0     : HAL.Word;
+      OTG_HS_HCDMA0     : HAL.UInt32;
       --  OTG_HS host channel-1 characteristics register
       OTG_HS_HCCHAR1    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-1 split control register
@@ -2322,7 +2322,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-1 transfer size register
       OTG_HS_HCTSIZ1    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-1 DMA address register
-      OTG_HS_HCDMA1     : HAL.Word;
+      OTG_HS_HCDMA1     : HAL.UInt32;
       --  OTG_HS host channel-2 characteristics register
       OTG_HS_HCCHAR2    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-2 split control register
@@ -2334,7 +2334,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-2 transfer size register
       OTG_HS_HCTSIZ2    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-2 DMA address register
-      OTG_HS_HCDMA2     : HAL.Word;
+      OTG_HS_HCDMA2     : HAL.UInt32;
       --  OTG_HS host channel-3 characteristics register
       OTG_HS_HCCHAR3    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-3 split control register
@@ -2346,7 +2346,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-3 transfer size register
       OTG_HS_HCTSIZ3    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-3 DMA address register
-      OTG_HS_HCDMA3     : HAL.Word;
+      OTG_HS_HCDMA3     : HAL.UInt32;
       --  OTG_HS host channel-4 characteristics register
       OTG_HS_HCCHAR4    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-4 split control register
@@ -2358,7 +2358,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-4 transfer size register
       OTG_HS_HCTSIZ4    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-4 DMA address register
-      OTG_HS_HCDMA4     : HAL.Word;
+      OTG_HS_HCDMA4     : HAL.UInt32;
       --  OTG_HS host channel-5 characteristics register
       OTG_HS_HCCHAR5    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-5 split control register
@@ -2370,7 +2370,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-5 transfer size register
       OTG_HS_HCTSIZ5    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-5 DMA address register
-      OTG_HS_HCDMA5     : HAL.Word;
+      OTG_HS_HCDMA5     : HAL.UInt32;
       --  OTG_HS host channel-6 characteristics register
       OTG_HS_HCCHAR6    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-6 split control register
@@ -2382,7 +2382,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-6 transfer size register
       OTG_HS_HCTSIZ6    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-6 DMA address register
-      OTG_HS_HCDMA6     : HAL.Word;
+      OTG_HS_HCDMA6     : HAL.UInt32;
       --  OTG_HS host channel-7 characteristics register
       OTG_HS_HCCHAR7    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-7 split control register
@@ -2394,7 +2394,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-7 transfer size register
       OTG_HS_HCTSIZ7    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-7 DMA address register
-      OTG_HS_HCDMA7     : HAL.Word;
+      OTG_HS_HCDMA7     : HAL.UInt32;
       --  OTG_HS host channel-8 characteristics register
       OTG_HS_HCCHAR8    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-8 split control register
@@ -2406,7 +2406,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-8 transfer size register
       OTG_HS_HCTSIZ8    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-8 DMA address register
-      OTG_HS_HCDMA8     : HAL.Word;
+      OTG_HS_HCDMA8     : HAL.UInt32;
       --  OTG_HS host channel-9 characteristics register
       OTG_HS_HCCHAR9    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-9 split control register
@@ -2418,7 +2418,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-9 transfer size register
       OTG_HS_HCTSIZ9    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-9 DMA address register
-      OTG_HS_HCDMA9     : HAL.Word;
+      OTG_HS_HCDMA9     : HAL.UInt32;
       --  OTG_HS host channel-10 characteristics register
       OTG_HS_HCCHAR10   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-10 split control register
@@ -2430,7 +2430,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-10 transfer size register
       OTG_HS_HCTSIZ10   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-10 DMA address register
-      OTG_HS_HCDMA10    : HAL.Word;
+      OTG_HS_HCDMA10    : HAL.UInt32;
       --  OTG_HS host channel-11 characteristics register
       OTG_HS_HCCHAR11   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-11 split control register
@@ -2442,7 +2442,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-11 transfer size register
       OTG_HS_HCTSIZ11   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-11 DMA address register
-      OTG_HS_HCDMA11    : HAL.Word;
+      OTG_HS_HCDMA11    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-adc.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-adc.ads
@@ -530,14 +530,14 @@ package STM32_SVD.ADC is
       Reserved_22_31 at 0 range 22 .. 31;
    end record;
 
-   subtype JDR_JDATA_Field is HAL.Short;
+   subtype JDR_JDATA_Field is HAL.UInt16;
 
    --  injected data register x
    type JDR_Register is record
       --  Read-only. Injected data
       JDATA          : JDR_JDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -547,14 +547,14 @@ package STM32_SVD.ADC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DR_DATA_Field is HAL.Short;
+   subtype DR_DATA_Field is HAL.UInt16;
 
    --  regular data register
    type DR_Register is record
       --  Read-only. Regular data
       DATA           : DR_DATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -684,7 +684,7 @@ package STM32_SVD.ADC is
    end record;
 
    --  CDR_DATA array element
-   subtype CDR_DATA_Element is HAL.Short;
+   subtype CDR_DATA_Element is HAL.UInt16;
 
    --  CDR_DATA array
    type CDR_DATA_Field_Array is array (1 .. 2) of CDR_DATA_Element
@@ -697,7 +697,7 @@ package STM32_SVD.ADC is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : CDR_DATA_Field_Array;

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-can.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-can.ads
@@ -446,7 +446,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT0R_DLC_Field is HAL.UInt4;
-   subtype TDT0R_TIME_Field is HAL.Short;
+   subtype TDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT0R_Register is record
@@ -486,7 +486,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL0R_DATA_Field_Array;
@@ -514,7 +514,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH0R_DATA_Field_Array;
@@ -556,7 +556,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT1R_DLC_Field is HAL.UInt4;
-   subtype TDT1R_TIME_Field is HAL.Short;
+   subtype TDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT1R_Register is record
@@ -596,7 +596,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL1R_DATA_Field_Array;
@@ -624,7 +624,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH1R_DATA_Field_Array;
@@ -666,7 +666,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT2R_DLC_Field is HAL.UInt4;
-   subtype TDT2R_TIME_Field is HAL.Short;
+   subtype TDT2R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT2R_Register is record
@@ -706,7 +706,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL2R_DATA_Field_Array;
@@ -734,7 +734,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH2R_DATA_Field_Array;
@@ -777,7 +777,7 @@ package STM32_SVD.CAN is
 
    subtype RDT0R_DLC_Field is HAL.UInt4;
    subtype RDT0R_FMI_Field is HAL.Byte;
-   subtype RDT0R_TIME_Field is HAL.Short;
+   subtype RDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
    type RDT0R_Register is record
@@ -814,7 +814,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDL0R_DATA_Field_Array;
@@ -842,7 +842,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDH0R_DATA_Field_Array;
@@ -885,7 +885,7 @@ package STM32_SVD.CAN is
 
    subtype RDT1R_DLC_Field is HAL.UInt4;
    subtype RDT1R_FMI_Field is HAL.Byte;
-   subtype RDT1R_TIME_Field is HAL.Short;
+   subtype RDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
    type RDT1R_Register is record
@@ -922,7 +922,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDL1R_DATA_Field_Array;
@@ -950,7 +950,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDH1R_DATA_Field_Array;
@@ -1154,7 +1154,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F0R_FB_Field_Array;
@@ -1179,7 +1179,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F1R_FB_Field_Array;
@@ -1204,7 +1204,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F2R_FB_Field_Array;
@@ -1229,7 +1229,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F3R_FB_Field_Array;
@@ -1254,7 +1254,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F4R_FB_Field_Array;
@@ -1279,7 +1279,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F5R_FB_Field_Array;
@@ -1304,7 +1304,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F6R_FB_Field_Array;
@@ -1329,7 +1329,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F7R_FB_Field_Array;
@@ -1354,7 +1354,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F8R_FB_Field_Array;
@@ -1379,7 +1379,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F9R_FB_Field_Array;
@@ -1404,7 +1404,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F10R_FB_Field_Array;
@@ -1429,7 +1429,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F11R_FB_Field_Array;
@@ -1454,7 +1454,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F12R_FB_Field_Array;
@@ -1479,7 +1479,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F13R_FB_Field_Array;
@@ -1504,7 +1504,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F14R_FB_Field_Array;
@@ -1529,7 +1529,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F15R_FB_Field_Array;
@@ -1554,7 +1554,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F16R_FB_Field_Array;
@@ -1579,7 +1579,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F17R_FB_Field_Array;
@@ -1604,7 +1604,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F18R_FB_Field_Array;
@@ -1629,7 +1629,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F19R_FB_Field_Array;
@@ -1654,7 +1654,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F20R_FB_Field_Array;
@@ -1679,7 +1679,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F21R_FB_Field_Array;
@@ -1704,7 +1704,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F22R_FB_Field_Array;
@@ -1729,7 +1729,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F23R_FB_Field_Array;
@@ -1754,7 +1754,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F24R_FB_Field_Array;
@@ -1779,7 +1779,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F25R_FB_Field_Array;
@@ -1804,7 +1804,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F26R_FB_Field_Array;
@@ -1829,7 +1829,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F27R_FB_Field_Array;

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-crc.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-crc.ads
@@ -52,15 +52,15 @@ package STM32_SVD.CRC is
    --  Cryptographic processor
    type CRC_Peripheral is record
       --  Data register
-      DR   : HAL.Word;
+      DR   : HAL.UInt32;
       --  Independent Data register
       IDR  : IDR_Register;
       --  Control register
       CR   : CR_Register;
       --  Initial CRC value
-      INIT : HAL.Word;
+      INIT : HAL.UInt32;
       --  CRC polynomial
-      POL  : HAL.Word;
+      POL  : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-cryp.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-cryp.ads
@@ -173,7 +173,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K0LR_b_Field_Array;
@@ -198,7 +198,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K0RR_b_Field_Array;
@@ -223,7 +223,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K1LR_b_Field_Array;
@@ -248,7 +248,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K1RR_b_Field_Array;
@@ -273,7 +273,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K2LR_b_Field_Array;
@@ -298,7 +298,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K2RR_b_Field_Array;
@@ -323,7 +323,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K3LR_b_Field_Array;
@@ -348,7 +348,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K3RR_b_Field_Array;
@@ -373,7 +373,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  IV as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IV as an array
             Arr : IV0LR_IV_Field_Array;
@@ -398,7 +398,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  IV as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IV as an array
             Arr : IV0RR_IV_Field_Array;
@@ -423,7 +423,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  IV as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IV as an array
             Arr : IV1LR_IV_Field_Array;
@@ -448,7 +448,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  IV as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IV as an array
             Arr : IV1RR_IV_Field_Array;
@@ -473,9 +473,9 @@ package STM32_SVD.CRYP is
       --  status register
       SR         : SR_Register;
       --  data input register
-      DIN        : HAL.Word;
+      DIN        : HAL.UInt32;
       --  data output register
-      DOUT       : HAL.Word;
+      DOUT       : HAL.UInt32;
       --  DMA control register
       DMACR      : DMACR_Register;
       --  interrupt mask set/clear register
@@ -509,37 +509,37 @@ package STM32_SVD.CRYP is
       --  initialization vector registers
       IV1RR      : IV1RR_Register;
       --  context swap register
-      CSGCMCCM0R : HAL.Word;
+      CSGCMCCM0R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM1R : HAL.Word;
+      CSGCMCCM1R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM2R : HAL.Word;
+      CSGCMCCM2R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM3R : HAL.Word;
+      CSGCMCCM3R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM4R : HAL.Word;
+      CSGCMCCM4R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM5R : HAL.Word;
+      CSGCMCCM5R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM6R : HAL.Word;
+      CSGCMCCM6R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM7R : HAL.Word;
+      CSGCMCCM7R : HAL.UInt32;
       --  context swap register
-      CSGCM0R    : HAL.Word;
+      CSGCM0R    : HAL.UInt32;
       --  context swap register
-      CSGCM1R    : HAL.Word;
+      CSGCM1R    : HAL.UInt32;
       --  context swap register
-      CSGCM2R    : HAL.Word;
+      CSGCM2R    : HAL.UInt32;
       --  context swap register
-      CSGCM3R    : HAL.Word;
+      CSGCM3R    : HAL.UInt32;
       --  context swap register
-      CSGCM4R    : HAL.Word;
+      CSGCM4R    : HAL.UInt32;
       --  context swap register
-      CSGCM5R    : HAL.Word;
+      CSGCM5R    : HAL.UInt32;
       --  context swap register
-      CSGCM6R    : HAL.Word;
+      CSGCM6R    : HAL.UInt32;
       --  context swap register
-      CSGCM7R    : HAL.Word;
+      CSGCM7R    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-dac.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-dac.ads
@@ -149,7 +149,7 @@ package STM32_SVD.DAC is
       --  DAC channel1 12-bit left-aligned data
       DACC1DHR       : DHR12L1_DACC1DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -203,7 +203,7 @@ package STM32_SVD.DAC is
       --  DAC channel2 12-bit left-aligned data
       DACC2DHR       : DHR12L2_DACC2DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -289,7 +289,7 @@ package STM32_SVD.DAC is
       --  DAC channel2 8-bit right-aligned data
       DACC2DHR       : DHR8RD_DACC2DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-dbg.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-dbg.ads
@@ -14,7 +14,7 @@ package STM32_SVD.DBG is
    ---------------
 
    subtype DBGMCU_IDCODE_DEV_ID_Field is HAL.UInt12;
-   subtype DBGMCU_IDCODE_REV_ID_Field is HAL.Short;
+   subtype DBGMCU_IDCODE_REV_ID_Field is HAL.UInt16;
 
    --  IDCODE
    type DBGMCU_IDCODE_Register is record

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-dcmi.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-dcmi.ads
@@ -307,7 +307,7 @@ package STM32_SVD.DCMI is
       case As_Array is
          when False =>
             --  Byte as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  Byte as an array
             Arr : DR_Byte_Field_Array;

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-dma.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-dma.ads
@@ -441,14 +441,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S0NDTR_NDT_Field is HAL.Short;
+   subtype S0NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S0NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S0NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -568,14 +568,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S1NDTR_NDT_Field is HAL.Short;
+   subtype S1NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S1NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S1NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -695,14 +695,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S2NDTR_NDT_Field is HAL.Short;
+   subtype S2NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S2NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S2NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -822,14 +822,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S3NDTR_NDT_Field is HAL.Short;
+   subtype S3NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S3NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S3NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -949,14 +949,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S4NDTR_NDT_Field is HAL.Short;
+   subtype S4NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S4NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S4NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1076,14 +1076,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S5NDTR_NDT_Field is HAL.Short;
+   subtype S5NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S5NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S5NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1203,14 +1203,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S6NDTR_NDT_Field is HAL.Short;
+   subtype S6NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S6NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S6NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1330,14 +1330,14 @@ package STM32_SVD.DMA is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype S7NDTR_NDT_Field is HAL.Short;
+   subtype S7NDTR_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type S7NDTR_Register is record
       --  Number of data items to transfer
       NDT            : S7NDTR_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1396,11 +1396,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S0NDTR : S0NDTR_Register;
       --  stream x peripheral address register
-      S0PAR  : HAL.Word;
+      S0PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S0M0AR : HAL.Word;
+      S0M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S0M1AR : HAL.Word;
+      S0M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S0FCR  : S0FCR_Register;
       --  stream x configuration register
@@ -1408,11 +1408,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S1NDTR : S1NDTR_Register;
       --  stream x peripheral address register
-      S1PAR  : HAL.Word;
+      S1PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S1M0AR : HAL.Word;
+      S1M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S1M1AR : HAL.Word;
+      S1M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S1FCR  : S1FCR_Register;
       --  stream x configuration register
@@ -1420,11 +1420,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S2NDTR : S2NDTR_Register;
       --  stream x peripheral address register
-      S2PAR  : HAL.Word;
+      S2PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S2M0AR : HAL.Word;
+      S2M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S2M1AR : HAL.Word;
+      S2M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S2FCR  : S2FCR_Register;
       --  stream x configuration register
@@ -1432,11 +1432,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S3NDTR : S3NDTR_Register;
       --  stream x peripheral address register
-      S3PAR  : HAL.Word;
+      S3PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S3M0AR : HAL.Word;
+      S3M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S3M1AR : HAL.Word;
+      S3M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S3FCR  : S3FCR_Register;
       --  stream x configuration register
@@ -1444,11 +1444,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S4NDTR : S4NDTR_Register;
       --  stream x peripheral address register
-      S4PAR  : HAL.Word;
+      S4PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S4M0AR : HAL.Word;
+      S4M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S4M1AR : HAL.Word;
+      S4M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S4FCR  : S4FCR_Register;
       --  stream x configuration register
@@ -1456,11 +1456,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S5NDTR : S5NDTR_Register;
       --  stream x peripheral address register
-      S5PAR  : HAL.Word;
+      S5PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S5M0AR : HAL.Word;
+      S5M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S5M1AR : HAL.Word;
+      S5M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S5FCR  : S5FCR_Register;
       --  stream x configuration register
@@ -1468,11 +1468,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S6NDTR : S6NDTR_Register;
       --  stream x peripheral address register
-      S6PAR  : HAL.Word;
+      S6PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S6M0AR : HAL.Word;
+      S6M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S6M1AR : HAL.Word;
+      S6M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S6FCR  : S6FCR_Register;
       --  stream x configuration register
@@ -1480,11 +1480,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       S7NDTR : S7NDTR_Register;
       --  stream x peripheral address register
-      S7PAR  : HAL.Word;
+      S7PAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      S7M0AR : HAL.Word;
+      S7M0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      S7M1AR : HAL.Word;
+      S7M1AR : HAL.UInt32;
       --  stream x FIFO control register
       S7FCR  : S7FCR_Register;
    end record

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-dma2d.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-dma2d.ads
@@ -343,7 +343,7 @@ package STM32_SVD.DMA2D is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype NLR_NL_Field is HAL.Short;
+   subtype NLR_NL_Field is HAL.UInt16;
    subtype NLR_PL_Field is HAL.UInt14;
 
    --  number of line register
@@ -364,14 +364,14 @@ package STM32_SVD.DMA2D is
       Reserved_30_31 at 0 range 30 .. 31;
    end record;
 
-   subtype LWR_LW_Field is HAL.Short;
+   subtype LWR_LW_Field is HAL.UInt16;
 
    --  line watermark register
    type LWR_Register is record
       --  Line watermark
       LW             : LWR_LW_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -392,7 +392,7 @@ package STM32_SVD.DMA2D is
       --  Dead Time
       DT             : AMTCR_DT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -469,11 +469,11 @@ package STM32_SVD.DMA2D is
       --  interrupt flag clear register
       IFCR    : IFCR_Register;
       --  foreground memory address register
-      FGMAR   : HAL.Word;
+      FGMAR   : HAL.UInt32;
       --  foreground offset register
       FGOR    : FGOR_Register;
       --  background memory address register
-      BGMAR   : HAL.Word;
+      BGMAR   : HAL.UInt32;
       --  background offset register
       BGOR    : BGOR_Register;
       --  foreground PFC control register
@@ -485,15 +485,15 @@ package STM32_SVD.DMA2D is
       --  background color register
       BGCOLR  : BGCOLR_Register;
       --  foreground CLUT memory address register
-      FGCMAR  : HAL.Word;
+      FGCMAR  : HAL.UInt32;
       --  background CLUT memory address register
-      BGCMAR  : HAL.Word;
+      BGCMAR  : HAL.UInt32;
       --  output PFC control register
       OPFCCR  : OPFCCR_Register;
       --  output color register
       OCOLR   : OCOLR_Register;
       --  output memory address register
-      OMAR    : HAL.Word;
+      OMAR    : HAL.UInt32;
       --  output offset register
       OOR     : OOR_Register;
       --  number of line register

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-ethernet.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-ethernet.ads
@@ -277,7 +277,7 @@ package STM32_SVD.Ethernet is
       Reserved_17_31 at 0 range 17 .. 31;
    end record;
 
-   subtype DMAMFBOCR_MFC_Field is HAL.Short;
+   subtype DMAMFBOCR_MFC_Field is HAL.UInt16;
    subtype DMAMFBOCR_MFA_Field is HAL.UInt11;
 
    --  Ethernet DMA missed frame and buffer overflow counter register
@@ -463,7 +463,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       PA             : MACMIIAR_PA_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -478,14 +478,14 @@ package STM32_SVD.Ethernet is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MACMIIDR_TD_Field is HAL.Short;
+   subtype MACMIIDR_TD_Field is HAL.UInt16;
 
    --  Ethernet MAC MII data register
    type MACMIIDR_Register is record
       --  no description available
       TD             : MACMIIDR_TD_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -496,7 +496,7 @@ package STM32_SVD.Ethernet is
    end record;
 
    subtype MACFCR_PLT_Field is HAL.UInt2;
-   subtype MACFCR_PT_Field is HAL.Short;
+   subtype MACFCR_PT_Field is HAL.UInt16;
 
    --  Ethernet MAC flow control register
    type MACFCR_Register is record
@@ -534,7 +534,7 @@ package STM32_SVD.Ethernet is
       PT            at 0 range 16 .. 31;
    end record;
 
-   subtype MACVLANTR_VLANTI_Field is HAL.Short;
+   subtype MACVLANTR_VLANTI_Field is HAL.UInt16;
 
    --  Ethernet MAC VLAN tag register
    type MACVLANTR_Register is record
@@ -680,7 +680,7 @@ package STM32_SVD.Ethernet is
       Reserved_10_31 at 0 range 10 .. 31;
    end record;
 
-   subtype MACA0HR_MACA0H_Field is HAL.Short;
+   subtype MACA0HR_MACA0H_Field is HAL.UInt16;
 
    --  Ethernet MAC address 0 high register
    type MACA0HR_Register is record
@@ -700,7 +700,7 @@ package STM32_SVD.Ethernet is
       MO             at 0 range 31 .. 31;
    end record;
 
-   subtype MACA1HR_MACA1H_Field is HAL.Short;
+   subtype MACA1HR_MACA1H_Field is HAL.UInt16;
    subtype MACA1HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 1 high register
@@ -727,7 +727,7 @@ package STM32_SVD.Ethernet is
       AE             at 0 range 31 .. 31;
    end record;
 
-   subtype MACA2HR_MAC2AH_Field is HAL.Short;
+   subtype MACA2HR_MAC2AH_Field is HAL.UInt16;
    subtype MACA2HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 2 high register
@@ -771,7 +771,7 @@ package STM32_SVD.Ethernet is
       Reserved_31_31 at 0 range 31 .. 31;
    end record;
 
-   subtype MACA3HR_MACA3H_Field is HAL.Short;
+   subtype MACA3HR_MACA3H_Field is HAL.UInt16;
    subtype MACA3HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 3 high register
@@ -1094,13 +1094,13 @@ package STM32_SVD.Ethernet is
       --  Ethernet DMA bus mode register
       DMABMR    : DMABMR_Register;
       --  Ethernet DMA transmit poll demand register
-      DMATPDR   : HAL.Word;
+      DMATPDR   : HAL.UInt32;
       --  EHERNET DMA receive poll demand register
-      DMARPDR   : HAL.Word;
+      DMARPDR   : HAL.UInt32;
       --  Ethernet DMA receive descriptor list address register
-      DMARDLAR  : HAL.Word;
+      DMARDLAR  : HAL.UInt32;
       --  Ethernet DMA transmit descriptor list address register
-      DMATDLAR  : HAL.Word;
+      DMATDLAR  : HAL.UInt32;
       --  Ethernet DMA status register
       DMASR     : DMASR_Register;
       --  Ethernet DMA operation mode register
@@ -1112,13 +1112,13 @@ package STM32_SVD.Ethernet is
       --  Ethernet DMA receive status watchdog timer register
       DMARSWTR  : DMARSWTR_Register;
       --  Ethernet DMA current host transmit descriptor register
-      DMACHTDR  : HAL.Word;
+      DMACHTDR  : HAL.UInt32;
       --  Ethernet DMA current host receive descriptor register
-      DMACHRDR  : HAL.Word;
+      DMACHRDR  : HAL.UInt32;
       --  Ethernet DMA current host transmit buffer address register
-      DMACHTBAR : HAL.Word;
+      DMACHTBAR : HAL.UInt32;
       --  Ethernet DMA current host receive buffer address register
-      DMACHRBAR : HAL.Word;
+      DMACHRBAR : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1150,9 +1150,9 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC frame filter register
       MACFFR     : MACFFR_Register;
       --  Ethernet MAC hash table high register
-      MACHTHR    : HAL.Word;
+      MACHTHR    : HAL.UInt32;
       --  Ethernet MAC hash table low register
-      MACHTLR    : HAL.Word;
+      MACHTLR    : HAL.UInt32;
       --  Ethernet MAC MII address register
       MACMIIAR   : MACMIIAR_Register;
       --  Ethernet MAC MII data register
@@ -1172,11 +1172,11 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC address 0 high register
       MACA0HR    : MACA0HR_Register;
       --  Ethernet MAC address 0 low register
-      MACA0LR    : HAL.Word;
+      MACA0LR    : HAL.UInt32;
       --  Ethernet MAC address 1 high register
       MACA1HR    : MACA1HR_Register;
       --  Ethernet MAC address1 low register
-      MACA1LR    : HAL.Word;
+      MACA1LR    : HAL.UInt32;
       --  Ethernet MAC address 2 high register
       MACA2HR    : MACA2HR_Register;
       --  Ethernet MAC address 2 low register
@@ -1184,9 +1184,9 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC address 3 high register
       MACA3HR    : MACA3HR_Register;
       --  Ethernet MAC address 3 low register
-      MACA3LR    : HAL.Word;
+      MACA3LR    : HAL.UInt32;
       --  Ethernet MAC remote wakeup frame filter register
-      MACRWUFFER : HAL.Word;
+      MACRWUFFER : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1231,18 +1231,18 @@ package STM32_SVD.Ethernet is
       --  Ethernet MMC transmit interrupt mask register
       MMCTIMR     : MMCTIMR_Register;
       --  Ethernet MMC transmitted good frames after a single collision counter
-      MMCTGFSCCR  : HAL.Word;
+      MMCTGFSCCR  : HAL.UInt32;
       --  Ethernet MMC transmitted good frames after more than a single
       --  collision
-      MMCTGFMSCCR : HAL.Word;
+      MMCTGFMSCCR : HAL.UInt32;
       --  Ethernet MMC transmitted good frames counter register
-      MMCTGFCR    : HAL.Word;
+      MMCTGFCR    : HAL.UInt32;
       --  Ethernet MMC received frames with CRC error counter register
-      MMCRFCECR   : HAL.Word;
+      MMCRFCECR   : HAL.UInt32;
       --  Ethernet MMC received frames with alignment error counter register
-      MMCRFAECR   : HAL.Word;
+      MMCRFAECR   : HAL.UInt32;
       --  MMC received good unicast frames counter register
-      MMCRGUFCR   : HAL.Word;
+      MMCRGUFCR   : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1271,19 +1271,19 @@ package STM32_SVD.Ethernet is
       --  Ethernet PTP subsecond increment register
       PTPSSIR  : PTPSSIR_Register;
       --  Ethernet PTP time stamp high register
-      PTPTSHR  : HAL.Word;
+      PTPTSHR  : HAL.UInt32;
       --  Ethernet PTP time stamp low register
       PTPTSLR  : PTPTSLR_Register;
       --  Ethernet PTP time stamp high update register
-      PTPTSHUR : HAL.Word;
+      PTPTSHUR : HAL.UInt32;
       --  Ethernet PTP time stamp low update register
       PTPTSLUR : PTPTSLUR_Register;
       --  Ethernet PTP time stamp addend register
-      PTPTSAR  : HAL.Word;
+      PTPTSAR  : HAL.UInt32;
       --  Ethernet PTP target time high register
-      PTPTTHR  : HAL.Word;
+      PTPTTHR  : HAL.UInt32;
       --  Ethernet PTP target time low register
-      PTPTTLR  : HAL.Word;
+      PTPTTLR  : HAL.UInt32;
       --  Ethernet PTP time stamp status register
       PTPTSSR  : PTPTSSR_Register;
       --  Ethernet PTP PPS control register

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-flash.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-flash.ads
@@ -186,7 +186,7 @@ package STM32_SVD.FLASH is
    --  Flash option control register 1
    type OPTCR1_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  Not write protect
       nWRP           : OPTCR1_nWRP_Field := 16#FFF#;
       --  unspecified
@@ -210,9 +210,9 @@ package STM32_SVD.FLASH is
       --  Flash access control register
       ACR     : ACR_Register;
       --  Flash key register
-      KEYR    : HAL.Word;
+      KEYR    : HAL.UInt32;
       --  Flash option key register
-      OPTKEYR : HAL.Word;
+      OPTKEYR : HAL.UInt32;
       --  Status register
       SR      : SR_Register;
       --  Control register

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-fsmc.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-fsmc.ads
@@ -597,7 +597,7 @@ package STM32_SVD.FSMC is
       --  Attribute memory space timing register
       PATT  : PATT_Register;
       --  ECC result register
-      ECCR  : HAL.Word;
+      ECCR  : HAL.UInt32;
       --  SRAM/NOR-Flash write timing registers 1
       BWTR1 : BWTR_Register;
       --  SRAM/NOR-Flash write timing registers 2

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-gpio.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-gpio.ads
@@ -27,7 +27,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  MODER as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  MODER as an array
             Arr : MODER_Field_Array;
@@ -52,7 +52,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  OT as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  OT as an array
             Arr : OTYPER_OT_Field_Array;
@@ -70,7 +70,7 @@ package STM32_SVD.GPIO is
       --  Port x configuration bits (y = 0..15)
       OT             : OTYPER_OT_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -94,7 +94,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  OSPEEDR as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  OSPEEDR as an array
             Arr : OSPEEDR_Field_Array;
@@ -122,7 +122,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  PUPDR as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  PUPDR as an array
             Arr : PUPDR_Field_Array;
@@ -147,7 +147,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  IDR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  IDR as an array
             Arr : IDR_Field_Array;
@@ -165,7 +165,7 @@ package STM32_SVD.GPIO is
       --  Read-only. Port input data (y = 0..15)
       IDR            : IDR_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -186,7 +186,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  ODR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  ODR as an array
             Arr : ODR_Field_Array;
@@ -204,7 +204,7 @@ package STM32_SVD.GPIO is
       --  Port output data (y = 0..15)
       ODR            : ODR_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -225,7 +225,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  BS as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  BS as an array
             Arr : BSRR_BS_Field_Array;
@@ -249,7 +249,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  BR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  BR as an array
             Arr : BSRR_BR_Field_Array;
@@ -288,7 +288,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  LCK as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  LCK as an array
             Arr : LCKR_LCK_Field_Array;
@@ -333,7 +333,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  AFRL as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  AFRL as an array
             Arr : AFRL_Field_Array;
@@ -361,7 +361,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  AFRH as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  AFRH as an array
             Arr : AFRH_Field_Array;
@@ -386,7 +386,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  BR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  BR as an array
             Arr : BRR_BR_Field_Array;
@@ -404,7 +404,7 @@ package STM32_SVD.GPIO is
       --  Port A Reset bit 0
       BR             : BRR_BR_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-hash.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-hash.ads
@@ -141,147 +141,147 @@ package STM32_SVD.HASH is
       --  control register
       CR       : CR_Register;
       --  data input register
-      DIN      : HAL.Word;
+      DIN      : HAL.UInt32;
       --  start register
       STR      : STR_Register;
       --  digest registers
-      HR0      : HAL.Word;
+      HR0      : HAL.UInt32;
       --  digest registers
-      HR1      : HAL.Word;
+      HR1      : HAL.UInt32;
       --  digest registers
-      HR2      : HAL.Word;
+      HR2      : HAL.UInt32;
       --  digest registers
-      HR3      : HAL.Word;
+      HR3      : HAL.UInt32;
       --  digest registers
-      HR4      : HAL.Word;
+      HR4      : HAL.UInt32;
       --  interrupt enable register
       IMR      : IMR_Register;
       --  status register
       SR       : SR_Register;
       --  context swap registers
-      CSR0     : HAL.Word;
+      CSR0     : HAL.UInt32;
       --  context swap registers
-      CSR1     : HAL.Word;
+      CSR1     : HAL.UInt32;
       --  context swap registers
-      CSR2     : HAL.Word;
+      CSR2     : HAL.UInt32;
       --  context swap registers
-      CSR3     : HAL.Word;
+      CSR3     : HAL.UInt32;
       --  context swap registers
-      CSR4     : HAL.Word;
+      CSR4     : HAL.UInt32;
       --  context swap registers
-      CSR5     : HAL.Word;
+      CSR5     : HAL.UInt32;
       --  context swap registers
-      CSR6     : HAL.Word;
+      CSR6     : HAL.UInt32;
       --  context swap registers
-      CSR7     : HAL.Word;
+      CSR7     : HAL.UInt32;
       --  context swap registers
-      CSR8     : HAL.Word;
+      CSR8     : HAL.UInt32;
       --  context swap registers
-      CSR9     : HAL.Word;
+      CSR9     : HAL.UInt32;
       --  context swap registers
-      CSR10    : HAL.Word;
+      CSR10    : HAL.UInt32;
       --  context swap registers
-      CSR11    : HAL.Word;
+      CSR11    : HAL.UInt32;
       --  context swap registers
-      CSR12    : HAL.Word;
+      CSR12    : HAL.UInt32;
       --  context swap registers
-      CSR13    : HAL.Word;
+      CSR13    : HAL.UInt32;
       --  context swap registers
-      CSR14    : HAL.Word;
+      CSR14    : HAL.UInt32;
       --  context swap registers
-      CSR15    : HAL.Word;
+      CSR15    : HAL.UInt32;
       --  context swap registers
-      CSR16    : HAL.Word;
+      CSR16    : HAL.UInt32;
       --  context swap registers
-      CSR17    : HAL.Word;
+      CSR17    : HAL.UInt32;
       --  context swap registers
-      CSR18    : HAL.Word;
+      CSR18    : HAL.UInt32;
       --  context swap registers
-      CSR19    : HAL.Word;
+      CSR19    : HAL.UInt32;
       --  context swap registers
-      CSR20    : HAL.Word;
+      CSR20    : HAL.UInt32;
       --  context swap registers
-      CSR21    : HAL.Word;
+      CSR21    : HAL.UInt32;
       --  context swap registers
-      CSR22    : HAL.Word;
+      CSR22    : HAL.UInt32;
       --  context swap registers
-      CSR23    : HAL.Word;
+      CSR23    : HAL.UInt32;
       --  context swap registers
-      CSR24    : HAL.Word;
+      CSR24    : HAL.UInt32;
       --  context swap registers
-      CSR25    : HAL.Word;
+      CSR25    : HAL.UInt32;
       --  context swap registers
-      CSR26    : HAL.Word;
+      CSR26    : HAL.UInt32;
       --  context swap registers
-      CSR27    : HAL.Word;
+      CSR27    : HAL.UInt32;
       --  context swap registers
-      CSR28    : HAL.Word;
+      CSR28    : HAL.UInt32;
       --  context swap registers
-      CSR29    : HAL.Word;
+      CSR29    : HAL.UInt32;
       --  context swap registers
-      CSR30    : HAL.Word;
+      CSR30    : HAL.UInt32;
       --  context swap registers
-      CSR31    : HAL.Word;
+      CSR31    : HAL.UInt32;
       --  context swap registers
-      CSR32    : HAL.Word;
+      CSR32    : HAL.UInt32;
       --  context swap registers
-      CSR33    : HAL.Word;
+      CSR33    : HAL.UInt32;
       --  context swap registers
-      CSR34    : HAL.Word;
+      CSR34    : HAL.UInt32;
       --  context swap registers
-      CSR35    : HAL.Word;
+      CSR35    : HAL.UInt32;
       --  context swap registers
-      CSR36    : HAL.Word;
+      CSR36    : HAL.UInt32;
       --  context swap registers
-      CSR37    : HAL.Word;
+      CSR37    : HAL.UInt32;
       --  context swap registers
-      CSR38    : HAL.Word;
+      CSR38    : HAL.UInt32;
       --  context swap registers
-      CSR39    : HAL.Word;
+      CSR39    : HAL.UInt32;
       --  context swap registers
-      CSR40    : HAL.Word;
+      CSR40    : HAL.UInt32;
       --  context swap registers
-      CSR41    : HAL.Word;
+      CSR41    : HAL.UInt32;
       --  context swap registers
-      CSR42    : HAL.Word;
+      CSR42    : HAL.UInt32;
       --  context swap registers
-      CSR43    : HAL.Word;
+      CSR43    : HAL.UInt32;
       --  context swap registers
-      CSR44    : HAL.Word;
+      CSR44    : HAL.UInt32;
       --  context swap registers
-      CSR45    : HAL.Word;
+      CSR45    : HAL.UInt32;
       --  context swap registers
-      CSR46    : HAL.Word;
+      CSR46    : HAL.UInt32;
       --  context swap registers
-      CSR47    : HAL.Word;
+      CSR47    : HAL.UInt32;
       --  context swap registers
-      CSR48    : HAL.Word;
+      CSR48    : HAL.UInt32;
       --  context swap registers
-      CSR49    : HAL.Word;
+      CSR49    : HAL.UInt32;
       --  context swap registers
-      CSR50    : HAL.Word;
+      CSR50    : HAL.UInt32;
       --  context swap registers
-      CSR51    : HAL.Word;
+      CSR51    : HAL.UInt32;
       --  context swap registers
-      CSR52    : HAL.Word;
+      CSR52    : HAL.UInt32;
       --  context swap registers
-      CSR53    : HAL.Word;
+      CSR53    : HAL.UInt32;
       --  HASH digest register
-      HASH_HR0 : HAL.Word;
+      HASH_HR0 : HAL.UInt32;
       --  read-only
-      HASH_HR1 : HAL.Word;
+      HASH_HR1 : HAL.UInt32;
       --  read-only
-      HASH_HR2 : HAL.Word;
+      HASH_HR2 : HAL.UInt32;
       --  read-only
-      HASH_HR3 : HAL.Word;
+      HASH_HR3 : HAL.UInt32;
       --  read-only
-      HASH_HR4 : HAL.Word;
+      HASH_HR4 : HAL.UInt32;
       --  read-only
-      HASH_HR5 : HAL.Word;
+      HASH_HR5 : HAL.UInt32;
       --  read-only
-      HASH_HR6 : HAL.Word;
+      HASH_HR6 : HAL.UInt32;
       --  read-only
-      HASH_HR7 : HAL.Word;
+      HASH_HR7 : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-i2c.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-i2c.ads
@@ -151,7 +151,7 @@ package STM32_SVD.I2C is
       --  Own Address 1 enable
       OA1EN          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -180,7 +180,7 @@ package STM32_SVD.I2C is
       --  Own Address 2 enable
       OA2EN          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-iwdg.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-iwdg.ads
@@ -13,14 +13,14 @@ package STM32_SVD.IWDG is
    -- Registers --
    ---------------
 
-   subtype KR_KEY_Field is HAL.Short;
+   subtype KR_KEY_Field is HAL.UInt16;
 
    --  Key register
    type KR_Register is record
       --  Write-only. Key value (write only, read 0000h)
       KEY            : KR_KEY_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-lptim.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-lptim.ads
@@ -203,14 +203,14 @@ package STM32_SVD.LPTIM is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype CMP_CMP_Field is HAL.Short;
+   subtype CMP_CMP_Field is HAL.UInt16;
 
    --  Compare Register
    type CMP_Register is record
       --  Compare value
       CMP            : CMP_CMP_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -220,14 +220,14 @@ package STM32_SVD.LPTIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype ARR_ARR_Field is HAL.Short;
+   subtype ARR_ARR_Field is HAL.UInt16;
 
    --  Autoreload Register
    type ARR_Register is record
       --  Auto reload value
       ARR            : ARR_ARR_Field := 16#1#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -237,14 +237,14 @@ package STM32_SVD.LPTIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CNT_CNT_Field is HAL.Short;
+   subtype CNT_CNT_Field is HAL.UInt16;
 
    --  Counter Register
    type CNT_Register is record
       --  Read-only. Counter value
       CNT            : CNT_CNT_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-ltdc.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-ltdc.ads
@@ -288,8 +288,8 @@ package STM32_SVD.LTDC is
       Reserved_11_31 at 0 range 11 .. 31;
    end record;
 
-   subtype CPSR_CYPOS_Field is HAL.Short;
-   subtype CPSR_CXPOS_Field is HAL.Short;
+   subtype CPSR_CYPOS_Field is HAL.UInt16;
+   subtype CPSR_CXPOS_Field is HAL.UInt16;
 
    --  Current Position Status Register
    type CPSR_Register is record
@@ -875,7 +875,7 @@ package STM32_SVD.LTDC is
       --  Layerx Blending Factors Configuration Register
       L1BFCR   : L1BFCR_Register;
       --  Layerx Color Frame Buffer Address Register
-      L1CFBAR  : HAL.Word;
+      L1CFBAR  : HAL.UInt32;
       --  Layerx Color Frame Buffer Length Register
       L1CFBLR  : L1CFBLR_Register;
       --  Layerx ColorFrame Buffer Line Number Register
@@ -899,7 +899,7 @@ package STM32_SVD.LTDC is
       --  Layerx Blending Factors Configuration Register
       L2BFCR   : L2BFCR_Register;
       --  Layerx Color Frame Buffer Address Register
-      L2CFBAR  : HAL.Word;
+      L2CFBAR  : HAL.UInt32;
       --  Layerx Color Frame Buffer Length Register
       L2CFBLR  : L2CFBLR_Register;
       --  Layerx ColorFrame Buffer Line Number Register

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-nvic.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-nvic.ads
@@ -44,7 +44,7 @@ package STM32_SVD.NVIC is
       case As_Array is
          when False =>
             --  IPR_N as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IPR_N as an array
             Arr : IPR_IPR_N_Field_Array;
@@ -84,35 +84,35 @@ package STM32_SVD.NVIC is
       --  Interrupt Controller Type Register
       ICTR  : ICTR_Register;
       --  Interrupt Set-Enable Register
-      ISER0 : HAL.Word;
+      ISER0 : HAL.UInt32;
       --  Interrupt Set-Enable Register
-      ISER1 : HAL.Word;
+      ISER1 : HAL.UInt32;
       --  Interrupt Set-Enable Register
-      ISER2 : HAL.Word;
+      ISER2 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER0 : HAL.Word;
+      ICER0 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER1 : HAL.Word;
+      ICER1 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER2 : HAL.Word;
+      ICER2 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR0 : HAL.Word;
+      ISPR0 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR1 : HAL.Word;
+      ISPR1 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR2 : HAL.Word;
+      ISPR2 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR0 : HAL.Word;
+      ICPR0 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR1 : HAL.Word;
+      ICPR1 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR2 : HAL.Word;
+      ICPR2 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR0 : HAL.Word;
+      IABR0 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR1 : HAL.Word;
+      IABR1 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR2 : HAL.Word;
+      IABR2 : HAL.UInt32;
       --  Interrupt Priority Register
       IPR0  : IPR_Register;
       --  Interrupt Priority Register

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-quadspi.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-quadspi.ads
@@ -238,14 +238,14 @@ package STM32_SVD.QUADSPI is
       DDRM           at 0 range 31 .. 31;
    end record;
 
-   subtype PIR_INTERVAL_Field is HAL.Short;
+   subtype PIR_INTERVAL_Field is HAL.UInt16;
 
    --  polling interval register
    type PIR_Register is record
       --  Polling interval
       INTERVAL       : PIR_INTERVAL_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -255,14 +255,14 @@ package STM32_SVD.QUADSPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype LPTR_TIMEOUT_Field is HAL.Short;
+   subtype LPTR_TIMEOUT_Field is HAL.UInt16;
 
    --  low-power timeout register
    type LPTR_Register is record
       --  Timeout period
       TIMEOUT        : LPTR_TIMEOUT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -287,19 +287,19 @@ package STM32_SVD.QUADSPI is
       --  flag clear register
       FCR   : FCR_Register;
       --  data length register
-      DLR   : HAL.Word;
+      DLR   : HAL.UInt32;
       --  communication configuration register
       CCR   : CCR_Register;
       --  address register
-      AR    : HAL.Word;
+      AR    : HAL.UInt32;
       --  ABR
-      ABR   : HAL.Word;
+      ABR   : HAL.UInt32;
       --  data register
-      DR    : HAL.Word;
+      DR    : HAL.UInt32;
       --  polling status mask register
-      PSMKR : HAL.Word;
+      PSMKR : HAL.UInt32;
       --  polling status match register
-      PSMAR : HAL.Word;
+      PSMAR : HAL.UInt32;
       --  polling interval register
       PIR   : PIR_Register;
       --  low-power timeout register

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-rng.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-rng.ads
@@ -75,7 +75,7 @@ package STM32_SVD.RNG is
       --  status register
       SR : SR_Register;
       --  data register
-      DR : HAL.Word;
+      DR : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-rtc.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-rtc.ads
@@ -270,14 +270,14 @@ package STM32_SVD.RTC is
       Reserved_23_31 at 0 range 23 .. 31;
    end record;
 
-   subtype WUTR_WUT_Field is HAL.Short;
+   subtype WUTR_WUT_Field is HAL.UInt16;
 
    --  wakeup timer register
    type WUTR_Register is record
       --  Wakeup auto-reload value bits
       WUT            : WUTR_WUT_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -424,14 +424,14 @@ package STM32_SVD.RTC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype SSR_SS_Field is HAL.Short;
+   subtype SSR_SS_Field is HAL.UInt16;
 
    --  sub second register
    type SSR_Register is record
       --  Read-only. Sub second value
       SS             : SSR_SS_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -448,7 +448,7 @@ package STM32_SVD.RTC is
       --  Write-only. Subtract a fraction of a second
       SUBFS          : SHIFTR_SUBFS_Field := 16#0#;
       --  unspecified
-      Reserved_15_30 : HAL.Short := 16#0#;
+      Reserved_15_30 : HAL.UInt16 := 16#0#;
       --  Write-only. Add one second
       ADD1S          : Boolean := False;
    end record
@@ -527,7 +527,7 @@ package STM32_SVD.RTC is
       --  Read-only. Week day units
       WDU            : TSDR_WDU_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -542,14 +542,14 @@ package STM32_SVD.RTC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype TSSSR_SS_Field is HAL.Short;
+   subtype TSSSR_SS_Field is HAL.UInt16;
 
    --  timestamp sub second register
    type TSSSR_Register is record
       --  Read-only. Sub second value
       SS             : TSSSR_SS_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -596,7 +596,7 @@ package STM32_SVD.RTC is
       --  Increase frequency of RTC by 488.5 ppm
       CALP           : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -799,69 +799,69 @@ package STM32_SVD.RTC is
       --  option register
       OR_k     : OR_Register;
       --  backup register
-      BKP0R    : HAL.Word;
+      BKP0R    : HAL.UInt32;
       --  backup register
-      BKP1R    : HAL.Word;
+      BKP1R    : HAL.UInt32;
       --  backup register
-      BKP2R    : HAL.Word;
+      BKP2R    : HAL.UInt32;
       --  backup register
-      BKP3R    : HAL.Word;
+      BKP3R    : HAL.UInt32;
       --  backup register
-      BKP4R    : HAL.Word;
+      BKP4R    : HAL.UInt32;
       --  backup register
-      BKP5R    : HAL.Word;
+      BKP5R    : HAL.UInt32;
       --  backup register
-      BKP6R    : HAL.Word;
+      BKP6R    : HAL.UInt32;
       --  backup register
-      BKP7R    : HAL.Word;
+      BKP7R    : HAL.UInt32;
       --  backup register
-      BKP8R    : HAL.Word;
+      BKP8R    : HAL.UInt32;
       --  backup register
-      BKP9R    : HAL.Word;
+      BKP9R    : HAL.UInt32;
       --  backup register
-      BKP10R   : HAL.Word;
+      BKP10R   : HAL.UInt32;
       --  backup register
-      BKP11R   : HAL.Word;
+      BKP11R   : HAL.UInt32;
       --  backup register
-      BKP12R   : HAL.Word;
+      BKP12R   : HAL.UInt32;
       --  backup register
-      BKP13R   : HAL.Word;
+      BKP13R   : HAL.UInt32;
       --  backup register
-      BKP14R   : HAL.Word;
+      BKP14R   : HAL.UInt32;
       --  backup register
-      BKP15R   : HAL.Word;
+      BKP15R   : HAL.UInt32;
       --  backup register
-      BKP16R   : HAL.Word;
+      BKP16R   : HAL.UInt32;
       --  backup register
-      BKP17R   : HAL.Word;
+      BKP17R   : HAL.UInt32;
       --  backup register
-      BKP18R   : HAL.Word;
+      BKP18R   : HAL.UInt32;
       --  backup register
-      BKP19R   : HAL.Word;
+      BKP19R   : HAL.UInt32;
       --  backup register
-      BKP20R   : HAL.Word;
+      BKP20R   : HAL.UInt32;
       --  backup register
-      BKP21R   : HAL.Word;
+      BKP21R   : HAL.UInt32;
       --  backup register
-      BKP22R   : HAL.Word;
+      BKP22R   : HAL.UInt32;
       --  backup register
-      BKP23R   : HAL.Word;
+      BKP23R   : HAL.UInt32;
       --  backup register
-      BKP24R   : HAL.Word;
+      BKP24R   : HAL.UInt32;
       --  backup register
-      BKP25R   : HAL.Word;
+      BKP25R   : HAL.UInt32;
       --  backup register
-      BKP26R   : HAL.Word;
+      BKP26R   : HAL.UInt32;
       --  backup register
-      BKP27R   : HAL.Word;
+      BKP27R   : HAL.UInt32;
       --  backup register
-      BKP28R   : HAL.Word;
+      BKP28R   : HAL.UInt32;
       --  backup register
-      BKP29R   : HAL.Word;
+      BKP29R   : HAL.UInt32;
       --  backup register
-      BKP30R   : HAL.Word;
+      BKP30R   : HAL.UInt32;
       --  backup register
-      BKP31R   : HAL.Word;
+      BKP31R   : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-sai.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-sai.ads
@@ -123,7 +123,7 @@ package STM32_SVD.SAI is
       --  Companding mode
       COMP           : ACR2_COMP_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -176,7 +176,7 @@ package STM32_SVD.SAI is
    subtype ASLOTR_FBOFF_Field is HAL.UInt5;
    subtype ASLOTR_SLOTSZ_Field is HAL.UInt2;
    subtype ASLOTR_NBSLOT_Field is HAL.UInt4;
-   subtype ASLOTR_SLOTEN_Field is HAL.Short;
+   subtype ASLOTR_SLOTEN_Field is HAL.UInt16;
 
    --  ASlot register
    type ASLOTR_Register is record
@@ -398,7 +398,7 @@ package STM32_SVD.SAI is
       --  Companding mode
       COMP           : BCR2_COMP_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -451,7 +451,7 @@ package STM32_SVD.SAI is
    subtype BSLOTR_FBOFF_Field is HAL.UInt5;
    subtype BSLOTR_SLOTSZ_Field is HAL.UInt2;
    subtype BSLOTR_NBSLOT_Field is HAL.UInt4;
-   subtype BSLOTR_SLOTEN_Field is HAL.Short;
+   subtype BSLOTR_SLOTEN_Field is HAL.UInt16;
 
    --  BSlot register
    type BSLOTR_Register is record
@@ -610,7 +610,7 @@ package STM32_SVD.SAI is
       --  AClear flag register
       ACLRFR : ACLRFR_Register;
       --  AData register
-      ADR    : HAL.Word;
+      ADR    : HAL.UInt32;
       --  BConfiguration register 1
       BCR1   : BCR1_Register;
       --  BConfiguration register 2
@@ -626,7 +626,7 @@ package STM32_SVD.SAI is
       --  BClear flag register
       BCLRFR : BCLRFR_Register;
       --  BData register
-      BDR    : HAL.Word;
+      BDR    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-sdmmc.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-sdmmc.ads
@@ -571,21 +571,21 @@ package STM32_SVD.SDMMC is
       --  SDI clock control register
       CLKCR   : CLKCR_Register;
       --  argument register
-      ARG     : HAL.Word;
+      ARG     : HAL.UInt32;
       --  command register
       CMD     : CMD_Register;
       --  command response register
       RESPCMD : RESPCMD_Register;
       --  response 1..4 register
-      RESP1   : HAL.Word;
+      RESP1   : HAL.UInt32;
       --  response 1..4 register
-      RESP2   : HAL.Word;
+      RESP2   : HAL.UInt32;
       --  response 1..4 register
-      RESP3   : HAL.Word;
+      RESP3   : HAL.UInt32;
       --  response 1..4 register
-      RESP4   : HAL.Word;
+      RESP4   : HAL.UInt32;
       --  data timer register
-      DTIMER  : HAL.Word;
+      DTIMER  : HAL.UInt32;
       --  data length register
       DLEN    : DLEN_Register;
       --  data control register
@@ -601,7 +601,7 @@ package STM32_SVD.SDMMC is
       --  FIFO counter register
       FIFOCNT : FIFOCNT_Register;
       --  data FIFO register
-      FIFO    : HAL.Word;
+      FIFO    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-spdif_rx.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-spdif_rx.ads
@@ -212,7 +212,7 @@ package STM32_SVD.SPDIF_RX is
       Reserved_30_31 at 0 range 30 .. 31;
    end record;
 
-   subtype CSR_USR_Field is HAL.Short;
+   subtype CSR_USR_Field is HAL.UInt16;
    subtype CSR_CS_Field is HAL.Byte;
 
    --  Channel Status register

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-spi.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-spi.ads
@@ -46,7 +46,7 @@ package STM32_SVD.SPI is
       --  Bidirectional data mode enable
       BIDIMODE       : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -268,14 +268,14 @@ package STM32_SVD.SPI is
       Reserved_13_31 at 0 range 13 .. 31;
    end record;
 
-   subtype DR_DR_Field is HAL.Short;
+   subtype DR_DR_Field is HAL.UInt16;
 
    --  data register
    type DR_Register is record
       --  Data register
       DR             : DR_DR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -285,14 +285,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CRCPR_CRCPOLY_Field is HAL.Short;
+   subtype CRCPR_CRCPOLY_Field is HAL.UInt16;
 
    --  CRC polynomial register
    type CRCPR_Register is record
       --  CRC polynomial register
       CRCPOLY        : CRCPR_CRCPOLY_Field := 16#7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -302,14 +302,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype RXCRCR_RxCRC_Field is HAL.Short;
+   subtype RXCRCR_RxCRC_Field is HAL.UInt16;
 
    --  RX CRC register
    type RXCRCR_Register is record
       --  Read-only. Rx CRC register
       RxCRC          : RXCRCR_RxCRC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -319,14 +319,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype TXCRCR_TxCRC_Field is HAL.Short;
+   subtype TXCRCR_TxCRC_Field is HAL.UInt16;
 
    --  TX CRC register
    type TXCRCR_Register is record
       --  Read-only. Tx CRC register
       TxCRC          : TXCRCR_TxCRC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-syscfg.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-syscfg.ads
@@ -46,7 +46,7 @@ package STM32_SVD.SYSCFG is
    --  peripheral mode configuration register
    type PMC_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  ADC1DC2
       ADC1DC2        : Boolean := False;
       --  ADC2DC2
@@ -87,7 +87,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR1_EXTI_Field_Array;
@@ -106,7 +106,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR1_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -130,7 +130,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR2_EXTI_Field_Array;
@@ -149,7 +149,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR2_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -173,7 +173,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR3_EXTI_Field_Array;
@@ -192,7 +192,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR3_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -216,7 +216,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR4_EXTI_Field_Array;
@@ -235,7 +235,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR4_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-tim.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-tim.ads
@@ -321,7 +321,7 @@ package STM32_SVD.TIM is
       --  Output Compare 2 clear enable
       OC2CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -362,7 +362,7 @@ package STM32_SVD.TIM is
       --  Input capture 2 filter
       IC2F           : CCMR1_Input_IC2F_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -405,7 +405,7 @@ package STM32_SVD.TIM is
       --  Output compare 4 clear enable
       OC4CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -446,7 +446,7 @@ package STM32_SVD.TIM is
       --  Input capture 4 filter
       IC4F           : CCMR2_Input_IC4F_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -515,14 +515,14 @@ package STM32_SVD.TIM is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype CNT_CNT_Field is HAL.Short;
+   subtype CNT_CNT_Field is HAL.UInt16;
 
    --  counter
    type CNT_Register is record
       --  counter value
       CNT            : CNT_CNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -532,14 +532,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype PSC_PSC_Field is HAL.Short;
+   subtype PSC_PSC_Field is HAL.UInt16;
 
    --  prescaler
    type PSC_Register is record
       --  Prescaler value
       PSC            : PSC_PSC_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -549,14 +549,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype ARR_ARR_Field is HAL.Short;
+   subtype ARR_ARR_Field is HAL.UInt16;
 
    --  auto-reload register
    type ARR_Register is record
       --  Auto-reload value
       ARR            : ARR_ARR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -583,14 +583,14 @@ package STM32_SVD.TIM is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype CCR1_CCR1_Field is HAL.Short;
+   subtype CCR1_CCR1_Field is HAL.UInt16;
 
    --  capture/compare register 1
    type CCR1_Register is record
       --  Capture/Compare 1 value
       CCR1           : CCR1_CCR1_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -600,14 +600,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR2_CCR2_Field is HAL.Short;
+   subtype CCR2_CCR2_Field is HAL.UInt16;
 
    --  capture/compare register 2
    type CCR2_Register is record
       --  Capture/Compare 2 value
       CCR2           : CCR2_CCR2_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -617,14 +617,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR3_CCR3_Field is HAL.Short;
+   subtype CCR3_CCR3_Field is HAL.UInt16;
 
    --  capture/compare register 3
    type CCR3_Register is record
       --  Capture/Compare value
       CCR3           : CCR3_CCR3_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -634,14 +634,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR4_CCR4_Field is HAL.Short;
+   subtype CCR4_CCR4_Field is HAL.UInt16;
 
    --  capture/compare register 4
    type CCR4_Register is record
       --  Capture/Compare value
       CCR4           : CCR4_CCR4_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -673,7 +673,7 @@ package STM32_SVD.TIM is
       --  Main output enable
       MOE            : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -714,14 +714,14 @@ package STM32_SVD.TIM is
       Reserved_13_31 at 0 range 13 .. 31;
    end record;
 
-   subtype DMAR_DMAB_Field is HAL.Short;
+   subtype DMAR_DMAB_Field is HAL.UInt16;
 
    --  DMA address for full transfer
    type DMAR_Register is record
       --  DMA register for burst accesses
       DMAB           : DMAR_DMAB_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -785,7 +785,7 @@ package STM32_SVD.TIM is
       Reserved_25_31 at 0 range 25 .. 31;
    end record;
 
-   subtype CCR5_CCR5_Field is HAL.Short;
+   subtype CCR5_CCR5_Field is HAL.UInt16;
 
    --  CCR5_GC5C array
    type CCR5_GC5C_Field_Array is array (1 .. 3) of Boolean
@@ -829,14 +829,14 @@ package STM32_SVD.TIM is
       GC5C           at 0 range 29 .. 31;
    end record;
 
-   subtype CRR6_CCR6_Field is HAL.Short;
+   subtype CRR6_CCR6_Field is HAL.UInt16;
 
    --  capture/compare register 6
    type CRR6_Register is record
       --  Capture/Compare 6 value
       CCR6           : CRR6_CCR6_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1031,7 +1031,7 @@ package STM32_SVD.TIM is
       --  O24CE
       O24CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1085,7 +1085,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1110,8 +1110,8 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CNT_CNT_L_Field is HAL.Short;
-   subtype CNT_CNT_H_Field is HAL.Short;
+   subtype CNT_CNT_L_Field is HAL.UInt16;
+   subtype CNT_CNT_H_Field is HAL.UInt16;
 
    --  counter
    type CNT_Register_1 is record
@@ -1128,8 +1128,8 @@ package STM32_SVD.TIM is
       CNT_H at 0 range 16 .. 31;
    end record;
 
-   subtype ARR_ARR_L_Field is HAL.Short;
-   subtype ARR_ARR_H_Field is HAL.Short;
+   subtype ARR_ARR_L_Field is HAL.UInt16;
+   subtype ARR_ARR_H_Field is HAL.UInt16;
 
    --  auto-reload register
    type ARR_Register_1 is record
@@ -1146,8 +1146,8 @@ package STM32_SVD.TIM is
       ARR_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR1_CCR1_L_Field is HAL.Short;
-   subtype CCR1_CCR1_H_Field is HAL.Short;
+   subtype CCR1_CCR1_L_Field is HAL.UInt16;
+   subtype CCR1_CCR1_H_Field is HAL.UInt16;
 
    --  capture/compare register 1
    type CCR1_Register_1 is record
@@ -1164,8 +1164,8 @@ package STM32_SVD.TIM is
       CCR1_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR2_CCR2_L_Field is HAL.Short;
-   subtype CCR2_CCR2_H_Field is HAL.Short;
+   subtype CCR2_CCR2_L_Field is HAL.UInt16;
+   subtype CCR2_CCR2_H_Field is HAL.UInt16;
 
    --  capture/compare register 2
    type CCR2_Register_1 is record
@@ -1182,8 +1182,8 @@ package STM32_SVD.TIM is
       CCR2_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR3_CCR3_L_Field is HAL.Short;
-   subtype CCR3_CCR3_H_Field is HAL.Short;
+   subtype CCR3_CCR3_L_Field is HAL.UInt16;
+   subtype CCR3_CCR3_H_Field is HAL.UInt16;
 
    --  capture/compare register 3
    type CCR3_Register_1 is record
@@ -1200,8 +1200,8 @@ package STM32_SVD.TIM is
       CCR3_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR4_CCR4_L_Field is HAL.Short;
-   subtype CCR4_CCR4_H_Field is HAL.Short;
+   subtype CCR4_CCR4_L_Field is HAL.UInt16;
+   subtype CCR4_CCR4_H_Field is HAL.UInt16;
 
    --  capture/compare register 4
    type CCR4_Register_1 is record

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-usart.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-usart.ads
@@ -322,7 +322,7 @@ package STM32_SVD.USART is
       --  DIV_Mantissa
       DIV_Mantissa   : BRR_DIV_Mantissa_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -343,7 +343,7 @@ package STM32_SVD.USART is
       --  Guard time value
       GT             : GTPR_GT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-usb_otg_fs.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-usb_otg_fs.ads
@@ -180,8 +180,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype OTG_FS_DAINT_IEPINT_Field is HAL.Short;
-   subtype OTG_FS_DAINT_OEPINT_Field is HAL.Short;
+   subtype OTG_FS_DAINT_IEPINT_Field is HAL.UInt16;
+   subtype OTG_FS_DAINT_OEPINT_Field is HAL.UInt16;
 
    --  OTG_FS device all endpoints interrupt register (OTG_FS_DAINT)
    type OTG_FS_DAINT_Register is record
@@ -198,8 +198,8 @@ package STM32_SVD.USB_OTG_FS is
       OEPINT at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_DAINTMSK_IEPM_Field is HAL.Short;
-   subtype OTG_FS_DAINTMSK_OEPM_Field is HAL.Short;
+   subtype OTG_FS_DAINTMSK_IEPM_Field is HAL.UInt16;
+   subtype OTG_FS_DAINTMSK_OEPM_Field is HAL.UInt16;
 
    --  OTG_FS all endpoints interrupt mask register (OTG_FS_DAINTMSK)
    type OTG_FS_DAINTMSK_Register is record
@@ -216,14 +216,14 @@ package STM32_SVD.USB_OTG_FS is
       OEPM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_DVBUSDIS_VBUSDT_Field is HAL.Short;
+   subtype OTG_FS_DVBUSDIS_VBUSDT_Field is HAL.UInt16;
 
    --  OTG_FS device VBUS discharge time register
    type OTG_FS_DVBUSDIS_Register is record
       --  Device VBUS discharge time
       VBUSDT         : OTG_FS_DVBUSDIS_VBUSDT_Field := 16#17D7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -250,14 +250,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_12_31 at 0 range 12 .. 31;
    end record;
 
-   subtype OTG_FS_DIEPEMPMSK_INEPTXFEM_Field is HAL.Short;
+   subtype OTG_FS_DIEPEMPMSK_INEPTXFEM_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint FIFO empty interrupt mask register
    type OTG_FS_DIEPEMPMSK_Register is record
       --  IN EP Tx FIFO empty interrupt mask bits
       INEPTXFEM      : OTG_FS_DIEPEMPMSK_INEPTXFEM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -382,14 +382,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype OTG_FS_DTXFSTS_INEPTFSAV_Field is HAL.Short;
+   subtype OTG_FS_DTXFSTS_INEPTFSAV_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint transmit FIFO status register
    type OTG_FS_DTXFSTS_Register is record
       --  Read-only. IN endpoint TxFIFO space available
       INEPTFSAV      : OTG_FS_DTXFSTS_INEPTFSAV_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1281,14 +1281,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype OTG_FS_GRXFSIZ_RXFD_Field is HAL.Short;
+   subtype OTG_FS_GRXFSIZ_RXFD_Field is HAL.UInt16;
 
    --  OTG_FS Receive FIFO size register (OTG_FS_GRXFSIZ)
    type OTG_FS_GRXFSIZ_Register is record
       --  RxFIFO depth
       RXFD           : OTG_FS_GRXFSIZ_RXFD_Field := 16#200#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1298,8 +1298,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_DIEPTXF0_Device_TX0FSA_Field is HAL.Short;
-   subtype OTG_FS_DIEPTXF0_Device_TX0FD_Field is HAL.Short;
+   subtype OTG_FS_DIEPTXF0_Device_TX0FSA_Field is HAL.UInt16;
+   subtype OTG_FS_DIEPTXF0_Device_TX0FD_Field is HAL.UInt16;
 
    --  OTG_FS Endpoint 0 Transmit FIFO size
    type OTG_FS_DIEPTXF0_Device_Register is record
@@ -1316,8 +1316,8 @@ package STM32_SVD.USB_OTG_FS is
       TX0FD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_HNPTXFSIZ_Host_NPTXFSA_Field is HAL.Short;
-   subtype OTG_FS_HNPTXFSIZ_Host_NPTXFD_Field is HAL.Short;
+   subtype OTG_FS_HNPTXFSIZ_Host_NPTXFSA_Field is HAL.UInt16;
+   subtype OTG_FS_HNPTXFSIZ_Host_NPTXFD_Field is HAL.UInt16;
 
    --  OTG_FS Host non-periodic transmit FIFO size register
    type OTG_FS_HNPTXFSIZ_Host_Register is record
@@ -1334,7 +1334,7 @@ package STM32_SVD.USB_OTG_FS is
       NPTXFD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_HNPTXSTS_NPTXFSAV_Field is HAL.Short;
+   subtype OTG_FS_HNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
    subtype OTG_FS_HNPTXSTS_NPTQXSAV_Field is HAL.Byte;
    subtype OTG_FS_HNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
@@ -1600,8 +1600,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_29_31 at 0 range 29 .. 31;
    end record;
 
-   subtype OTG_FS_HPTXFSIZ_PTXSA_Field is HAL.Short;
-   subtype OTG_FS_HPTXFSIZ_PTXFSIZ_Field is HAL.Short;
+   subtype OTG_FS_HPTXFSIZ_PTXSA_Field is HAL.UInt16;
+   subtype OTG_FS_HPTXFSIZ_PTXFSIZ_Field is HAL.UInt16;
 
    --  OTG_FS Host periodic transmit FIFO size register (OTG_FS_HPTXFSIZ)
    type OTG_FS_HPTXFSIZ_Register is record
@@ -1618,8 +1618,8 @@ package STM32_SVD.USB_OTG_FS is
       PTXFSIZ at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_DIEPTXF_INEPTXSA_Field is HAL.Short;
-   subtype OTG_FS_DIEPTXF_INEPTXFD_Field is HAL.Short;
+   subtype OTG_FS_DIEPTXF_INEPTXSA_Field is HAL.UInt16;
+   subtype OTG_FS_DIEPTXF_INEPTXFD_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint transmit FIFO size register (OTG_FS_DIEPTXF1)
    type OTG_FS_DIEPTXF_Register is record
@@ -1656,14 +1656,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype OTG_FS_HFIR_FRIVL_Field is HAL.Short;
+   subtype OTG_FS_HFIR_FRIVL_Field is HAL.UInt16;
 
    --  OTG_FS Host frame interval register
    type OTG_FS_HFIR_Register is record
       --  Frame interval
       FRIVL          : OTG_FS_HFIR_FRIVL_Field := 16#EA60#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1673,8 +1673,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_HFNUM_FRNUM_Field is HAL.Short;
-   subtype OTG_FS_HFNUM_FTREM_Field is HAL.Short;
+   subtype OTG_FS_HFNUM_FRNUM_Field is HAL.UInt16;
+   subtype OTG_FS_HFNUM_FTREM_Field is HAL.UInt16;
 
    --  OTG_FS host frame number/frame time remaining register (OTG_FS_HFNUM)
    type OTG_FS_HFNUM_Register is record
@@ -1691,7 +1691,7 @@ package STM32_SVD.USB_OTG_FS is
       FTREM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_HPTXSTS_PTXFSAVL_Field is HAL.Short;
+   subtype OTG_FS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
    subtype OTG_FS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
    subtype OTG_FS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
 
@@ -1714,14 +1714,14 @@ package STM32_SVD.USB_OTG_FS is
       PTXQTOP  at 0 range 24 .. 31;
    end record;
 
-   subtype OTG_FS_HAINT_HAINT_Field is HAL.Short;
+   subtype OTG_FS_HAINT_HAINT_Field is HAL.UInt16;
 
    --  OTG_FS Host all channels interrupt register
    type OTG_FS_HAINT_Register is record
       --  Read-only. Channel interrupts
       HAINT          : OTG_FS_HAINT_HAINT_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1731,14 +1731,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_HAINTMSK_HAINTM_Field is HAL.Short;
+   subtype OTG_FS_HAINTMSK_HAINTM_Field is HAL.UInt16;
 
    --  OTG_FS host all channels interrupt mask register
    type OTG_FS_HAINTMSK_Register is record
       --  Channel interrupt mask
       HAINTM         : OTG_FS_HAINTMSK_HAINTM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2203,7 +2203,7 @@ package STM32_SVD.USB_OTG_FS is
       --  OTG_FS general core configuration register (OTG_FS_GCCFG)
       OTG_FS_GCCFG           : OTG_FS_GCCFG_Register;
       --  core ID register
-      OTG_FS_CID             : HAL.Word;
+      OTG_FS_CID             : HAL.UInt32;
       --  OTG core LPM configuration register
       OTG_FS_GLPMCFG         : OTG_FS_GLPMCFG_Register;
       --  OTG power down register

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-usb_otg_hs.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-usb_otg_hs.ads
@@ -209,8 +209,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_10_31 at 0 range 10 .. 31;
    end record;
 
-   subtype OTG_HS_DAINT_IEPINT_Field is HAL.Short;
-   subtype OTG_HS_DAINT_OEPINT_Field is HAL.Short;
+   subtype OTG_HS_DAINT_IEPINT_Field is HAL.UInt16;
+   subtype OTG_HS_DAINT_OEPINT_Field is HAL.UInt16;
 
    --  OTG_HS device all endpoints interrupt register
    type OTG_HS_DAINT_Register is record
@@ -227,8 +227,8 @@ package STM32_SVD.USB_OTG_HS is
       OEPINT at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DAINTMSK_IEPM_Field is HAL.Short;
-   subtype OTG_HS_DAINTMSK_OEPM_Field is HAL.Short;
+   subtype OTG_HS_DAINTMSK_IEPM_Field is HAL.UInt16;
+   subtype OTG_HS_DAINTMSK_OEPM_Field is HAL.UInt16;
 
    --  OTG_HS all endpoints interrupt mask register
    type OTG_HS_DAINTMSK_Register is record
@@ -245,14 +245,14 @@ package STM32_SVD.USB_OTG_HS is
       OEPM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DVBUSDIS_VBUSDT_Field is HAL.Short;
+   subtype OTG_HS_DVBUSDIS_VBUSDT_Field is HAL.UInt16;
 
    --  OTG_HS device VBUS discharge time register
    type OTG_HS_DVBUSDIS_Register is record
       --  Device VBUS discharge time
       VBUSDT         : OTG_HS_DVBUSDIS_VBUSDT_Field := 16#17D7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -318,14 +318,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype OTG_HS_DIEPEMPMSK_INEPTXFEM_Field is HAL.Short;
+   subtype OTG_HS_DIEPEMPMSK_INEPTXFEM_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint FIFO empty interrupt mask register
    type OTG_HS_DIEPEMPMSK_Register is record
       --  IN EP Tx FIFO empty interrupt mask bits
       INEPTXFEM      : OTG_HS_DIEPEMPMSK_INEPTXFEM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -519,14 +519,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype OTG_HS_DTXFSTS_INEPTFSAV_Field is HAL.Short;
+   subtype OTG_HS_DTXFSTS_INEPTFSAV_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint transmit FIFO status register
    type OTG_HS_DTXFSTS_Register is record
       --  Read-only. IN endpoint TxFIFO space avail
       INEPTFSAV      : OTG_HS_DTXFSTS_INEPTFSAV_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1336,14 +1336,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_25_31 at 0 range 25 .. 31;
    end record;
 
-   subtype OTG_HS_GRXFSIZ_RXFD_Field is HAL.Short;
+   subtype OTG_HS_GRXFSIZ_RXFD_Field is HAL.UInt16;
 
    --  OTG_HS Receive FIFO size register
    type OTG_HS_GRXFSIZ_Register is record
       --  RxFIFO depth
       RXFD           : OTG_HS_GRXFSIZ_RXFD_Field := 16#200#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1353,8 +1353,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HNPTXFSIZ_Host_NPTXFSA_Field is HAL.Short;
-   subtype OTG_HS_HNPTXFSIZ_Host_NPTXFD_Field is HAL.Short;
+   subtype OTG_HS_HNPTXFSIZ_Host_NPTXFSA_Field is HAL.UInt16;
+   subtype OTG_HS_HNPTXFSIZ_Host_NPTXFD_Field is HAL.UInt16;
 
    --  OTG_HS nonperiodic transmit FIFO size register (host mode)
    type OTG_HS_HNPTXFSIZ_Host_Register is record
@@ -1371,8 +1371,8 @@ package STM32_SVD.USB_OTG_HS is
       NPTXFD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DIEPTXF0_Device_TX0FSA_Field is HAL.Short;
-   subtype OTG_HS_DIEPTXF0_Device_TX0FD_Field is HAL.Short;
+   subtype OTG_HS_DIEPTXF0_Device_TX0FSA_Field is HAL.UInt16;
+   subtype OTG_HS_DIEPTXF0_Device_TX0FD_Field is HAL.UInt16;
 
    --  Endpoint 0 transmit FIFO size (peripheral mode)
    type OTG_HS_DIEPTXF0_Device_Register is record
@@ -1389,7 +1389,7 @@ package STM32_SVD.USB_OTG_HS is
       TX0FD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.Short;
+   subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
    subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
    subtype OTG_HS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
@@ -1523,8 +1523,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_29_31 at 0 range 29 .. 31;
    end record;
 
-   subtype OTG_HS_HPTXFSIZ_PTXSA_Field is HAL.Short;
-   subtype OTG_HS_HPTXFSIZ_PTXFD_Field is HAL.Short;
+   subtype OTG_HS_HPTXFSIZ_PTXSA_Field is HAL.UInt16;
+   subtype OTG_HS_HPTXFSIZ_PTXFD_Field is HAL.UInt16;
 
    --  OTG_HS Host periodic transmit FIFO size register
    type OTG_HS_HPTXFSIZ_Register is record
@@ -1541,8 +1541,8 @@ package STM32_SVD.USB_OTG_HS is
       PTXFD at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DIEPTXF_INEPTXSA_Field is HAL.Short;
-   subtype OTG_HS_DIEPTXF_INEPTXFD_Field is HAL.Short;
+   subtype OTG_HS_DIEPTXF_INEPTXSA_Field is HAL.UInt16;
+   subtype OTG_HS_DIEPTXF_INEPTXFD_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint transmit FIFO size register
    type OTG_HS_DIEPTXF_Register is record
@@ -1579,14 +1579,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype OTG_HS_HFIR_FRIVL_Field is HAL.Short;
+   subtype OTG_HS_HFIR_FRIVL_Field is HAL.UInt16;
 
    --  OTG_HS Host frame interval register
    type OTG_HS_HFIR_Register is record
       --  Frame interval
       FRIVL          : OTG_HS_HFIR_FRIVL_Field := 16#EA60#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1596,8 +1596,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HFNUM_FRNUM_Field is HAL.Short;
-   subtype OTG_HS_HFNUM_FTREM_Field is HAL.Short;
+   subtype OTG_HS_HFNUM_FRNUM_Field is HAL.UInt16;
+   subtype OTG_HS_HFNUM_FTREM_Field is HAL.UInt16;
 
    --  OTG_HS host frame number/frame time remaining register
    type OTG_HS_HFNUM_Register is record
@@ -1614,7 +1614,7 @@ package STM32_SVD.USB_OTG_HS is
       FTREM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.Short;
+   subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
    subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
    subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
 
@@ -1636,14 +1636,14 @@ package STM32_SVD.USB_OTG_HS is
       PTXQTOP  at 0 range 24 .. 31;
    end record;
 
-   subtype OTG_HS_HAINT_HAINT_Field is HAL.Short;
+   subtype OTG_HS_HAINT_HAINT_Field is HAL.UInt16;
 
    --  OTG_HS Host all channels interrupt register
    type OTG_HS_HAINT_Register is record
       --  Read-only. Channel interrupts
       HAINT          : OTG_HS_HAINT_HAINT_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1653,14 +1653,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HAINTMSK_HAINTM_Field is HAL.Short;
+   subtype OTG_HS_HAINTMSK_HAINTM_Field is HAL.UInt16;
 
    --  OTG_HS host all channels interrupt mask register
    type OTG_HS_HAINTMSK_Register is record
       --  Channel interrupt mask
       HAINTM         : OTG_HS_HAINTMSK_HAINTM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2030,7 +2030,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device IN endpoint 0 transfer size register
       OTG_HS_DIEPTSIZ0   : OTG_HS_DIEPTSIZ0_Register;
       --  OTG_HS device endpoint-1 DMA address register
-      OTG_HS_DIEPDMA1    : HAL.Word;
+      OTG_HS_DIEPDMA1    : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS0    : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-1 control register
@@ -2040,7 +2040,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ1   : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-2 DMA address register
-      OTG_HS_DIEPDMA2    : HAL.Word;
+      OTG_HS_DIEPDMA2    : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS1    : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-2 control register
@@ -2050,7 +2050,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ2   : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-3 DMA address register
-      OTG_HS_DIEPDMA3    : HAL.Word;
+      OTG_HS_DIEPDMA3    : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS2    : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-3 control register
@@ -2060,7 +2060,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ3   : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-4 DMA address register
-      OTG_HS_DIEPDMA4    : HAL.Word;
+      OTG_HS_DIEPDMA4    : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS3    : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-4 control register
@@ -2070,7 +2070,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ4   : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-5 DMA address register
-      OTG_HS_DIEPDMA5    : HAL.Word;
+      OTG_HS_DIEPDMA5    : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS4    : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-5 control register
@@ -2261,7 +2261,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS general core configuration register
       OTG_HS_GCCFG           : OTG_HS_GCCFG_Register;
       --  OTG_HS core ID register
-      OTG_HS_CID             : HAL.Word;
+      OTG_HS_CID             : HAL.UInt32;
       --  OTG core LPM configuration register
       OTG_HS_GLPMCFG         : OTG_HS_GLPMCFG_Register;
       --  OTG_HS Host periodic transmit FIFO size register
@@ -2362,7 +2362,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-11 transfer size register
       OTG_HS_HCTSIZ0    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-0 DMA address register
-      OTG_HS_HCDMA0     : HAL.Word;
+      OTG_HS_HCDMA0     : HAL.UInt32;
       --  OTG_HS host channel-1 characteristics register
       OTG_HS_HCCHAR1    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-1 split control register
@@ -2374,7 +2374,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-1 transfer size register
       OTG_HS_HCTSIZ1    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-1 DMA address register
-      OTG_HS_HCDMA1     : HAL.Word;
+      OTG_HS_HCDMA1     : HAL.UInt32;
       --  OTG_HS host channel-2 characteristics register
       OTG_HS_HCCHAR2    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-2 split control register
@@ -2386,7 +2386,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-2 transfer size register
       OTG_HS_HCTSIZ2    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-2 DMA address register
-      OTG_HS_HCDMA2     : HAL.Word;
+      OTG_HS_HCDMA2     : HAL.UInt32;
       --  OTG_HS host channel-3 characteristics register
       OTG_HS_HCCHAR3    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-3 split control register
@@ -2398,7 +2398,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-3 transfer size register
       OTG_HS_HCTSIZ3    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-3 DMA address register
-      OTG_HS_HCDMA3     : HAL.Word;
+      OTG_HS_HCDMA3     : HAL.UInt32;
       --  OTG_HS host channel-4 characteristics register
       OTG_HS_HCCHAR4    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-4 split control register
@@ -2410,7 +2410,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-4 transfer size register
       OTG_HS_HCTSIZ4    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-4 DMA address register
-      OTG_HS_HCDMA4     : HAL.Word;
+      OTG_HS_HCDMA4     : HAL.UInt32;
       --  OTG_HS host channel-5 characteristics register
       OTG_HS_HCCHAR5    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-5 split control register
@@ -2422,7 +2422,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-5 transfer size register
       OTG_HS_HCTSIZ5    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-5 DMA address register
-      OTG_HS_HCDMA5     : HAL.Word;
+      OTG_HS_HCDMA5     : HAL.UInt32;
       --  OTG_HS host channel-6 characteristics register
       OTG_HS_HCCHAR6    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-6 split control register
@@ -2434,7 +2434,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-6 transfer size register
       OTG_HS_HCTSIZ6    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-6 DMA address register
-      OTG_HS_HCDMA6     : HAL.Word;
+      OTG_HS_HCDMA6     : HAL.UInt32;
       --  OTG_HS host channel-7 characteristics register
       OTG_HS_HCCHAR7    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-7 split control register
@@ -2446,7 +2446,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-7 transfer size register
       OTG_HS_HCTSIZ7    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-7 DMA address register
-      OTG_HS_HCDMA7     : HAL.Word;
+      OTG_HS_HCDMA7     : HAL.UInt32;
       --  OTG_HS host channel-8 characteristics register
       OTG_HS_HCCHAR8    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-8 split control register
@@ -2458,7 +2458,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-8 transfer size register
       OTG_HS_HCTSIZ8    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-8 DMA address register
-      OTG_HS_HCDMA8     : HAL.Word;
+      OTG_HS_HCDMA8     : HAL.UInt32;
       --  OTG_HS host channel-9 characteristics register
       OTG_HS_HCCHAR9    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-9 split control register
@@ -2470,7 +2470,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-9 transfer size register
       OTG_HS_HCTSIZ9    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-9 DMA address register
-      OTG_HS_HCDMA9     : HAL.Word;
+      OTG_HS_HCDMA9     : HAL.UInt32;
       --  OTG_HS host channel-10 characteristics register
       OTG_HS_HCCHAR10   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-10 split control register
@@ -2482,7 +2482,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-10 transfer size register
       OTG_HS_HCTSIZ10   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-10 DMA address register
-      OTG_HS_HCDMA10    : HAL.Word;
+      OTG_HS_HCDMA10    : HAL.UInt32;
       --  OTG_HS host channel-11 characteristics register
       OTG_HS_HCCHAR11   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-11 split control register
@@ -2494,7 +2494,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-11 transfer size register
       OTG_HS_HCTSIZ11   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-11 DMA address register
-      OTG_HS_HCDMA11    : HAL.Word;
+      OTG_HS_HCDMA11    : HAL.UInt32;
       --  OTG_HS host channel-12 characteristics register
       OTG_HS_HCCHAR12   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-12 split control register
@@ -2506,7 +2506,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-12 transfer size register
       OTG_HS_HCTSIZ12   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-12 DMA address register
-      OTG_HS_HCDMA12    : HAL.Word;
+      OTG_HS_HCDMA12    : HAL.UInt32;
       --  OTG_HS host channel-13 characteristics register
       OTG_HS_HCCHAR13   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-13 split control register
@@ -2518,7 +2518,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-13 transfer size register
       OTG_HS_HCTSIZ13   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-13 DMA address register
-      OTG_HS_HCDMA13    : HAL.Word;
+      OTG_HS_HCDMA13    : HAL.UInt32;
       --  OTG_HS host channel-14 characteristics register
       OTG_HS_HCCHAR14   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-14 split control register
@@ -2530,7 +2530,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-14 transfer size register
       OTG_HS_HCTSIZ14   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-14 DMA address register
-      OTG_HS_HCDMA14    : HAL.Word;
+      OTG_HS_HCDMA14    : HAL.UInt32;
       --  OTG_HS host channel-15 characteristics register
       OTG_HS_HCCHAR15   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-15 split control register
@@ -2542,7 +2542,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-15 transfer size register
       OTG_HS_HCTSIZ15   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-15 DMA address register
-      OTG_HS_HCDMA15    : HAL.Word;
+      OTG_HS_HCDMA15    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-adc.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-adc.ads
@@ -530,14 +530,14 @@ package STM32_SVD.ADC is
       Reserved_22_31 at 0 range 22 .. 31;
    end record;
 
-   subtype JDR_JDATA_Field is HAL.Short;
+   subtype JDR_JDATA_Field is HAL.UInt16;
 
    --  injected data register x
    type JDR_Register is record
       --  Read-only. Injected data
       JDATA          : JDR_JDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -547,14 +547,14 @@ package STM32_SVD.ADC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DR_DATA_Field is HAL.Short;
+   subtype DR_DATA_Field is HAL.UInt16;
 
    --  regular data register
    type DR_Register is record
       --  Read-only. Regular data
       DATA           : DR_DATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -684,7 +684,7 @@ package STM32_SVD.ADC is
    end record;
 
    --  CDR_DATA array element
-   subtype CDR_DATA_Element is HAL.Short;
+   subtype CDR_DATA_Element is HAL.UInt16;
 
    --  CDR_DATA array
    type CDR_DATA_Field_Array is array (1 .. 2) of CDR_DATA_Element
@@ -697,7 +697,7 @@ package STM32_SVD.ADC is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : CDR_DATA_Field_Array;

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-can.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-can.ads
@@ -446,7 +446,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT0R_DLC_Field is HAL.UInt4;
-   subtype TDT0R_TIME_Field is HAL.Short;
+   subtype TDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT0R_Register is record
@@ -486,7 +486,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL0R_DATA_Field_Array;
@@ -514,7 +514,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH0R_DATA_Field_Array;
@@ -556,7 +556,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT1R_DLC_Field is HAL.UInt4;
-   subtype TDT1R_TIME_Field is HAL.Short;
+   subtype TDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT1R_Register is record
@@ -596,7 +596,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL1R_DATA_Field_Array;
@@ -624,7 +624,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH1R_DATA_Field_Array;
@@ -666,7 +666,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype TDT2R_DLC_Field is HAL.UInt4;
-   subtype TDT2R_TIME_Field is HAL.Short;
+   subtype TDT2R_TIME_Field is HAL.UInt16;
 
    --  mailbox data length control and time stamp register
    type TDT2R_Register is record
@@ -706,7 +706,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDL2R_DATA_Field_Array;
@@ -734,7 +734,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : TDH2R_DATA_Field_Array;
@@ -777,7 +777,7 @@ package STM32_SVD.CAN is
 
    subtype RDT0R_DLC_Field is HAL.UInt4;
    subtype RDT0R_FMI_Field is HAL.Byte;
-   subtype RDT0R_TIME_Field is HAL.Short;
+   subtype RDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
    type RDT0R_Register is record
@@ -814,7 +814,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDL0R_DATA_Field_Array;
@@ -842,7 +842,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDH0R_DATA_Field_Array;
@@ -885,7 +885,7 @@ package STM32_SVD.CAN is
 
    subtype RDT1R_DLC_Field is HAL.UInt4;
    subtype RDT1R_FMI_Field is HAL.Byte;
-   subtype RDT1R_TIME_Field is HAL.Short;
+   subtype RDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
    type RDT1R_Register is record
@@ -922,7 +922,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDL1R_DATA_Field_Array;
@@ -950,7 +950,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : RDH1R_DATA_Field_Array;
@@ -1154,7 +1154,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F0R_FB_Field_Array;
@@ -1179,7 +1179,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F1R_FB_Field_Array;
@@ -1204,7 +1204,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F2R_FB_Field_Array;
@@ -1229,7 +1229,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F3R_FB_Field_Array;
@@ -1254,7 +1254,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F4R_FB_Field_Array;
@@ -1279,7 +1279,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F5R_FB_Field_Array;
@@ -1304,7 +1304,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F6R_FB_Field_Array;
@@ -1329,7 +1329,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F7R_FB_Field_Array;
@@ -1354,7 +1354,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F8R_FB_Field_Array;
@@ -1379,7 +1379,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F9R_FB_Field_Array;
@@ -1404,7 +1404,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F10R_FB_Field_Array;
@@ -1429,7 +1429,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F11R_FB_Field_Array;
@@ -1454,7 +1454,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F12R_FB_Field_Array;
@@ -1479,7 +1479,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F13R_FB_Field_Array;
@@ -1504,7 +1504,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F14R_FB_Field_Array;
@@ -1529,7 +1529,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F15R_FB_Field_Array;
@@ -1554,7 +1554,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F16R_FB_Field_Array;
@@ -1579,7 +1579,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F17R_FB_Field_Array;
@@ -1604,7 +1604,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F18R_FB_Field_Array;
@@ -1629,7 +1629,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F19R_FB_Field_Array;
@@ -1654,7 +1654,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F20R_FB_Field_Array;
@@ -1679,7 +1679,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F21R_FB_Field_Array;
@@ -1704,7 +1704,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F22R_FB_Field_Array;
@@ -1729,7 +1729,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F23R_FB_Field_Array;
@@ -1754,7 +1754,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F24R_FB_Field_Array;
@@ -1779,7 +1779,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F25R_FB_Field_Array;
@@ -1804,7 +1804,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F26R_FB_Field_Array;
@@ -1829,7 +1829,7 @@ package STM32_SVD.CAN is
       case As_Array is
          when False =>
             --  FB as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  FB as an array
             Arr : F27R_FB_Field_Array;

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-crc.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-crc.ads
@@ -52,15 +52,15 @@ package STM32_SVD.CRC is
    --  Cryptographic processor
    type CRC_Peripheral is record
       --  Data register
-      DR   : HAL.Word;
+      DR   : HAL.UInt32;
       --  Independent Data register
       IDR  : IDR_Register;
       --  Control register
       CR   : CR_Register;
       --  Initial CRC value
-      INIT : HAL.Word;
+      INIT : HAL.UInt32;
       --  CRC polynomial
-      POL  : HAL.Word;
+      POL  : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-cryp.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-cryp.ads
@@ -173,7 +173,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K0LR_b_Field_Array;
@@ -198,7 +198,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K0RR_b_Field_Array;
@@ -223,7 +223,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K1LR_b_Field_Array;
@@ -248,7 +248,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K1RR_b_Field_Array;
@@ -273,7 +273,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K2LR_b_Field_Array;
@@ -298,7 +298,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K2RR_b_Field_Array;
@@ -323,7 +323,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K3LR_b_Field_Array;
@@ -348,7 +348,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  b as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  b as an array
             Arr : K3RR_b_Field_Array;
@@ -373,7 +373,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  IV as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IV as an array
             Arr : IV0LR_IV_Field_Array;
@@ -398,7 +398,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  IV as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IV as an array
             Arr : IV0RR_IV_Field_Array;
@@ -423,7 +423,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  IV as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IV as an array
             Arr : IV1LR_IV_Field_Array;
@@ -448,7 +448,7 @@ package STM32_SVD.CRYP is
       case As_Array is
          when False =>
             --  IV as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IV as an array
             Arr : IV1RR_IV_Field_Array;
@@ -473,9 +473,9 @@ package STM32_SVD.CRYP is
       --  status register
       SR         : SR_Register;
       --  data input register
-      DIN        : HAL.Word;
+      DIN        : HAL.UInt32;
       --  data output register
-      DOUT       : HAL.Word;
+      DOUT       : HAL.UInt32;
       --  DMA control register
       DMACR      : DMACR_Register;
       --  interrupt mask set/clear register
@@ -509,37 +509,37 @@ package STM32_SVD.CRYP is
       --  initialization vector registers
       IV1RR      : IV1RR_Register;
       --  context swap register
-      CSGCMCCM0R : HAL.Word;
+      CSGCMCCM0R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM1R : HAL.Word;
+      CSGCMCCM1R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM2R : HAL.Word;
+      CSGCMCCM2R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM3R : HAL.Word;
+      CSGCMCCM3R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM4R : HAL.Word;
+      CSGCMCCM4R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM5R : HAL.Word;
+      CSGCMCCM5R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM6R : HAL.Word;
+      CSGCMCCM6R : HAL.UInt32;
       --  context swap register
-      CSGCMCCM7R : HAL.Word;
+      CSGCMCCM7R : HAL.UInt32;
       --  context swap register
-      CSGCM0R    : HAL.Word;
+      CSGCM0R    : HAL.UInt32;
       --  context swap register
-      CSGCM1R    : HAL.Word;
+      CSGCM1R    : HAL.UInt32;
       --  context swap register
-      CSGCM2R    : HAL.Word;
+      CSGCM2R    : HAL.UInt32;
       --  context swap register
-      CSGCM3R    : HAL.Word;
+      CSGCM3R    : HAL.UInt32;
       --  context swap register
-      CSGCM4R    : HAL.Word;
+      CSGCM4R    : HAL.UInt32;
       --  context swap register
-      CSGCM5R    : HAL.Word;
+      CSGCM5R    : HAL.UInt32;
       --  context swap register
-      CSGCM6R    : HAL.Word;
+      CSGCM6R    : HAL.UInt32;
       --  context swap register
-      CSGCM7R    : HAL.Word;
+      CSGCM7R    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-dac.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-dac.ads
@@ -149,7 +149,7 @@ package STM32_SVD.DAC is
       --  DAC channel1 12-bit left-aligned data
       DACC1DHR       : DHR12L1_DACC1DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -203,7 +203,7 @@ package STM32_SVD.DAC is
       --  DAC channel2 12-bit left-aligned data
       DACC2DHR       : DHR12L2_DACC2DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -289,7 +289,7 @@ package STM32_SVD.DAC is
       --  DAC channel2 8-bit right-aligned data
       DACC2DHR       : DHR8RD_DACC2DHR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-dcmi.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-dcmi.ads
@@ -307,7 +307,7 @@ package STM32_SVD.DCMI is
       case As_Array is
          when False =>
             --  Byte as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  Byte as an array
             Arr : DR_Byte_Field_Array;

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-dfsdm.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-dfsdm.ads
@@ -925,14 +925,14 @@ package STM32_SVD.DFSDM is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM_CHWDAT0R_WDATA_Field is HAL.Short;
+   subtype DFSDM_CHWDAT0R_WDATA_Field is HAL.UInt16;
 
    --  DFSDM channel watchdog filter data register
    type DFSDM_CHWDAT0R_Register is record
       --  Read-only. Input channel y watchdog data
       WDATA          : DFSDM_CHWDAT0R_WDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -942,14 +942,14 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM_CHWDAT1R_WDATA_Field is HAL.Short;
+   subtype DFSDM_CHWDAT1R_WDATA_Field is HAL.UInt16;
 
    --  DFSDM channel watchdog filter data register
    type DFSDM_CHWDAT1R_Register is record
       --  Read-only. Input channel y watchdog data
       WDATA          : DFSDM_CHWDAT1R_WDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -959,14 +959,14 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM_CHWDAT2R_WDATA_Field is HAL.Short;
+   subtype DFSDM_CHWDAT2R_WDATA_Field is HAL.UInt16;
 
    --  DFSDM channel watchdog filter data register
    type DFSDM_CHWDAT2R_Register is record
       --  Read-only. Input channel y watchdog data
       WDATA          : DFSDM_CHWDAT2R_WDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -976,14 +976,14 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM_CHWDAT3R_WDATA_Field is HAL.Short;
+   subtype DFSDM_CHWDAT3R_WDATA_Field is HAL.UInt16;
 
    --  DFSDM channel watchdog filter data register
    type DFSDM_CHWDAT3R_Register is record
       --  Read-only. Input channel y watchdog data
       WDATA          : DFSDM_CHWDAT3R_WDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -993,14 +993,14 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM_CHWDAT4R_WDATA_Field is HAL.Short;
+   subtype DFSDM_CHWDAT4R_WDATA_Field is HAL.UInt16;
 
    --  DFSDM channel watchdog filter data register
    type DFSDM_CHWDAT4R_Register is record
       --  Read-only. Input channel y watchdog data
       WDATA          : DFSDM_CHWDAT4R_WDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1010,14 +1010,14 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM_CHWDAT5R_WDATA_Field is HAL.Short;
+   subtype DFSDM_CHWDAT5R_WDATA_Field is HAL.UInt16;
 
    --  DFSDM channel watchdog filter data register
    type DFSDM_CHWDAT5R_Register is record
       --  Read-only. Input channel y watchdog data
       WDATA          : DFSDM_CHWDAT5R_WDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1027,14 +1027,14 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM_CHWDAT6R_WDATA_Field is HAL.Short;
+   subtype DFSDM_CHWDAT6R_WDATA_Field is HAL.UInt16;
 
    --  DFSDM channel watchdog filter data register
    type DFSDM_CHWDAT6R_Register is record
       --  Read-only. Input channel y watchdog data
       WDATA          : DFSDM_CHWDAT6R_WDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1044,14 +1044,14 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM_CHWDAT7R_WDATA_Field is HAL.Short;
+   subtype DFSDM_CHWDAT7R_WDATA_Field is HAL.UInt16;
 
    --  DFSDM channel watchdog filter data register
    type DFSDM_CHWDAT7R_Register is record
       --  Read-only. Input channel y watchdog data
       WDATA          : DFSDM_CHWDAT7R_WDATA_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1062,7 +1062,7 @@ package STM32_SVD.DFSDM is
    end record;
 
    --  DFSDM_CHDATIN0R_INDAT array element
-   subtype DFSDM_CHDATIN0R_INDAT_Element is HAL.Short;
+   subtype DFSDM_CHDATIN0R_INDAT_Element is HAL.UInt16;
 
    --  DFSDM_CHDATIN0R_INDAT array
    type DFSDM_CHDATIN0R_INDAT_Field_Array is array (0 .. 1)
@@ -1076,7 +1076,7 @@ package STM32_SVD.DFSDM is
       case As_Array is
          when False =>
             --  INDAT as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  INDAT as an array
             Arr : DFSDM_CHDATIN0R_INDAT_Field_Array;
@@ -1091,7 +1091,7 @@ package STM32_SVD.DFSDM is
    end record;
 
    --  DFSDM_CHDATIN1R_INDAT array element
-   subtype DFSDM_CHDATIN1R_INDAT_Element is HAL.Short;
+   subtype DFSDM_CHDATIN1R_INDAT_Element is HAL.UInt16;
 
    --  DFSDM_CHDATIN1R_INDAT array
    type DFSDM_CHDATIN1R_INDAT_Field_Array is array (0 .. 1)
@@ -1105,7 +1105,7 @@ package STM32_SVD.DFSDM is
       case As_Array is
          when False =>
             --  INDAT as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  INDAT as an array
             Arr : DFSDM_CHDATIN1R_INDAT_Field_Array;
@@ -1120,7 +1120,7 @@ package STM32_SVD.DFSDM is
    end record;
 
    --  DFSDM_CHDATIN2R_INDAT array element
-   subtype DFSDM_CHDATIN2R_INDAT_Element is HAL.Short;
+   subtype DFSDM_CHDATIN2R_INDAT_Element is HAL.UInt16;
 
    --  DFSDM_CHDATIN2R_INDAT array
    type DFSDM_CHDATIN2R_INDAT_Field_Array is array (0 .. 1)
@@ -1134,7 +1134,7 @@ package STM32_SVD.DFSDM is
       case As_Array is
          when False =>
             --  INDAT as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  INDAT as an array
             Arr : DFSDM_CHDATIN2R_INDAT_Field_Array;
@@ -1149,7 +1149,7 @@ package STM32_SVD.DFSDM is
    end record;
 
    --  DFSDM_CHDATIN3R_INDAT array element
-   subtype DFSDM_CHDATIN3R_INDAT_Element is HAL.Short;
+   subtype DFSDM_CHDATIN3R_INDAT_Element is HAL.UInt16;
 
    --  DFSDM_CHDATIN3R_INDAT array
    type DFSDM_CHDATIN3R_INDAT_Field_Array is array (0 .. 1)
@@ -1163,7 +1163,7 @@ package STM32_SVD.DFSDM is
       case As_Array is
          when False =>
             --  INDAT as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  INDAT as an array
             Arr : DFSDM_CHDATIN3R_INDAT_Field_Array;
@@ -1178,7 +1178,7 @@ package STM32_SVD.DFSDM is
    end record;
 
    --  DFSDM_CHDATIN4R_INDAT array element
-   subtype DFSDM_CHDATIN4R_INDAT_Element is HAL.Short;
+   subtype DFSDM_CHDATIN4R_INDAT_Element is HAL.UInt16;
 
    --  DFSDM_CHDATIN4R_INDAT array
    type DFSDM_CHDATIN4R_INDAT_Field_Array is array (0 .. 1)
@@ -1192,7 +1192,7 @@ package STM32_SVD.DFSDM is
       case As_Array is
          when False =>
             --  INDAT as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  INDAT as an array
             Arr : DFSDM_CHDATIN4R_INDAT_Field_Array;
@@ -1207,7 +1207,7 @@ package STM32_SVD.DFSDM is
    end record;
 
    --  DFSDM_CHDATIN5R_INDAT array element
-   subtype DFSDM_CHDATIN5R_INDAT_Element is HAL.Short;
+   subtype DFSDM_CHDATIN5R_INDAT_Element is HAL.UInt16;
 
    --  DFSDM_CHDATIN5R_INDAT array
    type DFSDM_CHDATIN5R_INDAT_Field_Array is array (0 .. 1)
@@ -1221,7 +1221,7 @@ package STM32_SVD.DFSDM is
       case As_Array is
          when False =>
             --  INDAT as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  INDAT as an array
             Arr : DFSDM_CHDATIN5R_INDAT_Field_Array;
@@ -1236,7 +1236,7 @@ package STM32_SVD.DFSDM is
    end record;
 
    --  DFSDM_CHDATIN6R_INDAT array element
-   subtype DFSDM_CHDATIN6R_INDAT_Element is HAL.Short;
+   subtype DFSDM_CHDATIN6R_INDAT_Element is HAL.UInt16;
 
    --  DFSDM_CHDATIN6R_INDAT array
    type DFSDM_CHDATIN6R_INDAT_Field_Array is array (0 .. 1)
@@ -1250,7 +1250,7 @@ package STM32_SVD.DFSDM is
       case As_Array is
          when False =>
             --  INDAT as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  INDAT as an array
             Arr : DFSDM_CHDATIN6R_INDAT_Field_Array;
@@ -1265,7 +1265,7 @@ package STM32_SVD.DFSDM is
    end record;
 
    --  DFSDM_CHDATIN7R_INDAT array element
-   subtype DFSDM_CHDATIN7R_INDAT_Element is HAL.Short;
+   subtype DFSDM_CHDATIN7R_INDAT_Element is HAL.UInt16;
 
    --  DFSDM_CHDATIN7R_INDAT array
    type DFSDM_CHDATIN7R_INDAT_Field_Array is array (0 .. 1)
@@ -1279,7 +1279,7 @@ package STM32_SVD.DFSDM is
       case As_Array is
          when False =>
             --  INDAT as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  INDAT as an array
             Arr : DFSDM_CHDATIN7R_INDAT_Field_Array;
@@ -2631,7 +2631,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Analog watchdog high threshold flag
       AWHTF          : DFSDM0_AWSR_AWHTF_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2652,7 +2652,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Analog watchdog high threshold flag
       AWHTF          : DFSDM1_AWSR_AWHTF_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2673,7 +2673,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Analog watchdog high threshold flag
       AWHTF          : DFSDM2_AWSR_AWHTF_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2694,7 +2694,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Analog watchdog high threshold flag
       AWHTF          : DFSDM3_AWSR_AWHTF_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2715,7 +2715,7 @@ package STM32_SVD.DFSDM is
       --  Clear the analog watchdog high threshold flag
       CLRAWHTF       : DFSDM0_AWCFR_CLRAWHTF_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2736,7 +2736,7 @@ package STM32_SVD.DFSDM is
       --  Clear the analog watchdog high threshold flag
       CLRAWHTF       : DFSDM1_AWCFR_CLRAWHTF_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2757,7 +2757,7 @@ package STM32_SVD.DFSDM is
       --  Clear the analog watchdog high threshold flag
       CLRAWHTF       : DFSDM2_AWCFR_CLRAWHTF_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2778,7 +2778,7 @@ package STM32_SVD.DFSDM is
       --  Clear the analog watchdog high threshold flag
       CLRAWHTF       : DFSDM3_AWCFR_CLRAWHTF_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-dma.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-dma.ads
@@ -445,14 +445,14 @@ package STM32_SVD.DMA is
       Reserved_29_31 at 0 range 29 .. 31;
    end record;
 
-   subtype SxNDTR_Stream_NDT_Field is HAL.Short;
+   subtype SxNDTR_Stream_NDT_Field is HAL.UInt16;
 
    --  stream x number of data register
    type SxNDTR_Stream_Register is record
       --  Number of data items to transfer
       NDT            : SxNDTR_Stream_NDT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -499,11 +499,11 @@ package STM32_SVD.DMA is
       --  stream x number of data register
       SxNDTR : SxNDTR_Stream_Register;
       --  stream x peripheral address register
-      SxPAR  : HAL.Word;
+      SxPAR  : HAL.UInt32;
       --  stream x memory 0 address register
-      SxM0AR : HAL.Word;
+      SxM0AR : HAL.UInt32;
       --  stream x memory 1 address register
-      SxM1AR : HAL.Word;
+      SxM1AR : HAL.UInt32;
       --  stream x FIFO control register
       SxFCR  : SxFCR_Stream_Register;
    end record

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-dma2d.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-dma2d.ads
@@ -343,7 +343,7 @@ package STM32_SVD.DMA2D is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype NLR_NL_Field is HAL.Short;
+   subtype NLR_NL_Field is HAL.UInt16;
    subtype NLR_PL_Field is HAL.UInt14;
 
    --  number of line register
@@ -364,14 +364,14 @@ package STM32_SVD.DMA2D is
       Reserved_30_31 at 0 range 30 .. 31;
    end record;
 
-   subtype LWR_LW_Field is HAL.Short;
+   subtype LWR_LW_Field is HAL.UInt16;
 
    --  line watermark register
    type LWR_Register is record
       --  Line watermark
       LW             : LWR_LW_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -392,7 +392,7 @@ package STM32_SVD.DMA2D is
       --  Dead Time
       DT             : AMTCR_DT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -469,11 +469,11 @@ package STM32_SVD.DMA2D is
       --  interrupt flag clear register
       IFCR    : IFCR_Register;
       --  foreground memory address register
-      FGMAR   : HAL.Word;
+      FGMAR   : HAL.UInt32;
       --  foreground offset register
       FGOR    : FGOR_Register;
       --  background memory address register
-      BGMAR   : HAL.Word;
+      BGMAR   : HAL.UInt32;
       --  background offset register
       BGOR    : BGOR_Register;
       --  foreground PFC control register
@@ -485,15 +485,15 @@ package STM32_SVD.DMA2D is
       --  background color register
       BGCOLR  : BGCOLR_Register;
       --  foreground CLUT memory address register
-      FGCMAR  : HAL.Word;
+      FGCMAR  : HAL.UInt32;
       --  background CLUT memory address register
-      BGCMAR  : HAL.Word;
+      BGCMAR  : HAL.UInt32;
       --  output PFC control register
       OPFCCR  : OPFCCR_Register;
       --  output color register
       OCOLR   : OCOLR_Register;
       --  output memory address register
-      OMAR    : HAL.Word;
+      OMAR    : HAL.UInt32;
       --  output offset register
       OOR     : OOR_Register;
       --  number of line register

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-dsi.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-dsi.ads
@@ -38,7 +38,7 @@ package STM32_SVD.DSI is
       --  Timeout Clock Division
       TOCKDIV        : DSI_CCR_TOCKDIV_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -422,14 +422,14 @@ package STM32_SVD.DSI is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype DSI_LCCR_CMDSIZE_Field is HAL.Short;
+   subtype DSI_LCCR_CMDSIZE_Field is HAL.UInt16;
 
    --  DSI Host LTDC Command Configuration Register
    type DSI_LCCR_Register is record
       --  Command Size
       CMDSIZE        : DSI_LCCR_CMDSIZE_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -545,7 +545,7 @@ package STM32_SVD.DSI is
       case As_Array is
          when False =>
             --  DATA as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  DATA as an array
             Arr : DSI_GPDR_DATA_Field_Array;
@@ -592,8 +592,8 @@ package STM32_SVD.DSI is
       Reserved_7_31 at 0 range 7 .. 31;
    end record;
 
-   subtype DSI_TCCR0_LPRX_TOCNT_Field is HAL.Short;
-   subtype DSI_TCCR0_HSTX_TOCNT_Field is HAL.Short;
+   subtype DSI_TCCR0_LPRX_TOCNT_Field is HAL.UInt16;
+   subtype DSI_TCCR0_HSTX_TOCNT_Field is HAL.UInt16;
 
    --  DSI Host Timeout Counter Configuration Register 0
    type DSI_TCCR0_Register is record
@@ -610,14 +610,14 @@ package STM32_SVD.DSI is
       HSTX_TOCNT at 0 range 16 .. 31;
    end record;
 
-   subtype DSI_TCCR1_HSRD_TOCNT_Field is HAL.Short;
+   subtype DSI_TCCR1_HSRD_TOCNT_Field is HAL.UInt16;
 
    --  DSI Host Timeout Counter Configuration Register 1
    type DSI_TCCR1_Register is record
       --  High-Speed Read Timeout Counter
       HSRD_TOCNT     : DSI_TCCR1_HSRD_TOCNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -627,14 +627,14 @@ package STM32_SVD.DSI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DSI_TCCR2_LPRD_TOCNT_Field is HAL.Short;
+   subtype DSI_TCCR2_LPRD_TOCNT_Field is HAL.UInt16;
 
    --  DSI Host Timeout Counter Configuration Register 2
    type DSI_TCCR2_Register is record
       --  Low-Power Read Timeout Counter
       LPRD_TOCNT     : DSI_TCCR2_LPRD_TOCNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -644,7 +644,7 @@ package STM32_SVD.DSI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DSI_TCCR3_HSWR_TOCNT_Field is HAL.Short;
+   subtype DSI_TCCR3_HSWR_TOCNT_Field is HAL.UInt16;
 
    --  DSI Host Timeout Counter Configuration Register 3
    type DSI_TCCR3_Register is record
@@ -667,14 +667,14 @@ package STM32_SVD.DSI is
       Reserved_25_31 at 0 range 25 .. 31;
    end record;
 
-   subtype DSI_TCCR4_LSWR_TOCNT_Field is HAL.Short;
+   subtype DSI_TCCR4_LSWR_TOCNT_Field is HAL.UInt16;
 
    --  DSI Host Timeout Counter Configuration Register 4
    type DSI_TCCR4_Register is record
       --  Low-Power Write Timeout Counter
       LSWR_TOCNT     : DSI_TCCR4_LSWR_TOCNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -684,14 +684,14 @@ package STM32_SVD.DSI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DSI_TCCR5_BTA_TOCNT_Field is HAL.Short;
+   subtype DSI_TCCR5_BTA_TOCNT_Field is HAL.UInt16;
 
    --  DSI Host Timeout Counter Configuration Register 5
    type DSI_TCCR5_Register is record
       --  Bus-Turn-Around Timeout Counter
       BTA_TOCNT      : DSI_TCCR5_BTA_TOCNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -801,7 +801,7 @@ package STM32_SVD.DSI is
       --  Stop Wait Time
       SW_TIME        : DSI_PCONFR_SW_TIME_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -904,7 +904,7 @@ package STM32_SVD.DSI is
       case As_Array is
          when False =>
             --  AE as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  AE as an array
             Arr : DSI_ISR0_AE_Field_Array;
@@ -1147,7 +1147,7 @@ package STM32_SVD.DSI is
       case As_Array is
          when False =>
             --  FAE as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  FAE as an array
             Arr : DSI_FIR0_FAE_Field_Array;
@@ -2023,7 +2023,7 @@ package STM32_SVD.DSI is
    --  DSI Host
    type DSI_Peripheral is record
       --  DSI Host Version Register
-      DSI_VR      : HAL.Word;
+      DSI_VR      : HAL.UInt32;
       --  DSI Host Control Register
       DSI_CR      : DSI_CR_Register;
       --  DSI HOST Clock Control Register

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-ethernet.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-ethernet.ads
@@ -277,7 +277,7 @@ package STM32_SVD.Ethernet is
       Reserved_17_31 at 0 range 17 .. 31;
    end record;
 
-   subtype DMAMFBOCR_MFC_Field is HAL.Short;
+   subtype DMAMFBOCR_MFC_Field is HAL.UInt16;
    subtype DMAMFBOCR_MFA_Field is HAL.UInt11;
 
    --  Ethernet DMA missed frame and buffer overflow counter register
@@ -463,7 +463,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       PA             : MACMIIAR_PA_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -478,14 +478,14 @@ package STM32_SVD.Ethernet is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MACMIIDR_TD_Field is HAL.Short;
+   subtype MACMIIDR_TD_Field is HAL.UInt16;
 
    --  Ethernet MAC MII data register
    type MACMIIDR_Register is record
       --  no description available
       TD             : MACMIIDR_TD_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -496,7 +496,7 @@ package STM32_SVD.Ethernet is
    end record;
 
    subtype MACFCR_PLT_Field is HAL.UInt2;
-   subtype MACFCR_PT_Field is HAL.Short;
+   subtype MACFCR_PT_Field is HAL.UInt16;
 
    --  Ethernet MAC flow control register
    type MACFCR_Register is record
@@ -534,7 +534,7 @@ package STM32_SVD.Ethernet is
       PT            at 0 range 16 .. 31;
    end record;
 
-   subtype MACVLANTR_VLANTI_Field is HAL.Short;
+   subtype MACVLANTR_VLANTI_Field is HAL.UInt16;
 
    --  Ethernet MAC VLAN tag register
    type MACVLANTR_Register is record
@@ -680,7 +680,7 @@ package STM32_SVD.Ethernet is
       Reserved_10_31 at 0 range 10 .. 31;
    end record;
 
-   subtype MACA0HR_MACA0H_Field is HAL.Short;
+   subtype MACA0HR_MACA0H_Field is HAL.UInt16;
 
    --  Ethernet MAC address 0 high register
    type MACA0HR_Register is record
@@ -700,7 +700,7 @@ package STM32_SVD.Ethernet is
       MO             at 0 range 31 .. 31;
    end record;
 
-   subtype MACA1HR_MACA1H_Field is HAL.Short;
+   subtype MACA1HR_MACA1H_Field is HAL.UInt16;
    subtype MACA1HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 1 high register
@@ -727,7 +727,7 @@ package STM32_SVD.Ethernet is
       AE             at 0 range 31 .. 31;
    end record;
 
-   subtype MACA2HR_MAC2AH_Field is HAL.Short;
+   subtype MACA2HR_MAC2AH_Field is HAL.UInt16;
    subtype MACA2HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 2 high register
@@ -771,7 +771,7 @@ package STM32_SVD.Ethernet is
       Reserved_31_31 at 0 range 31 .. 31;
    end record;
 
-   subtype MACA3HR_MACA3H_Field is HAL.Short;
+   subtype MACA3HR_MACA3H_Field is HAL.UInt16;
    subtype MACA3HR_MBC_Field is HAL.UInt6;
 
    --  Ethernet MAC address 3 high register
@@ -1094,13 +1094,13 @@ package STM32_SVD.Ethernet is
       --  Ethernet DMA bus mode register
       DMABMR    : DMABMR_Register;
       --  Ethernet DMA transmit poll demand register
-      DMATPDR   : HAL.Word;
+      DMATPDR   : HAL.UInt32;
       --  EHERNET DMA receive poll demand register
-      DMARPDR   : HAL.Word;
+      DMARPDR   : HAL.UInt32;
       --  Ethernet DMA receive descriptor list address register
-      DMARDLAR  : HAL.Word;
+      DMARDLAR  : HAL.UInt32;
       --  Ethernet DMA transmit descriptor list address register
-      DMATDLAR  : HAL.Word;
+      DMATDLAR  : HAL.UInt32;
       --  Ethernet DMA status register
       DMASR     : DMASR_Register;
       --  Ethernet DMA operation mode register
@@ -1112,13 +1112,13 @@ package STM32_SVD.Ethernet is
       --  Ethernet DMA receive status watchdog timer register
       DMARSWTR  : DMARSWTR_Register;
       --  Ethernet DMA current host transmit descriptor register
-      DMACHTDR  : HAL.Word;
+      DMACHTDR  : HAL.UInt32;
       --  Ethernet DMA current host receive descriptor register
-      DMACHRDR  : HAL.Word;
+      DMACHRDR  : HAL.UInt32;
       --  Ethernet DMA current host transmit buffer address register
-      DMACHTBAR : HAL.Word;
+      DMACHTBAR : HAL.UInt32;
       --  Ethernet DMA current host receive buffer address register
-      DMACHRBAR : HAL.Word;
+      DMACHRBAR : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1150,9 +1150,9 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC frame filter register
       MACFFR     : MACFFR_Register;
       --  Ethernet MAC hash table high register
-      MACHTHR    : HAL.Word;
+      MACHTHR    : HAL.UInt32;
       --  Ethernet MAC hash table low register
-      MACHTLR    : HAL.Word;
+      MACHTLR    : HAL.UInt32;
       --  Ethernet MAC MII address register
       MACMIIAR   : MACMIIAR_Register;
       --  Ethernet MAC MII data register
@@ -1172,11 +1172,11 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC address 0 high register
       MACA0HR    : MACA0HR_Register;
       --  Ethernet MAC address 0 low register
-      MACA0LR    : HAL.Word;
+      MACA0LR    : HAL.UInt32;
       --  Ethernet MAC address 1 high register
       MACA1HR    : MACA1HR_Register;
       --  Ethernet MAC address1 low register
-      MACA1LR    : HAL.Word;
+      MACA1LR    : HAL.UInt32;
       --  Ethernet MAC address 2 high register
       MACA2HR    : MACA2HR_Register;
       --  Ethernet MAC address 2 low register
@@ -1184,9 +1184,9 @@ package STM32_SVD.Ethernet is
       --  Ethernet MAC address 3 high register
       MACA3HR    : MACA3HR_Register;
       --  Ethernet MAC address 3 low register
-      MACA3LR    : HAL.Word;
+      MACA3LR    : HAL.UInt32;
       --  Ethernet MAC remote wakeup frame filter register
-      MACRWUFFER : HAL.Word;
+      MACRWUFFER : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1231,18 +1231,18 @@ package STM32_SVD.Ethernet is
       --  Ethernet MMC transmit interrupt mask register
       MMCTIMR     : MMCTIMR_Register;
       --  Ethernet MMC transmitted good frames after a single collision counter
-      MMCTGFSCCR  : HAL.Word;
+      MMCTGFSCCR  : HAL.UInt32;
       --  Ethernet MMC transmitted good frames after more than a single
       --  collision
-      MMCTGFMSCCR : HAL.Word;
+      MMCTGFMSCCR : HAL.UInt32;
       --  Ethernet MMC transmitted good frames counter register
-      MMCTGFCR    : HAL.Word;
+      MMCTGFCR    : HAL.UInt32;
       --  Ethernet MMC received frames with CRC error counter register
-      MMCRFCECR   : HAL.Word;
+      MMCRFCECR   : HAL.UInt32;
       --  Ethernet MMC received frames with alignment error counter register
-      MMCRFAECR   : HAL.Word;
+      MMCRFAECR   : HAL.UInt32;
       --  MMC received good unicast frames counter register
-      MMCRGUFCR   : HAL.Word;
+      MMCRGUFCR   : HAL.UInt32;
    end record
      with Volatile;
 
@@ -1271,19 +1271,19 @@ package STM32_SVD.Ethernet is
       --  Ethernet PTP subsecond increment register
       PTPSSIR  : PTPSSIR_Register;
       --  Ethernet PTP time stamp high register
-      PTPTSHR  : HAL.Word;
+      PTPTSHR  : HAL.UInt32;
       --  Ethernet PTP time stamp low register
       PTPTSLR  : PTPTSLR_Register;
       --  Ethernet PTP time stamp high update register
-      PTPTSHUR : HAL.Word;
+      PTPTSHUR : HAL.UInt32;
       --  Ethernet PTP time stamp low update register
       PTPTSLUR : PTPTSLUR_Register;
       --  Ethernet PTP time stamp addend register
-      PTPTSAR  : HAL.Word;
+      PTPTSAR  : HAL.UInt32;
       --  Ethernet PTP target time high register
-      PTPTTHR  : HAL.Word;
+      PTPTTHR  : HAL.UInt32;
       --  Ethernet PTP target time low register
-      PTPTTLR  : HAL.Word;
+      PTPTTLR  : HAL.UInt32;
       --  Ethernet PTP time stamp status register
       PTPTSSR  : PTPTSSR_Register;
       --  Ethernet PTP PPS control register

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-flash.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-flash.ads
@@ -186,7 +186,7 @@ package STM32_SVD.FLASH is
    --  Flash option control register 1
    type OPTCR1_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  Not write protect
       nWRP           : OPTCR1_nWRP_Field := 16#FFF#;
       --  unspecified
@@ -210,9 +210,9 @@ package STM32_SVD.FLASH is
       --  Flash access control register
       ACR     : ACR_Register;
       --  Flash key register
-      KEYR    : HAL.Word;
+      KEYR    : HAL.UInt32;
       --  Flash option key register
-      OPTKEYR : HAL.Word;
+      OPTKEYR : HAL.UInt32;
       --  Status register
       SR      : SR_Register;
       --  Control register

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-fsmc.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-fsmc.ads
@@ -597,7 +597,7 @@ package STM32_SVD.FSMC is
       --  Attribute memory space timing register
       PATT  : PATT_Register;
       --  ECC result register
-      ECCR  : HAL.Word;
+      ECCR  : HAL.UInt32;
       --  SRAM/NOR-Flash write timing registers 1
       BWTR1 : BWTR_Register;
       --  SRAM/NOR-Flash write timing registers 2

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-gpio.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-gpio.ads
@@ -27,7 +27,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  MODER as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  MODER as an array
             Arr : MODER_Field_Array;
@@ -52,7 +52,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  OT as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  OT as an array
             Arr : OTYPER_OT_Field_Array;
@@ -70,7 +70,7 @@ package STM32_SVD.GPIO is
       --  Port x configuration bits (y = 0..15)
       OT             : OTYPER_OT_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -94,7 +94,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  OSPEEDR as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  OSPEEDR as an array
             Arr : OSPEEDR_Field_Array;
@@ -122,7 +122,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  PUPDR as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  PUPDR as an array
             Arr : PUPDR_Field_Array;
@@ -147,7 +147,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  IDR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  IDR as an array
             Arr : IDR_Field_Array;
@@ -165,7 +165,7 @@ package STM32_SVD.GPIO is
       --  Read-only. Port input data (y = 0..15)
       IDR            : IDR_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -186,7 +186,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  ODR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  ODR as an array
             Arr : ODR_Field_Array;
@@ -204,7 +204,7 @@ package STM32_SVD.GPIO is
       --  Port output data (y = 0..15)
       ODR            : ODR_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -225,7 +225,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  BS as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  BS as an array
             Arr : BSRR_BS_Field_Array;
@@ -249,7 +249,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  BR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  BR as an array
             Arr : BSRR_BR_Field_Array;
@@ -288,7 +288,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  LCK as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  LCK as an array
             Arr : LCKR_LCK_Field_Array;
@@ -333,7 +333,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  AFRL as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  AFRL as an array
             Arr : AFRL_Field_Array;
@@ -361,7 +361,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  AFRH as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  AFRH as an array
             Arr : AFRH_Field_Array;
@@ -386,7 +386,7 @@ package STM32_SVD.GPIO is
       case As_Array is
          when False =>
             --  BR as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  BR as an array
             Arr : BRR_BR_Field_Array;
@@ -404,7 +404,7 @@ package STM32_SVD.GPIO is
       --  Port A Reset bit 0
       BR             : BRR_BR_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-hash.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-hash.ads
@@ -141,147 +141,147 @@ package STM32_SVD.HASH is
       --  control register
       CR       : CR_Register;
       --  data input register
-      DIN      : HAL.Word;
+      DIN      : HAL.UInt32;
       --  start register
       STR      : STR_Register;
       --  digest registers
-      HR0      : HAL.Word;
+      HR0      : HAL.UInt32;
       --  digest registers
-      HR1      : HAL.Word;
+      HR1      : HAL.UInt32;
       --  digest registers
-      HR2      : HAL.Word;
+      HR2      : HAL.UInt32;
       --  digest registers
-      HR3      : HAL.Word;
+      HR3      : HAL.UInt32;
       --  digest registers
-      HR4      : HAL.Word;
+      HR4      : HAL.UInt32;
       --  interrupt enable register
       IMR      : IMR_Register;
       --  status register
       SR       : SR_Register;
       --  context swap registers
-      CSR0     : HAL.Word;
+      CSR0     : HAL.UInt32;
       --  context swap registers
-      CSR1     : HAL.Word;
+      CSR1     : HAL.UInt32;
       --  context swap registers
-      CSR2     : HAL.Word;
+      CSR2     : HAL.UInt32;
       --  context swap registers
-      CSR3     : HAL.Word;
+      CSR3     : HAL.UInt32;
       --  context swap registers
-      CSR4     : HAL.Word;
+      CSR4     : HAL.UInt32;
       --  context swap registers
-      CSR5     : HAL.Word;
+      CSR5     : HAL.UInt32;
       --  context swap registers
-      CSR6     : HAL.Word;
+      CSR6     : HAL.UInt32;
       --  context swap registers
-      CSR7     : HAL.Word;
+      CSR7     : HAL.UInt32;
       --  context swap registers
-      CSR8     : HAL.Word;
+      CSR8     : HAL.UInt32;
       --  context swap registers
-      CSR9     : HAL.Word;
+      CSR9     : HAL.UInt32;
       --  context swap registers
-      CSR10    : HAL.Word;
+      CSR10    : HAL.UInt32;
       --  context swap registers
-      CSR11    : HAL.Word;
+      CSR11    : HAL.UInt32;
       --  context swap registers
-      CSR12    : HAL.Word;
+      CSR12    : HAL.UInt32;
       --  context swap registers
-      CSR13    : HAL.Word;
+      CSR13    : HAL.UInt32;
       --  context swap registers
-      CSR14    : HAL.Word;
+      CSR14    : HAL.UInt32;
       --  context swap registers
-      CSR15    : HAL.Word;
+      CSR15    : HAL.UInt32;
       --  context swap registers
-      CSR16    : HAL.Word;
+      CSR16    : HAL.UInt32;
       --  context swap registers
-      CSR17    : HAL.Word;
+      CSR17    : HAL.UInt32;
       --  context swap registers
-      CSR18    : HAL.Word;
+      CSR18    : HAL.UInt32;
       --  context swap registers
-      CSR19    : HAL.Word;
+      CSR19    : HAL.UInt32;
       --  context swap registers
-      CSR20    : HAL.Word;
+      CSR20    : HAL.UInt32;
       --  context swap registers
-      CSR21    : HAL.Word;
+      CSR21    : HAL.UInt32;
       --  context swap registers
-      CSR22    : HAL.Word;
+      CSR22    : HAL.UInt32;
       --  context swap registers
-      CSR23    : HAL.Word;
+      CSR23    : HAL.UInt32;
       --  context swap registers
-      CSR24    : HAL.Word;
+      CSR24    : HAL.UInt32;
       --  context swap registers
-      CSR25    : HAL.Word;
+      CSR25    : HAL.UInt32;
       --  context swap registers
-      CSR26    : HAL.Word;
+      CSR26    : HAL.UInt32;
       --  context swap registers
-      CSR27    : HAL.Word;
+      CSR27    : HAL.UInt32;
       --  context swap registers
-      CSR28    : HAL.Word;
+      CSR28    : HAL.UInt32;
       --  context swap registers
-      CSR29    : HAL.Word;
+      CSR29    : HAL.UInt32;
       --  context swap registers
-      CSR30    : HAL.Word;
+      CSR30    : HAL.UInt32;
       --  context swap registers
-      CSR31    : HAL.Word;
+      CSR31    : HAL.UInt32;
       --  context swap registers
-      CSR32    : HAL.Word;
+      CSR32    : HAL.UInt32;
       --  context swap registers
-      CSR33    : HAL.Word;
+      CSR33    : HAL.UInt32;
       --  context swap registers
-      CSR34    : HAL.Word;
+      CSR34    : HAL.UInt32;
       --  context swap registers
-      CSR35    : HAL.Word;
+      CSR35    : HAL.UInt32;
       --  context swap registers
-      CSR36    : HAL.Word;
+      CSR36    : HAL.UInt32;
       --  context swap registers
-      CSR37    : HAL.Word;
+      CSR37    : HAL.UInt32;
       --  context swap registers
-      CSR38    : HAL.Word;
+      CSR38    : HAL.UInt32;
       --  context swap registers
-      CSR39    : HAL.Word;
+      CSR39    : HAL.UInt32;
       --  context swap registers
-      CSR40    : HAL.Word;
+      CSR40    : HAL.UInt32;
       --  context swap registers
-      CSR41    : HAL.Word;
+      CSR41    : HAL.UInt32;
       --  context swap registers
-      CSR42    : HAL.Word;
+      CSR42    : HAL.UInt32;
       --  context swap registers
-      CSR43    : HAL.Word;
+      CSR43    : HAL.UInt32;
       --  context swap registers
-      CSR44    : HAL.Word;
+      CSR44    : HAL.UInt32;
       --  context swap registers
-      CSR45    : HAL.Word;
+      CSR45    : HAL.UInt32;
       --  context swap registers
-      CSR46    : HAL.Word;
+      CSR46    : HAL.UInt32;
       --  context swap registers
-      CSR47    : HAL.Word;
+      CSR47    : HAL.UInt32;
       --  context swap registers
-      CSR48    : HAL.Word;
+      CSR48    : HAL.UInt32;
       --  context swap registers
-      CSR49    : HAL.Word;
+      CSR49    : HAL.UInt32;
       --  context swap registers
-      CSR50    : HAL.Word;
+      CSR50    : HAL.UInt32;
       --  context swap registers
-      CSR51    : HAL.Word;
+      CSR51    : HAL.UInt32;
       --  context swap registers
-      CSR52    : HAL.Word;
+      CSR52    : HAL.UInt32;
       --  context swap registers
-      CSR53    : HAL.Word;
+      CSR53    : HAL.UInt32;
       --  HASH digest register
-      HASH_HR0 : HAL.Word;
+      HASH_HR0 : HAL.UInt32;
       --  read-only
-      HASH_HR1 : HAL.Word;
+      HASH_HR1 : HAL.UInt32;
       --  read-only
-      HASH_HR2 : HAL.Word;
+      HASH_HR2 : HAL.UInt32;
       --  read-only
-      HASH_HR3 : HAL.Word;
+      HASH_HR3 : HAL.UInt32;
       --  read-only
-      HASH_HR4 : HAL.Word;
+      HASH_HR4 : HAL.UInt32;
       --  read-only
-      HASH_HR5 : HAL.Word;
+      HASH_HR5 : HAL.UInt32;
       --  read-only
-      HASH_HR6 : HAL.Word;
+      HASH_HR6 : HAL.UInt32;
       --  read-only
-      HASH_HR7 : HAL.Word;
+      HASH_HR7 : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-i2c.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-i2c.ads
@@ -151,7 +151,7 @@ package STM32_SVD.I2C is
       --  Own Address 1 enable
       OA1EN          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -180,7 +180,7 @@ package STM32_SVD.I2C is
       --  Own Address 2 enable
       OA2EN          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-iwdg.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-iwdg.ads
@@ -13,14 +13,14 @@ package STM32_SVD.IWDG is
    -- Registers --
    ---------------
 
-   subtype KR_KEY_Field is HAL.Short;
+   subtype KR_KEY_Field is HAL.UInt16;
 
    --  Key register
    type KR_Register is record
       --  Write-only. Key value (write only, read 0000h)
       KEY            : KR_KEY_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-jpeg.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-jpeg.ads
@@ -31,7 +31,7 @@ package STM32_SVD.JPEG is
    subtype JPEG_CONFR1_NF_Field is HAL.UInt2;
    subtype JPEG_CONFR1_COLORSPACE_Field is HAL.UInt2;
    subtype JPEG_CONFR1_NS_Field is HAL.UInt2;
-   subtype JPEG_CONFR1_YSIZE_Field is HAL.Short;
+   subtype JPEG_CONFR1_YSIZE_Field is HAL.UInt16;
 
    --  JPEG codec configuration register 1
    type JPEG_CONFR1_Register is record
@@ -83,12 +83,12 @@ package STM32_SVD.JPEG is
       Reserved_26_31 at 0 range 26 .. 31;
    end record;
 
-   subtype JPEG_CONFR3_XSIZE_Field is HAL.Short;
+   subtype JPEG_CONFR3_XSIZE_Field is HAL.UInt16;
 
    --  JPEG codec configuration register 3
    type JPEG_CONFR3_Register is record
       --  unspecified
-      Reserved_0_15 : HAL.Short := 16#0#;
+      Reserved_0_15 : HAL.UInt16 := 16#0#;
       --  X size
       XSIZE         : JPEG_CONFR3_XSIZE_Field := 16#0#;
    end record
@@ -120,7 +120,7 @@ package STM32_SVD.JPEG is
       --  Horizontal Sampling Factor
       HSF            : JPEG_CONFR_HSF_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -269,9 +269,9 @@ package STM32_SVD.JPEG is
       --  JPEG clear flag register
       JPEG_CFR    : JPEG_CFR_Register;
       --  JPEG data input register
-      JPEG_DIR    : HAL.Word;
+      JPEG_DIR    : HAL.UInt32;
       --  JPEG data output register
-      JPEG_DOR    : HAL.Word;
+      JPEG_DOR    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-lptim.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-lptim.ads
@@ -203,14 +203,14 @@ package STM32_SVD.LPTIM is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype CMP_CMP_Field is HAL.Short;
+   subtype CMP_CMP_Field is HAL.UInt16;
 
    --  Compare Register
    type CMP_Register is record
       --  Compare value
       CMP            : CMP_CMP_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -220,14 +220,14 @@ package STM32_SVD.LPTIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype ARR_ARR_Field is HAL.Short;
+   subtype ARR_ARR_Field is HAL.UInt16;
 
    --  Autoreload Register
    type ARR_Register is record
       --  Auto reload value
       ARR            : ARR_ARR_Field := 16#1#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -237,14 +237,14 @@ package STM32_SVD.LPTIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CNT_CNT_Field is HAL.Short;
+   subtype CNT_CNT_Field is HAL.UInt16;
 
    --  Counter Register
    type CNT_Register is record
       --  Read-only. Counter value
       CNT            : CNT_CNT_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-ltdc.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-ltdc.ads
@@ -288,8 +288,8 @@ package STM32_SVD.LTDC is
       Reserved_11_31 at 0 range 11 .. 31;
    end record;
 
-   subtype CPSR_CYPOS_Field is HAL.Short;
-   subtype CPSR_CXPOS_Field is HAL.Short;
+   subtype CPSR_CYPOS_Field is HAL.UInt16;
+   subtype CPSR_CXPOS_Field is HAL.UInt16;
 
    --  Current Position Status Register
    type CPSR_Register is record
@@ -875,7 +875,7 @@ package STM32_SVD.LTDC is
       --  Layerx Blending Factors Configuration Register
       L1BFCR   : L1BFCR_Register;
       --  Layerx Color Frame Buffer Address Register
-      L1CFBAR  : HAL.Word;
+      L1CFBAR  : HAL.UInt32;
       --  Layerx Color Frame Buffer Length Register
       L1CFBLR  : L1CFBLR_Register;
       --  Layerx ColorFrame Buffer Line Number Register
@@ -899,7 +899,7 @@ package STM32_SVD.LTDC is
       --  Layerx Blending Factors Configuration Register
       L2BFCR   : L2BFCR_Register;
       --  Layerx Color Frame Buffer Address Register
-      L2CFBAR  : HAL.Word;
+      L2CFBAR  : HAL.UInt32;
       --  Layerx Color Frame Buffer Length Register
       L2CFBLR  : L2CFBLR_Register;
       --  Layerx ColorFrame Buffer Line Number Register

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-mdios.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-mdios.ads
@@ -90,14 +90,14 @@ package STM32_SVD.MDIOS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype MDIOS_DINR0_DIN0_Field is HAL.Short;
+   subtype MDIOS_DINR0_DIN0_Field is HAL.UInt16;
 
    --  MDIOS input data register 0
    type MDIOS_DINR0_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN0           : MDIOS_DINR0_DIN0_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -107,14 +107,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR1_DIN1_Field is HAL.Short;
+   subtype MDIOS_DINR1_DIN1_Field is HAL.UInt16;
 
    --  MDIOS input data register 1
    type MDIOS_DINR1_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN1           : MDIOS_DINR1_DIN1_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -124,14 +124,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR2_DIN2_Field is HAL.Short;
+   subtype MDIOS_DINR2_DIN2_Field is HAL.UInt16;
 
    --  MDIOS input data register 2
    type MDIOS_DINR2_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN2           : MDIOS_DINR2_DIN2_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -141,14 +141,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR3_DIN3_Field is HAL.Short;
+   subtype MDIOS_DINR3_DIN3_Field is HAL.UInt16;
 
    --  MDIOS input data register 3
    type MDIOS_DINR3_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN3           : MDIOS_DINR3_DIN3_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -158,14 +158,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR4_DIN4_Field is HAL.Short;
+   subtype MDIOS_DINR4_DIN4_Field is HAL.UInt16;
 
    --  MDIOS input data register 4
    type MDIOS_DINR4_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN4           : MDIOS_DINR4_DIN4_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -175,14 +175,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR5_DIN5_Field is HAL.Short;
+   subtype MDIOS_DINR5_DIN5_Field is HAL.UInt16;
 
    --  MDIOS input data register 5
    type MDIOS_DINR5_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN5           : MDIOS_DINR5_DIN5_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -192,14 +192,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR6_DIN6_Field is HAL.Short;
+   subtype MDIOS_DINR6_DIN6_Field is HAL.UInt16;
 
    --  MDIOS input data register 6
    type MDIOS_DINR6_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN6           : MDIOS_DINR6_DIN6_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -209,14 +209,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR7_DIN7_Field is HAL.Short;
+   subtype MDIOS_DINR7_DIN7_Field is HAL.UInt16;
 
    --  MDIOS input data register 7
    type MDIOS_DINR7_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN7           : MDIOS_DINR7_DIN7_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -226,14 +226,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR8_DIN8_Field is HAL.Short;
+   subtype MDIOS_DINR8_DIN8_Field is HAL.UInt16;
 
    --  MDIOS input data register 8
    type MDIOS_DINR8_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN8           : MDIOS_DINR8_DIN8_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -243,14 +243,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR9_DIN9_Field is HAL.Short;
+   subtype MDIOS_DINR9_DIN9_Field is HAL.UInt16;
 
    --  MDIOS input data register 9
    type MDIOS_DINR9_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN9           : MDIOS_DINR9_DIN9_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -260,14 +260,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR10_DIN10_Field is HAL.Short;
+   subtype MDIOS_DINR10_DIN10_Field is HAL.UInt16;
 
    --  MDIOS input data register 10
    type MDIOS_DINR10_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN10          : MDIOS_DINR10_DIN10_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -277,14 +277,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR11_DIN11_Field is HAL.Short;
+   subtype MDIOS_DINR11_DIN11_Field is HAL.UInt16;
 
    --  MDIOS input data register 11
    type MDIOS_DINR11_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN11          : MDIOS_DINR11_DIN11_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -294,14 +294,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR12_DIN12_Field is HAL.Short;
+   subtype MDIOS_DINR12_DIN12_Field is HAL.UInt16;
 
    --  MDIOS input data register 12
    type MDIOS_DINR12_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN12          : MDIOS_DINR12_DIN12_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -311,14 +311,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR13_DIN13_Field is HAL.Short;
+   subtype MDIOS_DINR13_DIN13_Field is HAL.UInt16;
 
    --  MDIOS input data register 13
    type MDIOS_DINR13_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN13          : MDIOS_DINR13_DIN13_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -328,14 +328,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR14_DIN14_Field is HAL.Short;
+   subtype MDIOS_DINR14_DIN14_Field is HAL.UInt16;
 
    --  MDIOS input data register 14
    type MDIOS_DINR14_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN14          : MDIOS_DINR14_DIN14_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -345,14 +345,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR15_DIN15_Field is HAL.Short;
+   subtype MDIOS_DINR15_DIN15_Field is HAL.UInt16;
 
    --  MDIOS input data register 15
    type MDIOS_DINR15_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN15          : MDIOS_DINR15_DIN15_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -362,14 +362,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR16_DIN16_Field is HAL.Short;
+   subtype MDIOS_DINR16_DIN16_Field is HAL.UInt16;
 
    --  MDIOS input data register 16
    type MDIOS_DINR16_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN16          : MDIOS_DINR16_DIN16_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -379,14 +379,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR17_DIN17_Field is HAL.Short;
+   subtype MDIOS_DINR17_DIN17_Field is HAL.UInt16;
 
    --  MDIOS input data register 17
    type MDIOS_DINR17_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN17          : MDIOS_DINR17_DIN17_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -396,14 +396,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR18_DIN18_Field is HAL.Short;
+   subtype MDIOS_DINR18_DIN18_Field is HAL.UInt16;
 
    --  MDIOS input data register 18
    type MDIOS_DINR18_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN18          : MDIOS_DINR18_DIN18_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -413,14 +413,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR19_DIN19_Field is HAL.Short;
+   subtype MDIOS_DINR19_DIN19_Field is HAL.UInt16;
 
    --  MDIOS input data register 19
    type MDIOS_DINR19_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN19          : MDIOS_DINR19_DIN19_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -430,14 +430,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR20_DIN20_Field is HAL.Short;
+   subtype MDIOS_DINR20_DIN20_Field is HAL.UInt16;
 
    --  MDIOS input data register 20
    type MDIOS_DINR20_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN20          : MDIOS_DINR20_DIN20_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -447,14 +447,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR21_DIN21_Field is HAL.Short;
+   subtype MDIOS_DINR21_DIN21_Field is HAL.UInt16;
 
    --  MDIOS input data register 21
    type MDIOS_DINR21_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN21          : MDIOS_DINR21_DIN21_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -464,14 +464,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR22_DIN22_Field is HAL.Short;
+   subtype MDIOS_DINR22_DIN22_Field is HAL.UInt16;
 
    --  MDIOS input data register 22
    type MDIOS_DINR22_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN22          : MDIOS_DINR22_DIN22_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -481,14 +481,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR23_DIN23_Field is HAL.Short;
+   subtype MDIOS_DINR23_DIN23_Field is HAL.UInt16;
 
    --  MDIOS input data register 23
    type MDIOS_DINR23_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN23          : MDIOS_DINR23_DIN23_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -498,14 +498,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR24_DIN24_Field is HAL.Short;
+   subtype MDIOS_DINR24_DIN24_Field is HAL.UInt16;
 
    --  MDIOS input data register 24
    type MDIOS_DINR24_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN24          : MDIOS_DINR24_DIN24_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -515,14 +515,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR25_DIN25_Field is HAL.Short;
+   subtype MDIOS_DINR25_DIN25_Field is HAL.UInt16;
 
    --  MDIOS input data register 25
    type MDIOS_DINR25_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN25          : MDIOS_DINR25_DIN25_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -532,14 +532,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR26_DIN26_Field is HAL.Short;
+   subtype MDIOS_DINR26_DIN26_Field is HAL.UInt16;
 
    --  MDIOS input data register 26
    type MDIOS_DINR26_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN26          : MDIOS_DINR26_DIN26_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -549,14 +549,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR27_DIN27_Field is HAL.Short;
+   subtype MDIOS_DINR27_DIN27_Field is HAL.UInt16;
 
    --  MDIOS input data register 27
    type MDIOS_DINR27_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN27          : MDIOS_DINR27_DIN27_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -566,14 +566,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR28_DIN28_Field is HAL.Short;
+   subtype MDIOS_DINR28_DIN28_Field is HAL.UInt16;
 
    --  MDIOS input data register 28
    type MDIOS_DINR28_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN28          : MDIOS_DINR28_DIN28_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -583,14 +583,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR29_DIN29_Field is HAL.Short;
+   subtype MDIOS_DINR29_DIN29_Field is HAL.UInt16;
 
    --  MDIOS input data register 29
    type MDIOS_DINR29_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN29          : MDIOS_DINR29_DIN29_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -600,14 +600,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR30_DIN30_Field is HAL.Short;
+   subtype MDIOS_DINR30_DIN30_Field is HAL.UInt16;
 
    --  MDIOS input data register 30
    type MDIOS_DINR30_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN30          : MDIOS_DINR30_DIN30_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -617,14 +617,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DINR31_DIN31_Field is HAL.Short;
+   subtype MDIOS_DINR31_DIN31_Field is HAL.UInt16;
 
    --  MDIOS input data register 31
    type MDIOS_DINR31_Register is record
       --  Read-only. Input data received from MDIO Master during write frames
       DIN31          : MDIOS_DINR31_DIN31_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -634,14 +634,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR0_DOUT0_Field is HAL.Short;
+   subtype MDIOS_DOUTR0_DOUT0_Field is HAL.UInt16;
 
    --  MDIOS output data register 0
    type MDIOS_DOUTR0_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT0          : MDIOS_DOUTR0_DOUT0_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -651,14 +651,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR1_DOUT1_Field is HAL.Short;
+   subtype MDIOS_DOUTR1_DOUT1_Field is HAL.UInt16;
 
    --  MDIOS output data register 1
    type MDIOS_DOUTR1_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT1          : MDIOS_DOUTR1_DOUT1_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -668,14 +668,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR2_DOUT2_Field is HAL.Short;
+   subtype MDIOS_DOUTR2_DOUT2_Field is HAL.UInt16;
 
    --  MDIOS output data register 2
    type MDIOS_DOUTR2_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT2          : MDIOS_DOUTR2_DOUT2_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -685,14 +685,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR3_DOUT3_Field is HAL.Short;
+   subtype MDIOS_DOUTR3_DOUT3_Field is HAL.UInt16;
 
    --  MDIOS output data register 3
    type MDIOS_DOUTR3_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT3          : MDIOS_DOUTR3_DOUT3_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -702,14 +702,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR4_DOUT4_Field is HAL.Short;
+   subtype MDIOS_DOUTR4_DOUT4_Field is HAL.UInt16;
 
    --  MDIOS output data register 4
    type MDIOS_DOUTR4_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT4          : MDIOS_DOUTR4_DOUT4_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -719,14 +719,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR5_DOUT5_Field is HAL.Short;
+   subtype MDIOS_DOUTR5_DOUT5_Field is HAL.UInt16;
 
    --  MDIOS output data register 5
    type MDIOS_DOUTR5_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT5          : MDIOS_DOUTR5_DOUT5_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -736,14 +736,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR6_DOUT6_Field is HAL.Short;
+   subtype MDIOS_DOUTR6_DOUT6_Field is HAL.UInt16;
 
    --  MDIOS output data register 6
    type MDIOS_DOUTR6_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT6          : MDIOS_DOUTR6_DOUT6_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -753,14 +753,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR7_DOUT7_Field is HAL.Short;
+   subtype MDIOS_DOUTR7_DOUT7_Field is HAL.UInt16;
 
    --  MDIOS output data register 7
    type MDIOS_DOUTR7_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT7          : MDIOS_DOUTR7_DOUT7_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -770,14 +770,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR8_DOUT8_Field is HAL.Short;
+   subtype MDIOS_DOUTR8_DOUT8_Field is HAL.UInt16;
 
    --  MDIOS output data register 8
    type MDIOS_DOUTR8_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT8          : MDIOS_DOUTR8_DOUT8_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -787,14 +787,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR9_DOUT9_Field is HAL.Short;
+   subtype MDIOS_DOUTR9_DOUT9_Field is HAL.UInt16;
 
    --  MDIOS output data register 9
    type MDIOS_DOUTR9_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT9          : MDIOS_DOUTR9_DOUT9_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -804,14 +804,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR10_DOUT10_Field is HAL.Short;
+   subtype MDIOS_DOUTR10_DOUT10_Field is HAL.UInt16;
 
    --  MDIOS output data register 10
    type MDIOS_DOUTR10_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT10         : MDIOS_DOUTR10_DOUT10_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -821,14 +821,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR11_DOUT11_Field is HAL.Short;
+   subtype MDIOS_DOUTR11_DOUT11_Field is HAL.UInt16;
 
    --  MDIOS output data register 11
    type MDIOS_DOUTR11_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT11         : MDIOS_DOUTR11_DOUT11_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -838,14 +838,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR12_DOUT12_Field is HAL.Short;
+   subtype MDIOS_DOUTR12_DOUT12_Field is HAL.UInt16;
 
    --  MDIOS output data register 12
    type MDIOS_DOUTR12_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT12         : MDIOS_DOUTR12_DOUT12_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -855,14 +855,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR13_DOUT13_Field is HAL.Short;
+   subtype MDIOS_DOUTR13_DOUT13_Field is HAL.UInt16;
 
    --  MDIOS output data register 13
    type MDIOS_DOUTR13_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT13         : MDIOS_DOUTR13_DOUT13_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -872,14 +872,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR14_DOUT14_Field is HAL.Short;
+   subtype MDIOS_DOUTR14_DOUT14_Field is HAL.UInt16;
 
    --  MDIOS output data register 14
    type MDIOS_DOUTR14_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT14         : MDIOS_DOUTR14_DOUT14_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -889,14 +889,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR15_DOUT15_Field is HAL.Short;
+   subtype MDIOS_DOUTR15_DOUT15_Field is HAL.UInt16;
 
    --  MDIOS output data register 15
    type MDIOS_DOUTR15_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT15         : MDIOS_DOUTR15_DOUT15_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -906,14 +906,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR16_DOUT16_Field is HAL.Short;
+   subtype MDIOS_DOUTR16_DOUT16_Field is HAL.UInt16;
 
    --  MDIOS output data register 16
    type MDIOS_DOUTR16_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT16         : MDIOS_DOUTR16_DOUT16_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -923,14 +923,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR17_DOUT17_Field is HAL.Short;
+   subtype MDIOS_DOUTR17_DOUT17_Field is HAL.UInt16;
 
    --  MDIOS output data register 17
    type MDIOS_DOUTR17_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT17         : MDIOS_DOUTR17_DOUT17_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -940,14 +940,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR18_DOUT18_Field is HAL.Short;
+   subtype MDIOS_DOUTR18_DOUT18_Field is HAL.UInt16;
 
    --  MDIOS output data register 18
    type MDIOS_DOUTR18_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT18         : MDIOS_DOUTR18_DOUT18_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -957,14 +957,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR19_DOUT19_Field is HAL.Short;
+   subtype MDIOS_DOUTR19_DOUT19_Field is HAL.UInt16;
 
    --  MDIOS output data register 19
    type MDIOS_DOUTR19_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT19         : MDIOS_DOUTR19_DOUT19_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -974,14 +974,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR20_DOUT20_Field is HAL.Short;
+   subtype MDIOS_DOUTR20_DOUT20_Field is HAL.UInt16;
 
    --  MDIOS output data register 20
    type MDIOS_DOUTR20_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT20         : MDIOS_DOUTR20_DOUT20_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -991,14 +991,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR21_DOUT21_Field is HAL.Short;
+   subtype MDIOS_DOUTR21_DOUT21_Field is HAL.UInt16;
 
    --  MDIOS output data register 21
    type MDIOS_DOUTR21_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT21         : MDIOS_DOUTR21_DOUT21_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1008,14 +1008,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR22_DOUT22_Field is HAL.Short;
+   subtype MDIOS_DOUTR22_DOUT22_Field is HAL.UInt16;
 
    --  MDIOS output data register 22
    type MDIOS_DOUTR22_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT22         : MDIOS_DOUTR22_DOUT22_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1025,14 +1025,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR23_DOUT23_Field is HAL.Short;
+   subtype MDIOS_DOUTR23_DOUT23_Field is HAL.UInt16;
 
    --  MDIOS output data register 23
    type MDIOS_DOUTR23_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT23         : MDIOS_DOUTR23_DOUT23_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1042,14 +1042,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR24_DOUT24_Field is HAL.Short;
+   subtype MDIOS_DOUTR24_DOUT24_Field is HAL.UInt16;
 
    --  MDIOS output data register 24
    type MDIOS_DOUTR24_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT24         : MDIOS_DOUTR24_DOUT24_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1059,14 +1059,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR25_DOUT25_Field is HAL.Short;
+   subtype MDIOS_DOUTR25_DOUT25_Field is HAL.UInt16;
 
    --  MDIOS output data register 25
    type MDIOS_DOUTR25_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT25         : MDIOS_DOUTR25_DOUT25_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1076,14 +1076,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR26_DOUT26_Field is HAL.Short;
+   subtype MDIOS_DOUTR26_DOUT26_Field is HAL.UInt16;
 
    --  MDIOS output data register 26
    type MDIOS_DOUTR26_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT26         : MDIOS_DOUTR26_DOUT26_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1093,14 +1093,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR27_DOUT27_Field is HAL.Short;
+   subtype MDIOS_DOUTR27_DOUT27_Field is HAL.UInt16;
 
    --  MDIOS output data register 27
    type MDIOS_DOUTR27_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT27         : MDIOS_DOUTR27_DOUT27_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1110,14 +1110,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR28_DOUT28_Field is HAL.Short;
+   subtype MDIOS_DOUTR28_DOUT28_Field is HAL.UInt16;
 
    --  MDIOS output data register 28
    type MDIOS_DOUTR28_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT28         : MDIOS_DOUTR28_DOUT28_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1127,14 +1127,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR29_DOUT29_Field is HAL.Short;
+   subtype MDIOS_DOUTR29_DOUT29_Field is HAL.UInt16;
 
    --  MDIOS output data register 29
    type MDIOS_DOUTR29_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT29         : MDIOS_DOUTR29_DOUT29_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1144,14 +1144,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR30_DOUT30_Field is HAL.Short;
+   subtype MDIOS_DOUTR30_DOUT30_Field is HAL.UInt16;
 
    --  MDIOS output data register 30
    type MDIOS_DOUTR30_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT30         : MDIOS_DOUTR30_DOUT30_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1161,14 +1161,14 @@ package STM32_SVD.MDIOS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype MDIOS_DOUTR31_DOUT31_Field is HAL.Short;
+   subtype MDIOS_DOUTR31_DOUT31_Field is HAL.UInt16;
 
    --  MDIOS output data register 31
    type MDIOS_DOUTR31_Register is record
       --  Output data sent to MDIO Master during read frames
       DOUT31         : MDIOS_DOUTR31_DOUT31_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1187,13 +1187,13 @@ package STM32_SVD.MDIOS is
       --  MDIOS configuration register
       MDIOS_CR      : MDIOS_CR_Register;
       --  MDIOS write flag register
-      MDIOS_WRFR    : HAL.Word;
+      MDIOS_WRFR    : HAL.UInt32;
       --  MDIOS clear write flag register
-      MDIOS_CWRFR   : HAL.Word;
+      MDIOS_CWRFR   : HAL.UInt32;
       --  MDIOS read flag register
-      MDIOS_RDFR    : HAL.Word;
+      MDIOS_RDFR    : HAL.UInt32;
       --  MDIOS clear read flag register
-      MDIOS_CRDFR   : HAL.Word;
+      MDIOS_CRDFR   : HAL.UInt32;
       --  MDIOS status register
       MDIOS_SR      : MDIOS_SR_Register;
       --  MDIOS clear flag register

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-nvic.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-nvic.ads
@@ -44,7 +44,7 @@ package STM32_SVD.NVIC is
       case As_Array is
          when False =>
             --  IPR_N as a value
-            Val : HAL.Word;
+            Val : HAL.UInt32;
          when True =>
             --  IPR_N as an array
             Arr : IPR_IPR_N_Field_Array;
@@ -84,35 +84,35 @@ package STM32_SVD.NVIC is
       --  Interrupt Controller Type Register
       ICTR  : ICTR_Register;
       --  Interrupt Set-Enable Register
-      ISER0 : HAL.Word;
+      ISER0 : HAL.UInt32;
       --  Interrupt Set-Enable Register
-      ISER1 : HAL.Word;
+      ISER1 : HAL.UInt32;
       --  Interrupt Set-Enable Register
-      ISER2 : HAL.Word;
+      ISER2 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER0 : HAL.Word;
+      ICER0 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER1 : HAL.Word;
+      ICER1 : HAL.UInt32;
       --  Interrupt Clear-Enable Register
-      ICER2 : HAL.Word;
+      ICER2 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR0 : HAL.Word;
+      ISPR0 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR1 : HAL.Word;
+      ISPR1 : HAL.UInt32;
       --  Interrupt Set-Pending Register
-      ISPR2 : HAL.Word;
+      ISPR2 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR0 : HAL.Word;
+      ICPR0 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR1 : HAL.Word;
+      ICPR1 : HAL.UInt32;
       --  Interrupt Clear-Pending Register
-      ICPR2 : HAL.Word;
+      ICPR2 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR0 : HAL.Word;
+      IABR0 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR1 : HAL.Word;
+      IABR1 : HAL.UInt32;
       --  Interrupt Active Bit Register
-      IABR2 : HAL.Word;
+      IABR2 : HAL.UInt32;
       --  Interrupt Priority Register
       IPR0  : IPR_Register;
       --  Interrupt Priority Register

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-quadspi.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-quadspi.ads
@@ -238,14 +238,14 @@ package STM32_SVD.QUADSPI is
       DDRM           at 0 range 31 .. 31;
    end record;
 
-   subtype PIR_INTERVAL_Field is HAL.Short;
+   subtype PIR_INTERVAL_Field is HAL.UInt16;
 
    --  polling interval register
    type PIR_Register is record
       --  Polling interval
       INTERVAL       : PIR_INTERVAL_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -255,14 +255,14 @@ package STM32_SVD.QUADSPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype LPTR_TIMEOUT_Field is HAL.Short;
+   subtype LPTR_TIMEOUT_Field is HAL.UInt16;
 
    --  low-power timeout register
    type LPTR_Register is record
       --  Timeout period
       TIMEOUT        : LPTR_TIMEOUT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -287,19 +287,19 @@ package STM32_SVD.QUADSPI is
       --  flag clear register
       FCR   : FCR_Register;
       --  data length register
-      DLR   : HAL.Word;
+      DLR   : HAL.UInt32;
       --  communication configuration register
       CCR   : CCR_Register;
       --  address register
-      AR    : HAL.Word;
+      AR    : HAL.UInt32;
       --  ABR
-      ABR   : HAL.Word;
+      ABR   : HAL.UInt32;
       --  data register
-      DR    : HAL.Word;
+      DR    : HAL.UInt32;
       --  polling status mask register
-      PSMKR : HAL.Word;
+      PSMKR : HAL.UInt32;
       --  polling status match register
-      PSMAR : HAL.Word;
+      PSMAR : HAL.UInt32;
       --  polling interval register
       PIR   : PIR_Register;
       --  low-power timeout register

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-rng.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-rng.ads
@@ -75,7 +75,7 @@ package STM32_SVD.RNG is
       --  status register
       SR : SR_Register;
       --  data register
-      DR : HAL.Word;
+      DR : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-rtc.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-rtc.ads
@@ -270,14 +270,14 @@ package STM32_SVD.RTC is
       Reserved_23_31 at 0 range 23 .. 31;
    end record;
 
-   subtype WUTR_WUT_Field is HAL.Short;
+   subtype WUTR_WUT_Field is HAL.UInt16;
 
    --  wakeup timer register
    type WUTR_Register is record
       --  Wakeup auto-reload value bits
       WUT            : WUTR_WUT_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -424,14 +424,14 @@ package STM32_SVD.RTC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype SSR_SS_Field is HAL.Short;
+   subtype SSR_SS_Field is HAL.UInt16;
 
    --  sub second register
    type SSR_Register is record
       --  Read-only. Sub second value
       SS             : SSR_SS_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -448,7 +448,7 @@ package STM32_SVD.RTC is
       --  Write-only. Subtract a fraction of a second
       SUBFS          : SHIFTR_SUBFS_Field := 16#0#;
       --  unspecified
-      Reserved_15_30 : HAL.Short := 16#0#;
+      Reserved_15_30 : HAL.UInt16 := 16#0#;
       --  Write-only. Add one second
       ADD1S          : Boolean := False;
    end record
@@ -527,7 +527,7 @@ package STM32_SVD.RTC is
       --  Read-only. Week day units
       WDU            : TSDR_WDU_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -542,14 +542,14 @@ package STM32_SVD.RTC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype TSSSR_SS_Field is HAL.Short;
+   subtype TSSSR_SS_Field is HAL.UInt16;
 
    --  timestamp sub second register
    type TSSSR_Register is record
       --  Read-only. Sub second value
       SS             : TSSSR_SS_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -596,7 +596,7 @@ package STM32_SVD.RTC is
       --  Increase frequency of RTC by 488.5 ppm
       CALP           : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -799,69 +799,69 @@ package STM32_SVD.RTC is
       --  option register
       OR_k     : OR_Register;
       --  backup register
-      BKP0R    : HAL.Word;
+      BKP0R    : HAL.UInt32;
       --  backup register
-      BKP1R    : HAL.Word;
+      BKP1R    : HAL.UInt32;
       --  backup register
-      BKP2R    : HAL.Word;
+      BKP2R    : HAL.UInt32;
       --  backup register
-      BKP3R    : HAL.Word;
+      BKP3R    : HAL.UInt32;
       --  backup register
-      BKP4R    : HAL.Word;
+      BKP4R    : HAL.UInt32;
       --  backup register
-      BKP5R    : HAL.Word;
+      BKP5R    : HAL.UInt32;
       --  backup register
-      BKP6R    : HAL.Word;
+      BKP6R    : HAL.UInt32;
       --  backup register
-      BKP7R    : HAL.Word;
+      BKP7R    : HAL.UInt32;
       --  backup register
-      BKP8R    : HAL.Word;
+      BKP8R    : HAL.UInt32;
       --  backup register
-      BKP9R    : HAL.Word;
+      BKP9R    : HAL.UInt32;
       --  backup register
-      BKP10R   : HAL.Word;
+      BKP10R   : HAL.UInt32;
       --  backup register
-      BKP11R   : HAL.Word;
+      BKP11R   : HAL.UInt32;
       --  backup register
-      BKP12R   : HAL.Word;
+      BKP12R   : HAL.UInt32;
       --  backup register
-      BKP13R   : HAL.Word;
+      BKP13R   : HAL.UInt32;
       --  backup register
-      BKP14R   : HAL.Word;
+      BKP14R   : HAL.UInt32;
       --  backup register
-      BKP15R   : HAL.Word;
+      BKP15R   : HAL.UInt32;
       --  backup register
-      BKP16R   : HAL.Word;
+      BKP16R   : HAL.UInt32;
       --  backup register
-      BKP17R   : HAL.Word;
+      BKP17R   : HAL.UInt32;
       --  backup register
-      BKP18R   : HAL.Word;
+      BKP18R   : HAL.UInt32;
       --  backup register
-      BKP19R   : HAL.Word;
+      BKP19R   : HAL.UInt32;
       --  backup register
-      BKP20R   : HAL.Word;
+      BKP20R   : HAL.UInt32;
       --  backup register
-      BKP21R   : HAL.Word;
+      BKP21R   : HAL.UInt32;
       --  backup register
-      BKP22R   : HAL.Word;
+      BKP22R   : HAL.UInt32;
       --  backup register
-      BKP23R   : HAL.Word;
+      BKP23R   : HAL.UInt32;
       --  backup register
-      BKP24R   : HAL.Word;
+      BKP24R   : HAL.UInt32;
       --  backup register
-      BKP25R   : HAL.Word;
+      BKP25R   : HAL.UInt32;
       --  backup register
-      BKP26R   : HAL.Word;
+      BKP26R   : HAL.UInt32;
       --  backup register
-      BKP27R   : HAL.Word;
+      BKP27R   : HAL.UInt32;
       --  backup register
-      BKP28R   : HAL.Word;
+      BKP28R   : HAL.UInt32;
       --  backup register
-      BKP29R   : HAL.Word;
+      BKP29R   : HAL.UInt32;
       --  backup register
-      BKP30R   : HAL.Word;
+      BKP30R   : HAL.UInt32;
       --  backup register
-      BKP31R   : HAL.Word;
+      BKP31R   : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-sai.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-sai.ads
@@ -123,7 +123,7 @@ package STM32_SVD.SAI is
       --  Companding mode
       COMP           : ACR2_COMP_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -176,7 +176,7 @@ package STM32_SVD.SAI is
    subtype ASLOTR_FBOFF_Field is HAL.UInt5;
    subtype ASLOTR_SLOTSZ_Field is HAL.UInt2;
    subtype ASLOTR_NBSLOT_Field is HAL.UInt4;
-   subtype ASLOTR_SLOTEN_Field is HAL.Short;
+   subtype ASLOTR_SLOTEN_Field is HAL.UInt16;
 
    --  ASlot register
    type ASLOTR_Register is record
@@ -398,7 +398,7 @@ package STM32_SVD.SAI is
       --  Companding mode
       COMP           : BCR2_COMP_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -451,7 +451,7 @@ package STM32_SVD.SAI is
    subtype BSLOTR_FBOFF_Field is HAL.UInt5;
    subtype BSLOTR_SLOTSZ_Field is HAL.UInt2;
    subtype BSLOTR_NBSLOT_Field is HAL.UInt4;
-   subtype BSLOTR_SLOTEN_Field is HAL.Short;
+   subtype BSLOTR_SLOTEN_Field is HAL.UInt16;
 
    --  BSlot register
    type BSLOTR_Register is record
@@ -610,7 +610,7 @@ package STM32_SVD.SAI is
       --  AClear flag register
       ACLRFR : ACLRFR_Register;
       --  AData register
-      ADR    : HAL.Word;
+      ADR    : HAL.UInt32;
       --  BConfiguration register 1
       BCR1   : BCR1_Register;
       --  BConfiguration register 2
@@ -626,7 +626,7 @@ package STM32_SVD.SAI is
       --  BClear flag register
       BCLRFR : BCLRFR_Register;
       --  BData register
-      BDR    : HAL.Word;
+      BDR    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-sdmmc.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-sdmmc.ads
@@ -571,21 +571,21 @@ package STM32_SVD.SDMMC is
       --  SDI clock control register
       CLKCR   : CLKCR_Register;
       --  argument register
-      ARG     : HAL.Word;
+      ARG     : HAL.UInt32;
       --  command register
       CMD     : CMD_Register;
       --  command response register
       RESPCMD : RESPCMD_Register;
       --  response 1..4 register
-      RESP1   : HAL.Word;
+      RESP1   : HAL.UInt32;
       --  response 1..4 register
-      RESP2   : HAL.Word;
+      RESP2   : HAL.UInt32;
       --  response 1..4 register
-      RESP3   : HAL.Word;
+      RESP3   : HAL.UInt32;
       --  response 1..4 register
-      RESP4   : HAL.Word;
+      RESP4   : HAL.UInt32;
       --  data timer register
-      DTIMER  : HAL.Word;
+      DTIMER  : HAL.UInt32;
       --  data length register
       DLEN    : DLEN_Register;
       --  data control register
@@ -601,7 +601,7 @@ package STM32_SVD.SDMMC is
       --  FIFO counter register
       FIFOCNT : FIFOCNT_Register;
       --  data FIFO register
-      FIFO    : HAL.Word;
+      FIFO    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-spdif_rx.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-spdif_rx.ads
@@ -212,7 +212,7 @@ package STM32_SVD.SPDIF_RX is
       Reserved_30_31 at 0 range 30 .. 31;
    end record;
 
-   subtype CSR_USR_Field is HAL.Short;
+   subtype CSR_USR_Field is HAL.UInt16;
    subtype CSR_CS_Field is HAL.Byte;
 
    --  Channel Status register

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-spi.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-spi.ads
@@ -46,7 +46,7 @@ package STM32_SVD.SPI is
       --  Bidirectional data mode enable
       BIDIMODE       : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -268,14 +268,14 @@ package STM32_SVD.SPI is
       Reserved_13_31 at 0 range 13 .. 31;
    end record;
 
-   subtype DR_DR_Field is HAL.Short;
+   subtype DR_DR_Field is HAL.UInt16;
 
    --  data register
    type DR_Register is record
       --  Data register
       DR             : DR_DR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -285,14 +285,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CRCPR_CRCPOLY_Field is HAL.Short;
+   subtype CRCPR_CRCPOLY_Field is HAL.UInt16;
 
    --  CRC polynomial register
    type CRCPR_Register is record
       --  CRC polynomial register
       CRCPOLY        : CRCPR_CRCPOLY_Field := 16#7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -302,14 +302,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype RXCRCR_RxCRC_Field is HAL.Short;
+   subtype RXCRCR_RxCRC_Field is HAL.UInt16;
 
    --  RX CRC register
    type RXCRCR_Register is record
       --  Read-only. Rx CRC register
       RxCRC          : RXCRCR_RxCRC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -319,14 +319,14 @@ package STM32_SVD.SPI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype TXCRCR_TxCRC_Field is HAL.Short;
+   subtype TXCRCR_TxCRC_Field is HAL.UInt16;
 
    --  TX CRC register
    type TXCRCR_Register is record
       --  Read-only. Tx CRC register
       TxCRC          : TXCRCR_TxCRC_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-syscfg.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-syscfg.ads
@@ -46,7 +46,7 @@ package STM32_SVD.SYSCFG is
    --  peripheral mode configuration register
    type PMC_Register is record
       --  unspecified
-      Reserved_0_15  : HAL.Short := 16#0#;
+      Reserved_0_15  : HAL.UInt16 := 16#0#;
       --  ADC1DC2
       ADC1DC2        : Boolean := False;
       --  ADC2DC2
@@ -87,7 +87,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR1_EXTI_Field_Array;
@@ -106,7 +106,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR1_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -130,7 +130,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR2_EXTI_Field_Array;
@@ -149,7 +149,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR2_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -173,7 +173,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR3_EXTI_Field_Array;
@@ -192,7 +192,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR3_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -216,7 +216,7 @@ package STM32_SVD.SYSCFG is
       case As_Array is
          when False =>
             --  EXTI as a value
-            Val : HAL.Short;
+            Val : HAL.UInt16;
          when True =>
             --  EXTI as an array
             Arr : EXTICR4_EXTI_Field_Array;
@@ -235,7 +235,7 @@ package STM32_SVD.SYSCFG is
       EXTI           : EXTICR4_EXTI_Field :=
                         (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-tim.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-tim.ads
@@ -321,7 +321,7 @@ package STM32_SVD.TIM is
       --  Output Compare 2 clear enable
       OC2CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -362,7 +362,7 @@ package STM32_SVD.TIM is
       --  Input capture 2 filter
       IC2F           : CCMR1_Input_IC2F_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -405,7 +405,7 @@ package STM32_SVD.TIM is
       --  Output compare 4 clear enable
       OC4CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -446,7 +446,7 @@ package STM32_SVD.TIM is
       --  Input capture 4 filter
       IC4F           : CCMR2_Input_IC4F_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -515,14 +515,14 @@ package STM32_SVD.TIM is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype CNT_CNT_Field is HAL.Short;
+   subtype CNT_CNT_Field is HAL.UInt16;
 
    --  counter
    type CNT_Register is record
       --  counter value
       CNT            : CNT_CNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -532,14 +532,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype PSC_PSC_Field is HAL.Short;
+   subtype PSC_PSC_Field is HAL.UInt16;
 
    --  prescaler
    type PSC_Register is record
       --  Prescaler value
       PSC            : PSC_PSC_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -549,14 +549,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype ARR_ARR_Field is HAL.Short;
+   subtype ARR_ARR_Field is HAL.UInt16;
 
    --  auto-reload register
    type ARR_Register is record
       --  Auto-reload value
       ARR            : ARR_ARR_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -583,14 +583,14 @@ package STM32_SVD.TIM is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype CCR1_CCR1_Field is HAL.Short;
+   subtype CCR1_CCR1_Field is HAL.UInt16;
 
    --  capture/compare register 1
    type CCR1_Register is record
       --  Capture/Compare 1 value
       CCR1           : CCR1_CCR1_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -600,14 +600,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR2_CCR2_Field is HAL.Short;
+   subtype CCR2_CCR2_Field is HAL.UInt16;
 
    --  capture/compare register 2
    type CCR2_Register is record
       --  Capture/Compare 2 value
       CCR2           : CCR2_CCR2_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -617,14 +617,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR3_CCR3_Field is HAL.Short;
+   subtype CCR3_CCR3_Field is HAL.UInt16;
 
    --  capture/compare register 3
    type CCR3_Register is record
       --  Capture/Compare value
       CCR3           : CCR3_CCR3_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -634,14 +634,14 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CCR4_CCR4_Field is HAL.Short;
+   subtype CCR4_CCR4_Field is HAL.UInt16;
 
    --  capture/compare register 4
    type CCR4_Register is record
       --  Capture/Compare value
       CCR4           : CCR4_CCR4_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -673,7 +673,7 @@ package STM32_SVD.TIM is
       --  Main output enable
       MOE            : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -714,14 +714,14 @@ package STM32_SVD.TIM is
       Reserved_13_31 at 0 range 13 .. 31;
    end record;
 
-   subtype DMAR_DMAB_Field is HAL.Short;
+   subtype DMAR_DMAB_Field is HAL.UInt16;
 
    --  DMA address for full transfer
    type DMAR_Register is record
       --  DMA register for burst accesses
       DMAB           : DMAR_DMAB_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -785,7 +785,7 @@ package STM32_SVD.TIM is
       Reserved_25_31 at 0 range 25 .. 31;
    end record;
 
-   subtype CCR5_CCR5_Field is HAL.Short;
+   subtype CCR5_CCR5_Field is HAL.UInt16;
 
    --  CCR5_GC5C array
    type CCR5_GC5C_Field_Array is array (1 .. 3) of Boolean
@@ -829,14 +829,14 @@ package STM32_SVD.TIM is
       GC5C           at 0 range 29 .. 31;
    end record;
 
-   subtype CRR6_CCR6_Field is HAL.Short;
+   subtype CRR6_CCR6_Field is HAL.UInt16;
 
    --  capture/compare register 6
    type CRR6_Register is record
       --  Capture/Compare 6 value
       CCR6           : CRR6_CCR6_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1031,7 +1031,7 @@ package STM32_SVD.TIM is
       --  O24CE
       O24CE          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1085,7 +1085,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1110,8 +1110,8 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype CNT_CNT_L_Field is HAL.Short;
-   subtype CNT_CNT_H_Field is HAL.Short;
+   subtype CNT_CNT_L_Field is HAL.UInt16;
+   subtype CNT_CNT_H_Field is HAL.UInt16;
 
    --  counter
    type CNT_Register_1 is record
@@ -1128,8 +1128,8 @@ package STM32_SVD.TIM is
       CNT_H at 0 range 16 .. 31;
    end record;
 
-   subtype ARR_ARR_L_Field is HAL.Short;
-   subtype ARR_ARR_H_Field is HAL.Short;
+   subtype ARR_ARR_L_Field is HAL.UInt16;
+   subtype ARR_ARR_H_Field is HAL.UInt16;
 
    --  auto-reload register
    type ARR_Register_1 is record
@@ -1146,8 +1146,8 @@ package STM32_SVD.TIM is
       ARR_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR1_CCR1_L_Field is HAL.Short;
-   subtype CCR1_CCR1_H_Field is HAL.Short;
+   subtype CCR1_CCR1_L_Field is HAL.UInt16;
+   subtype CCR1_CCR1_H_Field is HAL.UInt16;
 
    --  capture/compare register 1
    type CCR1_Register_1 is record
@@ -1164,8 +1164,8 @@ package STM32_SVD.TIM is
       CCR1_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR2_CCR2_L_Field is HAL.Short;
-   subtype CCR2_CCR2_H_Field is HAL.Short;
+   subtype CCR2_CCR2_L_Field is HAL.UInt16;
+   subtype CCR2_CCR2_H_Field is HAL.UInt16;
 
    --  capture/compare register 2
    type CCR2_Register_1 is record
@@ -1182,8 +1182,8 @@ package STM32_SVD.TIM is
       CCR2_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR3_CCR3_L_Field is HAL.Short;
-   subtype CCR3_CCR3_H_Field is HAL.Short;
+   subtype CCR3_CCR3_L_Field is HAL.UInt16;
+   subtype CCR3_CCR3_H_Field is HAL.UInt16;
 
    --  capture/compare register 3
    type CCR3_Register_1 is record
@@ -1200,8 +1200,8 @@ package STM32_SVD.TIM is
       CCR3_H at 0 range 16 .. 31;
    end record;
 
-   subtype CCR4_CCR4_L_Field is HAL.Short;
-   subtype CCR4_CCR4_H_Field is HAL.Short;
+   subtype CCR4_CCR4_L_Field is HAL.UInt16;
+   subtype CCR4_CCR4_H_Field is HAL.UInt16;
 
    --  capture/compare register 4
    type CCR4_Register_1 is record

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-usart.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-usart.ads
@@ -322,7 +322,7 @@ package STM32_SVD.USART is
       --  DIV_Mantissa
       DIV_Mantissa   : BRR_DIV_Mantissa_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -343,7 +343,7 @@ package STM32_SVD.USART is
       --  Guard time value
       GT             : GTPR_GT_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-usb_otg_fs.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-usb_otg_fs.ads
@@ -180,8 +180,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype OTG_FS_DAINT_IEPINT_Field is HAL.Short;
-   subtype OTG_FS_DAINT_OEPINT_Field is HAL.Short;
+   subtype OTG_FS_DAINT_IEPINT_Field is HAL.UInt16;
+   subtype OTG_FS_DAINT_OEPINT_Field is HAL.UInt16;
 
    --  OTG_FS device all endpoints interrupt register (OTG_FS_DAINT)
    type OTG_FS_DAINT_Register is record
@@ -198,8 +198,8 @@ package STM32_SVD.USB_OTG_FS is
       OEPINT at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_DAINTMSK_IEPM_Field is HAL.Short;
-   subtype OTG_FS_DAINTMSK_OEPM_Field is HAL.Short;
+   subtype OTG_FS_DAINTMSK_IEPM_Field is HAL.UInt16;
+   subtype OTG_FS_DAINTMSK_OEPM_Field is HAL.UInt16;
 
    --  OTG_FS all endpoints interrupt mask register (OTG_FS_DAINTMSK)
    type OTG_FS_DAINTMSK_Register is record
@@ -216,14 +216,14 @@ package STM32_SVD.USB_OTG_FS is
       OEPM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_DVBUSDIS_VBUSDT_Field is HAL.Short;
+   subtype OTG_FS_DVBUSDIS_VBUSDT_Field is HAL.UInt16;
 
    --  OTG_FS device VBUS discharge time register
    type OTG_FS_DVBUSDIS_Register is record
       --  Device VBUS discharge time
       VBUSDT         : OTG_FS_DVBUSDIS_VBUSDT_Field := 16#17D7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -250,14 +250,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_12_31 at 0 range 12 .. 31;
    end record;
 
-   subtype OTG_FS_DIEPEMPMSK_INEPTXFEM_Field is HAL.Short;
+   subtype OTG_FS_DIEPEMPMSK_INEPTXFEM_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint FIFO empty interrupt mask register
    type OTG_FS_DIEPEMPMSK_Register is record
       --  IN EP Tx FIFO empty interrupt mask bits
       INEPTXFEM      : OTG_FS_DIEPEMPMSK_INEPTXFEM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -382,14 +382,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype OTG_FS_DTXFSTS_INEPTFSAV_Field is HAL.Short;
+   subtype OTG_FS_DTXFSTS_INEPTFSAV_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint transmit FIFO status register
    type OTG_FS_DTXFSTS_Register is record
       --  Read-only. IN endpoint TxFIFO space available
       INEPTFSAV      : OTG_FS_DTXFSTS_INEPTFSAV_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1281,14 +1281,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype OTG_FS_GRXFSIZ_RXFD_Field is HAL.Short;
+   subtype OTG_FS_GRXFSIZ_RXFD_Field is HAL.UInt16;
 
    --  OTG_FS Receive FIFO size register (OTG_FS_GRXFSIZ)
    type OTG_FS_GRXFSIZ_Register is record
       --  RxFIFO depth
       RXFD           : OTG_FS_GRXFSIZ_RXFD_Field := 16#200#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1298,8 +1298,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_DIEPTXF0_Device_TX0FSA_Field is HAL.Short;
-   subtype OTG_FS_DIEPTXF0_Device_TX0FD_Field is HAL.Short;
+   subtype OTG_FS_DIEPTXF0_Device_TX0FSA_Field is HAL.UInt16;
+   subtype OTG_FS_DIEPTXF0_Device_TX0FD_Field is HAL.UInt16;
 
    --  OTG_FS Endpoint 0 Transmit FIFO size
    type OTG_FS_DIEPTXF0_Device_Register is record
@@ -1316,8 +1316,8 @@ package STM32_SVD.USB_OTG_FS is
       TX0FD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_HNPTXFSIZ_Host_NPTXFSA_Field is HAL.Short;
-   subtype OTG_FS_HNPTXFSIZ_Host_NPTXFD_Field is HAL.Short;
+   subtype OTG_FS_HNPTXFSIZ_Host_NPTXFSA_Field is HAL.UInt16;
+   subtype OTG_FS_HNPTXFSIZ_Host_NPTXFD_Field is HAL.UInt16;
 
    --  OTG_FS Host non-periodic transmit FIFO size register
    type OTG_FS_HNPTXFSIZ_Host_Register is record
@@ -1334,7 +1334,7 @@ package STM32_SVD.USB_OTG_FS is
       NPTXFD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_HNPTXSTS_NPTXFSAV_Field is HAL.Short;
+   subtype OTG_FS_HNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
    subtype OTG_FS_HNPTXSTS_NPTQXSAV_Field is HAL.Byte;
    subtype OTG_FS_HNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
@@ -1600,8 +1600,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_29_31 at 0 range 29 .. 31;
    end record;
 
-   subtype OTG_FS_HPTXFSIZ_PTXSA_Field is HAL.Short;
-   subtype OTG_FS_HPTXFSIZ_PTXFSIZ_Field is HAL.Short;
+   subtype OTG_FS_HPTXFSIZ_PTXSA_Field is HAL.UInt16;
+   subtype OTG_FS_HPTXFSIZ_PTXFSIZ_Field is HAL.UInt16;
 
    --  OTG_FS Host periodic transmit FIFO size register (OTG_FS_HPTXFSIZ)
    type OTG_FS_HPTXFSIZ_Register is record
@@ -1618,8 +1618,8 @@ package STM32_SVD.USB_OTG_FS is
       PTXFSIZ at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_DIEPTXF_INEPTXSA_Field is HAL.Short;
-   subtype OTG_FS_DIEPTXF_INEPTXFD_Field is HAL.Short;
+   subtype OTG_FS_DIEPTXF_INEPTXSA_Field is HAL.UInt16;
+   subtype OTG_FS_DIEPTXF_INEPTXFD_Field is HAL.UInt16;
 
    --  OTG_FS device IN endpoint transmit FIFO size register (OTG_FS_DIEPTXF1)
    type OTG_FS_DIEPTXF_Register is record
@@ -1656,14 +1656,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype OTG_FS_HFIR_FRIVL_Field is HAL.Short;
+   subtype OTG_FS_HFIR_FRIVL_Field is HAL.UInt16;
 
    --  OTG_FS Host frame interval register
    type OTG_FS_HFIR_Register is record
       --  Frame interval
       FRIVL          : OTG_FS_HFIR_FRIVL_Field := 16#EA60#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1673,8 +1673,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_HFNUM_FRNUM_Field is HAL.Short;
-   subtype OTG_FS_HFNUM_FTREM_Field is HAL.Short;
+   subtype OTG_FS_HFNUM_FRNUM_Field is HAL.UInt16;
+   subtype OTG_FS_HFNUM_FTREM_Field is HAL.UInt16;
 
    --  OTG_FS host frame number/frame time remaining register (OTG_FS_HFNUM)
    type OTG_FS_HFNUM_Register is record
@@ -1691,7 +1691,7 @@ package STM32_SVD.USB_OTG_FS is
       FTREM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_HPTXSTS_PTXFSAVL_Field is HAL.Short;
+   subtype OTG_FS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
    subtype OTG_FS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
    subtype OTG_FS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
 
@@ -1714,14 +1714,14 @@ package STM32_SVD.USB_OTG_FS is
       PTXQTOP  at 0 range 24 .. 31;
    end record;
 
-   subtype OTG_FS_HAINT_HAINT_Field is HAL.Short;
+   subtype OTG_FS_HAINT_HAINT_Field is HAL.UInt16;
 
    --  OTG_FS Host all channels interrupt register
    type OTG_FS_HAINT_Register is record
       --  Read-only. Channel interrupts
       HAINT          : OTG_FS_HAINT_HAINT_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1731,14 +1731,14 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_FS_HAINTMSK_HAINTM_Field is HAL.Short;
+   subtype OTG_FS_HAINTMSK_HAINTM_Field is HAL.UInt16;
 
    --  OTG_FS host all channels interrupt mask register
    type OTG_FS_HAINTMSK_Register is record
       --  Channel interrupt mask
       HAINTM         : OTG_FS_HAINTMSK_HAINTM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2203,7 +2203,7 @@ package STM32_SVD.USB_OTG_FS is
       --  OTG_FS general core configuration register (OTG_FS_GCCFG)
       OTG_FS_GCCFG           : OTG_FS_GCCFG_Register;
       --  core ID register
-      OTG_FS_CID             : HAL.Word;
+      OTG_FS_CID             : HAL.UInt32;
       --  OTG core LPM configuration register
       OTG_FS_GLPMCFG         : OTG_FS_GLPMCFG_Register;
       --  OTG power down register

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-usb_otg_hs.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-usb_otg_hs.ads
@@ -209,8 +209,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_10_31 at 0 range 10 .. 31;
    end record;
 
-   subtype OTG_HS_DAINT_IEPINT_Field is HAL.Short;
-   subtype OTG_HS_DAINT_OEPINT_Field is HAL.Short;
+   subtype OTG_HS_DAINT_IEPINT_Field is HAL.UInt16;
+   subtype OTG_HS_DAINT_OEPINT_Field is HAL.UInt16;
 
    --  OTG_HS device all endpoints interrupt register
    type OTG_HS_DAINT_Register is record
@@ -227,8 +227,8 @@ package STM32_SVD.USB_OTG_HS is
       OEPINT at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DAINTMSK_IEPM_Field is HAL.Short;
-   subtype OTG_HS_DAINTMSK_OEPM_Field is HAL.Short;
+   subtype OTG_HS_DAINTMSK_IEPM_Field is HAL.UInt16;
+   subtype OTG_HS_DAINTMSK_OEPM_Field is HAL.UInt16;
 
    --  OTG_HS all endpoints interrupt mask register
    type OTG_HS_DAINTMSK_Register is record
@@ -245,14 +245,14 @@ package STM32_SVD.USB_OTG_HS is
       OEPM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DVBUSDIS_VBUSDT_Field is HAL.Short;
+   subtype OTG_HS_DVBUSDIS_VBUSDT_Field is HAL.UInt16;
 
    --  OTG_HS device VBUS discharge time register
    type OTG_HS_DVBUSDIS_Register is record
       --  Device VBUS discharge time
       VBUSDT         : OTG_HS_DVBUSDIS_VBUSDT_Field := 16#17D7#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -318,14 +318,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_28_31 at 0 range 28 .. 31;
    end record;
 
-   subtype OTG_HS_DIEPEMPMSK_INEPTXFEM_Field is HAL.Short;
+   subtype OTG_HS_DIEPEMPMSK_INEPTXFEM_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint FIFO empty interrupt mask register
    type OTG_HS_DIEPEMPMSK_Register is record
       --  IN EP Tx FIFO empty interrupt mask bits
       INEPTXFEM      : OTG_HS_DIEPEMPMSK_INEPTXFEM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -519,14 +519,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_21_31 at 0 range 21 .. 31;
    end record;
 
-   subtype OTG_HS_DTXFSTS_INEPTFSAV_Field is HAL.Short;
+   subtype OTG_HS_DTXFSTS_INEPTFSAV_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint transmit FIFO status register
    type OTG_HS_DTXFSTS_Register is record
       --  Read-only. IN endpoint TxFIFO space avail
       INEPTFSAV      : OTG_HS_DTXFSTS_INEPTFSAV_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1336,14 +1336,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_25_31 at 0 range 25 .. 31;
    end record;
 
-   subtype OTG_HS_GRXFSIZ_RXFD_Field is HAL.Short;
+   subtype OTG_HS_GRXFSIZ_RXFD_Field is HAL.UInt16;
 
    --  OTG_HS Receive FIFO size register
    type OTG_HS_GRXFSIZ_Register is record
       --  RxFIFO depth
       RXFD           : OTG_HS_GRXFSIZ_RXFD_Field := 16#200#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1353,8 +1353,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HNPTXFSIZ_Host_NPTXFSA_Field is HAL.Short;
-   subtype OTG_HS_HNPTXFSIZ_Host_NPTXFD_Field is HAL.Short;
+   subtype OTG_HS_HNPTXFSIZ_Host_NPTXFSA_Field is HAL.UInt16;
+   subtype OTG_HS_HNPTXFSIZ_Host_NPTXFD_Field is HAL.UInt16;
 
    --  OTG_HS nonperiodic transmit FIFO size register (host mode)
    type OTG_HS_HNPTXFSIZ_Host_Register is record
@@ -1371,8 +1371,8 @@ package STM32_SVD.USB_OTG_HS is
       NPTXFD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DIEPTXF0_Device_TX0FSA_Field is HAL.Short;
-   subtype OTG_HS_DIEPTXF0_Device_TX0FD_Field is HAL.Short;
+   subtype OTG_HS_DIEPTXF0_Device_TX0FSA_Field is HAL.UInt16;
+   subtype OTG_HS_DIEPTXF0_Device_TX0FD_Field is HAL.UInt16;
 
    --  Endpoint 0 transmit FIFO size (peripheral mode)
    type OTG_HS_DIEPTXF0_Device_Register is record
@@ -1389,7 +1389,7 @@ package STM32_SVD.USB_OTG_HS is
       TX0FD  at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.Short;
+   subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
    subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
    subtype OTG_HS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
@@ -1523,8 +1523,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_29_31 at 0 range 29 .. 31;
    end record;
 
-   subtype OTG_HS_HPTXFSIZ_PTXSA_Field is HAL.Short;
-   subtype OTG_HS_HPTXFSIZ_PTXFD_Field is HAL.Short;
+   subtype OTG_HS_HPTXFSIZ_PTXSA_Field is HAL.UInt16;
+   subtype OTG_HS_HPTXFSIZ_PTXFD_Field is HAL.UInt16;
 
    --  OTG_HS Host periodic transmit FIFO size register
    type OTG_HS_HPTXFSIZ_Register is record
@@ -1541,8 +1541,8 @@ package STM32_SVD.USB_OTG_HS is
       PTXFD at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_DIEPTXF_INEPTXSA_Field is HAL.Short;
-   subtype OTG_HS_DIEPTXF_INEPTXFD_Field is HAL.Short;
+   subtype OTG_HS_DIEPTXF_INEPTXSA_Field is HAL.UInt16;
+   subtype OTG_HS_DIEPTXF_INEPTXFD_Field is HAL.UInt16;
 
    --  OTG_HS device IN endpoint transmit FIFO size register
    type OTG_HS_DIEPTXF_Register is record
@@ -1579,14 +1579,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype OTG_HS_HFIR_FRIVL_Field is HAL.Short;
+   subtype OTG_HS_HFIR_FRIVL_Field is HAL.UInt16;
 
    --  OTG_HS Host frame interval register
    type OTG_HS_HFIR_Register is record
       --  Frame interval
       FRIVL          : OTG_HS_HFIR_FRIVL_Field := 16#EA60#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1596,8 +1596,8 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HFNUM_FRNUM_Field is HAL.Short;
-   subtype OTG_HS_HFNUM_FTREM_Field is HAL.Short;
+   subtype OTG_HS_HFNUM_FRNUM_Field is HAL.UInt16;
+   subtype OTG_HS_HFNUM_FTREM_Field is HAL.UInt16;
 
    --  OTG_HS host frame number/frame time remaining register
    type OTG_HS_HFNUM_Register is record
@@ -1614,7 +1614,7 @@ package STM32_SVD.USB_OTG_HS is
       FTREM at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.Short;
+   subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
    subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
    subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
 
@@ -1636,14 +1636,14 @@ package STM32_SVD.USB_OTG_HS is
       PTXQTOP  at 0 range 24 .. 31;
    end record;
 
-   subtype OTG_HS_HAINT_HAINT_Field is HAL.Short;
+   subtype OTG_HS_HAINT_HAINT_Field is HAL.UInt16;
 
    --  OTG_HS Host all channels interrupt register
    type OTG_HS_HAINT_Register is record
       --  Read-only. Channel interrupts
       HAINT          : OTG_HS_HAINT_HAINT_Field;
       --  unspecified
-      Reserved_16_31 : HAL.Short;
+      Reserved_16_31 : HAL.UInt16;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1653,14 +1653,14 @@ package STM32_SVD.USB_OTG_HS is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype OTG_HS_HAINTMSK_HAINTM_Field is HAL.Short;
+   subtype OTG_HS_HAINTMSK_HAINTM_Field is HAL.UInt16;
 
    --  OTG_HS host all channels interrupt mask register
    type OTG_HS_HAINTMSK_Register is record
       --  Channel interrupt mask
       HAINTM         : OTG_HS_HAINTMSK_HAINTM_Field := 16#0#;
       --  unspecified
-      Reserved_16_31 : HAL.Short := 16#0#;
+      Reserved_16_31 : HAL.UInt16 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2030,7 +2030,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device IN endpoint 0 transfer size register
       OTG_HS_DIEPTSIZ0   : OTG_HS_DIEPTSIZ0_Register;
       --  OTG_HS device endpoint-1 DMA address register
-      OTG_HS_DIEPDMA1    : HAL.Word;
+      OTG_HS_DIEPDMA1    : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS0    : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-1 control register
@@ -2040,7 +2040,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ1   : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-2 DMA address register
-      OTG_HS_DIEPDMA2    : HAL.Word;
+      OTG_HS_DIEPDMA2    : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS1    : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-2 control register
@@ -2050,7 +2050,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ2   : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-3 DMA address register
-      OTG_HS_DIEPDMA3    : HAL.Word;
+      OTG_HS_DIEPDMA3    : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS2    : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-3 control register
@@ -2060,7 +2060,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ3   : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-4 DMA address register
-      OTG_HS_DIEPDMA4    : HAL.Word;
+      OTG_HS_DIEPDMA4    : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS3    : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-4 control register
@@ -2070,7 +2070,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS device endpoint transfer size register
       OTG_HS_DIEPTSIZ4   : OTG_HS_DIEPTSIZ_Register;
       --  OTG_HS device endpoint-5 DMA address register
-      OTG_HS_DIEPDMA5    : HAL.Word;
+      OTG_HS_DIEPDMA5    : HAL.UInt32;
       --  OTG_HS device IN endpoint transmit FIFO status register
       OTG_HS_DTXFSTS4    : OTG_HS_DTXFSTS_Register;
       --  OTG device endpoint-5 control register
@@ -2261,7 +2261,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS general core configuration register
       OTG_HS_GCCFG           : OTG_HS_GCCFG_Register;
       --  OTG_HS core ID register
-      OTG_HS_CID             : HAL.Word;
+      OTG_HS_CID             : HAL.UInt32;
       --  OTG core LPM configuration register
       OTG_HS_GLPMCFG         : OTG_HS_GLPMCFG_Register;
       --  OTG_HS Host periodic transmit FIFO size register
@@ -2362,7 +2362,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-11 transfer size register
       OTG_HS_HCTSIZ0    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-0 DMA address register
-      OTG_HS_HCDMA0     : HAL.Word;
+      OTG_HS_HCDMA0     : HAL.UInt32;
       --  OTG_HS host channel-1 characteristics register
       OTG_HS_HCCHAR1    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-1 split control register
@@ -2374,7 +2374,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-1 transfer size register
       OTG_HS_HCTSIZ1    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-1 DMA address register
-      OTG_HS_HCDMA1     : HAL.Word;
+      OTG_HS_HCDMA1     : HAL.UInt32;
       --  OTG_HS host channel-2 characteristics register
       OTG_HS_HCCHAR2    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-2 split control register
@@ -2386,7 +2386,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-2 transfer size register
       OTG_HS_HCTSIZ2    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-2 DMA address register
-      OTG_HS_HCDMA2     : HAL.Word;
+      OTG_HS_HCDMA2     : HAL.UInt32;
       --  OTG_HS host channel-3 characteristics register
       OTG_HS_HCCHAR3    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-3 split control register
@@ -2398,7 +2398,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-3 transfer size register
       OTG_HS_HCTSIZ3    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-3 DMA address register
-      OTG_HS_HCDMA3     : HAL.Word;
+      OTG_HS_HCDMA3     : HAL.UInt32;
       --  OTG_HS host channel-4 characteristics register
       OTG_HS_HCCHAR4    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-4 split control register
@@ -2410,7 +2410,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-4 transfer size register
       OTG_HS_HCTSIZ4    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-4 DMA address register
-      OTG_HS_HCDMA4     : HAL.Word;
+      OTG_HS_HCDMA4     : HAL.UInt32;
       --  OTG_HS host channel-5 characteristics register
       OTG_HS_HCCHAR5    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-5 split control register
@@ -2422,7 +2422,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-5 transfer size register
       OTG_HS_HCTSIZ5    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-5 DMA address register
-      OTG_HS_HCDMA5     : HAL.Word;
+      OTG_HS_HCDMA5     : HAL.UInt32;
       --  OTG_HS host channel-6 characteristics register
       OTG_HS_HCCHAR6    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-6 split control register
@@ -2434,7 +2434,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-6 transfer size register
       OTG_HS_HCTSIZ6    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-6 DMA address register
-      OTG_HS_HCDMA6     : HAL.Word;
+      OTG_HS_HCDMA6     : HAL.UInt32;
       --  OTG_HS host channel-7 characteristics register
       OTG_HS_HCCHAR7    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-7 split control register
@@ -2446,7 +2446,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-7 transfer size register
       OTG_HS_HCTSIZ7    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-7 DMA address register
-      OTG_HS_HCDMA7     : HAL.Word;
+      OTG_HS_HCDMA7     : HAL.UInt32;
       --  OTG_HS host channel-8 characteristics register
       OTG_HS_HCCHAR8    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-8 split control register
@@ -2458,7 +2458,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-8 transfer size register
       OTG_HS_HCTSIZ8    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-8 DMA address register
-      OTG_HS_HCDMA8     : HAL.Word;
+      OTG_HS_HCDMA8     : HAL.UInt32;
       --  OTG_HS host channel-9 characteristics register
       OTG_HS_HCCHAR9    : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-9 split control register
@@ -2470,7 +2470,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-9 transfer size register
       OTG_HS_HCTSIZ9    : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-9 DMA address register
-      OTG_HS_HCDMA9     : HAL.Word;
+      OTG_HS_HCDMA9     : HAL.UInt32;
       --  OTG_HS host channel-10 characteristics register
       OTG_HS_HCCHAR10   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-10 split control register
@@ -2482,7 +2482,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-10 transfer size register
       OTG_HS_HCTSIZ10   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-10 DMA address register
-      OTG_HS_HCDMA10    : HAL.Word;
+      OTG_HS_HCDMA10    : HAL.UInt32;
       --  OTG_HS host channel-11 characteristics register
       OTG_HS_HCCHAR11   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-11 split control register
@@ -2494,7 +2494,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-11 transfer size register
       OTG_HS_HCTSIZ11   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-11 DMA address register
-      OTG_HS_HCDMA11    : HAL.Word;
+      OTG_HS_HCDMA11    : HAL.UInt32;
       --  OTG_HS host channel-12 characteristics register
       OTG_HS_HCCHAR12   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-12 split control register
@@ -2506,7 +2506,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-12 transfer size register
       OTG_HS_HCTSIZ12   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-12 DMA address register
-      OTG_HS_HCDMA12    : HAL.Word;
+      OTG_HS_HCDMA12    : HAL.UInt32;
       --  OTG_HS host channel-13 characteristics register
       OTG_HS_HCCHAR13   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-13 split control register
@@ -2518,7 +2518,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-13 transfer size register
       OTG_HS_HCTSIZ13   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-13 DMA address register
-      OTG_HS_HCDMA13    : HAL.Word;
+      OTG_HS_HCDMA13    : HAL.UInt32;
       --  OTG_HS host channel-14 characteristics register
       OTG_HS_HCCHAR14   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-14 split control register
@@ -2530,7 +2530,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-14 transfer size register
       OTG_HS_HCTSIZ14   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-14 DMA address register
-      OTG_HS_HCDMA14    : HAL.Word;
+      OTG_HS_HCDMA14    : HAL.UInt32;
       --  OTG_HS host channel-15 characteristics register
       OTG_HS_HCCHAR15   : OTG_HS_HCCHAR_Register;
       --  OTG_HS host channel-15 split control register
@@ -2542,7 +2542,7 @@ package STM32_SVD.USB_OTG_HS is
       --  OTG_HS host channel-15 transfer size register
       OTG_HS_HCTSIZ15   : OTG_HS_HCTSIZ_Register;
       --  OTG_HS host channel-15 DMA address register
-      OTG_HS_HCDMA15    : HAL.Word;
+      OTG_HS_HCDMA15    : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/cortex_m/src/cache/cortex_m-cache.adb
+++ b/ARM/cortex_m/src/cache/cortex_m-cache.adb
@@ -41,7 +41,7 @@ with Cortex_M_SVD.Cache;       use Cortex_M_SVD.Cache;
 
 package body Cortex_M.Cache is
 
-   Data_Cache_Line_Size : constant Word :=
+   Data_Cache_Line_Size : constant UInt32 :=
                             2 ** Natural (PF_Periph.CCSIDR.LineSize + 2);
 
    procedure DSB with Inline_Always;
@@ -93,7 +93,7 @@ package body Cortex_M.Cache is
 
          Op_Size   : Integer_32 := Integer_32 (Len);
          Op_Addr   : Unsigned_32 := To_U32 (Start);
-         Reg       : Word with Volatile, Address => Reg_Address;
+         Reg       : UInt32 with Volatile, Address => Reg_Address;
 
       begin
          DSB;

--- a/ARM/cortex_m/src/cm4/cortex_m_svd-debug.ads
+++ b/ARM/cortex_m/src/cm4/cortex_m_svd-debug.ads
@@ -15,19 +15,19 @@ package Cortex_M_SVD.Debug is
 
    --  Debug Fault Status Register
    type DFSR_Register is record
-      HALTED        : Boolean := True;
+      HALTED        : Boolean := False;
       --  BKPT instruction executed or breakpoint match in FPB.
       BKPT          : Boolean := False;
       --  Data Watchpoint and Trace trap. Indicates that the core halted due to
       --  at least one DWT trap event.
-      DWTTRAP       : Boolean := True;
+      DWTTRAP       : Boolean := False;
       --  Vector catch triggered. Corresponding FSR will contain the primary
       --  cause of the exception.
       VCATCH        : Boolean := False;
       --  An asynchronous exception generated due to the assertion of EDBGRQ.
       EXTERNAL      : Boolean := False;
       --  unspecified
-      Reserved_5_31 : HAL.UInt27 := 16#0#;
+      Reserved_5_31 : HAL.UInt27 := 16#214C8A3#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -98,27 +98,27 @@ package Cortex_M_SVD.Debug is
       Reserved_26_31 at 0 range 26 .. 31;
    end record;
 
-   subtype Write_DHCSR_S_RESET_ST_Field is HAL.Short;
+   subtype Write_DHCSR_S_RESET_ST_Field is HAL.UInt16;
 
    type Write_DHCSR_Register is record
       --  Write-only.
-      C_DEBUGGEN    : Boolean := True;
+      C_DEBUGGEN    : Boolean := False;
       --  Write-only.
       C_HALT        : Boolean := False;
       --  Write-only.
-      C_STEP        : Boolean := True;
+      C_STEP        : Boolean := False;
       --  Write-only.
       C_MASKINTS    : Boolean := False;
       --  unspecified
       Reserved_4_4  : HAL.Bit := 16#0#;
       --  Write-only.
-      C_SNAPSTALL   : Boolean := False;
+      C_SNAPSTALL   : Boolean := True;
       --  unspecified
-      Reserved_6_15 : HAL.UInt10 := 16#0#;
+      Reserved_6_15 : HAL.UInt10 := 16#51#;
       --  Write-only. Debug Key. The value 0xA05F must be written to enable
       --  write accesses to bits [15:0], otherwise the write access will be
       --  ignored. Read behavior of bits [31:16] is as listed below.
-      S_RESET_ST    : Write_DHCSR_S_RESET_ST_Field := 16#0#;
+      S_RESET_ST    : Write_DHCSR_S_RESET_ST_Field := 16#4299#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -218,13 +218,13 @@ package Cortex_M_SVD.Debug is
    --  register is only accessible from Debug state.
    type DCRSR_Register is record
       --  Write-only.
-      HALTED         : DCRSR_HALTED_Field := Cortex_M_SVD.Debug.Register_5;
+      HALTED         : DCRSR_HALTED_Field := Cortex_M_SVD.Debug.Register_0;
       --  unspecified
-      Reserved_5_15  : HAL.UInt11 := 16#0#;
+      Reserved_5_15  : HAL.UInt11 := 16#A3#;
       --  Write-only.
-      REGWnR         : DCRSR_REGWnR_Field := Cortex_M_SVD.Debug.Read;
+      REGWnR         : DCRSR_REGWnR_Field := Cortex_M_SVD.Debug.Write;
       --  unspecified
-      Reserved_17_31 : HAL.UInt15 := 16#0#;
+      Reserved_17_31 : HAL.UInt15 := 16#214C#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -238,27 +238,27 @@ package Cortex_M_SVD.Debug is
 
    --  Debug Exception and Monitor Control Register
    type DEMCR_Register is record
-      VC_CORERESET   : Boolean := True;
+      VC_CORERESET   : Boolean := False;
       --  unspecified
-      Reserved_1_3   : HAL.UInt3 := 16#2#;
+      Reserved_1_3   : HAL.UInt3 := 16#0#;
       VC_MMERR       : Boolean := False;
-      VC_NOCPERR     : Boolean := False;
-      VC_CHKERR      : Boolean := False;
+      VC_NOCPERR     : Boolean := True;
+      VC_CHKERR      : Boolean := True;
       VC_STATERR     : Boolean := False;
       VC_BUSERR      : Boolean := False;
       VC_INTERR      : Boolean := False;
-      VC_HARDERR     : Boolean := False;
+      VC_HARDERR     : Boolean := True;
       --  unspecified
-      Reserved_11_15 : HAL.UInt5 := 16#0#;
-      MON_EN         : Boolean := False;
+      Reserved_11_15 : HAL.UInt5 := 16#2#;
+      MON_EN         : Boolean := True;
       MON_PEND       : Boolean := False;
       MON_STEP       : Boolean := False;
-      MON_REQ        : Boolean := False;
+      MON_REQ        : Boolean := True;
       --  unspecified
-      Reserved_20_23 : HAL.UInt4 := 16#0#;
+      Reserved_20_23 : HAL.UInt4 := 16#9#;
       TRCENA         : Boolean := False;
       --  unspecified
-      Reserved_25_31 : HAL.UInt7 := 16#0#;
+      Reserved_25_31 : HAL.UInt7 := 16#21#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -299,7 +299,7 @@ package Cortex_M_SVD.Debug is
       --  This register is only accessible from Debug state.
       DCRSR : DCRSR_Register;
       --  Debug Core Register Data Register
-      DCRDR : HAL.Word;
+      DCRDR : HAL.UInt32;
       --  Debug Exception and Monitor Control Register
       DEMCR : DEMCR_Register;
    end record

--- a/ARM/cortex_m/src/cm4/cortex_m_svd-nvic.ads
+++ b/ARM/cortex_m/src/cm4/cortex_m_svd-nvic.ads
@@ -16,32 +16,32 @@ package Cortex_M_SVD.NVIC is
    --  Interrupt Set-Enable Registers
 
    --  Interrupt Set-Enable Registers
-   type NVIC_ISER_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_ISER_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Clear-Enable Registers
 
    --  Interrupt Clear-Enable Registers
-   type NVIC_ICER_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_ICER_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Set-Pending Registers
 
    --  Interrupt Set-Pending Registers
-   type NVIC_ISPR_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_ISPR_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Clear-Pending Registers
 
    --  Interrupt Clear-Pending Registers
-   type NVIC_ICPR_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_ICPR_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Active Bit Register
 
    --  Interrupt Active Bit Register
-   type NVIC_IABR_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_IABR_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Priority Register
 
    --  Interrupt Priority Register
-   type NVIC_IPR_Registers is array (0 .. 59) of HAL.Word;
+   type NVIC_IPR_Registers is array (0 .. 59) of HAL.UInt32;
 
    subtype STIR_INTID_Field is HAL.UInt9;
 
@@ -49,9 +49,9 @@ package Cortex_M_SVD.NVIC is
    type STIR_Register is record
       --  Write-only. Interrupt ID of the interrupt to trigger, in the range
       --  0-239.
-      INTID         : STIR_INTID_Field := 16#5#;
+      INTID         : STIR_INTID_Field := 16#60#;
       --  unspecified
-      Reserved_9_31 : HAL.UInt23 := 16#0#;
+      Reserved_9_31 : HAL.UInt23 := 16#214C8A#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/cortex_m/src/cm4/cortex_m_svd-scb.ads
+++ b/ARM/cortex_m/src/cm4/cortex_m_svd-scb.ads
@@ -696,7 +696,7 @@ package Cortex_M_SVD.SCB is
    --  System Handler Priority Register 3
    type SHPR3_Register is record
       --  unspecified
-      Reserved_0_15 : HAL.Short := 16#0#;
+      Reserved_0_15 : HAL.UInt16 := 16#0#;
       --  Priority of the system handler, PendSV
       PRI_14        : SHPR3_PRI_14_Field := 16#0#;
       --  Priority of the system handler, SysTick
@@ -927,7 +927,7 @@ package Cortex_M_SVD.SCB is
       --  Interrupt Control and State Register
       ICSR  : ICSR_Register;
       --  Vector Table Offset Register
-      VTOR  : HAL.Word;
+      VTOR  : HAL.UInt32;
       --  Application Interrupt and Reset Control Register
       AIRCR : AIRCR_Register;
       --  System Control Register
@@ -951,9 +951,9 @@ package Cortex_M_SVD.SCB is
       --  HardFault Status Register
       HFSR  : HFSR_Register;
       --  MemManage Fault Address Register
-      MMAR  : HAL.Word;
+      MMAR  : HAL.UInt32;
       --  BusFault Address Register
-      BFAR  : HAL.Word;
+      BFAR  : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/cortex_m/src/cm4f/cortex_m_svd-debug.ads
+++ b/ARM/cortex_m/src/cm4f/cortex_m_svd-debug.ads
@@ -15,19 +15,19 @@ package Cortex_M_SVD.Debug is
 
    --  Debug Fault Status Register
    type DFSR_Register is record
-      HALTED        : Boolean := True;
+      HALTED        : Boolean := False;
       --  BKPT instruction executed or breakpoint match in FPB.
       BKPT          : Boolean := False;
       --  Data Watchpoint and Trace trap. Indicates that the core halted due to
       --  at least one DWT trap event.
-      DWTTRAP       : Boolean := True;
+      DWTTRAP       : Boolean := False;
       --  Vector catch triggered. Corresponding FSR will contain the primary
       --  cause of the exception.
       VCATCH        : Boolean := False;
       --  An asynchronous exception generated due to the assertion of EDBGRQ.
       EXTERNAL      : Boolean := False;
       --  unspecified
-      Reserved_5_31 : HAL.UInt27 := 16#0#;
+      Reserved_5_31 : HAL.UInt27 := 16#2B45D72#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -98,15 +98,15 @@ package Cortex_M_SVD.Debug is
       Reserved_26_31 at 0 range 26 .. 31;
    end record;
 
-   subtype Write_DHCSR_S_RESET_ST_Field is HAL.Short;
+   subtype Write_DHCSR_S_RESET_ST_Field is HAL.UInt16;
 
    type Write_DHCSR_Register is record
       --  Write-only.
-      C_DEBUGGEN    : Boolean := True;
+      C_DEBUGGEN    : Boolean := False;
       --  Write-only.
       C_HALT        : Boolean := False;
       --  Write-only.
-      C_STEP        : Boolean := True;
+      C_STEP        : Boolean := False;
       --  Write-only.
       C_MASKINTS    : Boolean := False;
       --  unspecified
@@ -114,11 +114,11 @@ package Cortex_M_SVD.Debug is
       --  Write-only.
       C_SNAPSTALL   : Boolean := False;
       --  unspecified
-      Reserved_6_15 : HAL.UInt10 := 16#0#;
+      Reserved_6_15 : HAL.UInt10 := 16#2B9#;
       --  Write-only. Debug Key. The value 0xA05F must be written to enable
       --  write accesses to bits [15:0], otherwise the write access will be
       --  ignored. Read behavior of bits [31:16] is as listed below.
-      S_RESET_ST    : Write_DHCSR_S_RESET_ST_Field := 16#0#;
+      S_RESET_ST    : Write_DHCSR_S_RESET_ST_Field := 16#568B#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -218,13 +218,13 @@ package Cortex_M_SVD.Debug is
    --  register is only accessible from Debug state.
    type DCRSR_Register is record
       --  Write-only.
-      HALTED         : DCRSR_HALTED_Field := Cortex_M_SVD.Debug.Register_5;
+      HALTED         : DCRSR_HALTED_Field := Cortex_M_SVD.Debug.Register_0;
       --  unspecified
-      Reserved_5_15  : HAL.UInt11 := 16#0#;
+      Reserved_5_15  : HAL.UInt11 := 16#572#;
       --  Write-only.
-      REGWnR         : DCRSR_REGWnR_Field := Cortex_M_SVD.Debug.Read;
+      REGWnR         : DCRSR_REGWnR_Field := Cortex_M_SVD.Debug.Write;
       --  unspecified
-      Reserved_17_31 : HAL.UInt15 := 16#0#;
+      Reserved_17_31 : HAL.UInt15 := 16#2B45#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -238,27 +238,27 @@ package Cortex_M_SVD.Debug is
 
    --  Debug Exception and Monitor Control Register
    type DEMCR_Register is record
-      VC_CORERESET   : Boolean := True;
+      VC_CORERESET   : Boolean := False;
       --  unspecified
-      Reserved_1_3   : HAL.UInt3 := 16#2#;
+      Reserved_1_3   : HAL.UInt3 := 16#0#;
       VC_MMERR       : Boolean := False;
       VC_NOCPERR     : Boolean := False;
-      VC_CHKERR      : Boolean := False;
+      VC_CHKERR      : Boolean := True;
       VC_STATERR     : Boolean := False;
       VC_BUSERR      : Boolean := False;
-      VC_INTERR      : Boolean := False;
-      VC_HARDERR     : Boolean := False;
+      VC_INTERR      : Boolean := True;
+      VC_HARDERR     : Boolean := True;
       --  unspecified
-      Reserved_11_15 : HAL.UInt5 := 16#0#;
-      MON_EN         : Boolean := False;
-      MON_PEND       : Boolean := False;
+      Reserved_11_15 : HAL.UInt5 := 16#15#;
+      MON_EN         : Boolean := True;
+      MON_PEND       : Boolean := True;
       MON_STEP       : Boolean := False;
-      MON_REQ        : Boolean := False;
+      MON_REQ        : Boolean := True;
       --  unspecified
-      Reserved_20_23 : HAL.UInt4 := 16#0#;
+      Reserved_20_23 : HAL.UInt4 := 16#8#;
       TRCENA         : Boolean := False;
       --  unspecified
-      Reserved_25_31 : HAL.UInt7 := 16#0#;
+      Reserved_25_31 : HAL.UInt7 := 16#2B#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -299,7 +299,7 @@ package Cortex_M_SVD.Debug is
       --  This register is only accessible from Debug state.
       DCRSR : DCRSR_Register;
       --  Debug Core Register Data Register
-      DCRDR : HAL.Word;
+      DCRDR : HAL.UInt32;
       --  Debug Exception and Monitor Control Register
       DEMCR : DEMCR_Register;
    end record

--- a/ARM/cortex_m/src/cm4f/cortex_m_svd-nvic.ads
+++ b/ARM/cortex_m/src/cm4f/cortex_m_svd-nvic.ads
@@ -16,32 +16,32 @@ package Cortex_M_SVD.NVIC is
    --  Interrupt Set-Enable Registers
 
    --  Interrupt Set-Enable Registers
-   type NVIC_ISER_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_ISER_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Clear-Enable Registers
 
    --  Interrupt Clear-Enable Registers
-   type NVIC_ICER_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_ICER_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Set-Pending Registers
 
    --  Interrupt Set-Pending Registers
-   type NVIC_ISPR_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_ISPR_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Clear-Pending Registers
 
    --  Interrupt Clear-Pending Registers
-   type NVIC_ICPR_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_ICPR_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Active Bit Register
 
    --  Interrupt Active Bit Register
-   type NVIC_IABR_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_IABR_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Priority Register
 
    --  Interrupt Priority Register
-   type NVIC_IPR_Registers is array (0 .. 59) of HAL.Word;
+   type NVIC_IPR_Registers is array (0 .. 59) of HAL.UInt32;
 
    subtype STIR_INTID_Field is HAL.UInt9;
 
@@ -49,9 +49,9 @@ package Cortex_M_SVD.NVIC is
    type STIR_Register is record
       --  Write-only. Interrupt ID of the interrupt to trigger, in the range
       --  0-239.
-      INTID         : STIR_INTID_Field := 16#5#;
+      INTID         : STIR_INTID_Field := 16#40#;
       --  unspecified
-      Reserved_9_31 : HAL.UInt23 := 16#0#;
+      Reserved_9_31 : HAL.UInt23 := 16#2B45D7#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/ARM/cortex_m/src/cm4f/cortex_m_svd-scb.ads
+++ b/ARM/cortex_m/src/cm4f/cortex_m_svd-scb.ads
@@ -696,7 +696,7 @@ package Cortex_M_SVD.SCB is
    --  System Handler Priority Register 3
    type SHPR3_Register is record
       --  unspecified
-      Reserved_0_15 : HAL.Short := 16#0#;
+      Reserved_0_15 : HAL.UInt16 := 16#0#;
       --  Priority of the system handler, PendSV
       PRI_14        : SHPR3_PRI_14_Field := 16#0#;
       --  Priority of the system handler, SysTick
@@ -927,7 +927,7 @@ package Cortex_M_SVD.SCB is
       --  Interrupt Control and State Register
       ICSR  : ICSR_Register;
       --  Vector Table Offset Register
-      VTOR  : HAL.Word;
+      VTOR  : HAL.UInt32;
       --  Application Interrupt and Reset Control Register
       AIRCR : AIRCR_Register;
       --  System Control Register
@@ -951,9 +951,9 @@ package Cortex_M_SVD.SCB is
       --  HardFault Status Register
       HFSR  : HFSR_Register;
       --  MemManage Fault Address Register
-      MMAR  : HAL.Word;
+      MMAR  : HAL.UInt32;
       --  BusFault Address Register
-      BFAR  : HAL.Word;
+      BFAR  : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/cortex_m/src/cm7/cortex_m_svd-cache.ads
+++ b/ARM/cortex_m/src/cm7/cortex_m_svd-cache.ads
@@ -26,7 +26,7 @@ package Cortex_M_SVD.Cache is
       --  less than the maximum, use the LSB of this field.
       Set            : DCISW_Set_Field := 16#0#;
       --  unspecified
-      Reserved_14_29 : HAL.Short := 16#0#;
+      Reserved_14_29 : HAL.UInt16 := 16#0#;
       --  Write-only. Way that operation applies to. For the data cache, values
       --  0, 1, 2 and 3 are supported..
       Way            : DCISW_Way_Field := 16#0#;
@@ -53,7 +53,7 @@ package Cortex_M_SVD.Cache is
       --  less than the maximum, use the LSB of this field.
       Set            : DCCSW_Set_Field := 16#0#;
       --  unspecified
-      Reserved_14_29 : HAL.Short := 16#0#;
+      Reserved_14_29 : HAL.UInt16 := 16#0#;
       --  Write-only. Way that operation applies to. For the data cache, values
       --  0, 1, 2 and 3 are supported..
       Way            : DCCSW_Way_Field := 16#0#;
@@ -80,7 +80,7 @@ package Cortex_M_SVD.Cache is
       --  less than the maximum, use the LSB of this field.
       Set            : DCCISW_Set_Field := 16#0#;
       --  unspecified
-      Reserved_14_29 : HAL.Short := 16#0#;
+      Reserved_14_29 : HAL.UInt16 := 16#0#;
       --  Write-only. Way that operation applies to. For the data cache, values
       --  0, 1, 2 and 3 are supported..
       Way            : DCCISW_Way_Field := 16#0#;
@@ -102,21 +102,21 @@ package Cortex_M_SVD.Cache is
    --  Cache maintenance operations
    type Cache_Peripheral is record
       --  Instruction cache invalidate all to the PoU
-      ICIALLU  : HAL.Word;
+      ICIALLU  : HAL.UInt32;
       --  Instruction cache invalidate by address to the PoU
-      ICIMVAU  : HAL.Word;
+      ICIMVAU  : HAL.UInt32;
       --  Data cache invalidate by address to the PoC
-      DCIMVAC  : HAL.Word;
+      DCIMVAC  : HAL.UInt32;
       --  Data cache invalidate by set/way
       DCISW    : DCISW_Register;
       --  Data cache clean by address to the PoU
-      DCCMVAU  : HAL.Word;
+      DCCMVAU  : HAL.UInt32;
       --  Data cache clean by address to the PoC
-      DCCMVAC  : HAL.Word;
+      DCCMVAC  : HAL.UInt32;
       --  Data cache clean by set/way
       DCCSW    : DCCSW_Register;
       --  Data cache clean and invalidate by address to the PoC
-      DCCIMVAC : HAL.Word;
+      DCCIMVAC : HAL.UInt32;
       --  Data cache clean and invalidate by set/way
       DCCISW   : DCCISW_Register;
    end record

--- a/ARM/cortex_m/src/cm7/cortex_m_svd-debug.ads
+++ b/ARM/cortex_m/src/cm7/cortex_m_svd-debug.ads
@@ -98,7 +98,7 @@ package Cortex_M_SVD.Debug is
       Reserved_26_31 at 0 range 26 .. 31;
    end record;
 
-   subtype Write_DHCSR_S_RESET_ST_Field is HAL.Short;
+   subtype Write_DHCSR_S_RESET_ST_Field is HAL.UInt16;
 
    type Write_DHCSR_Register is record
       --  Write-only.
@@ -300,7 +300,7 @@ package Cortex_M_SVD.Debug is
       --  This register is only accessible from Debug state.
       DCRSR : DCRSR_Register;
       --  Debug Core Register Data Register
-      DCRDR : HAL.Word;
+      DCRDR : HAL.UInt32;
       --  Debug Exception and Monitor Control Register
       DEMCR : DEMCR_Register;
    end record

--- a/ARM/cortex_m/src/cm7/cortex_m_svd-nvic.ads
+++ b/ARM/cortex_m/src/cm7/cortex_m_svd-nvic.ads
@@ -16,32 +16,32 @@ package Cortex_M_SVD.NVIC is
    --  Interrupt Set-Enable Registers
 
    --  Interrupt Set-Enable Registers
-   type NVIC_ISER_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_ISER_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Clear-Enable Registers
 
    --  Interrupt Clear-Enable Registers
-   type NVIC_ICER_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_ICER_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Set-Pending Registers
 
    --  Interrupt Set-Pending Registers
-   type NVIC_ISPR_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_ISPR_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Clear-Pending Registers
 
    --  Interrupt Clear-Pending Registers
-   type NVIC_ICPR_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_ICPR_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Active Bit Register
 
    --  Interrupt Active Bit Register
-   type NVIC_IABR_Registers is array (0 .. 7) of HAL.Word;
+   type NVIC_IABR_Registers is array (0 .. 7) of HAL.UInt32;
 
    --  Interrupt Priority Register
 
    --  Interrupt Priority Register
-   type NVIC_IPR_Registers is array (0 .. 59) of HAL.Word;
+   type NVIC_IPR_Registers is array (0 .. 59) of HAL.UInt32;
 
    subtype STIR_INTID_Field is HAL.UInt9;
 

--- a/ARM/cortex_m/src/cm7/cortex_m_svd-scb.ads
+++ b/ARM/cortex_m/src/cm7/cortex_m_svd-scb.ads
@@ -696,7 +696,7 @@ package Cortex_M_SVD.SCB is
    --  System Handler Priority Register 3
    type SHPR3_Register is record
       --  unspecified
-      Reserved_0_15 : HAL.Short := 16#0#;
+      Reserved_0_15 : HAL.UInt16 := 16#0#;
       --  Priority of the system handler, PendSV
       PRI_14        : SHPR3_PRI_14_Field := 16#0#;
       --  Priority of the system handler, SysTick
@@ -927,7 +927,7 @@ package Cortex_M_SVD.SCB is
       --  Interrupt Control and State Register
       ICSR  : ICSR_Register;
       --  Vector Table Offset Register
-      VTOR  : HAL.Word;
+      VTOR  : HAL.UInt32;
       --  Application Interrupt and Reset Control Register
       AIRCR : AIRCR_Register;
       --  System Control Register
@@ -951,9 +951,9 @@ package Cortex_M_SVD.SCB is
       --  HardFault Status Register
       HFSR  : HFSR_Register;
       --  MemManage Fault Address Register
-      MMAR  : HAL.Word;
+      MMAR  : HAL.UInt32;
       --  BusFault Address Register
-      BFAR  : HAL.Word;
+      BFAR  : HAL.UInt32;
    end record
      with Volatile;
 

--- a/ARM/cortex_m/src/cortex_m-nvic.adb
+++ b/ARM/cortex_m/src/cortex_m-nvic.adb
@@ -47,7 +47,7 @@ package body Cortex_M.NVIC is
    -- Priority_Grouping --
    -----------------------
 
-   function Priority_Grouping return Word is
+   function Priority_Grouping return UInt32 is
    begin
       return Shift_Right (SCB.AIRCR and SCB_AIRCR_PRIGROUP_Mask,
                           SCB_AIRCR_PRIGROUP_Pos);
@@ -57,9 +57,9 @@ package body Cortex_M.NVIC is
    -- Set_Priority_Grouping --
    ---------------------------
 
-   procedure Set_Priority_Grouping (Priority_Group : Word) is
-      Reg_Value : Word;
-      PriorityGroupTmp : constant Word := Priority_Group and 16#07#;
+   procedure Set_Priority_Grouping (Priority_Group : UInt32) is
+      Reg_Value : UInt32;
+      PriorityGroupTmp : constant UInt32 := Priority_Group and 16#07#;
       Key              : constant := 16#5FA#;
    begin
       Reg_Value := SCB.AIRCR;
@@ -77,10 +77,10 @@ package body Cortex_M.NVIC is
 
    procedure Set_Priority
      (IRQn     : Interrupt_ID;
-      Priority : Word)
+      Priority : UInt32)
    is
       Index : constant Natural := Integer (IRQn);
-      Value : constant Word :=
+      Value : constant UInt32 :=
         Shift_Left (Priority, 8 - NVIC_PRIO_BITS) and 16#FF#;
    begin
       --  IRQ numbers are never less than 0 in the current definition, hence
@@ -93,17 +93,17 @@ package body Cortex_M.NVIC is
    ----------------------
 
    function Encoded_Priority
-     (Priority_Group : Word;  Preempt_Priority : Word;  Subpriority : Word)
-      return Word
+     (Priority_Group : UInt32;  Preempt_Priority : UInt32;  Subpriority : UInt32)
+      return UInt32
    is
-      PriorityGroupTmp    : constant Word := Priority_Group and 16#07#;
-      PreemptPriorityBits : Word;
-      SubPriorityBits     : Word;
-      Temp1 : Word;
-      Temp2 : Word;
-      Temp3 : Word;
-      Temp4 : Word;
-      Temp5 : Word;
+      PriorityGroupTmp    : constant UInt32 := Priority_Group and 16#07#;
+      PreemptPriorityBits : UInt32;
+      SubPriorityBits     : UInt32;
+      Temp1 : UInt32;
+      Temp2 : UInt32;
+      Temp3 : UInt32;
+      Temp4 : UInt32;
+      Temp5 : UInt32;
    begin
       if (7 - PriorityGroupTmp) > NVIC_PRIO_BITS then
          PreemptPriorityBits := NVIC_PRIO_BITS;
@@ -133,10 +133,10 @@ package body Cortex_M.NVIC is
 
    procedure Set_Priority
      (IRQn             : Interrupt_ID;
-      Preempt_Priority : Word;
-      Subpriority      : Word)
+      Preempt_Priority : UInt32;
+      Subpriority      : UInt32)
    is
-      Priority_Group : constant Word := Priority_Grouping;
+      Priority_Group : constant UInt32 := Priority_Grouping;
    begin
       Set_Priority
         (IRQn,
@@ -148,7 +148,7 @@ package body Cortex_M.NVIC is
    ----------------------
 
    procedure Enable_Interrupt (IRQn : Interrupt_ID) is
-      IRQn_As_Word : constant Word := Word (IRQn);
+      IRQn_As_Word : constant UInt32 := UInt32 (IRQn);
       Index        : constant Natural :=
         Integer (Shift_Right (IRQn_As_Word, 5));
    begin
@@ -160,7 +160,7 @@ package body Cortex_M.NVIC is
    -----------------------
 
    procedure Disable_Interrupt (IRQn : Interrupt_ID) is
-      IRQn_As_Word : constant Word := Word (IRQn);
+      IRQn_As_Word : constant UInt32 := UInt32 (IRQn);
       Index        : constant Natural :=
         Integer (Shift_Right (IRQn_As_Word, 5));
    begin
@@ -173,10 +173,10 @@ package body Cortex_M.NVIC is
    ------------
 
    function Active (IRQn : Interrupt_ID) return Boolean is
-      IRQn_As_Word : constant Word := Word (IRQn);
+      IRQn_As_Word : constant UInt32 := UInt32 (IRQn);
       Index        : constant Natural :=
         Integer (Shift_Right (IRQn_As_Word, 5));
-      Value        : constant Word :=
+      Value        : constant UInt32 :=
         Shift_Left (1, Integer (IRQn_As_Word and 16#1F#));
    begin
       return (NVIC.IABR (Index) and Value) /= 0;
@@ -187,10 +187,10 @@ package body Cortex_M.NVIC is
    -------------
 
    function Pending (IRQn : Interrupt_ID) return Boolean is
-      IRQn_As_Word : constant Word := Word (IRQn);
+      IRQn_As_Word : constant UInt32 := UInt32 (IRQn);
       Index        : constant Natural :=
         Integer (Shift_Right (IRQn_As_Word, 5));
-      Value        : constant Word :=
+      Value        : constant UInt32 :=
         Shift_Left (1, Integer (IRQn_As_Word and 16#1F#));
    begin
       return (NVIC.ISPR (Index) and Value) /= 0;
@@ -201,7 +201,7 @@ package body Cortex_M.NVIC is
    -----------------
 
    procedure Set_Pending (IRQn : Interrupt_ID) is
-      IRQn_As_Word : constant Word := Word (IRQn);
+      IRQn_As_Word : constant UInt32 := UInt32 (IRQn);
       Index        : constant Natural :=
         Integer (Shift_Right (IRQn_As_Word, 5));
    begin
@@ -213,7 +213,7 @@ package body Cortex_M.NVIC is
    -------------------
 
    procedure Clear_Pending (IRQn : Interrupt_ID) is
-      IRQn_As_Word : constant Word := Word (IRQn);
+      IRQn_As_Word : constant UInt32 := UInt32 (IRQn);
       Index        : constant Natural :=
         Integer (Shift_Right (IRQn_As_Word, 5));
    begin

--- a/ARM/cortex_m/src/cortex_m-nvic.ads
+++ b/ARM/cortex_m/src/cortex_m-nvic.ads
@@ -50,37 +50,37 @@ with Ada.Interrupts;       use Ada.Interrupts;
 package Cortex_M.NVIC is  -- the Nested Vectored Interrupt Controller
 
    --  0 bits for pre-emption priority;  4 bits for subpriority
-   Priority_Group_0 : constant Word := 16#00000007#;
+   Priority_Group_0 : constant UInt32 := 16#00000007#;
 
    --  1 bits for pre-emption priority;  3 bits for subpriority
-   Priority_Group_1 : constant Word := 16#00000006#;
+   Priority_Group_1 : constant UInt32 := 16#00000006#;
 
    --  2 bits for pre-emption priority;  2 bits for subpriority
-   Priority_Group_2 : constant Word := 16#00000005#;
+   Priority_Group_2 : constant UInt32 := 16#00000005#;
 
    --  3 bits for pre-emption priority;  1 bits for subpriority
-   Priority_Group_3 : constant Word := 16#00000004#;
+   Priority_Group_3 : constant UInt32 := 16#00000004#;
 
    --  4 bits for pre-emption priority;  0 bits for subpriority
-   Priority_Group_4 : constant Word := 16#00000003#;
+   Priority_Group_4 : constant UInt32 := 16#00000003#;
 
 
-   procedure Set_Priority_Grouping (Priority_Group : Word) with Inline;
+   procedure Set_Priority_Grouping (Priority_Group : UInt32) with Inline;
 
-   function Priority_Grouping return Word with Inline;
+   function Priority_Grouping return UInt32 with Inline;
 
    procedure Set_Priority
      (IRQn     : Interrupt_ID;
-      Priority : Word) with Inline;
+      Priority : UInt32) with Inline;
 
    function Encoded_Priority
-     (Priority_Group : Word;  Preempt_Priority : Word;  Subpriority : Word)
-      return Word with Inline;
+     (Priority_Group : UInt32;  Preempt_Priority : UInt32;  Subpriority : UInt32)
+      return UInt32 with Inline;
 
    procedure Set_Priority
      (IRQn             : Interrupt_ID;
-      Preempt_Priority : Word;
-      Subpriority      : Word) with Inline;
+      Preempt_Priority : UInt32;
+      Subpriority      : UInt32) with Inline;
    --  A convenience routine that first encodes (Priority_Grouping(),
    --  Preempt_Priority, and Subpriority), and then calls the other
    --  Set_Priority with the resulting encoding for the Priority argument.
@@ -101,7 +101,7 @@ package Cortex_M.NVIC is  -- the Nested Vectored Interrupt Controller
 
 private
 
-   type Words is array (Natural range <>) of Word;
+   type Words is array (Natural range <>) of UInt32;
    type Bytes is array (Natural range <>) of Byte;
 
 
@@ -124,7 +124,7 @@ private
       IP        : Bytes (0 .. 239);
       --  Interrupt Priority Register
       Reserved5 : Words (0 .. 643);
-      STIR      : Word;
+      STIR      : UInt32;
       --  Software Trigger Interrupt Register (write-only)
    end record
      with Volatile;
@@ -147,46 +147,46 @@ private
 
 
    type System_Control_Block is record
-      CPUID     : Word;
+      CPUID     : UInt32;
       --  CPUID Base Register   (read-only)
-      ICSR      : Word;
+      ICSR      : UInt32;
       --  Interrupt Control and State Register
-      VTOR      : Word;
+      VTOR      : UInt32;
       --  Vector Table Offset Register
-      AIRCR     : Word;
+      AIRCR     : UInt32;
       --  Application Interrupt and Reset Control Register
-      SCR       : Word;
+      SCR       : UInt32;
       --  System Control Register
-      CCR       : Word;
+      CCR       : UInt32;
       --  Configuration Control Register
       SHP       : Bytes (0 .. 11);
       --  System Handlers Priority Registers (4-7, 8-11, 12-15)
-      SHCSR     : Word;
+      SHCSR     : UInt32;
       --  System Handler Control and State Register
-      CFSR      : Word;
+      CFSR      : UInt32;
       --  Configurable Fault Status Register
-      HFSR      : Word;
+      HFSR      : UInt32;
       --  HardFault Status Register
-      DFSR      : Word;
+      DFSR      : UInt32;
       --  Debug Fault Status Register
-      MMFAR     : Word;
+      MMFAR     : UInt32;
       --  MemManage Fault Address Register
-      BFAR      : Word;
+      BFAR      : UInt32;
       --  BusFault Address Register
-      AFSR      : Word;
+      AFSR      : UInt32;
       --  Auxiliary Fault Status Register
       PFR       : Words (0 .. 1);
       --  Processor Feature Register           (read-only)
-      DFR       : Word;
+      DFR       : UInt32;
       --  Debug Feature Register               (read-only)
-      ADR       : Word;
+      ADR       : UInt32;
       --  Auxiliary Feature Register           (read-only)
       MMFR      : Words (0 .. 3);
       --  Memory Model Feature Register        (read-only)
       ISAR      : Words (0 .. 4);
       --  Instruction Set Attributes Register  (read-only)
       RESERVED0 : Words (0 .. 4);
-      CPACR     : Word;
+      CPACR     : UInt32;
       --  Coprocessor Access Control Register
    end record
      with Volatile;
@@ -234,15 +234,15 @@ private
 
 
    SCB_AIRCR_PRIGROUP_Pos  : constant := 8;
-   SCB_AIRCR_PRIGROUP_Mask : constant Word :=
+   SCB_AIRCR_PRIGROUP_Mask : constant UInt32 :=
      Shift_Left (7, SCB_AIRCR_PRIGROUP_Pos);
 
    SCB_AIRCR_VECTKEY_Pos   : constant := 16;
-   SCB_AIRCR_VECTKEY_Mask  : constant Word :=
+   SCB_AIRCR_VECTKEY_Mask  : constant UInt32 :=
      Shift_Left (16#FFFF#, SCB_AIRCR_VECTKEY_Pos);
 
    SCB_AIRCR_SYSRESETREQ_Pos  : constant := 2;
-   SCB_AIRCR_SYSRESETREQ_Mask : constant Word :=
+   SCB_AIRCR_SYSRESETREQ_Mask : constant UInt32 :=
      Shift_Left (1, SCB_AIRCR_SYSRESETREQ_Pos);
 
    NVIC_PRIO_BITS : constant := 4;

--- a/boards/OpenMV2/src/openmv-bitmap.adb
+++ b/boards/OpenMV2/src/openmv-bitmap.adb
@@ -4,7 +4,7 @@ with OpenMV.LCD_Shield;
 
 package body OpenMV.Bitmap is
 
-   subtype Pixel_Data is Short_Array
+   subtype Pixel_Data is UInt16_Array
      (0 .. (OpenMV.LCD_Shield.Width * OpenMV.LCD_Shield.Height) - 1);
 
    --------------

--- a/boards/stm32_common/dma2d/stm32-dma2d_bitmap.adb
+++ b/boards/stm32_common/dma2d/stm32-dma2d_bitmap.adb
@@ -39,7 +39,7 @@ package body STM32.DMA2D_Bitmap is
      (Buffer : DMA2D_Bitmap_Buffer;
       X      : Natural;
       Y      : Natural;
-      Value  : Word)
+      Value  : UInt32)
    is
    begin
       DMA2D_Wait_Transfer;
@@ -84,7 +84,7 @@ package body STM32.DMA2D_Bitmap is
    overriding function Get_Pixel
      (Buffer : DMA2D_Bitmap_Buffer;
       X      : Natural;
-      Y      : Natural) return Word
+      Y      : Natural) return UInt32
    is
    begin
       DMA2D_Wait_Transfer;
@@ -97,7 +97,7 @@ package body STM32.DMA2D_Bitmap is
 
    overriding procedure Fill
      (Buffer : DMA2D_Bitmap_Buffer;
-      Color  : Word)
+      Color  : UInt32)
    is
    begin
       if To_DMA2D_CM (Buffer.Color_Mode) in DMA2D_Dst_Color_Mode then
@@ -113,7 +113,7 @@ package body STM32.DMA2D_Bitmap is
 
    overriding procedure Fill_Rect
      (Buffer : DMA2D_Bitmap_Buffer;
-      Color  : Word;
+      Color  : UInt32;
       X      : Integer;
       Y      : Integer;
       Width  : Integer;

--- a/boards/stm32_common/dma2d/stm32-dma2d_bitmap.ads
+++ b/boards/stm32_common/dma2d/stm32-dma2d_bitmap.ads
@@ -12,7 +12,7 @@ package STM32.DMA2D_Bitmap is
      (Buffer : DMA2D_Bitmap_Buffer;
       X      : Natural;
       Y      : Natural;
-      Value  : Word);
+      Value  : UInt32);
 
    overriding procedure Set_Pixel_Blend
      (Buffer : DMA2D_Bitmap_Buffer;
@@ -23,15 +23,15 @@ package STM32.DMA2D_Bitmap is
    overriding function Get_Pixel
      (Buffer : DMA2D_Bitmap_Buffer;
       X      : Natural;
-      Y      : Natural) return Word;
+      Y      : Natural) return UInt32;
 
    overriding procedure Fill
      (Buffer : DMA2D_Bitmap_Buffer;
-      Color  : Word);
+      Color  : UInt32);
 
    overriding procedure Fill_Rect
      (Buffer : DMA2D_Bitmap_Buffer;
-      Color  : Word;
+      Color  : UInt32;
       X      : Integer;
       Y      : Integer;
       Width  : Integer;

--- a/boards/stm32_common/ltdc/framebuffer_ltdc.adb
+++ b/boards/stm32_common/ltdc/framebuffer_ltdc.adb
@@ -276,7 +276,7 @@ package body Framebuffer_LTDC is
          for Buf in 1 .. 2 loop
             Display.Buffers (LCD_Layer, Buf) :=
               (Addr       =>
-                 Reserve (Word (HAL.Bitmap.Bits_Per_Pixel (Mode) * W * H / 8)),
+                 Reserve (UInt32 (HAL.Bitmap.Bits_Per_Pixel (Mode) * W * H / 8)),
                Width      => W,
                Height     => H,
                Color_Mode => Mode,
@@ -287,7 +287,7 @@ package body Framebuffer_LTDC is
          for Buf in 1 .. 2 loop
             Display.Buffers (LCD_Layer, Buf) :=
               (Addr       =>
-                 Reserve (Word (HAL.Bitmap.Bits_Per_Pixel (Mode) * W * H / 8)),
+                 Reserve (UInt32 (HAL.Bitmap.Bits_Per_Pixel (Mode) * W * H / 8)),
                Width      => H,
                Height     => W,
                Color_Mode => Mode,

--- a/boards/stm32_common/sdram/stm32-sdram.adb
+++ b/boards/stm32_common/sdram/stm32-sdram.adb
@@ -13,7 +13,7 @@ with STM32_SVD.RCC;   use STM32_SVD.RCC;
 package body STM32.SDRAM is
 
    Initialized : Boolean := False;
-   G_Base_Addr : Word;
+   G_Base_Addr : UInt32;
 
    procedure SDRAM_GPIOConfig;
    procedure SDRAM_InitSequence;
@@ -202,12 +202,12 @@ package body STM32.SDRAM is
    -------------
 
    function Reserve
-     (Amount : Word;
-      Align  : Word := Standard'Maximum_Alignment) return System.Address
+     (Amount : UInt32;
+      Align  : UInt32 := Standard'Maximum_Alignment) return System.Address
    is
       Ret          : constant System.Address :=
                        System'To_Address (G_Base_Addr);
-      Rounded_Size : Word;
+      Rounded_Size : UInt32;
 
    begin
       Initialize;

--- a/boards/stm32_common/sdram/stm32-sdram.ads
+++ b/boards/stm32_common/sdram/stm32-sdram.ads
@@ -7,7 +7,7 @@ package STM32.SDRAM is
    function Base_Address return System.Address;
 
    function Reserve
-     (Amount : Word;
-      Align  : Word := Standard'Maximum_Alignment) return System.Address;
+     (Amount : UInt32;
+      Align  : UInt32 := Standard'Maximum_Alignment) return System.Address;
 
 end STM32.SDRAM;

--- a/boards/stm32f469_discovery/src/framebuffer_otm8009a.adb
+++ b/boards/stm32f469_discovery/src/framebuffer_otm8009a.adb
@@ -234,7 +234,7 @@ package body Framebuffer_OTM8009A is
       DSIHOST.DSI_Setup_Adapted_Command_Mode
         (Virtual_Channel         => LCD_Channel,
          Color_Coding            => STM32.DSI.RGB888,
-         Command_Size            => Short (Display.Get_Width),
+         Command_Size            => UInt16 (Display.Get_Width),
          Tearing_Effect_Source   => STM32.DSI.TE_DSI_Link,
          Tearing_Effect_Polarity => STM32.DSI.Rising_Edge,
          HSync_Polarity          => STM32.DSI.Active_High,
@@ -430,7 +430,7 @@ package body Framebuffer_OTM8009A is
 
       Display.Buffers (LCD_Layer) :=
         (Addr       =>
-           Reserve (Word (HAL.Bitmap.Bits_Per_Pixel (Mode) * W * H / 8)),
+           Reserve (UInt32 (HAL.Bitmap.Bits_Per_Pixel (Mode) * W * H / 8)),
          Width      => W,
          Height     => H,
          Color_Mode => Mode,

--- a/boards/stm32f769_discovery/src/framebuffer_otm8009a.adb
+++ b/boards/stm32f769_discovery/src/framebuffer_otm8009a.adb
@@ -236,7 +236,7 @@ package body Framebuffer_OTM8009A is
       DSIHOST.DSI_Setup_Adapted_Command_Mode
         (Virtual_Channel         => LCD_Channel,
          Color_Coding            => STM32.DSI.RGB888,
-         Command_Size            => Short (Display.Get_Width),
+         Command_Size            => UInt16 (Display.Get_Width),
          Tearing_Effect_Source   => STM32.DSI.TE_DSI_Link,
          Tearing_Effect_Polarity => STM32.DSI.Rising_Edge,
          HSync_Polarity          => STM32.DSI.Active_High,
@@ -432,7 +432,7 @@ package body Framebuffer_OTM8009A is
 
       Display.Buffers (LCD_Layer) :=
         (Addr       =>
-           Reserve (Word (HAL.Bitmap.Bits_Per_Pixel (Mode) * W * H / 8)),
+           Reserve (UInt32 (HAL.Bitmap.Bits_Per_Pixel (Mode) * W * H / 8)),
          Width      => W,
          Height     => H,
          Color_Mode => Mode,

--- a/boards/stm32f769_discovery/src/stm32-board.ads
+++ b/boards/stm32f769_discovery/src/stm32-board.ads
@@ -40,7 +40,6 @@ with STM32.DMA;     use STM32.DMA;
 with STM32.FMC;     use STM32.FMC;
 with STM32.GPIO;    use STM32.GPIO;
 with STM32.I2C;     use STM32.I2C;
-with STM32.SAI;     use STM32.SAI;
 
 use STM32;
 

--- a/components/eth/stm32-eth.adb
+++ b/components/eth/stm32-eth.adb
@@ -154,7 +154,7 @@ package body STM32.Eth is
    procedure Init_Rx_Desc (I : Rx_Desc_Range)
    is
       function W is new Ada.Unchecked_Conversion
-        (Address, Word);
+        (Address, UInt32);
       Last : constant Boolean := I = Rx_Desc_Range'Last;
    begin
       Rx_Descs (I) :=
@@ -173,7 +173,7 @@ package body STM32.Eth is
       function To_Rx_Buffer_Arr_Ptr is new Ada.Unchecked_Conversion
         (System.Address, Rx_Buffer_Arr_Ptr);
       function W is new Ada.Unchecked_Conversion
-        (Address, Word);
+        (Address, UInt32);
       Desc_Addr : Address;
    begin
       --  FIXME: check speed, full duplex

--- a/components/eth/stm32-eth.ads
+++ b/components/eth/stm32-eth.ads
@@ -200,8 +200,8 @@ package STM32.Eth is
    type Rx_Desc_Type is record
       Rdes0 : Rdes0_Type;
       Rdes1 : Rdes1_Type;
-      Rdes2 : Word;
-      Rdes3 : Word;
+      Rdes2 : UInt32;
+      Rdes3 : UInt32;
    end record;
 
    for Rx_Desc_Type use record

--- a/components/src/audio/W8994/wm8994.adb
+++ b/components/src/audio/W8994/wm8994.adb
@@ -16,12 +16,12 @@ package body WM8994 is
    ---------------
 
    procedure I2C_Write (This  : in out WM8994_Device;
-                        Reg   : Short;
-                        Value : Short)
+                        Reg   : UInt16;
+                        Value : UInt16)
    is
       Status : I2C_Status with Unreferenced;
       Data   : I2C_Data (1 .. 2);
-      Check  : Short;
+      Check  : UInt16;
    begin
       --  Device is MSB first
       Data (1) := Byte (Shift_Right (Value and 16#FF00#, 8));
@@ -50,12 +50,12 @@ package body WM8994 is
    --------------
 
    function I2C_Read (This : in out WM8994_Device;
-                      Reg : Short)
-                      return Short
+                      Reg : UInt16)
+                      return UInt16
    is
       Status : I2C_Status;
       Data   : I2C_Data (1 .. 2);
-      Ret    : Short;
+      Ret    : UInt16;
    begin
       This.Port.Mem_Read
         (Addr          => This.I2C_Addr,
@@ -63,7 +63,7 @@ package body WM8994 is
          Mem_Addr_Size => Memory_Size_16b,
          Data          => Data,
          Status        => Status);
-      Ret := Shift_Left (Short (Data (1)), 8) or Short (Data (2));
+      Ret := Shift_Left (UInt16 (Data (1)), 8) or UInt16 (Data (2));
 
       return Ret;
    end I2C_Read;

--- a/components/src/audio/W8994/wm8994.ads
+++ b/components/src/audio/W8994/wm8994.ads
@@ -84,10 +84,10 @@ private
                        I2C_Addr : UInt10) is tagged limited null record;
 
    procedure I2C_Write (This   : in out WM8994_Device;
-                        Reg   : Short;
-                        Value : Short);
+                        Reg   : UInt16;
+                        Value : UInt16);
    function I2C_Read (This : in out WM8994_Device;
-                      Reg : Short)
-                      return Short;
+                      Reg : UInt16)
+                      return UInt16;
 
 end WM8994;

--- a/components/src/camera/OV2640/bit_fields.adb
+++ b/components/src/camera/OV2640/bit_fields.adb
@@ -16,7 +16,7 @@ package body Bit_Fields is
    type Convert_16 (As_Array : Boolean := False) is record
       case As_Array is
          when False =>
-            Value : Short;
+            Value : UInt16;
          when True =>
             Bits : Bit_Field (0 .. 15);
       end case;
@@ -30,7 +30,7 @@ package body Bit_Fields is
    type Convert_32 (As_Array : Boolean := False) is record
       case As_Array is
          when False =>
-            Value : Word;
+            Value : UInt32;
          when True =>
             Bits : Bit_Field (0 .. 31);
       end case;
@@ -46,7 +46,7 @@ package body Bit_Fields is
    -- To_Word --
    -------------
 
-   function To_Word (Bits : Bit_Field) return Word is
+   function To_Word (Bits : Bit_Field) return UInt32 is
       Tmp : Convert_32;
    begin
       Tmp.Bits := Bits;
@@ -54,15 +54,15 @@ package body Bit_Fields is
    end To_Word;
 
    --------------
-   -- To_Short --
+   -- To_UInt16 --
    --------------
 
-   function To_Short (Bits : Bit_Field) return Short is
+   function To_UInt16 (Bits : Bit_Field) return UInt16 is
       Tmp : Convert_16;
    begin
       Tmp.Bits := Bits;
       return Tmp.Value;
-   end To_Short;
+   end To_UInt16;
 
    -------------
    -- To_Byte --
@@ -79,7 +79,7 @@ package body Bit_Fields is
    -- To_Bit_Field --
    ------------------
 
-   function To_Bit_Field (Value : Word) return Bit_Field is
+   function To_Bit_Field (Value : UInt32) return Bit_Field is
       Tmp : Convert_32;
    begin
       Tmp.Value := Value;
@@ -90,7 +90,7 @@ package body Bit_Fields is
    -- To_Bit_Field --
    ------------------
 
-   function To_Bit_Field (Value : Short) return Bit_Field is
+   function To_Bit_Field (Value : UInt16) return Bit_Field is
       Tmp : Convert_16;
    begin
       Tmp.Value := Value;

--- a/components/src/camera/OV2640/bit_fields.ads
+++ b/components/src/camera/OV2640/bit_fields.ads
@@ -4,15 +4,15 @@ package Bit_Fields is
    type Bit_Field is array (Natural range <>) of Bit
      with Component_Size => 1;
 
-   function To_Word (Bits : Bit_Field) return Word;
-   function To_Short (Bits : Bit_Field) return Short;
+   function To_Word (Bits : Bit_Field) return UInt32;
+   function To_UInt16 (Bits : Bit_Field) return UInt16;
    function To_Byte (Bits : Bit_Field) return Byte;
 
-   function To_Bit_Field (Value : Word) return Bit_Field
+   function To_Bit_Field (Value : UInt32) return Bit_Field
      with Post => To_Bit_Field'Result'First = 0
      and then
        To_Bit_Field'Result'Last = 31;
-   function To_Bit_Field (Value : Short) return Bit_Field
+   function To_Bit_Field (Value : UInt16) return Bit_Field
      with Post => To_Bit_Field'Result'First = 0
      and then
        To_Bit_Field'Result'Last = 15;

--- a/components/src/camera/OV2640/ov2640.adb
+++ b/components/src/camera/OV2640/ov2640.adb
@@ -226,7 +226,7 @@ package body OV2640 is
       Status : I2C_Status;
    begin
       This.I2C.Mem_Write (Addr          => This.Addr,
-                          Mem_Addr      => Short (Addr),
+                          Mem_Addr      => UInt16 (Addr),
                           Mem_Addr_Size => Memory_Size_8b,
                           Data          => (1 => Data),
                           Status        => Status);
@@ -244,7 +244,7 @@ package body OV2640 is
       Status : I2C_Status;
    begin
       This.I2C.Mem_Read (Addr          => This.Addr,
-                         Mem_Addr      => Short (Addr),
+                         Mem_Addr      => UInt16 (Addr),
                          Mem_Addr_Size => Memory_Size_8b,
                          Data          => Data,
                          Status        => Status);
@@ -332,8 +332,8 @@ package body OV2640 is
       Res  : Frame_Size)
    is
       H_SIZE, V_SIZE : Bit_Field (0 .. 15);
-      Width : constant Short := Resolutions (Res).Width;
-      Height : constant Short := Resolutions (Res).Height;
+      Width : constant UInt16 := Resolutions (Res).Width;
+      Height : constant UInt16 := Resolutions (Res).Height;
       Is_UXGA : constant Boolean := Res = SXGA or else Res = UXGA;
       CLK_Divider : constant Boolean := Is_UXGA;
    begin
@@ -399,8 +399,8 @@ package body OV2640 is
       Write (This, REG_DSP_SIZEL,
              To_Byte (V_SIZE (0 .. 2) & H_SIZE (0 .. 2) & (H_SIZE (11), 0)));
 
-      H_SIZE := To_Bit_Field (To_Short (H_SIZE) / 4);
-      V_SIZE := To_Bit_Field (To_Short (V_SIZE) / 4);
+      H_SIZE := To_Bit_Field (To_UInt16 (H_SIZE) / 4);
+      V_SIZE := To_Bit_Field (To_UInt16 (V_SIZE) / 4);
 
       Write (This, REG_DSP_XOFFL, 0);
       Write (This, REG_DSP_YOFFL, 0);

--- a/components/src/camera/OV2640/ov2640.ads
+++ b/components/src/camera/OV2640/ov2640.ads
@@ -13,7 +13,7 @@ package OV2640 is
    type Frame_Rate is (FR_2FPS, FR_8FPS, FR_15FPS, FR_30FPS, FR_60FPS);
 
    type Resolution is record
-     Width, Height : Short;
+     Width, Height : UInt16;
    end record;
 
    Resolutions : constant array (Frame_Size) of Resolution :=

--- a/components/src/io_expander/MCP23xxx/mcp23008.adb
+++ b/components/src/io_expander/MCP23xxx/mcp23008.adb
@@ -16,7 +16,7 @@ package body MCP23008 is
    begin
       This.Port.Mem_Write
         (BASE_ADDRESS or I2C_Address (This.Addr),
-         Short (WriteAddr),
+         UInt16 (WriteAddr),
          Memory_Size_8b,
          (1 => Value),
          Status,
@@ -43,7 +43,7 @@ package body MCP23008 is
    begin
       This.Port.Mem_Read
         (BASE_ADDRESS or I2C_Address (This.Addr),
-         Short (ReadAddr),
+         UInt16 (ReadAddr),
          Memory_Size_8b,
          Ret,
          Status,

--- a/components/src/io_expander/ht16k33/ht16k33.adb
+++ b/components/src/io_expander/ht16k33/ht16k33.adb
@@ -45,7 +45,7 @@ package body HT16K33 is
    begin
       This.Port.Mem_Read
         (I2C_Addr (This),
-         Short (Reg),
+         UInt16 (Reg),
          Memory_Size_8b,
          Data,
          Tmp_Status,
@@ -66,7 +66,7 @@ package body HT16K33 is
    begin
       This.Port.Mem_Write
         (I2C_Addr (This),
-         Short (Reg),
+         UInt16 (Reg),
          Memory_Size_8b,
          Data,
          Tmp_Status,

--- a/components/src/motion/ak8963/ak8963.adb
+++ b/components/src/motion/ak8963/ak8963.adb
@@ -42,21 +42,21 @@ package body AK8963 is
 
    function I2C_Read
      (Device : AK8963_Device;
-      Reg    : Short) return Byte;
+      Reg    : UInt16) return Byte;
 
    function I2C_Read
      (Device : AK8963_Device;
-      Reg    : Short;
+      Reg    : UInt16;
       Bit    : Natural) return Boolean;
 
    procedure I2C_Write
      (Device : AK8963_Device;
-      Reg    : Short;
+      Reg    : UInt16;
       Data   : Byte);
 
    procedure I2C_Write
      (Device : AK8963_Device;
-      Reg    : Short;
+      Reg    : UInt16;
       Bit    : Natural;
       State  : Boolean);
 
@@ -66,7 +66,7 @@ package body AK8963 is
 
    function I2C_Read
      (Device : AK8963_Device;
-      Reg    : Short) return Byte
+      Reg    : UInt16) return Byte
    is
       Data   : I2C_Data (1 .. 1);
       Status : I2C_Status;
@@ -86,7 +86,7 @@ package body AK8963 is
 
    function I2C_Read
      (Device : AK8963_Device;
-      Reg    : Short;
+      Reg    : UInt16;
       Bit    : Natural) return Boolean
    is
       Mask : constant Byte := 2 ** Bit;
@@ -101,7 +101,7 @@ package body AK8963 is
 
    procedure I2C_Write
      (Device : AK8963_Device;
-      Reg    : Short;
+      Reg    : UInt16;
       Data   : Byte)
    is
       Status : I2C_Status with Unreferenced;
@@ -120,7 +120,7 @@ package body AK8963 is
 
    procedure I2C_Write
      (Device : AK8963_Device;
-      Reg    : Short;
+      Reg    : UInt16;
       Bit    : Natural;
       State  : Boolean)
    is

--- a/components/src/motion/l3gd20/l3gd20.adb
+++ b/components/src/motion/l3gd20/l3gd20.adb
@@ -955,9 +955,9 @@ package body L3GD20 is
    -----------
 
    procedure Swap2 (Location : System.Address) is
-      X : Short;
+      X : UInt16;
       for X'Address use Location;
-      function Bswap_16 (X : Short) return Short;
+      function Bswap_16 (X : UInt16) return UInt16;
       pragma Import (Intrinsic, Bswap_16, "__builtin_bswap16");
    begin
       X := Bswap_16 (X);

--- a/components/src/motion/l3gd20/l3gd20.ads
+++ b/components/src/motion/l3gd20/l3gd20.ads
@@ -408,7 +408,7 @@ package L3GD20 is
      (This  : in out Three_Axis_Gyroscope;
       Event : Axes_Interrupts);
 
-   type Axis_Sample_Threshold is new Short range 0 .. 2 ** 15;
+   type Axis_Sample_Threshold is new UInt16 range 0 .. 2 ** 15;
    --  Threshold values do not use the high-order bit
 
    procedure Set_Threshold

--- a/components/src/motion/lis3dsh/lis3dsh.adb
+++ b/components/src/motion/lis3dsh/lis3dsh.adb
@@ -165,7 +165,7 @@ package body LIS3DSH is
       Full_Scale      : Full_Scale_Selection;
       Filter_BW       : Anti_Aliasing_Filter_Bandwidth)
    is
-      Temp  : Short;
+      Temp  : UInt16;
       Value : Byte;
    begin
       Temp := Output_DataRate'Enum_Rep or

--- a/components/src/motion/mpu9250/mpu9250.adb
+++ b/components/src/motion/mpu9250/mpu9250.adb
@@ -636,7 +636,7 @@ package body MPU9250 is
    begin
       Device.Port.Mem_Read
         (Addr          => Device.Address,
-         Mem_Addr      => Short (Reg_Addr),
+         Mem_Addr      => UInt16 (Reg_Addr),
          Mem_Addr_Size => Memory_Size_8b,
          Data          => Data,
          Status        => Status);
@@ -656,7 +656,7 @@ package body MPU9250 is
    begin
       Device.Port.Mem_Read
         (Addr          => Device.Address,
-         Mem_Addr      => Short (Reg_Addr),
+         Mem_Addr      => UInt16 (Reg_Addr),
          Mem_Addr_Size => Memory_Size_8b,
          Data          => I_Data,
          Status        => Status);
@@ -692,7 +692,7 @@ package body MPU9250 is
    begin
       Device.Port.Mem_Write
         (Addr          => Device.Address,
-         Mem_Addr      => Short (Reg_Addr),
+         Mem_Addr      => UInt16 (Reg_Addr),
          Mem_Addr_Size => Memory_Size_8b,
          Data          => Data,
          Status        => Status);
@@ -711,7 +711,7 @@ package body MPU9250 is
    begin
       Device.Port.Mem_Write
         (Addr          => Device.Address,
-         Mem_Addr      => Short (Reg_Addr),
+         Mem_Addr      => UInt16 (Reg_Addr),
          Mem_Addr_Size => Memory_Size_8b,
          Data          => (1 => Data),
          Status        => Status);

--- a/components/src/screen/ST7735R/st7735r.adb
+++ b/components/src/screen/ST7735R/st7735r.adb
@@ -44,7 +44,7 @@ package body ST7735R is
    procedure Write_Data (LCD  : ST7735R_Device;
                          Data : HAL.Byte_Array);
    procedure Write_Data (LCD  : ST7735R_Device;
-                         Data : HAL.Short_Array);
+                         Data : HAL.UInt16_Array);
 
    procedure Set_Command_Mode (LCD : ST7735R_Device);
    procedure Set_Data_Mode (LCD : ST7735R_Device);
@@ -167,7 +167,7 @@ package body ST7735R is
    ----------------
 
    procedure Write_Data (LCD  : ST7735R_Device;
-                         Data : HAL.Short_Array)
+                         Data : HAL.UInt16_Array)
    is
       B1, B2 : Byte;
       Status : SPI_Status;
@@ -460,7 +460,7 @@ package body ST7735R is
    -- Set_Column_Address --
    ------------------------
 
-   procedure Set_Column_Address (LCD : ST7735R_Device; X_Start, X_End : Short)
+   procedure Set_Column_Address (LCD : ST7735R_Device; X_Start, X_End : UInt16)
    is
       P1, P2, P3, P4 : Byte;
    begin
@@ -475,7 +475,7 @@ package body ST7735R is
    -- Set_Row_Address --
    ---------------------
 
-   procedure Set_Row_Address (LCD : ST7735R_Device; Y_Start, Y_End : Short)
+   procedure Set_Row_Address (LCD : ST7735R_Device; Y_Start, Y_End : UInt16)
    is
       P1, P2, P3, P4 : Byte;
    begin
@@ -491,7 +491,7 @@ package body ST7735R is
    -----------------
 
    procedure Set_Address (LCD : ST7735R_Device;
-                          X_Start, X_End, Y_Start, Y_End : Short)
+                          X_Start, X_End, Y_Start, Y_End : UInt16)
    is
    begin
       Set_Column_Address (LCD, X_Start, X_End);
@@ -503,10 +503,10 @@ package body ST7735R is
    ---------------
 
    procedure Set_Pixel (LCD   : ST7735R_Device;
-                        X, Y  : Short;
-                        Color : Short)
+                        X, Y  : UInt16;
+                        Color : UInt16)
    is
-      Data : constant HAL.Short_Array (1 .. 1) := (1 => Color);
+      Data : constant HAL.UInt16_Array (1 .. 1) := (1 => Color);
    begin
       Set_Address (LCD, X, X + 1, Y, Y + 1);
       Write_Raw_Pixels (LCD, Data);
@@ -529,7 +529,7 @@ package body ST7735R is
    ----------------------
 
    procedure Write_Raw_Pixels (LCD  : ST7735R_Device;
-                               Data : HAL.Short_Array)
+                               Data : HAL.UInt16_Array)
    is
    begin
       Write_Command (LCD, 16#2C#);

--- a/components/src/screen/ST7735R/st7735r.ads
+++ b/components/src/screen/ST7735R/st7735r.ads
@@ -106,19 +106,19 @@ package ST7735R is
 
    procedure Set_Vcom (LCD : ST7735R_Device; VCOMS : UInt6);
 
-   procedure Set_Column_Address (LCD : ST7735R_Device; X_Start, X_End : Short);
-   procedure Set_Row_Address (LCD : ST7735R_Device; Y_Start, Y_End : Short);
+   procedure Set_Column_Address (LCD : ST7735R_Device; X_Start, X_End : UInt16);
+   procedure Set_Row_Address (LCD : ST7735R_Device; Y_Start, Y_End : UInt16);
    procedure Set_Address (LCD : ST7735R_Device;
-                          X_Start, X_End, Y_Start, Y_End : Short);
+                          X_Start, X_End, Y_Start, Y_End : UInt16);
 
    procedure Set_Pixel (LCD   : ST7735R_Device;
-                        X, Y  : Short;
-                        Color : Short);
+                        X, Y  : UInt16;
+                        Color : UInt16);
 
    procedure Write_Raw_Pixels (LCD  : ST7735R_Device;
                                Data : HAL.Byte_Array);
    procedure Write_Raw_Pixels (LCD  : ST7735R_Device;
-                               Data : HAL.Short_Array);
+                               Data : HAL.UInt16_Array);
 
    overriding
    function Get_Max_Layers
@@ -233,7 +233,7 @@ private
      (Column_Address_Left_Right => 0,
       Column_Address_Right_Left => 1);
 
-   subtype Pixel_Data is Short_Array (0 .. (Screen_Width * Screen_Height) - 1);
+   subtype Pixel_Data is UInt16_Array (0 .. (Screen_Width * Screen_Height) - 1);
 
    type ST7735R_Device
      (Port : not null SPI_Port_Ref;

--- a/components/src/screen/ili9341/ili9341.adb
+++ b/components/src/screen/ili9341/ili9341.adb
@@ -49,8 +49,8 @@ with ILI9341_Regs;  use ILI9341_Regs;
 
 package body ILI9341 is
 
-   function As_Short is new Ada.Unchecked_Conversion
-     (Source => Colors, Target => Short);
+   function As_UInt16 is new Ada.Unchecked_Conversion
+     (Source => Colors, Target => UInt16);
 
    -------------------
    -- Current_Width --
@@ -108,9 +108,9 @@ package body ILI9341 is
       Color : Colors)
    is
       Color_High_Byte : constant Byte :=
-        Byte (Shift_Right (As_Short (Color), 8));
+        Byte (Shift_Right (As_UInt16 (Color), 8));
       Color_Low_Byte  : constant Byte :=
-        Byte (As_Short (Color) and 16#FF#);
+        Byte (As_UInt16 (Color) and 16#FF#);
    begin
       This.Set_Cursor_Position (X, Y, X, Y);
       This.Send_Command (ILI9341_GRAM);
@@ -124,9 +124,9 @@ package body ILI9341 is
 
    procedure Fill (This : in out ILI9341_Device; Color : Colors) is
       Color_High_Byte : constant Byte :=
-        Byte (Shift_Right (As_Short (Color), 8));
+        Byte (Shift_Right (As_UInt16 (Color), 8));
       Color_Low_Byte  : constant Byte :=
-        Byte (As_Short (Color) and 16#FF#);
+        Byte (As_UInt16 (Color) and 16#FF#);
    begin
       This.Set_Cursor_Position (X1 => 0,
                                 Y1 => 0,
@@ -197,15 +197,15 @@ package body ILI9341 is
       X2   : Width;
       Y2   : Height)
    is
-      X1_High : constant Byte := Byte (Shift_Right (Short (X1), 8));
-      X1_Low  : constant Byte := Byte (Short (X1) and 16#FF#);
-      X2_High : constant Byte := Byte (Shift_Right (Short (X2), 8));
-      X2_Low  : constant Byte := Byte (Short (X2) and 16#FF#);
+      X1_High : constant Byte := Byte (Shift_Right (UInt16 (X1), 8));
+      X1_Low  : constant Byte := Byte (UInt16 (X1) and 16#FF#);
+      X2_High : constant Byte := Byte (Shift_Right (UInt16 (X2), 8));
+      X2_Low  : constant Byte := Byte (UInt16 (X2) and 16#FF#);
 
-      Y1_High : constant Byte := Byte (Shift_Right (Short (Y1), 8));
-      Y1_Low  : constant Byte := Byte (Short (Y1) and 16#FF#);
-      Y2_High : constant Byte := Byte (Shift_Right (Short (Y2), 8));
-      Y2_Low  : constant Byte := Byte (Short (Y2) and 16#FF#);
+      Y1_High : constant Byte := Byte (Shift_Right (UInt16 (Y1), 8));
+      Y1_Low  : constant Byte := Byte (UInt16 (Y1) and 16#FF#);
+      Y2_High : constant Byte := Byte (Shift_Right (UInt16 (Y2), 8));
+      Y2_Low  : constant Byte := Byte (UInt16 (Y2) and 16#FF#);
    begin
       This.Send_Command (ILI9341_COLUMN_ADDR);
       This.Send_Data (X1_High);

--- a/components/src/touch_panel/ft5336/ft5336.adb
+++ b/components/src/touch_panel/ft5336/ft5336.adb
@@ -245,7 +245,7 @@ package body FT5336 is
    begin
       This.Port.Mem_Read
         (This.I2C_Addr,
-         Short (Reg),
+         UInt16 (Reg),
          Memory_Size_8b,
          Ret,
          Tmp_Status,
@@ -268,7 +268,7 @@ package body FT5336 is
    begin
       This.Port.Mem_Write
         (This.I2C_Addr,
-         Short (Reg),
+         UInt16 (Reg),
          Memory_Size_8b,
          (1 => Data),
          Tmp_Status,
@@ -371,20 +371,20 @@ package body FT5336 is
                              Touch_Id : Touch_Identifier)
                              return TP_Touch_State
    is
-      type Short_HL_Type is record
+      type UInt16_HL_Type is record
          High, Low : Unsigned_8;
       end record with Size => 16;
-      for Short_HL_Type use record
+      for UInt16_HL_Type use record
          High at 1 range 0 .. 7;
          Low  at 0 range 0 .. 7;
       end record;
 
-      function To_Short is
-        new Ada.Unchecked_Conversion (Short_HL_Type, Unsigned_16);
+      function To_UInt16 is
+        new Ada.Unchecked_Conversion (UInt16_HL_Type, Unsigned_16);
 
       Ret    : TP_Touch_State;
       Regs   : FT5336_Pressure_Registers;
-      Tmp    : Short_HL_Type;
+      Tmp    : UInt16_HL_Type;
       Status : Boolean;
 
    begin
@@ -411,7 +411,7 @@ package body FT5336 is
          return (0, 0, 0);
       end if;
 
-      Ret.Y := Natural (To_Short (Tmp));
+      Ret.Y := Natural (To_UInt16 (Tmp));
 
       Tmp.Low := This.I2C_Read (Regs.YL_Reg, Status);
 
@@ -426,7 +426,7 @@ package body FT5336 is
          return (0, 0, 0);
       end if;
 
-      Ret.X := Natural (To_Short (Tmp));
+      Ret.X := Natural (To_UInt16 (Tmp));
 
       Ret.Weight := Natural (This.I2C_Read (Regs.Weight_Reg, Status));
 

--- a/components/src/touch_panel/ft6x06/ft6x06.adb
+++ b/components/src/touch_panel/ft6x06/ft6x06.adb
@@ -135,20 +135,20 @@ package body FT6x06 is
                              Touch_Id : Touch_Identifier)
                              return HAL.Touch_Panel.TP_Touch_State
    is
-      type Short_HL_Type is record
+      type UInt16_HL_Type is record
          High, Low : Byte;
       end record with Size => 16;
-      for Short_HL_Type use record
+      for UInt16_HL_Type use record
          High at 1 range 0 .. 7;
          Low  at 0 range 0 .. 7;
       end record;
 
-      function To_Short is
-        new Ada.Unchecked_Conversion (Short_HL_Type, Short);
+      function To_UInt16 is
+        new Ada.Unchecked_Conversion (UInt16_HL_Type, UInt16);
 
       Ret  : TP_Touch_State;
       Regs : FT6206_Pressure_Registers;
-      Tmp  : Short_HL_Type;
+      Tmp  : UInt16_HL_Type;
       Status : Boolean;
    begin
       if Touch_Id not in FT6206_Px_Regs'Range then
@@ -176,7 +176,7 @@ package body FT6x06 is
          return (0, 0, 0);
       end if;
 
-      Ret.Y := Natural (To_Short (Tmp));
+      Ret.Y := Natural (To_UInt16 (Tmp));
 
       Tmp.Low := This.I2C_Read (Regs.YL_Reg, Status);
 
@@ -191,7 +191,7 @@ package body FT6x06 is
          return (0, 0, 0);
       end if;
 
-      Ret.X := Natural (To_Short (Tmp));
+      Ret.X := Natural (To_UInt16 (Tmp));
 
       Ret.Weight := Natural (This.I2C_Read (Regs.Weight_Reg, Status));
 
@@ -264,7 +264,7 @@ package body FT6x06 is
    begin
       This.Port.Mem_Read
         (This.I2C_Addr,
-         Short (Reg),
+         UInt16 (Reg),
          Memory_Size_8b,
          Ret,
          Tmp_Status,
@@ -287,7 +287,7 @@ package body FT6x06 is
    begin
       This.Port.Mem_Write
         (This.I2C_Addr,
-         Short (Reg),
+         UInt16 (Reg),
          Memory_Size_8b,
          (1 => Data),
          Tmp_Status,

--- a/components/src/touch_panel/stmpe811/stmpe811.adb
+++ b/components/src/touch_panel/stmpe811/stmpe811.adb
@@ -130,7 +130,7 @@ package body STMPE811 is
 
    begin
       This.Port.Mem_Read (This.I2C_Addr,
-                          Short (Data_Addr),
+                          UInt16 (Data_Addr),
                           Memory_Size_8b, Data,
                           Status);
 
@@ -153,7 +153,7 @@ package body STMPE811 is
 
    begin
       This.Port.Mem_Read (This.I2C_Addr,
-                          Short (Reg_Addr),
+                          UInt16 (Reg_Addr),
                           Memory_Size_8b,
                           Data,
                           Status);
@@ -176,7 +176,7 @@ package body STMPE811 is
 
    begin
       This.Port.Mem_Write (This.I2C_Addr,
-                           Short (Reg_Addr),
+                           UInt16 (Reg_Addr),
                            Memory_Size_8b,
                            (1 => Data),
                            Status);
@@ -243,10 +243,10 @@ package body STMPE811 is
    -- Get_IOE_ID --
    ----------------
 
-   function Get_IOE_ID (This : in out STMPE811_Device) return Short is
+   function Get_IOE_ID (This : in out STMPE811_Device) return UInt16 is
    begin
-      return (Short (This.Read_Register (0)) * (2**8))
-        or Short (This.Read_Register (1));
+      return (UInt16 (This.Read_Register (0)) * (2**8))
+        or UInt16 (This.Read_Register (1));
    end Get_IOE_ID;
 
    ----------------
@@ -341,9 +341,9 @@ package body STMPE811 is
                              return TP_Touch_State
    is
       State     : TP_Touch_State;
-      Raw_X     : Word;
-      Raw_Y     : Word;
-      Raw_Z     : Word;
+      Raw_X     : UInt32;
+      Raw_Y     : UInt32;
+      Raw_Z     : UInt32;
       X         : Integer;
       Y         : Integer;
       Tmp       : Integer;
@@ -363,17 +363,17 @@ package body STMPE811 is
 
       begin
          Raw_X := 2 ** 12 -
-           (Shift_Left (Word (Data_X (1)) and 16#0F#, 8) or Word (Data_X (2)));
+           (Shift_Left (UInt32 (Data_X (1)) and 16#0F#, 8) or UInt32 (Data_X (2)));
          Raw_Y :=
-           Shift_Left (Word (Data_Y (1)) and 16#0F#, 8) or Word (Data_Y (2));
+           Shift_Left (UInt32 (Data_Y (1)) and 16#0F#, 8) or UInt32 (Data_Y (2));
          Raw_Z :=
-           Shift_Right (Word (Data_Z (1)), Natural (Z_Frac (1) and 2#111#));
+           Shift_Right (UInt32 (Data_Z (1)), Natural (Z_Frac (1) and 2#111#));
       end;
 
       --  Now we adapt the 12 bit resolution to the LCD width.
       X :=
         Integer
-          (Shift_Right (Raw_X * (Word (This.LCD_Natural_Width) + 32), 12));
+          (Shift_Right (Raw_X * (UInt32 (This.LCD_Natural_Width) + 32), 12));
       X := X - 16;
 
       X := Integer'Max (X, 0);

--- a/components/src/touch_panel/stmpe811/stmpe811.ads
+++ b/components/src/touch_panel/stmpe811/stmpe811.ads
@@ -94,6 +94,6 @@ private
    procedure IOE_AF_Config (This      : in out STMPE811_Device;
                             Pin       : Byte;
                             Enabled   : Boolean);
-   function Get_IOE_ID (This : in out STMPE811_Device) return Short;
+   function Get_IOE_ID (This : in out STMPE811_Device) return UInt16;
 
 end STMPE811;

--- a/examples/balls/src/balls_demo.adb
+++ b/examples/balls/src/balls_demo.adb
@@ -142,8 +142,8 @@ procedure Balls_Demo is
 
    function To_RGB (Col : HSV_Color) return Bitmap_Color
    is
-      V, S, H : Word;
-      Region, FPart, p, q, t : Word;
+      V, S, H : UInt32;
+      Region, FPart, p, q, t : UInt32;
       Ret     : Bitmap_Color;
    begin
       Ret.Alpha := 255;
@@ -156,9 +156,9 @@ procedure Balls_Demo is
          return Ret;
       end if;
 
-      V := Word (Col.Val);
-      S := Word (Col.Sat);
-      H := Word (Col.Hue);
+      V := UInt32 (Col.Val);
+      S := UInt32 (Col.Sat);
+      H := UInt32 (Col.Hue);
 
       --  Hue in the range 0 .. 5
       Region := H / 43;
@@ -292,8 +292,8 @@ procedure Balls_Demo is
                  Natural'Min (LCD_Natural_Width, LCD_Natural_Height);
       R_Min  : constant Natural :=
                  Size / 24;
-      R_Var  : constant Word :=
-                 Word (R_Min) * 4 / 5;
+      R_Var  : constant UInt32 :=
+                 UInt32 (R_Min) * 4 / 5;
       SP_Max : constant Integer :=
                  Size / 7;
    begin
@@ -305,19 +305,19 @@ procedure Balls_Demo is
                          Integer (RNG.Interrupts.Random mod R_Var) + R_Min;
                Col   : constant Byte :=
                          Byte (RNG.Interrupts.Random mod 255);
-               X_Raw : constant Word :=
+               X_Raw : constant UInt32 :=
                          (RNG.Interrupts.Random mod
-                                    Word (LCD_Natural_Width - 2 * R)) +
-                         Word (R);
-               Y_Raw : constant Word :=
+                                    UInt32 (LCD_Natural_Width - 2 * R)) +
+                         UInt32 (R);
+               Y_Raw : constant UInt32 :=
                          (RNG.Interrupts.Random mod
-                                    Word (LCD_Natural_Height - 2 * R)) +
-                         Word (R);
+                                    UInt32 (LCD_Natural_Height - 2 * R)) +
+                         UInt32 (R);
                Sp_X  : constant Integer :=
-                 Integer (RNG.Interrupts.Random mod Word (SP_Max * 2 + 1)) -
+                 Integer (RNG.Interrupts.Random mod UInt32 (SP_Max * 2 + 1)) -
                    SP_Max;
                Sp_Y  : constant Integer :=
-                 Integer (RNG.Interrupts.Random mod Word (SP_Max * 2 + 1)) -
+                 Integer (RNG.Interrupts.Random mod UInt32 (SP_Max * 2 + 1)) -
                    SP_Max;
                Redo  : Boolean := False;
 

--- a/examples/common/gui/bitmapped_drawing.adb
+++ b/examples/common/gui/bitmapped_drawing.adb
@@ -96,7 +96,7 @@ package body Bitmapped_Drawing is
       Foreground : Bitmap_Color;
       Fast       : Boolean := True)
    is
-      FG    : constant Word := Bitmap_Color_To_Word (Buffer.Color_Mode,
+      FG    : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
                                                      Foreground);
 
       procedure Internal_Draw_Line
@@ -153,9 +153,9 @@ package body Bitmapped_Drawing is
       Ratio   : Float;
       Current : Point := (0, 0);
       Prev    : Unsigned_32;
-      FG      : constant Word := Bitmap_Color_To_Word (Buffer.Color_Mode,
+      FG      : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
                                                        Foreground);
-      Blk     : constant Word := Bitmap_Color_To_Word (Buffer.Color_Mode,
+      Blk     : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
                                                        Black);
 
       procedure Internal_Draw_Line
@@ -492,7 +492,7 @@ package body Bitmapped_Drawing is
       Radius : Natural;
       Hue    : Bitmap_Color)
    is
-      Col   : constant Word := Bitmap_Color_To_Word (Buffer.Color_Mode, Hue);
+      Col   : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode, Hue);
       F          : Integer := 1 - Radius;
       ddF_X      : Integer := 0;
       ddF_Y      : Integer := (-2) * Radius;
@@ -611,7 +611,7 @@ package body Bitmapped_Drawing is
      (Buffer : Bitmap_Buffer'Class;
       Center : Point;
       Radius : Natural;
-      Hue    : Word)
+      Hue    : UInt32)
    is
       F     : Integer := 1 - Radius;
       ddF_X : Integer := 0;
@@ -654,7 +654,7 @@ package body Bitmapped_Drawing is
       Radius : Natural;
       Hue    : Bitmap_Color)
    is
-      Col : constant Word := Bitmap_Color_To_Word (Buffer.Color_Mode,
+      Col : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
                                                    Hue);
    begin
       Fill_Circle (Buffer, Center, Radius, Col);

--- a/examples/common/gui/bmp_fonts.adb
+++ b/examples/common/gui/bmp_fonts.adb
@@ -41,7 +41,7 @@
 
 package body BMP_Fonts is
 
-   BMP_Font16x24 : constant array (0 .. 2279) of Short :=
+   BMP_Font16x24 : constant array (0 .. 2279) of UInt16 :=
      (16#0000#,
       16#0000#,
       16#0000#,
@@ -2323,7 +2323,7 @@ package body BMP_Fonts is
       16#0000#,
       16#0000#);
 
-   BMP_Font12x12 : constant array (0 .. 1151) of Short :=
+   BMP_Font12x12 : constant array (0 .. 1151) of UInt16 :=
      (16#0000#,
       16#0000#,
       16#0000#,
@@ -4251,7 +4251,7 @@ package body BMP_Fonts is
    -- Mask --
    ----------
 
-   function Mask (Font : BMP_Font; Width_Offset : Natural) return Short is
+   function Mask (Font : BMP_Font; Width_Offset : Natural) return UInt16 is
    begin
       case Font is
          when Font8x8 =>
@@ -4270,7 +4270,7 @@ package body BMP_Fonts is
    function Data
      (Font          : BMP_Font;
       C             : Character;
-      Height_Offset : Natural) return Short
+      Height_Offset : Natural) return UInt16
    is
       Char_Num   : constant Natural := Character'Pos (C);
       Char_Index : constant Natural := Char_Height (Font) *
@@ -4280,7 +4280,7 @@ package body BMP_Fonts is
    begin
       case Font is
          when Font8x8 =>
-            return Short (BMP_Font8x8 (Char_Index + Height_Offset));
+            return UInt16 (BMP_Font8x8 (Char_Index + Height_Offset));
          when Font12x12 =>
             return BMP_Font12x12 (Char_Index + Height_Offset);
          when Font16x24 =>

--- a/examples/common/gui/bmp_fonts.ads
+++ b/examples/common/gui/bmp_fonts.ads
@@ -49,12 +49,12 @@ package BMP_Fonts is
      (Font          : BMP_Font;
       C             : Character;
       Height_Offset : Natural)
-      return Short with Inline;
+      return UInt16 with Inline;
    --  Provides the numeric data values representing individual characters. For
    --  the given font and character within that font, returns the numeric value
    --  representing the bits at the Height_Offset within the representation.
 
-   function Mask (Font : BMP_Font; Width_Offset : Natural) return Short
+   function Mask (Font : BMP_Font; Width_Offset : Natural) return UInt16
      with Inline;
    --  Provides the mask value used to test individual bits in the data
    --  values representing individual characters. For example, to see if bit W

--- a/examples/conway/src/conway_driver.adb
+++ b/examples/conway/src/conway_driver.adb
@@ -154,7 +154,7 @@ package body Conway_Driver is
    G, G2, Tmp : Grid_Access;
 
    Format : constant HAL.Framebuffer.FB_Color_Mode := RGB_565;
-   Colors : constant array (Cell_State) of Word :=
+   Colors : constant array (Cell_State) of UInt32 :=
      (case Format is
          when ARGB_1555 => (Alive => 16#ffff#, Dead => 16#801f#),
          when ARGB_4444 => (Alive => 16#ffff#, Dead => 16#f00f#),

--- a/examples/fractals/src/fractals_demo.adb
+++ b/examples/fractals/src/fractals_demo.adb
@@ -248,10 +248,10 @@ begin
                for Y in 0 .. Display.Get_Height / Size - 1 loop
                   declare
                      use HAL;
-                     use type HAL.Word;
+                     use type HAL.UInt32;
                      Buff : constant HAL.Bitmap.Bitmap_Buffer'Class :=
                               Display.Get_Hidden_Buffer (1);
-                     Col  : Word;
+                     Col  : UInt32;
                   begin
                      for X in 0 .. Display.Get_Width / Size - 1 loop
                         if First_Pass then

--- a/hal/src/hal-bitmap.adb
+++ b/hal/src/hal-bitmap.adb
@@ -38,7 +38,7 @@ package body HAL.Bitmap is
       Y       : Natural;
       Value   : Bitmap_Color)
    is
-      Col : constant Word :=
+      Col : constant UInt32 :=
               Bitmap_Color_To_Word (Buffer.Color_Mode, Value);
    begin
       Set_Pixel (Bitmap_Buffer'Class (Buffer), X, Y, Col);
@@ -52,7 +52,7 @@ package body HAL.Bitmap is
      (Buffer : Bitmap_Buffer;
       X      : Natural;
       Y      : Natural;
-      Value  : Word)
+      Value  : UInt32)
    is
       X0 : Natural := X;
       Y0 : Natural := Y;
@@ -76,7 +76,7 @@ package body HAL.Bitmap is
       case Buffer.Color_Mode is
          when ARGB_8888 =>
             declare
-               Pixel : aliased Word
+               Pixel : aliased UInt32
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset * 4);
             begin
@@ -107,11 +107,11 @@ package body HAL.Bitmap is
 
          when ARGB_1555 | ARGB_4444 | RGB_565 | AL_88 =>
             declare
-               Pixel : aliased Short
+               Pixel : aliased UInt16
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset * 2);
             begin
-               Pixel := Short (Value and 16#FF_FF#);
+               Pixel := UInt16 (Value and 16#FF_FF#);
             end;
 
          when L_8 | AL_44 | A_8 =>
@@ -194,7 +194,7 @@ package body HAL.Bitmap is
       Y      : Natural)
       return Bitmap_Color
    is
-      Native_Color : Word;
+      Native_Color : UInt32;
    begin
       Native_Color := Get_Pixel
         (Bitmap_Buffer'Class (Buffer),
@@ -211,7 +211,7 @@ package body HAL.Bitmap is
      (Buffer : Bitmap_Buffer;
       X      : Natural;
       Y      : Natural)
-      return Word
+      return UInt32
    is
       X0 : Natural := X;
       Y0 : Natural := Y;
@@ -229,7 +229,7 @@ package body HAL.Bitmap is
       case Buffer.Color_Mode is
          when ARGB_8888 =>
             declare
-               Pixel : aliased Word
+               Pixel : aliased UInt32
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset * 4);
             begin
@@ -248,17 +248,17 @@ package body HAL.Bitmap is
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset * 3 + 2);
             begin
-               return Shift_Left (Word (Pixel_R), 16)
-                 or Shift_Left (Word (Pixel_G), 8) or Word (Pixel_B);
+               return Shift_Left (UInt32 (Pixel_R), 16)
+                 or Shift_Left (UInt32 (Pixel_G), 8) or UInt32 (Pixel_B);
             end;
 
          when ARGB_1555 | ARGB_4444 | RGB_565 | AL_88 =>
             declare
-               Pixel : aliased Short
+               Pixel : aliased UInt16
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset * 2);
             begin
-               return Word (Pixel);
+               return UInt32 (Pixel);
             end;
 
          when L_8 | AL_44 | A_8 =>
@@ -267,7 +267,7 @@ package body HAL.Bitmap is
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset);
             begin
-               return Word (Pixel);
+               return UInt32 (Pixel);
             end;
 
          when L_4 | A_4 =>
@@ -277,9 +277,9 @@ package body HAL.Bitmap is
                       Address => Buffer.Addr + Storage_Offset (Offset / 2);
             begin
                if Offset mod 2 = 0 then
-                  return Word (Shift_Right (Pixel and 16#F0#, 4));
+                  return UInt32 (Shift_Right (Pixel and 16#F0#, 4));
                else
-                  return Word (Pixel and 16#0F#);
+                  return UInt32 (Pixel and 16#0F#);
                end if;
             end;
       end case;
@@ -293,7 +293,7 @@ package body HAL.Bitmap is
      (Buffer : Bitmap_Buffer;
       Color  : Bitmap_Color)
    is
-      Col : constant Word := Bitmap_Color_To_Word (Buffer.Color_Mode, Color);
+      Col : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode, Color);
    begin
       Fill (Bitmap_Buffer'Class (Buffer), Col);
    end Fill;
@@ -304,7 +304,7 @@ package body HAL.Bitmap is
 
    procedure Fill
      (Buffer : Bitmap_Buffer;
-      Color  : Word)
+      Color  : UInt32)
    is
    begin
       for Y in 0 .. Buffer.Height - 1 loop
@@ -339,7 +339,7 @@ package body HAL.Bitmap is
 
    procedure Fill_Rect
      (Buffer : Bitmap_Buffer;
-      Color  : Word;
+      Color  : UInt32;
       X      : Integer;
       Y      : Integer;
       Width  : Integer;
@@ -449,7 +449,7 @@ package body HAL.Bitmap is
 
    procedure Draw_Vertical_Line
      (Buffer : Bitmap_Buffer;
-      Color  : Word;
+      Color  : UInt32;
       X      : Integer;
       Y      : Integer;
       Height : Integer)
@@ -479,7 +479,7 @@ package body HAL.Bitmap is
 
    procedure Draw_Horizontal_Line
      (Buffer : Bitmap_Buffer;
-      Color  : Word;
+      Color  : UInt32;
       X      : Integer;
       Y      : Integer;
       Width  : Integer)
@@ -555,9 +555,9 @@ package body HAL.Bitmap is
 
    function Bitmap_Color_To_Word
      (Mode : Bitmap_Color_Mode; Col : Bitmap_Color)
-      return Word
+      return UInt32
    is
-      Ret : Word := 0;
+      Ret : UInt32 := 0;
 
       procedure Add_Byte
         (Value : Byte; Pos : Natural; Size : Positive) with Inline;
@@ -571,9 +571,9 @@ package body HAL.Bitmap is
       procedure Add_Byte
         (Value : Byte; Pos : Natural; Size : Positive)
       is
-         Val : constant Word :=
+         Val : constant UInt32 :=
                  Shift_Left
-                   (Word
+                   (UInt32
                       (Shift_Right (Value,
                                     abs (Integer (Size) - 8))),
                     Pos);
@@ -590,7 +590,7 @@ package body HAL.Bitmap is
       begin
          return Byte
            (Shift_Right
-              (Word (Col.Red) * 3 + Word (Col.Blue) + Word (Col.Green) * 4,
+              (UInt32 (Col.Red) * 3 + UInt32 (Col.Blue) + UInt32 (Col.Green) * 4,
                3));
       end Luminance;
 
@@ -653,7 +653,7 @@ package body HAL.Bitmap is
    --------------------------
 
    function Word_To_Bitmap_Color
-     (Mode : Bitmap_Color_Mode; Col : Word)
+     (Mode : Bitmap_Color_Mode; Col : UInt32)
       return Bitmap_Color
    is
 
@@ -668,7 +668,7 @@ package body HAL.Bitmap is
         (Pos : Natural; Size : Positive) return Byte
       is
          Ret : Byte;
-         Mask : constant Word := Shift_Left (2 ** Size - 1, Pos);
+         Mask : constant UInt32 := Shift_Left (2 ** Size - 1, Pos);
       begin
          Ret := Byte (Shift_Right (Col and Mask, Pos));
 

--- a/hal/src/hal-bitmap.ads
+++ b/hal/src/hal-bitmap.ads
@@ -85,7 +85,7 @@ package HAL.Bitmap is
      (Buffer  : Bitmap_Buffer;
       X       : Natural;
       Y       : Natural;
-      Value   : Word);
+      Value   : UInt32);
 
    procedure Set_Pixel_Blend
      (Buffer : Bitmap_Buffer;
@@ -103,7 +103,7 @@ package HAL.Bitmap is
      (Buffer : Bitmap_Buffer;
       X      : Natural;
       Y      : Natural)
-      return Word;
+      return UInt32;
 
    procedure Fill
      (Buffer : Bitmap_Buffer;
@@ -112,7 +112,7 @@ package HAL.Bitmap is
 
    procedure Fill
      (Buffer : Bitmap_Buffer;
-      Color  : Word);
+      Color  : UInt32);
    --  Same as above, using the destination buffer native color representation
 
    procedure Fill_Rect
@@ -126,7 +126,7 @@ package HAL.Bitmap is
 
    procedure Fill_Rect
      (Buffer : Bitmap_Buffer;
-      Color  : Word;
+      Color  : UInt32;
       X      : Integer;
       Y      : Integer;
       Width  : Integer;
@@ -171,7 +171,7 @@ package HAL.Bitmap is
 
    procedure Draw_Vertical_Line
      (Buffer : Bitmap_Buffer;
-      Color  : Word;
+      Color  : UInt32;
       X      : Integer;
       Y      : Integer;
       Height : Integer);
@@ -185,7 +185,7 @@ package HAL.Bitmap is
 
    procedure Draw_Horizontal_Line
      (Buffer : Bitmap_Buffer;
-      Color  : Word;
+      Color  : UInt32;
       X      : Integer;
       Y      : Integer;
       Width  : Integer);
@@ -210,11 +210,11 @@ package HAL.Bitmap is
 
    function Bitmap_Color_To_Word
      (Mode : Bitmap_Color_Mode; Col : Bitmap_Color)
-     return Word;
+     return UInt32;
    --  Translates the DMA2D Color into native buffer color
 
    function Word_To_Bitmap_Color
-     (Mode : Bitmap_Color_Mode; Col : Word)
+     (Mode : Bitmap_Color_Mode; Col : UInt32)
      return Bitmap_Color;
    --  Translates the native buffer color into DMA2D Color
 

--- a/hal/src/hal-i2c.ads
+++ b/hal/src/hal-i2c.ads
@@ -35,7 +35,7 @@ package HAL.I2C is
    procedure Mem_Write
      (This          : in out I2C_Port;
       Addr          : I2C_Address;
-      Mem_Addr      : Short;
+      Mem_Addr      : UInt16;
       Mem_Addr_Size : I2C_Memory_Address_Size;
       Data          : I2C_Data;
       Status        : out I2C_Status;
@@ -44,7 +44,7 @@ package HAL.I2C is
    procedure Mem_Read
      (This          : in out I2C_Port;
       Addr          : I2C_Address;
-      Mem_Addr      : Short;
+      Mem_Addr      : UInt16;
       Mem_Addr_Size : I2C_Memory_Address_Size;
       Data          : out I2C_Data;
       Status        : out I2C_Status;

--- a/hal/src/hal-spi.ads
+++ b/hal/src/hal-spi.ads
@@ -12,7 +12,7 @@ package HAL.SPI is
 
    type SPI_Data_8b is array (Natural range <>) of Byte;
 
-   type SPI_Data_16b is array (Natural range <>) of Short;
+   type SPI_Data_16b is array (Natural range <>) of UInt16;
 
    type SPI_Port is limited interface;
 

--- a/hal/src/hal.ads
+++ b/hal/src/hal.ads
@@ -3,10 +3,6 @@ with Interfaces;
 package HAL is
    pragma Pure;
 
-   subtype Word is Interfaces.Unsigned_32;
-   subtype Short is Interfaces.Unsigned_16;
-   subtype Byte is Interfaces.Unsigned_8;
-
    type Bit is mod 2**1
      with Size => 1;
    type UInt2 is mod 2**2
@@ -23,6 +19,8 @@ package HAL is
      with Size => 7;
    type UInt9 is mod 2**9
      with Size => 9;
+   subtype UInt8 is Interfaces.Unsigned_8;
+   subtype Byte is Interfaces.Unsigned_8;
    type UInt10 is mod 2**10
      with Size => 10;
    type UInt11 is mod 2**11
@@ -35,6 +33,7 @@ package HAL is
      with Size => 14;
    type UInt15 is mod 2**15
      with Size => 15;
+   subtype UInt16 is Interfaces.Unsigned_16;
    type UInt17 is mod 2**17
      with Size => 17;
    type UInt18 is mod 2**18
@@ -65,9 +64,73 @@ package HAL is
      with Size => 30;
    type UInt31 is mod 2**31
      with Size => 31;
+   subtype UInt32 is Interfaces.Unsigned_32;
+   type UInt33 is mod 2**33
+     with Size => 33;
+   type UInt34 is mod 2**34
+     with Size => 34;
+   type UInt35 is mod 2**35
+     with Size => 35;
+   type UInt36 is mod 2**36
+     with Size => 36;
+   type UInt37 is mod 2**37
+     with Size => 37;
+   type UInt38 is mod 2**38
+     with Size => 38;
+   type UInt39 is mod 2**39
+     with Size => 39;
+   type UInt40 is mod 2**40
+     with Size => 40;
+   type UInt41 is mod 2**41
+     with Size => 41;
+   type UInt42 is mod 2**42
+     with Size => 42;
+   type UInt43 is mod 2**43
+     with Size => 43;
+   type UInt44 is mod 2**44
+     with Size => 44;
+   type UInt45 is mod 2**45
+     with Size => 45;
+   type UInt46 is mod 2**46
+     with Size => 46;
+   type UInt47 is mod 2**47
+     with Size => 47;
+   type UInt48 is mod 2**48
+     with Size => 48;
+   type UInt49 is mod 2**49
+     with Size => 49;
+   type UInt50 is mod 2**50
+     with Size => 50;
+   type UInt51 is mod 2**51
+     with Size => 51;
+   type UInt52 is mod 2**52
+     with Size => 52;
+   type UInt53 is mod 2**53
+     with Size => 53;
+   type UInt54 is mod 2**54
+     with Size => 54;
+   type UInt55 is mod 2**55
+     with Size => 55;
+   type UInt56 is mod 2**56
+     with Size => 56;
+   type UInt57 is mod 2**57
+     with Size => 57;
+   type UInt58 is mod 2**58
+     with Size => 58;
+   type UInt59 is mod 2**59
+     with Size => 59;
+   type UInt60 is mod 2**60
+     with Size => 60;
+   type UInt61 is mod 2**61
+     with Size => 61;
+   type UInt62 is mod 2**62
+     with Size => 62;
+   type UInt63 is mod 2**63
+     with Size => 63;
+   subtype UInt64 is Interfaces.Unsigned_64;
 
    type Byte_Array is array (Natural range <>) of Byte;
-   type Short_Array is array (Natural range <>) of Short;
-   type Word_Array is array (Natural range <>) of Word;
+   type UInt16_Array is array (Natural range <>) of UInt16;
+   type Word_Array is array (Natural range <>) of UInt32;
 
 end HAL;


### PR DESCRIPTION
The use of Word and Short to designate data type is ambiguous, not only
they do not express the signed or unsigned nature of the type, the size
is also different depending on the architecture. We might support 64bit
machines in the near future so it's time to change. Using UInt32 and
UInt16 is also more coherent with the other unsigned integer types used
all across the library.

This patch also define UIntXX up to 64.