### PR TITLE
Components Ravenscar dependency

### DIFF
--- a/boards/OpenMV2/src/openmv-lcd_shield.adb
+++ b/boards/OpenMV2/src/openmv-lcd_shield.adb
@@ -2,6 +2,7 @@ with STM32.GPIO;
 with STM32.Device;
 with OpenMV;
 with ST7735R; use ST7735R;
+with Ravenscar_Time;
 
 package body OpenMV.LCD_Shield is
 
@@ -13,7 +14,8 @@ package body OpenMV.LCD_Shield is
    LCD_Driver : ST7735R.ST7735R_Device (Shield_SPI'Access,
                                         LCD_CS'Access,
                                         LCD_RS'Access,
-                                        LCD_RST'Access);
+                                        LCD_RST'Access,
+                                        Ravenscar_Time.Delays);
    Is_Initialized : Boolean := False;
 
    -----------------

--- a/boards/crazyflie/board.gpr
+++ b/boards/crazyflie/board.gpr
@@ -1,6 +1,7 @@
 with "config";
 with "../../ARM/STM32/stm32f40x";
 with "../../components/components";
+with "../../services/services";
 
 library project Board is
 

--- a/boards/crazyflie/src/stm32-board.ads
+++ b/boards/crazyflie/src/stm32-board.ads
@@ -43,17 +43,18 @@
 --  This file provides declarations for devices on the STM32F4 Discovery kits
 --  manufactured by ST Microelectronics.
 
-with STM32.Device;  use STM32.Device;
+with STM32.Device;   use STM32.Device;
 
-with STM32.GPIO;    use STM32.GPIO;
-with STM32.I2C;     use STM32.I2C;
-with STM32.SPI;     use STM32.SPI;
-with STM32.Timers;  use STM32.Timers;
-with STM32.USARTs;  use STM32.USARTs;
+with STM32.GPIO;     use STM32.GPIO;
+with STM32.I2C;      use STM32.I2C;
+with STM32.SPI;      use STM32.SPI;
+with STM32.Timers;   use STM32.Timers;
+with STM32.USARTs;   use STM32.USARTs;
 
-with MPU9250;       use MPU9250;
-with AK8963;        use AK8963;
+with MPU9250;        use MPU9250;
+with AK8963;         use AK8963;
 
+with Ravenscar_Time;
 package STM32.Board is
    pragma Elaborate_Body;
 
@@ -176,10 +177,14 @@ package STM32.Board is
    -- MPU --
    ---------
 
