### PR TITLE
MCP23x008: Move the IO primitives to the private part of the specs

### DIFF
--- a/components/src/io_expander/MCP23xxx/mcp23x08-i2c.adb
+++ b/components/src/io_expander/MCP23xxx/mcp23x08-i2c.adb
@@ -31,7 +31,7 @@
 
 with HAL.I2C; use HAL.I2C;
 
-package body MCP23008 is
+package body MCP23x08.I2C is
 
    --------------
    -- IO_Write --
@@ -39,7 +39,7 @@ package body MCP23008 is
 
    overriding
    procedure IO_Write
-     (This      : in out MCP23008_Device;
+     (This      : in out MCP23008_IO_Expander;
       WriteAddr : Register_Address;
       Value     : Byte)
    is
@@ -65,7 +65,7 @@ package body MCP23008 is
 
    overriding
    procedure IO_Read
-     (This     : MCP23008_Device;
+     (This     : MCP23008_IO_Expander;
       ReadAddr : Register_Address;
       Value    : out Byte)
    is
@@ -88,4 +88,4 @@ package body MCP23008 is
       Value := Ret (1);
    end IO_Read;
 
-end MCP23008;
+end MCP23x08.I2C;

--- a/components/src/io_expander/MCP23xxx/mcp23x08-i2c.ads
+++ b/components/src/io_expander/MCP23xxx/mcp23x08-i2c.ads
@@ -29,7 +29,31 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with MCP23x08.I2C;
+with HAL.I2C;
 
-package MCP23008 renames MCP23x08.I2C;
+package MCP23x08.I2C is
 
+   type MCP23008_IO_Expander (Port : HAL.I2C.I2C_Port_Ref;
+                         Addr : UInt3) is
+     new MCP23x08_IO_Expander with private;
+
+private
+
+   type MCP23008_IO_Expander (Port : HAL.I2C.I2C_Port_Ref;
+                         Addr : UInt3) is
+     new MCP23x08_IO_Expander with null record;
+
+   overriding
+   procedure IO_Write
+     (This      : in out MCP23008_IO_Expander;
+      WriteAddr : Register_Address;
+      Value     : Byte);
+
+   overriding
+   procedure IO_Read
+     (This     : MCP23008_IO_Expander;
+      ReadAddr : Register_Address;
+      Value    : out Byte);
+
+   BASE_ADDRESS : constant HAL.I2C.I2C_Address := 16#40#;
+end MCP23x08.I2C;

--- a/components/src/io_expander/MCP23xxx/mcp23x08.adb
+++ b/components/src/io_expander/MCP23xxx/mcp23x08.adb
@@ -41,24 +41,24 @@ package body MCP23x08 is
       new Ada.Unchecked_Conversion (Source => Byte,
                                     Target => ALl_IO_Array);
    procedure Loc_IO_Write
-     (This      : in out MCP23x08_Device;
+     (This      : in out MCP23x08_IO_Expander'Class;
       WriteAddr : Register_Address;
       Value     : Byte)
      with Inline_Always;
 
    procedure Loc_IO_Read
-     (This     : MCP23x08_Device;
+     (This     : MCP23x08_IO_Expander'Class;
       ReadAddr : Register_Address;
       Value    : out Byte)
      with Inline_Always;
 
    procedure Set_Bit
-     (This     : in out MCP23x08_Device;
+     (This     : in out MCP23x08_IO_Expander;
       RegAddr  : Register_Address;
       Pin      : MCP23x08_Pin);
 
    procedure Clear_Bit
-     (This     : in out MCP23x08_Device;
+     (This     : in out MCP23x08_IO_Expander;
       RegAddr  : Register_Address;
       Pin      : MCP23x08_Pin);
 
@@ -67,15 +67,13 @@ package body MCP23x08 is
    ------------------
 
    procedure Loc_IO_Write
-     (This      : in out MCP23x08_Device;
+     (This      : in out MCP23x08_IO_Expander'Class;
       WriteAddr : Register_Address;
       Value     : Byte)
    is
 
    begin
-      IO_Write (MCP23x08_Device'Class (This),
-                WriteAddr,
-                Value);
+      IO_Write (This, WriteAddr, Value);
    end Loc_IO_Write;
 
    -----------------
@@ -83,14 +81,12 @@ package body MCP23x08 is
    -----------------
 
    procedure Loc_IO_Read
-     (This     : MCP23x08_Device;
+     (This     : MCP23x08_IO_Expander'Class;
       ReadAddr : Register_Address;
       Value    : out Byte)
       is
    begin
-      IO_Read (MCP23x08_Device'Class (This),
-               ReadAddr,
-               Value);
+      IO_Read (This, ReadAddr, Value);
    end Loc_IO_Read;
 
    -------------
@@ -98,7 +94,7 @@ package body MCP23x08 is
    -------------
 
    procedure Set_Bit
-     (This     : in out MCP23x08_Device;
+     (This     : in out MCP23x08_IO_Expander;
       RegAddr  : Register_Address;
       Pin      : MCP23x08_Pin)
    is
@@ -116,7 +112,7 @@ package body MCP23x08 is
    ---------------
 
    procedure Clear_Bit
-     (This     : in out MCP23x08_Device;
+     (This     : in out MCP23x08_IO_Expander;
       RegAddr : Register_Address;
       Pin      : MCP23x08_Pin)
    is
@@ -133,7 +129,7 @@ package body MCP23x08 is
    -- Configure --
    ---------------
 
-   procedure Configure (This    : in out MCP23x08_Device;
+   procedure Configure (This    : in out MCP23x08_IO_Expander;
                         Pin     : MCP23x08_Pin;
                         Output  : Boolean;
                         Pull_Up : Boolean)
@@ -156,7 +152,7 @@ package body MCP23x08 is
    -- Set --
    ---------
 
-   function Set (This  : MCP23x08_Device;
+   function Set (This  : MCP23x08_IO_Expander;
                  Pin   : MCP23x08_Pin) return Boolean
    is
       Val : Byte;
@@ -169,7 +165,7 @@ package body MCP23x08 is
    -- Set --
    ---------
 
-   procedure Set (This  : in out MCP23x08_Device;
+   procedure Set (This  : in out MCP23x08_IO_Expander;
                   Pin   : MCP23x08_Pin)
    is
    begin
@@ -180,7 +176,7 @@ package body MCP23x08 is
    -- Clear --
    -----------
 
-   procedure Clear (This  : in out MCP23x08_Device;
+   procedure Clear (This  : in out MCP23x08_IO_Expander;
                     Pin   : MCP23x08_Pin)
    is
    begin
@@ -191,7 +187,7 @@ package body MCP23x08 is
    -- Toggle --
    ------------
 
-   procedure Toggle (This  : in out MCP23x08_Device;
+   procedure Toggle (This  : in out MCP23x08_IO_Expander;
                      Pin   : MCP23x08_Pin)
    is
    begin
@@ -202,31 +198,31 @@ package body MCP23x08 is
       end if;
    end Toggle;
 
-   ----------------
-   -- Get_All_IO --
-   ----------------
+   ------------
+   -- All_IO --
+   ------------
 
-   function Get_All_IO (This : in out MCP23x08_Device) return ALl_IO_Array is
+   function All_IO (This : in out MCP23x08_IO_Expander) return ALl_IO_Array is
       Val : Byte;
    begin
       Loc_IO_Read (This, LOGIC_LEVLEL_REG, Val);
       return To_All_IO_Array (Val);
-   end Get_All_IO;
+   end All_IO;
 
    ----------------
    -- Set_All_IO --
    ----------------
 
-   procedure Set_All_IO (This : in out MCP23x08_Device; IOs : ALl_IO_Array) is
+   procedure Set_All_IO (This : in out MCP23x08_IO_Expander; IOs : ALl_IO_Array) is
    begin
       Loc_IO_Write (This, LOGIC_LEVLEL_REG, To_Byte (IOs));
    end Set_All_IO;
 
-   --------------------
-   -- Get_GPIO_Point --
-   --------------------
+   -------------------
+   -- As_GPIO_Point --
+   -------------------
 
-   function Get_GPIO_Point (This : in out MCP23x08_Device;
+   function As_GPIO_Point (This : in out MCP23x08_IO_Expander;
                             Pin  : MCP23x08_Pin)
                             return not null HAL.GPIO.GPIO_Point_Ref
    is
@@ -234,7 +230,7 @@ package body MCP23x08 is
       This.Points (Pin) := (Device => This'Unchecked_Access,
                             Pin    => Pin);
       return This.Points (Pin)'Unchecked_Access;
-   end Get_GPIO_Point;
+   end As_GPIO_Point;
 
    ---------
    -- Set --


### PR DESCRIPTION
And implement MCP23003 (I2C version) in a child package: MCP23x008.I2C.