### PR TITLE
STM32: Rename Enable_Clock procedures to Power_Up

### DIFF
--- a/ARM/STM32/devices/stm32f42x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f42x/stm32-device.adb
@@ -56,7 +56,7 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
-   procedure Enable_Clock (This : aliased in out GPIO_Port) is
+   procedure Power_Up (This : aliased in out GPIO_Port) is
    begin
       if This'Address = GPIOA_Base then
          RCC_Periph.AHB1ENR.GPIOAEN := True;
@@ -83,29 +83,29 @@ package body STM32.Device is
       else
          raise Unknown_Device;
       end if;
-   end Enable_Clock;
+   end Power_Up;
 
    ------------------
    -- Enable_Clock --
    ------------------
 
-   procedure Enable_Clock (Point : GPIO_Point)
+   procedure Power_Up (Point : GPIO_Point)
    is
    begin
-      Enable_Clock (Point.Periph.all);
-   end Enable_Clock;
+      Power_Up (Point.Periph.all);
+   end Power_Up;
 
    ------------------
    -- Enable_Clock --
    ------------------
 
-   procedure Enable_Clock (Points : GPIO_Points)
+   procedure Power_Up (Points : GPIO_Points)
    is
    begin
       for Point of Points loop
-         Enable_Clock (Point.Periph.all);
+         Power_Up (Point.Periph.all);
       end loop;
-   end Enable_Clock;
+   end Power_Up;
 
    -----------
    -- Reset --
@@ -222,7 +222,7 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
-   procedure Enable_Clock (This : aliased in out Analog_To_Digital_Converter)
+   procedure Power_Up (This : aliased in out Analog_To_Digital_Converter)
    is
    begin
       if This'Address = ADC1_Base then
@@ -234,7 +234,7 @@ package body STM32.Device is
       else
          raise Unknown_Device;
       end if;
-   end Enable_Clock;
+   end Power_Up;
 
    -------------------------
    -- Reset_All_ADC_Units --
@@ -250,12 +250,12 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
-   procedure Enable_Clock (This : aliased in out Digital_To_Analog_Converter)
+   procedure Power_Up (This : aliased in out Digital_To_Analog_Converter)
    is
       pragma Unreferenced (This);
    begin
       RCC_Periph.APB1ENR.DACEN := True;
-   end Enable_Clock;
+   end Power_Up;
 
    -----------
    -- Reset --
@@ -272,7 +272,7 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
-   procedure Enable_Clock (This : aliased in out USART) is
+   procedure Power_Up (This : aliased in out USART) is
    begin
       if This.Periph.all'Address = USART1_Base then
          RCC_Periph.APB2ENR.USART1EN := True;
@@ -293,7 +293,7 @@ package body STM32.Device is
       else
          raise Unknown_Device;
       end if;
-   end Enable_Clock;
+   end Power_Up;
 
    -----------
    -- Reset --
@@ -334,7 +334,7 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
-   procedure Enable_Clock (This : aliased in out DMA_Controller) is
+   procedure Power_Up (This : aliased in out DMA_Controller) is
    begin
       if This'Address = STM32_SVD.DMA1_Base then
          RCC_Periph.AHB1ENR.DMA1EN := True;
@@ -343,7 +343,7 @@ package body STM32.Device is
       else
          raise Unknown_Device;
       end if;
-   end Enable_Clock;
+   end Power_Up;
 
    -----------
    -- Reset --
@@ -383,16 +383,16 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
-   procedure Enable_Clock (This : I2C_Port) is
+   procedure Power_Up (This : I2C_Port) is
    begin
-      Enable_Clock (As_Port_Id (This));
-   end Enable_Clock;
+      Power_Up (As_Port_Id (This));
+   end Power_Up;
 
    ------------------
    -- Enable_Clock --
    ------------------
 
-   procedure Enable_Clock (This : I2C_Port_Id) is
+   procedure Power_Up (This : I2C_Port_Id) is
    begin
       case This is
          when I2C_Id_1 =>
@@ -402,7 +402,7 @@ package body STM32.Device is
          when I2C_Id_3 =>
             RCC_Periph.APB1ENR.I2C3EN := True;
       end case;
-   end Enable_Clock;
+   end Power_Up;
 
    -----------
    -- Reset --
@@ -436,7 +436,7 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
-   procedure Enable_Clock (This : SPI_Port) is
+   procedure Power_Up (This : SPI_Port) is
    begin
       if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2ENR.SPI1EN := True;
@@ -453,7 +453,7 @@ package body STM32.Device is
       else
          raise Unknown_Device;
       end if;
-   end Enable_Clock;
+   end Power_Up;
 
    -----------
    -- Reset --
@@ -488,7 +488,7 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
-   procedure Enable_Clock (This : in out Timer) is
+   procedure Power_Up (This : in out Timer) is
    begin
       if This'Address = TIM1_Base then
          RCC_Periph.APB2ENR.TIM1EN := True;
@@ -521,7 +521,7 @@ package body STM32.Device is
       else
          raise Unknown_Device;
       end if;