-   MPU_Device   : MPU9250.MPU9250_Device (I2C_MPU_Port'Access, High);
+   MPU_Device   : MPU9250.MPU9250_Device (I2C_MPU_Port'Access,
+                                          High,
+                                          Ravenscar_Time.Delays);
    MPU_INT      : GPIO_Point renames PC13;
    MPU_FSYNC    : GPIO_Point renames PC14;
 
-   MAG_Device   : AK8963_Device (I2C_MPU_Port'Access, Add_00);
+   MAG_Device   : AK8963_Device (I2C_MPU_Port'Access,
+                                 Add_00,
+                                 Ravenscar_Time.Delays);
 
 end STM32.Board;

--- a/boards/stm32f429_discovery/src/framebuffer_ili9341.ads
+++ b/boards/stm32f429_discovery/src/framebuffer_ili9341.ads
@@ -1,5 +1,6 @@
 with HAL;             use HAL;
 with HAL.Framebuffer; use HAL.Framebuffer;
+with Ravenscar_Time;
 
 with Framebuffer_LTDC;
 private with ILI9341;
@@ -28,7 +29,8 @@ private
       Device : ILI9341.ILI9341_Device (STM32.Device.SPI_5'Access,
                                        Chip_Select => LCD_CSX'Access,
                                        WRX         => LCD_WRX_DCX'Access,
-                                       Reset       => LCD_RESET'Access);
+                                       Reset       => LCD_RESET'Access,
+                                       Time        => Ravenscar_Time.Delays);
    end record;
 
 end Framebuffer_ILI9341;

--- a/boards/stm32f429_discovery/src/touch_panel_stmpe811.ads
+++ b/boards/stm32f429_discovery/src/touch_panel_stmpe811.ads
@@ -31,6 +31,7 @@
 
 with HAL.Touch_Panel;
 with HAL.Framebuffer;
+with Ravenscar_Time;
 
 private with STMPE811;
 private with STM32.Device;
@@ -61,6 +62,7 @@ private
 
    type Touch_Panel is limited new STMPE811.STMPE811_Device
      (Port     => TP_I2C'Access,
-      I2C_Addr => 16#82#) with null record;
+      I2C_Addr => 16#82#,
+      Time     => Ravenscar_Time.Delays) with null record;
 
 end Touch_Panel_STMPE811;

--- a/boards/stm32f469_discovery/src/audio.ads
+++ b/boards/stm32f469_discovery/src/audio.ads
@@ -32,8 +32,9 @@
 --   @author  MCD Application Team                                          --
 ------------------------------------------------------------------------------
 
-with HAL.Audio;   use HAL.Audio;
-with HAL.I2C;     use HAL.I2C;
+with HAL.Audio;      use HAL.Audio;
+with HAL.I2C;        use HAL.I2C;
+with Ravenscar_Time;
 
 private with CS43L22;
 
@@ -72,7 +73,7 @@ private
 
    type CS43L22_Audio_Device (Port : not null I2C_Port_Ref) is limited
    new HAL.Audio.Audio_Device with record
-      Device : CS43L22.CS43L22_Device (Port);
+      Device : CS43L22.CS43L22_Device (Port, Ravenscar_Time.Delays);
    end record;
 
 end Audio;

--- a/boards/stm32f469_discovery/src/framebuffer_otm8009a.ads
+++ b/boards/stm32f469_discovery/src/framebuffer_otm8009a.ads
@@ -1,6 +1,7 @@
 with HAL;             use HAL;
 with HAL.Framebuffer; use HAL.Framebuffer;
 with HAL.Bitmap;
+with Ravenscar_Time;
 
 private with STM32.Device;
 private with STM32.DMA2D_Bitmap;
@@ -106,7 +107,8 @@ private
       record
          Device  : OTM8009A.OTM8009A_Device
                     (DSI_Host   => STM32.Device.DSIHOST'Access,
-                     Channel_Id => LCD_Channel);
+                     Channel_Id => LCD_Channel,
+                     Time       => Ravenscar_Time.Delays);
          Swapped : Boolean;
          Buffers : FB_Array := (others => STM32.DMA2D_Bitmap.Null_Buffer);
       end record;

--- a/boards/stm32f746_discovery/src/audio.ads
+++ b/boards/stm32f746_discovery/src/audio.ads
@@ -34,6 +34,7 @@
 
 with HAL.Audio; use HAL.Audio;
 with HAL.I2C;   use HAL.I2C;
+with Ravenscar_Time;
 
 private with WM8994;
 
@@ -74,7 +75,7 @@ private
 
    type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is limited new
      Audio_Device with record
-      Device : WM8994.WM8994_Device (Port, Audio_I2C_Addr);
+      Device : WM8994.WM8994_Device (Port, Audio_I2C_Addr, Ravenscar_Time.Delays);
    end record;
 
 end Audio;

--- a/boards/stm32f769_discovery/src/audio.ads
+++ b/boards/stm32f769_discovery/src/audio.ads
@@ -32,8 +32,9 @@
 --   @author  MCD Application Team                                          --
 ------------------------------------------------------------------------------
 
-with HAL.Audio; use HAL.Audio;
-with HAL.I2C;   use HAL.I2C;
+with HAL.Audio;      use HAL.Audio;
+with HAL.I2C;        use HAL.I2C;
+with Ravenscar_Time;
 
 private with WM8994;
 
@@ -74,7 +75,7 @@ private
 
    type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is limited new
      Audio_Device with record
-      Device : WM8994.WM8994_Device (Port, Audio_I2C_Addr);
+      Device : WM8994.WM8994_Device (Port, Audio_I2C_Addr, Ravenscar_Time.Delays);
    end record;
 
 end Audio;

--- a/boards/stm32f769_discovery/src/framebuffer_otm8009a.ads
+++ b/boards/stm32f769_discovery/src/framebuffer_otm8009a.ads
@@ -1,6 +1,7 @@
 with HAL;             use HAL;
 with HAL.Framebuffer; use HAL.Framebuffer;
 with HAL.Bitmap;
+with Ravenscar_Time;
 
 private with STM32.Device;
 private with STM32.DMA2D_Bitmap;
@@ -106,7 +107,8 @@ private
       record
          Device  : OTM8009A.OTM8009A_Device
                     (DSI_Host   => STM32.Device.DSIHOST'Access,
-                     Channel_Id => LCD_Channel);
+                     Channel_Id => LCD_Channel,
+                     Time       => Ravenscar_Time.Delays);
          Swapped : Boolean;
          Buffers : FB_Array := (others => STM32.DMA2D_Bitmap.Null_Buffer);
       end record;

