### PR TITLE
Change name of user button package 

### DIFF
--- a/ARM/STM32/drivers/stm32-gpio.adb
+++ b/ARM/STM32/drivers/stm32-gpio.adb
@@ -319,16 +319,16 @@ package body STM32.GPIO is
       end loop;
    end Configure_Alternate_Function;
 
-   -------------------------------
-   -- Get_Interrupt_Line_Number --
-   -------------------------------
+   ---------------------------
+   -- Interrupt_Line_Number --
+   ---------------------------
 
-   function Get_Interrupt_Line_Number
+   function Interrupt_Line_Number
      (This : GPIO_Point) return EXTI.External_Line_Number
    is
    begin
       return EXTI.External_Line_Number'Val (This.Pin);
-   end Get_Interrupt_Line_Number;
+   end Interrupt_Line_Number;
 
    -----------------------
    -- Configure_Trigger --
@@ -339,8 +339,7 @@ package body STM32.GPIO is
       Trigger : EXTI.External_Triggers)
    is
       use STM32.EXTI;
-      Line : constant External_Line_Number :=
-        External_Line_Number'Val (This.Pin);
+      Line : constant External_Line_Number := External_Line_Number'Val (This.Pin);
       use STM32.SYSCFG, STM32.RCC;
    begin
       SYSCFG_Clock_Enable;

--- a/ARM/STM32/drivers/stm32-gpio.ads
+++ b/ARM/STM32/drivers/stm32-gpio.ads
@@ -172,7 +172,7 @@ package STM32.GPIO is
    --  For Point.Pin on the Point.Port.all, configures the
    --  characteristics specified by Config
 
-   function Get_Interrupt_Line_Number
+   function Interrupt_Line_Number
      (This : GPIO_Point) return EXTI.External_Line_Number;
    --  Returns the external interrupt line number that corresponds to the
    --  GPIO point.

--- a/boards/stm32_common/stm32-user_button.ads
+++ b/boards/stm32_common/stm32-user_button.ads
@@ -33,7 +33,7 @@
 --  on many (most) STM boards. It uses an interrupt handler to track presses,
 --  reflected in the result of calling function Has_Been_Pressed.
 
-package STM32.Button is
+package STM32.User_Button is
 
    procedure Initialize (Use_Rising_Edge : Boolean := True) with
      Pre  => not Initialized,
@@ -41,7 +41,9 @@ package STM32.Button is
 
    function Has_Been_Pressed return Boolean with
      Pre => Initialized;
+   --  Returns whether the user button has been pressed since the last time
+   --  this subprogram was called.
 
    function Initialized return Boolean;
 
-end STM32.Button;
+end STM32.User_Button;

--- a/examples/draw/src/draw.adb
+++ b/examples/draw/src/draw.adb
@@ -40,7 +40,7 @@ with Last_Chance_Handler;  pragma Unreferenced (Last_Chance_Handler);
 with STM32.Board;           use STM32.Board;
 with HAL.Bitmap;            use HAL.Bitmap;
 with HAL.Touch_Panel;       use HAL.Touch_Panel;
-with STM32.Button;
+with STM32.User_Button;     use STM32;
 
 with Bitmapped_Drawing;     use Bitmapped_Drawing;
 
@@ -70,7 +70,7 @@ begin
    Touch_Panel.Initialize;
 
    --  Initialize button
-   STM32.Button.Initialize;
+   User_Button.Initialize;
 
    --  Clear LCD (set background)
    Clear;
@@ -78,7 +78,7 @@ begin
    --  The application: set pixel where the finger is (so that you
    --  cannot see what you are drawing).
    loop
-      if STM32.Button.Has_Been_Pressed then
+      if User_Button.Has_Been_Pressed then
          Clear;
       end if;
 

--- a/examples/hello_world_tasking/src/driver.adb
+++ b/examples/hello_world_tasking/src/driver.adb
@@ -29,9 +29,11 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with STM32.Board;   use STM32.Board;
-with STM32.Button;  use STM32.Button;
-with Ada.Real_Time; use Ada.Real_Time;
+with STM32.Board;       use STM32.Board;
+with STM32.User_Button; use STM32.User_Button;
+with Ada.Real_Time;     use Ada.Real_Time;
+
+use STM32;
 
 package body Driver is
 
@@ -51,25 +53,25 @@ package body Driver is
    begin
       Initialize_LEDs;
       All_LEDs_Off;
-      STM32.Button.Initialize;
+      User_Button.Initialize;
 
       loop
-            Turn_Off (Pattern (Next_LED));
+         Turn_Off (Pattern (Next_LED));
 
-            if STM32.Button.Has_Been_Pressed then
-               Clockwise := not Clockwise;
-            end if;
+         if User_Button.Has_Been_Pressed then
+            Clockwise := not Clockwise;
+         end if;
 
-            if Clockwise then
-               Next_LED := Next_LED + 1;
-            else
-               Next_LED := Next_LED - 1;
-            end if;
+         if Clockwise then
+            Next_LED := Next_LED + 1;
+         else
+            Next_LED := Next_LED - 1;
+         end if;
 
-            Turn_On (Pattern (Next_LED));
+         Turn_On (Pattern (Next_LED));
 
-            Next_Release := Next_Release + Period;
-            delay until Next_Release;
+         Next_Release := Next_Release + Period;
+         delay until Next_Release;
       end loop;
    end Controller;
 


### PR DESCRIPTION
To reflect that it is not a general user-defined button. Misc readability name changes and formatting.
Update examples applying the user button for package name change.

Change name of GPIO function returning the external interrupt line number.