-   end Enable_Clock;
+   end Power_Up;
 
    -----------
    -- Reset --
@@ -728,10 +728,10 @@ package body STM32.Device is
    -- Enable_DCMI_Clock --
    -----------------------
 
-   procedure Enable_DCMI_Clock is
+   procedure Power_Up_DCMI is
    begin
       RCC_Periph.AHB2ENR.DCMIEN := True;
-   end Enable_DCMI_Clock;
+   end Power_Up_DCMI;
 
    ----------------
    -- Reset_DCMI --

--- a/ARM/STM32/devices/stm32f42x/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f42x/stm32-device.ads
@@ -60,13 +60,12 @@ package STM32.Device is
    --  Raised by the routines below for a device passed as an actual parameter
    --  when that device is not present on the given hardware instance.
 
-   procedure Enable_Clock (This : aliased in out GPIO_Port)
+   procedure Power_Up (This : aliased in out GPIO_Port)
      with Inline;
-   procedure Enable_Clock (Point : GPIO_Point)
+   procedure Power_Up (Point : GPIO_Point)
      with Inline;
-   procedure Enable_Clock (Points : GPIO_Points)
+   procedure Power_Up (Points : GPIO_Points)
      with Inline;
-
 
    procedure Reset (This : aliased in out GPIO_Port)
      with Inline;
@@ -331,7 +330,7 @@ package STM32.Device is
    --  voltage is the raw conversion value * the divisor. See section 13.11,
    --  pg 412 of the RM.
 
-   procedure Enable_Clock (This : aliased in out Analog_To_Digital_Converter);
+   procedure Power_Up (This : aliased in out Analog_To_Digital_Converter);
 
    procedure Reset_All_ADC_Units;
 
@@ -340,7 +339,7 @@ package STM32.Device is
    DAC_Channel_1_IO : GPIO_Point renames PA4;
    DAC_Channel_2_IO : GPIO_Point renames PA5;
 
-   procedure Enable_Clock (This : aliased in out Digital_To_Analog_Converter);
+   procedure Power_Up (This : aliased in out Digital_To_Analog_Converter);
 
    procedure Reset (This : aliased in out Digital_To_Analog_Converter);
 