--- a/components/src/audio/CS43L22/cs43l22.adb
+++ b/components/src/audio/CS43L22/cs43l22.adb
@@ -1,4 +1,3 @@
-with Ada.Real_Time; use Ada.Real_Time;
 
 package body CS43L22 is
 
@@ -153,7 +152,7 @@ package body CS43L22 is
       --  Unmute the output first
       This.Set_Mute (Mute_Off);
 
-      delay until Clock + Milliseconds (1);
+      This.Time.Delay_Milliseconds (1);
 
       This.I2C_Write (CS43L22_REG_POWER_CTL2, This.Output_Dev);
 

--- a/components/src/audio/CS43L22/cs43l22.ads
+++ b/components/src/audio/CS43L22/cs43l22.ads
@@ -3,6 +3,7 @@
 with Interfaces; use Interfaces;
 with HAL;        use HAL;
 with HAL.I2C;    use HAL.I2C;
+with HAL.Time;
 
 package CS43L22 is
 
@@ -46,7 +47,8 @@ package CS43L22 is
 
    subtype Volume_Level is Unsigned_8 range 0 .. 100;
 
-   type CS43L22_Device (Port : not null I2C_Port_Ref) is
+   type CS43L22_Device (Port : not null I2C_Port_Ref;
+                        Time : not null HAL.Time.Delays_Ref) is
      tagged limited private;
 
    procedure Init (This      : in out CS43L22_Device;
@@ -108,7 +110,9 @@ private
    CS43L22_REG_THERMAL_FOLDBACK    : constant := 16#33#;
    CS43L22_REG_CHARGE_PUMP_FREQ    : constant := 16#34#;
 
-   type CS43L22_Device (Port : not null I2C_Port_Ref) is tagged limited record
+   type CS43L22_Device (Port : not null I2C_Port_Ref;
+                        Time : not null HAL.Time.Delays_Ref) is
+     tagged limited record
       Output_Enabled : Boolean := False;
       Output_Dev     : Byte := 0;
    end record;

--- a/components/src/audio/W8994/wm8994.adb
+++ b/components/src/audio/W8994/wm8994.adb
@@ -1,4 +1,3 @@
-with Ada.Real_Time; use Ada.Real_Time;
 
 with Ada.Text_IO;
 
@@ -93,7 +92,7 @@ package body WM8994 is
       --  Enable BIAS generator, Enable VMID
       I2C_Write (This, 16#01#, 16#0003#);
 
-      delay until Clock + Milliseconds (50);
+      This.Time.Delay_Milliseconds (50);
 
       Output_Enabled := Output /= No_Output;
       Input_Enabled  := Input /= No_Input;
@@ -194,7 +193,7 @@ package body WM8994 is
          I2C_Write (This, 16#4C#, 16#9F25#);
 
          --  Add Delay
-         delay until Clock + Milliseconds (15);
+         This.Time.Delay_Milliseconds (15);
 
          --  Select DAC1 (Left) to Left Headphone Output PGA (HPOUT1LVOL) path
          I2C_Write (This, 16#2D#, 16#0001#);
@@ -212,7 +211,7 @@ package body WM8994 is
          I2C_Write (This, 16#54#, 16#0033#);
 
          --  Add Delay
-         delay until Clock + Milliseconds (250);
+         This.Time.Delay_Milliseconds (250);
 
          --  Enable HPOUT1 (Left) and HPOUT1 (Right) intermediate and output
          --  stages. Remove clamps.

--- a/components/src/audio/W8994/wm8994.ads
+++ b/components/src/audio/W8994/wm8994.ads
@@ -3,6 +3,7 @@
 with Interfaces; use Interfaces;
 with HAL;        use HAL;
 with HAL.I2C;    use HAL.I2C;
+with HAL.Time;
 
 package WM8994 is
 
@@ -57,7 +58,8 @@ package WM8994 is
 
    type WM8994_Device
      (Port     : not null I2C_Port_Ref;
-      I2C_Addr : UInt10)
+      I2C_Addr : UInt10;
+      Time     : not null HAL.Time.Delays_Ref)
    is tagged limited private;
 
    procedure Init (This      : in out WM8994_Device;
@@ -81,7 +83,8 @@ package WM8994 is
 
 private
    type WM8994_Device (Port     : not null I2C_Port_Ref;
-                       I2C_Addr : UInt10) is tagged limited null record;
+                       I2C_Addr : UInt10;
+                       Time     : not null HAL.Time.Delays_Ref) is tagged limited null record;
 
    procedure I2C_Write (This   : in out WM8994_Device;
                         Reg   : UInt16;

--- a/components/src/motion/ak8963/ak8963.adb
+++ b/components/src/motion/ak8963/ak8963.adb
@@ -1,5 +1,4 @@
 with Ada.Unchecked_Conversion;
-with Ada.Real_Time; use Ada.Real_Time;
 with Interfaces;    use Interfaces;
 
 with HAL.I2C;       use HAL.I2C;
@@ -206,7 +205,7 @@ package body AK8963 is
       while Retry > 0 loop
          exit when Get_Data_Ready (Device);
          Retry := Retry - 1;
-         delay until Clock + Milliseconds (10);
+         Device.Time.Delay_Milliseconds (10);
       end loop;
 
       if Retry = 0 then

--- a/components/src/motion/ak8963/ak8963.ads
+++ b/components/src/motion/ak8963/ak8963.ads
@@ -30,6 +30,7 @@
 --  AK8963 I2C device class package
 
 with HAL.I2C;    use HAL;
+with HAL.Time;
 
 package AK8963 is
 
@@ -49,7 +50,8 @@ package AK8963 is
       Fuse_ROM_Access);
 
    type AK8963_Device (I2C_Port         : not null HAL.I2C.I2C_Port_Ref;
-                       Address_Selector : AK8963_Address_Selector) is private;
+                       Address_Selector : AK8963_Address_Selector;
+                        Time            : not null HAL.Time.Delays_Ref) is private;
 
    procedure Initialize (Device : in out AK8963_Device);
 
@@ -77,7 +79,8 @@ package AK8963 is
 private
 
    type AK8963_Device (I2C_Port         : not null HAL.I2C.I2C_Port_Ref;
-                       Address_Selector : AK8963_Address_Selector)
+                       Address_Selector : AK8963_Address_Selector;
+                        Time            : not null HAL.Time.Delays_Ref)
    is record
       Address : UInt10;
       Is_Init : Boolean := False;

--- a/components/src/motion/mpu9250/mpu9250.adb
+++ b/components/src/motion/mpu9250/mpu9250.adb
@@ -55,7 +55,7 @@ package body MPU9250 is
       end if;
 
       --  Wait for MPU9250 startup
-      delay until Time_First + MPU9250_STARTUP_TIME_MS;
+      Device.Time.Delay_Milliseconds (MPU9250_STARTUP_TIME_MS);
 
       --  Set the device address
       Device.Address :=
@@ -170,7 +170,6 @@ package body MPU9250 is
       Gyro_Diff    : Float_Array_3;
       FS           : constant Unsigned_8 := 0;
 
-      Next_Period : Time;
       Test_Status : Boolean;
    begin
       --  Save old configuration
@@ -241,8 +240,7 @@ package body MPU9250 is
         (Device, MPU9250_RA_GYRO_CONFIG, 16#E0#);
 
       --  Delay a while to let the device stabilize
-      Next_Period := Clock + Milliseconds (25);
-      delay until Next_Period;
+      Device.Time.Delay_Milliseconds (25);
 
       --  Get average self-test values of gyro and accelerometer
       for I in 1 .. 200 loop
@@ -288,8 +286,7 @@ package body MPU9250 is
         (Device, MPU9250_RA_GYRO_CONFIG, 16#00#);
 
       --  Delay a while to let the device stabilize
-      Next_Period := Clock + Milliseconds (25);
-      delay until Next_Period;
+      Device.Time.Delay_Milliseconds (25);
 
       --  Retrieve Accelerometer and Gyro Factory Self - Test Code From USR_Reg
       MPU9250_Read_Byte_At_Register

--- a/components/src/motion/mpu9250/mpu9250.ads
+++ b/components/src/motion/mpu9250/mpu9250.ads
@@ -29,11 +29,11 @@
 
 --  MPU9250 I2C device class package
 
-with Ada.Real_Time;       use Ada.Real_Time;
 with Interfaces;          use Interfaces;
 
 with HAL;                 use HAL;
 with HAL.I2C;             use HAL.I2C;
+with HAL.Time;
 
 package MPU9250 is
 
@@ -43,7 +43,8 @@ package MPU9250 is
 
    --  Types and subtypes
    type MPU9250_Device (Port        : HAL.I2C.I2C_Port_Ref;
-                        I2C_AD0_Pin : MPU9250_AD0_Pin_State) is private;
+                        I2C_AD0_Pin : MPU9250_AD0_Pin_State;
+                        Time        : not null HAL.Time.Delays_Ref) is private;
 
    --  Type reprensnting all the different clock sources of the MPU9250.
    --  See the MPU9250 register map section 4.4 for more details.
@@ -220,7 +221,8 @@ private
 
    type MPU9250_Device
      (Port        : HAL.I2C.I2C_Port_Ref;
-      I2C_AD0_Pin : MPU9250_AD0_Pin_State)
+      I2C_AD0_Pin : MPU9250_AD0_Pin_State;
+      Time        : not null HAL.Time.Delays_Ref)
    is record
       Is_Init : Boolean := False;
       Address : UInt10;
@@ -238,7 +240,7 @@ private
    --  Address pin high (VCC)
    MPU9250_ADDRESS_AD0_HIGH : constant := 16#69#;
 
-   MPU9250_STARTUP_TIME_MS  : constant Time_Span := Milliseconds (1_000);
+   MPU9250_STARTUP_TIME_MS  : constant := 1_000;
 
    --  MPU9250 register adresses and other defines
 

--- a/components/src/screen/ST7735R/st7735r.adb
+++ b/components/src/screen/ST7735R/st7735r.adb
@@ -1,4 +1,3 @@
-with Ada.Real_Time; use Ada.Real_Time;
 with Ada.Unchecked_Conversion;
 with System;
 with Interfaces; use Interfaces;
@@ -196,14 +195,14 @@ package body ST7735R is
       LCD.Initialized := True;
 
       LCD.RST.Clear;
-      delay until Clock + Milliseconds (100);
+      LCD.Time.Delay_Milliseconds (100);
       LCD.RST.Set;
-      delay until Clock + Milliseconds (100);
+      LCD.Time.Delay_Milliseconds (100);
 
       --  Sleep Exit
       Write_Command (LCD, 16#11#);
 
-      delay until Clock + Milliseconds (100);
+      LCD.Time.Delay_Milliseconds (100);
    end Initialize;
 
    -----------------

--- a/components/src/screen/ST7735R/st7735r.ads
+++ b/components/src/screen/ST7735R/st7735r.ads
@@ -3,6 +3,7 @@ with HAL.SPI;         use HAL.SPI;
 with HAL.GPIO;        use HAL.GPIO;
 with HAL.Framebuffer; use HAL.Framebuffer;
 with HAL.Bitmap;      use HAL.Bitmap;
+with HAL.Time;
 
 package ST7735R is
 
@@ -10,7 +11,8 @@ package ST7735R is
      (Port : not null SPI_Port_Ref;
       CS   : not null GPIO_Point_Ref;
       RS   : not null GPIO_Point_Ref;
-      RST  : not null GPIO_Point_Ref)
+      RST  : not null GPIO_Point_Ref;
+      Time : not null HAL.Time.Delays_Ref)
    is limited new HAL.Framebuffer.Frame_Buffer_Display with private;
 
    procedure Initialize (LCD : in out ST7735R_Device);
@@ -239,7 +241,8 @@ private
      (Port : not null SPI_Port_Ref;
       CS   : not null GPIO_Point_Ref;
       RS   : not null GPIO_Point_Ref;
-      RST  : not null GPIO_Point_Ref)
+      RST  : not null GPIO_Point_Ref;
+      Time : not null HAL.Time.Delays_Ref)
    is limited new HAL.Framebuffer.Frame_Buffer_Display with record
       Initialized : Boolean := True;
       Layer : aliased Bitmap_Buffer;

--- a/components/src/screen/ili9341/ili9341.adb
+++ b/components/src/screen/ili9341/ili9341.adb
@@ -42,10 +42,9 @@
 ------------------------------------------------------------------------------
 
 with Ada.Unchecked_Conversion;
-with Ada.Real_Time; use Ada.Real_Time;
-with Interfaces;    use Interfaces;
+with Interfaces;   use Interfaces;
 
-with ILI9341_Regs;  use ILI9341_Regs;
+with ILI9341_Regs; use ILI9341_Regs;
 
 package body ILI9341 is
 
@@ -279,7 +278,7 @@ package body ILI9341 is
    begin
       This.Reset.Set;
       This.Send_Command (ILI9341_RESET);
-      delay until Clock + Milliseconds (5);
+      This.Time.Delay_Milliseconds (5);
 
       This.Send_Command (ILI9341_POWERA);
       This.Send_Data (16#39#);
@@ -390,9 +389,9 @@ package body ILI9341 is
 
       case Mode is
          when RGB_Mode =>
-            delay until Clock + Milliseconds (150);
+            This.Time.Delay_Milliseconds (150);
          when SPI_Mode =>
-            delay until Clock + Milliseconds (20);
+            This.Time.Delay_Milliseconds (20);
       end case;
       --  document ILI9341_DS_V1.02, section 11.2, pg 205 says we need
       --  either 120ms or 5ms, depending on the mode, but seems incorrect.

--- a/components/src/screen/ili9341/ili9341.ads
+++ b/components/src/screen/ili9341/ili9341.ads
@@ -48,6 +48,7 @@
 with HAL;      use HAL;
 with HAL.SPI;  use HAL.SPI;
 with HAL.GPIO; use HAL.GPIO;
+with HAL.Time;
 
 package ILI9341 is
 
@@ -55,7 +56,8 @@ package ILI9341 is
      (Port        : not null access SPI_Port'Class;
       Chip_Select : not null GPIO_Point_Ref;
       WRX         : not null GPIO_Point_Ref;
-      Reset       : not null GPIO_Point_Ref)
+      Reset       : not null GPIO_Point_Ref;
+      Time        : not null HAL.Time.Delays_Ref)
    is tagged limited private;
 
    type ILI9341_Mode is
@@ -152,7 +154,8 @@ private
      (Port        : not null access SPI_Port'Class;
       Chip_Select : not null GPIO_Point_Ref;
       WRX         : not null GPIO_Point_Ref;
-      Reset       : not null GPIO_Point_Ref)
+      Reset       : not null GPIO_Point_Ref;
+      Time        : not null HAL.Time.Delays_Ref)
    is tagged limited record
       Selected_Orientation : Orientations;
 

