### PR TITLE
Make PWM abstract type simpler and more robust. Add additional new demo for PWM ADT.

### DIFF
--- a/ARM/STM32/driver_demos/demo_timer_pwm/demo_timer_pwm.gpr
+++ b/ARM/STM32/driver_demos/demo_timer_pwm/demo_timer_pwm.gpr
@@ -1,15 +1,16 @@
-with "../../../../config.gpr";
-with "../../../../boards/stm32f4_discovery.gpr";
+--  with "../../../../config.gpr";
+with "../../../../boards/stm32f407_discovery.gpr";
 
 project Demo_Timer_PWM extends "../../../../examples/common/common.gpr" is
 
    for Languages use ("Ada");
-   for Main use ("demo.adb");
+   for Main use ("demo.adb", "demo_pwm_adt");
    for Source_Dirs use ("src");
    for Object_Dir use "obj";
+   for Create_Missing_Dirs use "true";
 
-   for Runtime ("Ada") use Config.RTS & "-stm32f4";
- 
+   for Runtime ("Ada") use STM32F407_Discovery'Runtime("Ada");
+
    package Builder is
       for Global_Configuration_Pragmas use "gnat.adc";
    end Builder;

--- a/ARM/STM32/drivers/stm32-pwm.ads
+++ b/ARM/STM32/drivers/stm32-pwm.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                 Copyright (C) 2015-2016, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -34,23 +34,29 @@
 
 --  Example use, with arbitrary hardware selections:
 
