### PR TITLE
Fix improper link in README.md and formatting issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,6 @@ GitHub page.
  * [Giza: Giza is trying to be a simple widget tool kit for embedded platforms](https://github.com/Fabien-Chouteau/Giza)
  * [solenoid-engine-controller: Software controller for solenoid engines](https://github.com/Fabien-Chouteau/solenoid-engine-controller)
  * [un_pola: DIY instant camera with OpenMV](https://github.com/Fabien-Chouteau/un_pola)
- * [bare metal demos: Various Ada Demos on STM32*-Disco boards using this library](https://github.com/lambourg/Ada_Drivers_Library.git) 
+ * [bare metal demos: Various Ada Demos on STM32*-Disco boards using this library](https://github.com/lambourg/Ada_Bare_Metal_Demos)
+
 (Add yours to the list!)


### PR DESCRIPTION
The link to the Bare Metal demo is incorrect, and there's a glitch in the list of external projects formatting