--- a/components/src/screen/otm8009a/otm8009a.adb
+++ b/components/src/screen/otm8009a/otm8009a.adb
@@ -1,4 +1,3 @@
-with Ada.Real_Time; use Ada.Real_Time;
 
 package body OTM8009A is
 
@@ -61,11 +60,11 @@ package body OTM8009A is
       --  -> Source output level during porch and non-display area to GND --
       This.Write (Address => 16#C480#,
                   Data    => (1 => 16#30#));
-      delay until Clock + Milliseconds (10);
+      This.Time.Delay_Milliseconds (10);
       --  Not documented...
       This.Write (Address => 16#C48A#,
                   Data    => (1 => 16#40#));
-      delay until Clock + Milliseconds (10);
+      This.Time.Delay_Milliseconds (10);
       ----------------------------------------------------------------------
 
       ----------------------------------------------------------------------
@@ -271,7 +270,7 @@ package body OTM8009A is
                   Data   => (1 .. 0 => <>));
 
       --  Wait for Sleep Out exit
-      delay until Clock + Milliseconds (120);
+      This.Time.Delay_Milliseconds (120);
 
       case Color_Mode is
          when RGB565 =>

--- a/components/src/screen/otm8009a/otm8009a.ads
+++ b/components/src/screen/otm8009a/otm8009a.ads
@@ -1,6 +1,7 @@
 with Interfaces; use Interfaces;
 with HAL;        use HAL;
 with HAL.DSI;    use HAL.DSI;
+with HAL.Time;
 
 package OTM8009A is
 
@@ -56,7 +57,8 @@ package OTM8009A is
 
    type OTM8009A_Device
      (DSI_Host   : not null DSI_Port_Ref;
-      Channel_ID : DSI_Virtual_Channel_ID)
+      Channel_ID : DSI_Virtual_Channel_ID;
+      Time       : not null HAL.Time.Delays_Ref)
    is tagged limited private;
 
    procedure Initialize
@@ -68,7 +70,8 @@ private
 
    type OTM8009A_Device
      (DSI_Host   : not null DSI_Port_Ref;
-      Channel_ID : DSI_Virtual_Channel_ID)
+      Channel_ID : DSI_Virtual_Channel_ID;
+      Time       : not null HAL.Time.Delays_Ref)
    is tagged limited record
       Current_Shift : Byte := 0;
    end record;

--- a/components/src/touch_panel/stmpe811/stmpe811.adb
+++ b/components/src/touch_panel/stmpe811/stmpe811.adb
@@ -41,7 +41,6 @@
 --   COPYRIGHT(c) 2014 STMicroelectronics                                   --
 ------------------------------------------------------------------------------
 
-with Ada.Real_Time; use Ada.Real_Time;
 with Interfaces; use Interfaces;
 
 package body STMPE811 is
@@ -195,7 +194,7 @@ package body STMPE811 is
       This.Write_Register (IOE_REG_SYS_CTRL1, 16#02#);
 
       --  Give some time for the reset
-      delay until Clock + Milliseconds (2);
+      This.Time.Delay_Milliseconds (2);
 
       This.Write_Register (IOE_REG_SYS_CTRL1, 16#00#);
    end IOE_Reset;
@@ -257,7 +256,7 @@ package body STMPE811 is
    is
    begin
 
-      delay until Clock + Milliseconds (100);
+      This.Time.Delay_Milliseconds (100);
 
       if This.Get_IOE_ID /= 16#0811# then
          return False;
@@ -270,7 +269,7 @@ package body STMPE811 is
 
       This.Write_Register (IOE_REG_ADC_CTRL1, 16#49#);
 
-      delay until Clock + Milliseconds (2);
+      This.Time.Delay_Milliseconds (2);
 
       This.Write_Register (IOE_REG_ADC_CTRL2, 16#01#);
 

--- a/components/src/touch_panel/stmpe811/stmpe811.ads
+++ b/components/src/touch_panel/stmpe811/stmpe811.ads
@@ -30,13 +30,15 @@
 ------------------------------------------------------------------------------
 
 with HAL;             use HAL;
+with HAL.Time;        use HAL.Time;
 with HAL.I2C;         use HAL.I2C;
 with HAL.Touch_Panel; use HAL.Touch_Panel;
 
 package STMPE811 is
 
    type STMPE811_Device (Port     : not null I2C_Port_Ref;
-                         I2C_Addr : I2C_Address) is
+                         I2C_Addr : I2C_Address;
+                         Time     : not null HAL.Time.Delays_Ref) is
      limited new Touch_Panel_Device with private;
 
    function Initialize (This : in out STMPE811_Device) return Boolean;
@@ -70,7 +72,8 @@ package STMPE811 is
 private
 
    type STMPE811_Device (Port     : not null I2C_Port_Ref;
-                         I2C_Addr : I2C_Address) is
+                         I2C_Addr : I2C_Address;
+                         Time     : not null HAL.Time.Delays_Ref) is
      limited new Touch_Panel_Device with record
       LCD_Natural_Width  : Natural := 0;
       LCD_Natural_Height : Natural := 0;

--- a/services/services.gpr
+++ b/services/services.gpr
@@ -3,7 +3,17 @@ with "config";
 
 library project Services is
 
-   for Source_Dirs use ("src/**");
+   Src_Dirs := ("src/filesystems",
+                "src/utils");
+
+   case Config.RTS is
+      when "ravenscar-sfp" | "ravenscar-full" =>
+         Src_Dirs := Src_Dirs & ("src/ravenscar-common");
+      when others =>
+         null;
+   end case;
+
+   for Source_Dirs use Src_Dirs;
 
    for Languages use ("Ada");
    for Library_Name use "services";

--- a/services/src/ravenscar-common/ravenscar_time.adb
+++ b/services/src/ravenscar-common/ravenscar_time.adb
@@ -1,0 +1,86 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2016, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Real_Time; use Ada.Real_Time;
+
+package body Ravenscar_Time is
+
+   Delay_Singleton : aliased Ravenscar_Delays;
+
+   ------------
+   -- Delays --
+   ------------
+
+   function Delays return not null HAL.Time.Delays_Ref is
+   begin
+      return Delay_Singleton'Access;
+   end Delays;
+
+   ------------------------
+   -- Delay_Microseconds --
+   ------------------------
+
+   overriding procedure Delay_Microseconds
+     (This : in out Ravenscar_Delays;
+      Us   : Integer)
+   is
+      pragma Unreferenced (This);
+   begin
+      delay until Clock + Microseconds (Us);
+   end Delay_Microseconds;
+
+   ------------------------
+   -- Delay_Milliseconds --
+   ------------------------
+
+   overriding procedure Delay_Milliseconds
+     (This : in out Ravenscar_Delays;
+      Ms   : Integer)
+   is
+      pragma Unreferenced (This);
+   begin
+      delay until Clock + Milliseconds (Ms);
+   end Delay_Milliseconds;
+
+   -------------------
+   -- Delay_Seconds --
+   -------------------
+
+   overriding procedure Delay_Seconds
+     (This : in out Ravenscar_Delays;
+      S    : Integer)
+   is
+      pragma Unreferenced (This);
+   begin
+      delay until Clock + Seconds (S);
+   end Delay_Seconds;
+
+end Ravenscar_Time;

--- a/services/src/ravenscar-common/ravenscar_time.ads
+++ b/services/src/ravenscar-common/ravenscar_time.ads
@@ -1,0 +1,53 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2016, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with HAL.Time;
+
+package Ravenscar_Time is
+
+   function Delays return not null HAL.Time.Delays_Ref;
+
+private
+
+   type Ravenscar_Delays is new HAL.Time.Delays with null record;
+
+   overriding
+   procedure Delay_Microseconds (This : in out Ravenscar_Delays;
+                                 Us   : Integer);
+
+   overriding
+   procedure Delay_Milliseconds (This : in out Ravenscar_Delays;
+                                 Ms   : Integer);
+
+   overriding
+   procedure Delay_Seconds      (This : in out Ravenscar_Delays;
+                                 S    : Integer);
+end Ravenscar_Time;


### PR DESCRIPTION
Some components are using Ravenscar Ada.Real_Time, this means that the layer cannot be used on some targets where only ZFP is available. This goes against the intent of components and HAL layers.

The patch series replaces the dependency on Ada.Real_Time by HAL.Time. 