---     Timer  : aliased PWM_Timer (Timer_4'Access);
---     Output : PWM_Modulator;
+--     PWM_Timer : STM32.Timers.Timer renames Timer_4;
 --
---     Initialize_PWM_Timer
---       (Timer,
---        Requested_Frequency    => 30_000.0,
+--     Requested_Frequency : constant Hertz := 30_000;  -- arbitrary
+--
+--     Power_Control : PWM_Modulator;
+--
+--     ...
+--
+--     Initialize_PWM_Modulator
+--       (Power_Control,
+--        Generator => PWM_Timer'Access,
+--        Frequency => Requested_Frequency,
+--        Configure_Generator => True);
 --
 --     Attach_PWM_Channel
---       (Timer'Access,
---        Output,
---        Channel_2,
---        (GPIO_D'Access, Pin_13),  -- must match selected channel
---        PWM_AF                 => GPIO_AF_TIM4);
+--       (Power_Control,
+--        Output_Channel,
+--        LED_For (Output_Channel),
+--        GPIO_AF_2_TIM4);
 --
---     Enable_PWM_Channel (Output, Channel_2);
+--     Enable_PWM (Power_Control);
 --
---     Set_Duty_Cycle (Output, Channel_2, Value);
+--     Set_Duty_Cycle (Power_Control, Value);
 
 with STM32.GPIO;   use STM32.GPIO;
 with STM32.Timers; use STM32.Timers;
@@ -58,40 +64,47 @@ with STM32.Timers; use STM32.Timers;
 package STM32.PWM is
    pragma Elaborate_Body;
 
-   type PWM_Timer
-     (Output_Timer : not null access STM32.Timers.Timer) is limited private;
-
-   procedure Initialise_PWM_Timer
-     (This                   : in out PWM_Timer;
-      Requested_Frequency    : Float);
-   --  Initializes the specified timer for PWM generation at the requested
-   --  frequency. You must attach at least one channel to the modulator in
-   --  order to drive PWM output values.
-
    type PWM_Modulator is limited private;
 
+   subtype Hertz is UInt32;
+
+   procedure Initialize_PWM_Modulator
+     (This                : in out PWM_Modulator;
+      Generator           : not null access STM32.Timers.Timer;
+      Frequency           : Hertz;
+      Configure_Generator : Boolean := True);
+   --  Initializes the PWM modulator. To be called at least once per
+   --  PWM_Modulator object, before any other use of the given modulator. Can
+   --  be called more than once in case the user wants to tie the modulator to
+   --  a different timer.
+   --
+   --  Frequency is that value intended for the underlying timer. To be
+   --  specified regardless of whether Configure_Generator is True.
+   --
+   --  If Configure_Generator is True, the Generator timer hardware will be
+   --  configured for PWM generation with the specified frequency. For any
+   --  given timer, this configuration need only be done once, unless a
+   --  different frequency is required for some reason.
+
    procedure Attach_PWM_Channel
-     (This      : access PWM_Timer;
-      Modulator : in out PWM_Modulator;
-      Channel   : Timer_Channel;
-      Point     : GPIO_Point;
-      PWM_AF    : GPIO_Alternate_Function)
-     with Post => Attached (Modulator) and
-                  not Enabled (Modulator) and
-                  Current_Duty_Cycle (Modulator) = 0;
-   --  Initializes the channel on the timer associated with This, and the
-   --  corresponding GPIO port/pin pair, for PWM output. May be called multiple
-   --  times for the same PWM_Modulator object, with different channels,
-   --  because the corresponding timer can drive multiple channels (assuming
-   --  such a timer is in use).
+     (This    : in out PWM_Modulator;
+      Channel : Timer_Channel;
+      Point   : GPIO_Point;
+      PWM_AF  : GPIO_Alternate_Function)
+     with Post => not Enabled (This) and
+                  Current_Duty_Cycle (This) = 0;
+   --  Initializes the channel on the timer associated with This modulator,
+   --  and the corresponding GPIO port/pin pair, for PWM output.
+   --
+   --  To be called at least once. May Be called multiple times for the same
+   --  PWM_Modulator object, with different channels, because the corresponding
+   --  timer can drive multiple channels (assuming such a timer is in use).
 
    procedure Enable_PWM
      (This : in out PWM_Modulator)
      with Post => Enabled (This);
 
-   function Enabled
-     (This : PWM_Modulator)
-      return Boolean;
+   function Enabled (This : PWM_Modulator) return Boolean;
 
    procedure Disable_PWM
      (This : in out PWM_Modulator)
@@ -104,13 +117,11 @@ package STM32.PWM is
       Value : Percentage)
      with
        Inline,
-       Pre  => (Attached (This) or else raise Not_Attached),
        Post => Current_Duty_Cycle (This) = Value;
    --  Sets the pulse width such that the requested percentage is achieved.
 
    function Current_Duty_Cycle (This : PWM_Modulator) return Percentage
-     with Inline,
-          Pre => Attached (This) or else raise Not_Attached;
+     with Inline;
 
    subtype Microseconds is UInt32;
 
@@ -118,48 +129,39 @@ package STM32.PWM is
      (This  : in out PWM_Modulator;
       Value : Microseconds)
      with
-       Inline,
-       Pre => (Attached (This) or else raise Not_Attached);
+       Inline;
    --  Set the pulse width such that the requested number of microseconds is
    --  achieved. Raises Invalid_Request if the requested time is greater than
-   --  the period previously configured via Initialise_PWM_Modulator.
+   --  the period previously configured via Configure_PWM_Timer.
 
    Invalid_Request : exception;
    --  Raised when the requested frequency is too high or too low for the given
-   --  timer and system clocks when calling Initialize_PWM_Modulator, or when
+   --  timer and system clocks when calling Configure_PWM_Timer, or when
    --  the requested time is too high for the specified frequency when calling
    --  Set_Duty_Time
 
    Unknown_Timer : exception;
-   --  Raised if a timer that is not physically present is passed to
-   --  Initialize_PWM_Modulator
-
-   Not_Attached : exception;
-
-   function Attached
-     (This    : PWM_Modulator)
-      return Boolean;
+   --  Raised if a timer that is not known to the package is passed to
+   --  Configure_PWM_Timer
 
 private
 
-   type PWM_Output is record
-      Duty_Cycle : Percentage := 0;
-      Attached   : Boolean := False;
-   end record;
-
-   type PWM_Outputs is array (Timer_Channel) of PWM_Output;
-
-   type PWM_Timer
-     (Output_Timer : not null access STM32.Timers.Timer)
-   is record
-      Outputs      : PWM_Outputs;
+   type PWM_Modulator is record
+      Generator    : access STM32.Timers.Timer;
       Timer_Period : UInt32;
       Frequency    : UInt32;
+      Duty_Cycle   : Percentage := 0;
+      Channel      : Timer_Channel;
    end record;
 
-   type PWM_Modulator is record
-      Timer   : access PWM_Timer;
-      Channel : Timer_Channel;
-   end record;
+   procedure Configure_PWM_Timer
+     (This                : not null access STM32.Timers.Timer;
+      Requested_Frequency : Hertz;
+      Computed_Period     : out UInt32);
+   --  Configures the specified timer hardware for PWM generation at the
+   --  requested frequency. Computes the period required for the requested
+   --  frequency. This is a separate procedure, distinct from the
+   --  initialization for objects of type PWM_Modulator, because a timer can
+   --  be used by several modulator objects.
 
 end STM32.PWM;

--- a/boards/OpenMV2/src/openmv-sensor.adb
+++ b/boards/OpenMV2/src/openmv-sensor.adb
@@ -6,6 +6,7 @@ with Interfaces;    use Interfaces;
 with HAL.I2C;       use HAL.I2C;
 with HAL.Bitmap;    use HAL.Bitmap;
 with HAL;           use HAL;
+with STM32.PWM;     use STM32.PWM;
 
 package body OpenMV.Sensor is
 
@@ -62,14 +63,16 @@ package body OpenMV.Sensor is
 
       procedure Initialize_Clock is
       begin
-         Initialise_PWM_Timer (SENSOR_CLK_TIM,
-                               Float (SENSOR_CLK_FREQ));
+         Initialize_PWM_Modulator
+           (This                => CLK_PWM_Mod,
+            Generator           => SENSOR_CLK_TIM'Access,
+            Frequency           => SENSOR_CLK_FREQ,
+            Configure_Generator => True);
 
-         Attach_PWM_Channel (This      => SENSOR_CLK_TIM'Access,
-                             Modulator => CLK_PWM_Mod,
-                             Channel   => SENSOR_CLK_CHAN,
-                             Point     => SENSOR_CLK_IO,
-                             PWM_AF    => SENSOR_CLK_AF);
+         Attach_PWM_Channel (This    => CLK_PWM_Mod,
+                             Channel => SENSOR_CLK_CHAN,
+                             Point   => SENSOR_CLK_IO,
+                             PWM_AF  => SENSOR_CLK_AF);
 
          Set_Duty_Cycle (This    => CLK_PWM_Mod,
                          Value   => 50);

--- a/boards/OpenMV2/src/openmv.ads
+++ b/boards/OpenMV2/src/openmv.ads
@@ -7,7 +7,6 @@ with STM32.Timers; use STM32.Timers;
 with STM32.DMA;
 with STM32.I2C; use STM32.I2C;
 with STM32.USARTs; use STM32.USARTs;
-with STM32.PWM; use STM32.PWM;
 
 with HAL.UART;
 
@@ -144,7 +143,7 @@ private
 
    SENSOR_CLK_IO   : GPIO_Point renames PA8;
    SENSOR_CLK_AF   : GPIO_Alternate_Function renames GPIO_AF_1_TIM1;
-   SENSOR_CLK_TIM  : aliased PWM_Timer (Timer_1'Access);
+   SENSOR_CLK_TIM  : STM32.Timers.Timer renames Timer_1;
    SENSOR_CLK_CHAN : constant Timer_Channel := Channel_1;
    SENSOR_CLK_FREQ : constant := 12_000_000;
 


### PR DESCRIPTION
Timers can still be shared among modulator objects.
Add new demo for using the abstraction (in addition to existing demo that used the timer directly).