@@ -362,14 +361,14 @@ package STM32.Device is
    UART_7  : aliased USART (Internal_UART_7'Access);
    UART_8  : aliased USART (Internal_UART_8'Access);
 
-   procedure Enable_Clock (This : aliased in out USART);
+   procedure Power_Up (This : aliased in out USART);
 
    procedure Reset (This : aliased in out USART);
 
    DMA_1 : aliased DMA_Controller with Import, Volatile, Address => DMA1_Base;
    DMA_2 : aliased DMA_Controller with Import, Volatile, Address => DMA2_Base;
 
-   procedure Enable_Clock (This : aliased in out DMA_Controller);
+   procedure Power_Up (This : aliased in out DMA_Controller);
    procedure Reset (This : aliased in out DMA_Controller);
 
    Internal_I2C_Port_1 : aliased Internal_I2C_Port with Import, Volatile, Address => I2C1_Base;
@@ -384,8 +383,8 @@ package STM32.Device is
 
    function As_Port_Id (Port : I2C_Port) return I2C_Port_Id with Inline;
 
-   procedure Enable_Clock (This : I2C_Port);
-   procedure Enable_Clock (This : I2C_Port_Id);
+   procedure Power_Up (This : I2C_Port);
+   procedure Power_Up (This : I2C_Port_Id);
 
    procedure Reset (This : I2C_Port);
    procedure Reset (This : I2C_Port_Id);
@@ -404,7 +403,7 @@ package STM32.Device is
    SPI_5 : aliased SPI_Port (Internal_SPI_5'Access);
    SPI_6 : aliased SPI_Port (Internal_SPI_6'Access);
 
-   procedure Enable_Clock (This : SPI_Port);
+   procedure Power_Up (This : SPI_Port);
    procedure Reset (This : SPI_Port);
 
    Timer_1  : aliased Timer with Import, Volatile, Address => TIM1_Base;
@@ -422,7 +421,7 @@ package STM32.Device is
    Timer_13 : aliased Timer with Import, Volatile, Address => TIM13_Base;
    Timer_14 : aliased Timer with Import, Volatile, Address => TIM14_Base;
 
-   procedure Enable_Clock (This : in out Timer);
+   procedure Power_Up (This : in out Timer);
 
    procedure Reset (This : in out Timer);
 
@@ -459,7 +458,7 @@ package STM32.Device is
 
    function PLLSAI_Ready return Boolean;
 
-   procedure Enable_DCMI_Clock;
+   procedure Power_Up_DCMI;
 
    procedure Reset_DCMI;
 

--- a/ARM/STM32/drivers/stm32-pwm.adb
+++ b/ARM/STM32/drivers/stm32-pwm.adb
@@ -125,7 +125,7 @@ package body STM32.PWM is
    is
       Prescalar : UInt32;
    begin
-      Enable_Clock (This.Output_Timer.all);
+      Power_Up (This.Output_Timer.all);
 
       Compute_Prescalar_and_Period
         (This.Output_Timer,
@@ -172,7 +172,7 @@ package body STM32.PWM is
       Modulator.Timer   := This;
       Modulator.Channel := Channel;
 
-      Enable_Clock (Point);
+      Power_Up (Point);
 
       Configure_PWM_GPIO (Point, PWM_AF);
 

--- a/boards/stm32_common/sdram/stm32-sdram.adb
+++ b/boards/stm32_common/sdram/stm32-sdram.adb
@@ -25,7 +25,7 @@ package body STM32.SDRAM is
    procedure SDRAM_GPIOConfig
    is
    begin
-      Enable_Clock (SDRAM_PINS);
+      Power_Up (SDRAM_PINS);
 
       Configure_IO (SDRAM_PINS,
                     (Speed       => Speed_50MHz,

--- a/boards/stm32_common/stm32-button.adb
+++ b/boards/stm32_common/stm32-button.adb
@@ -117,7 +117,7 @@ package body STM32.Button is
 
    procedure Initialize (Use_Rising_Edge : Boolean := True) is
    begin
-      Enable_Clock (User_Button_Point);
+      Power_Up (User_Button_Point);
 
       User_Button_Point.Configure_IO
         ((Mode        => Mode_In,

--- a/boards/stm32f429_discovery/src/framebuffer_ili9341.adb
+++ b/boards/stm32f429_discovery/src/framebuffer_ili9341.adb
@@ -28,8 +28,8 @@ package body Framebuffer_ILI9341 is
                    (SPI5_SCK, SPI5_MOSI, SPI5_MISO);
 
    begin
-      Enable_Clock (SPI_Pins);
-      Enable_Clock (LCD_SPI);
+      Power_Up (SPI_Pins);
+      Power_Up (LCD_SPI);
 
       Conf.Speed       := Speed_100MHz;
       Conf.Mode        := Mode_AF;
@@ -63,8 +63,8 @@ package body Framebuffer_ILI9341 is
 
    procedure LCD_Pins_Init is
    begin
-      Enable_Clock (GPIO_Points'(LCD_RESET, LCD_CSX, LCD_WRX_DCX));
-      Enable_Clock (LCD_PINS);
+      Power_Up (GPIO_Points'(LCD_RESET, LCD_CSX, LCD_WRX_DCX));
+      Power_Up (LCD_PINS);
 
       Configure_IO
         (Points => (LCD_RESET, LCD_CSX, LCD_WRX_DCX),

--- a/boards/stm32f429_discovery/src/stm32-board.adb
+++ b/boards/stm32f429_discovery/src/stm32-board.adb
@@ -70,7 +70,7 @@ package body STM32.Board is
    procedure Initialize_LEDs is
       Conf : GPIO_Port_Configuration;
    begin
-      Enable_Clock (All_LEDs);
+      Power_Up (All_LEDs);
 
       Conf.Mode        := Mode_Out;
       Conf.Output_Type := Push_Pull;
@@ -87,8 +87,8 @@ package body STM32.Board is
    procedure Initialize_Gyro_IO is
       --  See the STM32F429 Discovery kit User Manual (UM1670) pages 21 and 23.
    begin
-      Enable_Clock (Gyro_SPI);
-      Enable_Clock (NCS_MEMS_SPI & SPI5_SCK & SPI5_MISO & SPI5_MOSI);
+      Power_Up (Gyro_SPI);
+      Power_Up (NCS_MEMS_SPI & SPI5_SCK & SPI5_MISO & SPI5_MOSI);
 
       Init_Chip_Select : declare
          Config : GPIO_Port_Configuration;
@@ -151,7 +151,7 @@ package body STM32.Board is
    procedure Configure_User_Button_GPIO is
       Config : GPIO_Port_Configuration;
    begin
-      Enable_Clock (User_Button_Point);
+      Power_Up (User_Button_Point);
 
       Config.Mode := Mode_In;
       Config.Resistors := Floating;

--- a/boards/stm32f429_discovery/src/touch_panel_stmpe811.adb
+++ b/boards/stm32f429_discovery/src/touch_panel_stmpe811.adb
@@ -72,9 +72,9 @@ package body Touch_Panel_STMPE811 is
    procedure TP_Ctrl_Lines is
       GPIO_Conf : GPIO_Port_Configuration;
    begin
-      Enable_Clock (GPIO_Points'(SDA, SCL));
+      Power_Up (GPIO_Points'(SDA, SCL));
 
-      Enable_Clock (TP_I2C);
+      Power_Up (TP_I2C);
 
       SCL.Configure_Alternate_Function (SCL_AF);
       SDA.Configure_Alternate_Function (SDA_AF);


### PR DESCRIPTION
Even if the name Enable_Clock is accurate with regards to the
documentation and the internal behavior of the MCU, it is not clear at
all from a user point of view.

This patches use the name Power_Up which describes better the actual use
a these procedures.

Note: This is a partial commit to propose the idea. If it is well
received I will rename the remaining Enable_Clock.