### PR TITLE
Unify access to classwide type names

### DIFF
--- a/ARM/cortex_m/src/semihosting-filesystem.adb
+++ b/ARM/cortex_m/src/semihosting-filesystem.adb
@@ -126,7 +126,7 @@ package body Semihosting.Filesystem is
      (This    : in out SHFS;
       Path    : Pathname;
       Mode    : File_Mode;
-      Handler : out File_Handle_Ref)
+      Handler : out Any_File_Handle)
       return Status_Kind
    is
       FH : SHFS_File_Handle_Access;
@@ -149,7 +149,7 @@ package body Semihosting.Filesystem is
          FH := This.Get_File_Handle;
          FH.FD := FD;
          FH.Is_Open := True;
-         Handler := File_Handle_Ref (FH);
+         Handler := Any_File_Handle (FH);
          return Status_Ok;
       end if;
    end Open;
@@ -161,7 +161,7 @@ package body Semihosting.Filesystem is
    overriding function Open_Directory
      (This   : in out SHFS;
       Path   : Pathname;
-      Handle : out Directory_Handle_Ref)
+      Handle : out Any_Directory_Handle)
       return Status_Kind
    is
       pragma Unreferenced (This, Path, Handle);

--- a/ARM/cortex_m/src/semihosting-filesystem.ads
+++ b/ARM/cortex_m/src/semihosting-filesystem.ads
@@ -35,7 +35,7 @@ with HAL; use HAL;
 package Semihosting.Filesystem is
 
    type SHFS is new HAL.Filesystem.FS_Driver with private;
-   type SHFS_Ref is access all SHFS'Class;
+   type Any_SHFS is access all SHFS'Class;
 
    -------------------------------
    --  FS_Driver implementation --
@@ -78,13 +78,13 @@ package Semihosting.Filesystem is
    function Open (This    : in out SHFS;
                   Path    : Pathname;
                   Mode    : File_Mode;
-                  Handler : out File_Handle_Ref)
+                  Handler : out Any_File_Handle)
                   return Status_Kind;
 
    overriding
    function Open_Directory (This   : in out SHFS;
                             Path   : Pathname;
-                            Handle : out Directory_Handle_Ref)
+                            Handle : out Any_Directory_Handle)
                             return Status_Kind;
 private
 

--- a/boards/OpenMV2/src/openmv.adb
+++ b/boards/OpenMV2/src/openmv.adb
@@ -172,7 +172,7 @@ package body OpenMV is
    -- Get_Shield_USART --
    ----------------------
 
-   function Get_Shield_USART return not null HAL.UART.UART_Port_Ref is
+   function Get_Shield_USART return not null HAL.UART.Any_UART_Port is
       (USART_3'Access);
 
 end OpenMV;

--- a/boards/OpenMV2/src/openmv.ads
+++ b/boards/OpenMV2/src/openmv.ads
@@ -70,7 +70,7 @@ package OpenMV is
    procedure Initialize_Shield_USART (Baud : STM32.USARTs.Baud_Rates);
    --  Initialize the USART port available for shields (USART3)
 
-   function Get_Shield_USART return not null HAL.UART.UART_Port_Ref;
+   function Get_Shield_USART return not null HAL.UART.Any_UART_Port;
    --  Get the USART port available for shields (USART3)
 
    Shield_MOSI  : GPIO_Point renames PB15;

--- a/boards/stm32f469_discovery/src/audio.ads
+++ b/boards/stm32f469_discovery/src/audio.ads
@@ -40,7 +40,7 @@ private with CS43L22;
 
 package Audio is
 
-   type CS43L22_Audio_Device (Port : not null I2C_Port_Ref) is limited
+   type CS43L22_Audio_Device (Port : not null Any_I2C_Port) is limited
      new HAL.Audio.Audio_Device with private;
 
    overriding procedure Initialize_Audio_Out
@@ -71,7 +71,7 @@ package Audio is
 
 private
 
-   type CS43L22_Audio_Device (Port : not null I2C_Port_Ref) is limited
+   type CS43L22_Audio_Device (Port : not null Any_I2C_Port) is limited
    new HAL.Audio.Audio_Device with record
       Device : CS43L22.CS43L22_Device (Port, Ravenscar_Time.Delays);
    end record;

--- a/boards/stm32f746_discovery/src/audio.ads
+++ b/boards/stm32f746_discovery/src/audio.ads
@@ -40,7 +40,7 @@ private with WM8994;
 
 package Audio is
 
-   type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is limited new
+   type WM8994_Audio_Device (Port : not null Any_I2C_Port) is limited new
      Audio_Device with private;
 
    overriding procedure Initialize_Audio_Out
@@ -73,7 +73,7 @@ private
 
    Audio_I2C_Addr  : constant I2C_Address := 16#34#;
 
-   type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is limited new
+   type WM8994_Audio_Device (Port : not null Any_I2C_Port) is limited new
      Audio_Device with record
       Device : WM8994.WM8994_Device (Port, Audio_I2C_Addr, Ravenscar_Time.Delays);
    end record;

--- a/boards/stm32f769_discovery/src/audio.ads
+++ b/boards/stm32f769_discovery/src/audio.ads
@@ -40,7 +40,7 @@ private with WM8994;
 
 package Audio is
 
-   type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is limited new
+   type WM8994_Audio_Device (Port : not null Any_I2C_Port) is limited new
      Audio_Device with private;
 
    overriding procedure Initialize_Audio_Out
@@ -73,7 +73,7 @@ private
 
    Audio_I2C_Addr  : constant I2C_Address := 16#34#;
 
-   type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is limited new
+   type WM8994_Audio_Device (Port : not null Any_I2C_Port) is limited new
      Audio_Device with record
       Device : WM8994.WM8994_Device (Port, Audio_I2C_Addr, Ravenscar_Time.Delays);
    end record;

--- a/components/src/audio/CS43L22/cs43l22.ads
+++ b/components/src/audio/CS43L22/cs43l22.ads
@@ -78,8 +78,8 @@ package CS43L22 is
 
    subtype Volume_Level is Unsigned_8 range 0 .. 100;
 
-   type CS43L22_Device (Port : not null I2C_Port_Ref;
-                        Time : not null HAL.Time.Delays_Ref) is
+   type CS43L22_Device (Port : not null Any_I2C_Port;
+                        Time : not null HAL.Time.Any_Delays) is
      tagged limited private;
 
    procedure Init (This      : in out CS43L22_Device;
@@ -141,8 +141,8 @@ private
    CS43L22_REG_THERMAL_FOLDBACK    : constant := 16#33#;
    CS43L22_REG_CHARGE_PUMP_FREQ    : constant := 16#34#;
 
-   type CS43L22_Device (Port : not null I2C_Port_Ref;
-                        Time : not null HAL.Time.Delays_Ref) is
+   type CS43L22_Device (Port : not null Any_I2C_Port;
+                        Time : not null HAL.Time.Any_Delays) is
      tagged limited record
       Output_Enabled : Boolean := False;
       Output_Dev     : Byte := 0;

--- a/components/src/audio/W8994/wm8994.ads
+++ b/components/src/audio/W8994/wm8994.ads
@@ -88,9 +88,9 @@ package WM8994 is
    subtype Volume_Level is Unsigned_8 range 0 .. 100;
 
    type WM8994_Device
-     (Port     : not null I2C_Port_Ref;
+     (Port     : not null Any_I2C_Port;
       I2C_Addr : UInt10;
-      Time     : not null HAL.Time.Delays_Ref)
+      Time     : not null HAL.Time.Any_Delays)
    is tagged limited private;
 
    procedure Init (This      : in out WM8994_Device;
@@ -113,9 +113,9 @@ package WM8994 is
    procedure Reset (This : in out WM8994_Device);
 
 private
-   type WM8994_Device (Port     : not null I2C_Port_Ref;
+   type WM8994_Device (Port     : not null Any_I2C_Port;
                        I2C_Addr : UInt10;
-                       Time     : not null HAL.Time.Delays_Ref) is tagged limited null record;
+                       Time     : not null HAL.Time.Any_Delays) is tagged limited null record;
 
    procedure I2C_Write (This   : in out WM8994_Device;
                         Reg   : UInt16;

--- a/components/src/camera/OV2640/ov2640.ads
+++ b/components/src/camera/OV2640/ov2640.ads
@@ -61,7 +61,7 @@ package OV2640 is
       (1600,  1200)  --  /* UXGA  */
      );
 
-   type OV2640_Camera (I2C : not null I2C_Port_Ref) is private;
+   type OV2640_Camera (I2C : not null Any_I2C_Port) is private;
 
    procedure Initialize (This : in out OV2640_Camera;
                          Addr : I2C_Address);
@@ -87,7 +87,7 @@ package OV2640 is
                                       Enable : Boolean := True);
 private
 
-   type OV2640_Camera (I2C  : not null I2C_Port_Ref) is record
+   type OV2640_Camera (I2C  : not null Any_I2C_Port) is record
       Addr : UInt10;
    end record;
 

--- a/components/src/camera/OV7725/ov7725.ads
+++ b/components/src/camera/OV7725/ov7725.ads
@@ -39,7 +39,7 @@ package OV7725 is
 
    type Pixel_Format is (Pix_RGB565, Pix_RGB555, Pix_RGB444);
 
-   type OV7725_Camera (I2C : not null I2C_Port_Ref) is private;
+   type OV7725_Camera (I2C : not null Any_I2C_Port) is private;
 
    procedure Initialize (This : in out OV7725_Camera;
                          Addr : I2C_Address);
@@ -54,7 +54,7 @@ package OV7725 is
 
 private
 
-   type OV7725_Camera (I2C  : not null I2C_Port_Ref) is record
+   type OV7725_Camera (I2C  : not null Any_I2C_Port) is record
       Addr : UInt10;
    end record;
 

--- a/components/src/io_expander/MCP23xxx/mcp23x08-i2c.ads
+++ b/components/src/io_expander/MCP23xxx/mcp23x08-i2c.ads
@@ -33,13 +33,13 @@ with HAL.I2C;
 
 package MCP23x08.I2C is
 
-   type MCP23008_IO_Expander (Port : HAL.I2C.I2C_Port_Ref;
+   type MCP23008_IO_Expander (Port : HAL.I2C.Any_I2C_Port;
                          Addr : UInt3) is
      new MCP23x08_IO_Expander with private;
 
 private
 
-   type MCP23008_IO_Expander (Port : HAL.I2C.I2C_Port_Ref;
+   type MCP23008_IO_Expander (Port : HAL.I2C.Any_I2C_Port;
                          Addr : UInt3) is
      new MCP23x08_IO_Expander with null record;
 

--- a/components/src/io_expander/MCP23xxx/mcp23x08.adb
+++ b/components/src/io_expander/MCP23xxx/mcp23x08.adb
@@ -224,7 +224,7 @@ package body MCP23x08 is
 
    function As_GPIO_Point (This : in out MCP23x08_IO_Expander;
                             Pin  : MCP23x08_Pin)
-                            return not null HAL.GPIO.GPIO_Point_Ref
+                            return not null HAL.GPIO.Any_GPIO_Point
    is
    begin
       This.Points (Pin) := (Device => This'Unchecked_Access,

--- a/components/src/io_expander/MCP23xxx/mcp23x08.ads
+++ b/components/src/io_expander/MCP23xxx/mcp23x08.ads
@@ -81,7 +81,7 @@ package MCP23x08 is
 
    function As_GPIO_Point (This : in out MCP23x08_IO_Expander;
                            Pin  : MCP23x08_Pin)
-                           return not null HAL.GPIO.GPIO_Point_Ref;
+                           return not null HAL.GPIO.Any_GPIO_Point;
    --  Return the HAL.GPIO interface conresponding to Pin
 
 private

--- a/components/src/io_expander/ht16k33/ht16k33.ads
+++ b/components/src/io_expander/ht16k33/ht16k33.ads
@@ -34,7 +34,7 @@ with HAL; use HAL;
 
 package HT16K33 is
 
-   type HT16K33_Device (Port : not null I2C_Port_Ref;
+   type HT16K33_Device (Port : not null Any_I2C_Port;
                         Addr : UInt3) is tagged private;
 
    type HT16K33_Brightness is new Positive range 1 .. 16;
@@ -89,7 +89,7 @@ private
                           Blink_1hz  => 2#10#,
                           Blink_05hz => 2#11#);
 
-   type HT16K33_Device (Port : not null I2C_Port_Ref;
+   type HT16K33_Device (Port : not null Any_I2C_Port;
                         Addr : UInt3) is tagged
       record
          Enabled : Boolean := False;

--- a/components/src/motion/ak8963/ak8963.ads
+++ b/components/src/motion/ak8963/ak8963.ads
@@ -51,9 +51,9 @@ package AK8963 is
       Self_Test,
       Fuse_ROM_Access);
 
-   type AK8963_Device (I2C_Port         : not null HAL.I2C.I2C_Port_Ref;
+   type AK8963_Device (I2C_Port         : not null HAL.I2C.Any_I2C_Port;
                        Address_Selector : AK8963_Address_Selector;
-                        Time            : not null HAL.Time.Delays_Ref) is private;
+                        Time            : not null HAL.Time.Any_Delays) is private;
 
    procedure Initialize (Device : in out AK8963_Device);
 
@@ -80,9 +80,9 @@ package AK8963 is
 
 private
 
-   type AK8963_Device (I2C_Port         : not null HAL.I2C.I2C_Port_Ref;
+   type AK8963_Device (I2C_Port         : not null HAL.I2C.Any_I2C_Port;
                        Address_Selector : AK8963_Address_Selector;
-                        Time            : not null HAL.Time.Delays_Ref)
+                        Time            : not null HAL.Time.Any_Delays)
    is record
       Address : UInt10;
       Is_Init : Boolean := False;

--- a/components/src/motion/bno055/bno055_i2c_io.ads
+++ b/components/src/motion/bno055/bno055_i2c_io.ads
@@ -38,7 +38,7 @@ use HAL;
 package BNO055_I2C_IO is
 
    type IO_Port is tagged record
-      Port   : I2C_Port_Ref;
+      Port   : Any_I2C_Port;
       Device : I2C_Address;
    end record;
 

--- a/components/src/motion/l3gd20/l3gd20.adb
+++ b/components/src/motion/l3gd20/l3gd20.adb
@@ -148,8 +148,8 @@ package body L3GD20 is
 
    procedure Initialize
      (This        : in out Three_Axis_Gyroscope;
-      Port        : SPI_Port_Ref;
-      Chip_Select : GPIO_Point_Ref)
+      Port        : Any_SPI_Port;
+      Chip_Select : Any_GPIO_Point)
    is
    begin
       This.Port := Port;

--- a/components/src/motion/l3gd20/l3gd20.ads
+++ b/components/src/motion/l3gd20/l3gd20.ads
@@ -58,8 +58,8 @@ package L3GD20 is
 
    procedure Initialize
      (This        : in out Three_Axis_Gyroscope;
-      Port        : SPI_Port_Ref;
-      Chip_Select : GPIO_Point_Ref);
+      Port        : Any_SPI_Port;
+      Chip_Select : Any_GPIO_Point);
    --  Does device-specific initialization. Must be called prior to use.
    --
    --  NB: does NOT init/configure SPI and GPIO IO, which must be done
@@ -528,8 +528,8 @@ package L3GD20 is
 private
 
    type Three_Axis_Gyroscope is tagged limited record
-      Port : SPI_Port_Ref;
-      CS   : GPIO_Point_Ref;
+      Port : Any_SPI_Port;
+      CS   : Any_GPIO_Point;
    end record;
 
    type Register is new Byte;

--- a/components/src/motion/lis3dsh/lis3dsh-spi.ads
+++ b/components/src/motion/lis3dsh/lis3dsh-spi.ads
@@ -49,8 +49,8 @@ with HAL.GPIO;  use HAL.GPIO;
 package LIS3DSH.SPI is
 
    type Three_Axis_Accelerometer_SPI
-     (Port        : not null SPI_Port_Ref;
-      Chip_Select : not null GPIO_Point_Ref)
+     (Port        : not null Any_SPI_Port;
+      Chip_Select : not null Any_GPIO_Point)
    is new Three_Axis_Accelerometer with private;
 
    overriding
@@ -68,8 +68,8 @@ package LIS3DSH.SPI is
 private
 
    type Three_Axis_Accelerometer_SPI
-     (Port        : not null SPI_Port_Ref;
-      Chip_Select : not null GPIO_Point_Ref)
+     (Port        : not null Any_SPI_Port;
+      Chip_Select : not null Any_GPIO_Point)
    is new Three_Axis_Accelerometer with null record;
 
 end LIS3DSH.SPI;

--- a/components/src/motion/mpu9250/mpu9250.ads
+++ b/components/src/motion/mpu9250/mpu9250.ads
@@ -44,9 +44,9 @@ package MPU9250 is
    --  its I2C address.
 
    --  Types and subtypes
-   type MPU9250_Device (Port        : HAL.I2C.I2C_Port_Ref;
+   type MPU9250_Device (Port        : HAL.I2C.Any_I2C_Port;
                         I2C_AD0_Pin : MPU9250_AD0_Pin_State;
-                        Time        : not null HAL.Time.Delays_Ref) is private;
+                        Time        : not null HAL.Time.Any_Delays) is private;
 
    --  Type reprensnting all the different clock sources of the MPU9250.
    --  See the MPU9250 register map section 4.4 for more details.
@@ -222,9 +222,9 @@ package MPU9250 is
 private
 
    type MPU9250_Device
-     (Port        : HAL.I2C.I2C_Port_Ref;
+     (Port        : HAL.I2C.Any_I2C_Port;
       I2C_AD0_Pin : MPU9250_AD0_Pin_State;
-      Time        : not null HAL.Time.Delays_Ref)
+      Time        : not null HAL.Time.Any_Delays)
    is record
       Is_Init : Boolean := False;
       Address : UInt10;

--- a/components/src/printer/adafruit_thermal_printer/adafruit-thermal_printer.ads
+++ b/components/src/printer/adafruit_thermal_printer/adafruit-thermal_printer.ads
@@ -35,8 +35,8 @@ with HAL.Time;
 
 package AdaFruit.Thermal_Printer is
 
-   type TP_Device (Port : not null HAL.UART.UART_Port_Ref;
-                   Time : not null HAL.Time.Delays_Ref) is
+   type TP_Device (Port : not null HAL.UART.Any_UART_Port;
+                   Time : not null HAL.Time.Any_Delays) is
      tagged private;
 
    --  The baud rate for this printers is usually 19_200 but some printers
@@ -103,8 +103,8 @@ package AdaFruit.Thermal_Printer is
    procedure Print_Test_Page (This : in out TP_Device);
 
 private
-   type TP_Device (Port : not null HAL.UART.UART_Port_Ref;
-                   Time : not null HAL.Time.Delays_Ref) is
+   type TP_Device (Port : not null HAL.UART.Any_UART_Port;
+                   Time : not null HAL.Time.Any_Delays) is
      tagged null record;
 
 end AdaFruit.Thermal_Printer;

--- a/components/src/screen/ST7735R/st7735r.ads
+++ b/components/src/screen/ST7735R/st7735r.ads
@@ -39,11 +39,11 @@ with HAL.Time;
 package ST7735R is
 
    type ST7735R_Device
-     (Port : not null SPI_Port_Ref;
-      CS   : not null GPIO_Point_Ref;
-      RS   : not null GPIO_Point_Ref;
-      RST  : not null GPIO_Point_Ref;
-      Time : not null HAL.Time.Delays_Ref)
+     (Port : not null Any_SPI_Port;
+      CS   : not null Any_GPIO_Point;
+      RS   : not null Any_GPIO_Point;
+      RST  : not null Any_GPIO_Point;
+      Time : not null HAL.Time.Any_Delays)
    is limited new HAL.Framebuffer.Frame_Buffer_Display with private;
 
    procedure Initialize (LCD : in out ST7735R_Device);
@@ -269,11 +269,11 @@ private
    subtype Pixel_Data is UInt16_Array (0 .. (Screen_Width * Screen_Height) - 1);
 
    type ST7735R_Device
-     (Port : not null SPI_Port_Ref;
-      CS   : not null GPIO_Point_Ref;
-      RS   : not null GPIO_Point_Ref;
-      RST  : not null GPIO_Point_Ref;
-      Time : not null HAL.Time.Delays_Ref)
+     (Port : not null Any_SPI_Port;
+      CS   : not null Any_GPIO_Point;
+      RS   : not null Any_GPIO_Point;
+      RST  : not null Any_GPIO_Point;
+      Time : not null HAL.Time.Any_Delays)
    is limited new HAL.Framebuffer.Frame_Buffer_Display with record
       Initialized : Boolean := True;
       Layer : aliased Bitmap_Buffer;

--- a/components/src/screen/ili9341/ili9341.ads
+++ b/components/src/screen/ili9341/ili9341.ads
@@ -54,10 +54,10 @@ package ILI9341 is
 
    type ILI9341_Device
      (Port        : not null access SPI_Port'Class;
-      Chip_Select : not null GPIO_Point_Ref;
-      WRX         : not null GPIO_Point_Ref;
-      Reset       : not null GPIO_Point_Ref;
-      Time        : not null HAL.Time.Delays_Ref)
+      Chip_Select : not null Any_GPIO_Point;
+      WRX         : not null Any_GPIO_Point;
+      Reset       : not null Any_GPIO_Point;
+      Time        : not null HAL.Time.Any_Delays)
    is tagged limited private;
 
    type ILI9341_Mode is
@@ -152,10 +152,10 @@ private
 
    type ILI9341_Device
      (Port        : not null access SPI_Port'Class;
-      Chip_Select : not null GPIO_Point_Ref;
-      WRX         : not null GPIO_Point_Ref;
-      Reset       : not null GPIO_Point_Ref;
-      Time        : not null HAL.Time.Delays_Ref)
+      Chip_Select : not null Any_GPIO_Point;
+      WRX         : not null Any_GPIO_Point;
+      Reset       : not null Any_GPIO_Point;
+      Time        : not null HAL.Time.Any_Delays)
    is tagged limited record
       Selected_Orientation : Orientations;
 

--- a/components/src/screen/otm8009a/otm8009a.ads
+++ b/components/src/screen/otm8009a/otm8009a.ads
@@ -87,9 +87,9 @@ package OTM8009A is
    type LCD_Orientation is (Portrait, Landscape);
 
    type OTM8009A_Device
-     (DSI_Host   : not null DSI_Port_Ref;
+     (DSI_Host   : not null Any_DSI_Port;
       Channel_ID : DSI_Virtual_Channel_ID;
-      Time       : not null HAL.Time.Delays_Ref)
+      Time       : not null HAL.Time.Any_Delays)
    is tagged limited private;
 
    procedure Initialize
@@ -100,9 +100,9 @@ package OTM8009A is
 private
 
    type OTM8009A_Device
-     (DSI_Host   : not null DSI_Port_Ref;
+     (DSI_Host   : not null Any_DSI_Port;
       Channel_ID : DSI_Virtual_Channel_ID;
-      Time       : not null HAL.Time.Delays_Ref)
+      Time       : not null HAL.Time.Any_Delays)
    is tagged limited record
       Current_Shift : Byte := 0;
    end record;

--- a/components/src/touch_panel/ft5336/ft5336.ads
+++ b/components/src/touch_panel/ft5336/ft5336.ads
@@ -37,7 +37,7 @@ with HAL.Touch_Panel; use HAL.Touch_Panel;
 
 package FT5336 is
 
-   type FT5336_Device (Port     : not null I2C_Port_Ref;
+   type FT5336_Device (Port     : not null Any_I2C_Port;
                        I2C_Addr : I2C_Address) is
      limited new Touch_Panel_Device with private;
 
@@ -78,7 +78,7 @@ package FT5336 is
 
 private
 
-   type FT5336_Device (Port     : not null I2C_Port_Ref;
+   type FT5336_Device (Port     : not null Any_I2C_Port;
                        I2C_Addr : I2C_Address) is
      limited new HAL.Touch_Panel.Touch_Panel_Device with record
       LCD_Natural_Width  : Natural := 0;

--- a/components/src/touch_panel/ft6x06/ft6x06.ads
+++ b/components/src/touch_panel/ft6x06/ft6x06.ads
@@ -39,7 +39,7 @@ with HAL.Touch_Panel;
 
 package FT6x06 is
 
-   type FT6x06_Device (Port     : not null I2C_Port_Ref;
+   type FT6x06_Device (Port     : not null Any_I2C_Port;
                        I2C_Addr : I2C_Address) is
      limited new HAL.Touch_Panel.Touch_Panel_Device with private;
 
@@ -79,7 +79,7 @@ package FT6x06 is
    --  points
 private
 
-   type FT6x06_Device (Port     : not null I2C_Port_Ref;
+   type FT6x06_Device (Port     : not null Any_I2C_Port;
                        I2C_Addr : I2C_Address) is
      limited new HAL.Touch_Panel.Touch_Panel_Device with record
       LCD_Natural_Width  : Natural := 0;

--- a/components/src/touch_panel/stmpe811/stmpe811.ads
+++ b/components/src/touch_panel/stmpe811/stmpe811.ads
@@ -36,9 +36,9 @@ with HAL.Touch_Panel; use HAL.Touch_Panel;
 
 package STMPE811 is
 
-   type STMPE811_Device (Port     : not null I2C_Port_Ref;
+   type STMPE811_Device (Port     : not null Any_I2C_Port;
                          I2C_Addr : I2C_Address;
-                         Time     : not null HAL.Time.Delays_Ref) is
+                         Time     : not null HAL.Time.Any_Delays) is
      limited new Touch_Panel_Device with private;
 
    function Initialize (This : in out STMPE811_Device) return Boolean;
@@ -71,9 +71,9 @@ package STMPE811 is
 
 private
 
-   type STMPE811_Device (Port     : not null I2C_Port_Ref;
+   type STMPE811_Device (Port     : not null Any_I2C_Port;
                          I2C_Addr : I2C_Address;
-                         Time     : not null HAL.Time.Delays_Ref) is
+                         Time     : not null HAL.Time.Any_Delays) is
      limited new Touch_Panel_Device with record
       LCD_Natural_Width  : Natural := 0;
       LCD_Natural_Height : Natural := 0;

--- a/examples/filesystem/src/main.adb
+++ b/examples/filesystem/src/main.adb
@@ -53,7 +53,7 @@ procedure Main is
 
    procedure List_Dir (FS : in out FS_Driver'Class; Path : Pathname) is
       Status : Status_Kind;
-      DH : Directory_Handle_Ref;
+      DH : Any_Directory_Handle;
    begin
       Status := FS.Open_Directory (Path, DH);
       if Status /= Status_Ok then
@@ -86,7 +86,7 @@ procedure Main is
    procedure List_Partitions (FS : in out FS_Driver'Class;
                               Path_To_Disk_Image : Pathname)
    is
-      File : File_Handle_Ref;
+      File : Any_File_Handle;
    begin
       if FS.Open (Path_To_Disk_Image, Read_Only, File) /= Status_Ok then
          Semihosting.Log_Line ("Cannot open disk image '" &
@@ -125,7 +125,7 @@ procedure Main is
    My_VFS3 : aliased VFS;
    My_SHFS : aliased SHFS;
    Status : Status_Kind;
-   FH : File_Handle_Ref;
+   FH : Any_File_Handle;
    Data : Byte_Array (1 .. 10);
 
 begin

--- a/examples/stm32_dma2d/dma2d_stm32f429disco.gpr
+++ b/examples/stm32_dma2d/dma2d_stm32f429disco.gpr
@@ -13,4 +13,4 @@ project Dma2d_STM32F429Disco extends "../common/common.gpr" is
         ("-gc-section", "-Wl,--print-memory-usage");
    end Linker;
 
-end Dma2dy_STM32F429Disco;
+end Dma2d_STM32F429Disco;

--- a/hal/src/hal-block_drivers.ads
+++ b/hal/src/hal-block_drivers.ads
@@ -34,7 +34,7 @@ with Interfaces; use Interfaces;
 package HAL.Block_Drivers is
 
    type Block_Driver is limited interface;
-   type Block_Driver_Ref is access all Block_Driver'Class;
+   type Any_Block_Driver is access all Block_Driver'Class;
 
    subtype Block is Byte_Array;
 

--- a/hal/src/hal-dsi.ads
+++ b/hal/src/hal-dsi.ads
@@ -58,7 +58,7 @@ package HAL.DSI is
 
    type DSI_Port is limited interface;
 
-   type DSI_Port_Ref is access all DSI_Port'Class;
+   type Any_DSI_Port is access all DSI_Port'Class;
 
    procedure DSI_Short_Write
      (Port       : in out DSI_Port;

--- a/hal/src/hal-filesystem.ads
+++ b/hal/src/hal-filesystem.ads
@@ -68,15 +68,15 @@ package HAL.Filesystem is
    type IO_Count is new Unsigned_64;
 
    type FS_Driver is limited interface;
-   type FS_Driver_Ref is access all FS_Driver'Class;
+   type Any_FS_Driver is access all FS_Driver'Class;
    --  Interface to provide access a filesystem
 
    type File_Handle is limited interface;
-   type File_Handle_Ref is access all File_Handle'Class;
+   type Any_File_Handle is access all File_Handle'Class;
    --  Interface to provide access to a regular file
 
    type Directory_Handle is limited interface;
-   type Directory_Handle_Ref is access all Directory_Handle'Class;
+   type Any_Directory_Handle is access all Directory_Handle'Class;
    --  Interface to provide access to a directory
 
    --  ??? Document error cases for all primitives below
@@ -123,7 +123,7 @@ package HAL.Filesystem is
    function Open (This   : in out FS_Driver;
                   Path   : Pathname;
                   Mode   : File_Mode;
-                  Handle : out File_Handle_Ref)
+                  Handle : out Any_File_Handle)
                   return Status_Kind is abstract;
    --  Assuming Path designates a regular file, open it with the given Mode and
    --  create a Handle for it.
@@ -133,7 +133,7 @@ package HAL.Filesystem is
 
    function Open_Directory (This   : in out FS_Driver;
                             Path   : Pathname;
-                            Handle : out Directory_Handle_Ref)
+                            Handle : out Any_Directory_Handle)
                             return Status_Kind is abstract;
    --  Assuming Path designates a directory, open it and create a Handle for
    --  it.

--- a/hal/src/hal-framebuffer.ads
+++ b/hal/src/hal-framebuffer.ads
@@ -43,7 +43,7 @@ package HAL.Framebuffer is
 
    type Frame_Buffer_Display is limited interface;
 
-   type Frame_Buffer_Display_Access is access all Frame_Buffer_Display'Class;
+   type Any_Frame_Buffer_Display is access all Frame_Buffer_Display'Class;
 
    function Get_Max_Layers
      (This : Frame_Buffer_Display) return Positive

--- a/hal/src/hal-gpio.ads
+++ b/hal/src/hal-gpio.ads
@@ -33,7 +33,7 @@ package HAL.GPIO is
 
    type GPIO_Point is limited interface;
 
-   type GPIO_Point_Ref is access all GPIO_Point'Class;
+   type Any_GPIO_Point is access all GPIO_Point'Class;
 
    function Set (This : GPIO_Point) return Boolean is abstract;
 

--- a/hal/src/hal-i2c.ads
+++ b/hal/src/hal-i2c.ads
@@ -47,7 +47,7 @@ package HAL.I2C is
 
    type I2C_Port is limited interface;
 
-   type I2C_Port_Ref is access all I2C_Port'Class;
+   type Any_I2C_Port is access all I2C_Port'Class;
 
    procedure Master_Transmit
      (This    : in out I2C_Port;

--- a/hal/src/hal-real_time_clock.ads
+++ b/hal/src/hal-real_time_clock.ads
@@ -77,7 +77,7 @@ package HAL.Real_Time_Clock is
                       December  => 12);
 
    type RTC_Device is limited interface;
-   type RTC_Device_Ref is access all RTC_Device'Class;
+   type Any_RTC_Device is access all RTC_Device'Class;
 
    procedure Set (This : in out RTC_Device;
                   Time : RTC_Time;

--- a/hal/src/hal-spi.ads
+++ b/hal/src/hal-spi.ads
@@ -47,7 +47,7 @@ package HAL.SPI is
 
    type SPI_Port is limited interface;
 
-   type SPI_Port_Ref is access all SPI_Port'Class;
+   type Any_SPI_Port is access all SPI_Port'Class;
 
    function Data_Size (This : SPI_Port) return SPI_Data_Size is abstract;
 

--- a/hal/src/hal-time.ads
+++ b/hal/src/hal-time.ads
@@ -33,7 +33,7 @@ package HAL.Time is
 
    type Delays is limited interface;
 
-   type Delays_Ref is access all Delays'Class;
+   type Any_Delays is access all Delays'Class;
 
    procedure Delay_Microseconds (This : in out Delays;
                                  Us   : Integer) is abstract;

--- a/hal/src/hal-touch_panel.ads
+++ b/hal/src/hal-touch_panel.ads
@@ -51,7 +51,7 @@ package HAL.Touch_Panel is
 
    type Touch_Panel_Device is limited interface;
 
-   type Touch_Panel_Ref is access all Touch_Panel_Device'Class;
+   type Any_Touch_Panel is access all Touch_Panel_Device'Class;
 
    procedure Set_Bounds (This   : in out Touch_Panel_Device;
                          Width  : Natural;

--- a/hal/src/hal-uart.ads
+++ b/hal/src/hal-uart.ads
@@ -47,7 +47,7 @@ package HAL.UART is
 
    type UART_Port is limited interface;
 
-   type UART_Port_Ref is access all UART_Port'Class;
+   type Any_UART_Port is access all UART_Port'Class;
 
    function Data_Size (Port : UART_Port) return UART_Data_Size is abstract;
 

--- a/services/src/filesystems/partitions.adb
+++ b/services/src/filesystems/partitions.adb
@@ -43,11 +43,11 @@ package body Partitions is
                                 P_Entry : out Partition_Entry)
      with Pre => Index <= 3;
 
-   function Number_Of_Logical_Partitions (Disk        : not null Block_Driver_Ref;
+   function Number_Of_Logical_Partitions (Disk        : not null Any_Block_Driver;
                                           EBR_Address : Logical_Block_Address)
                                           return Natural;
 
-   function Get_Logical_Partition_Entry (Disk         : not null Block_Driver_Ref;
+   function Get_Logical_Partition_Entry (Disk         : not null Any_Block_Driver;
                                          EBR_Address  : Logical_Block_Address;
                                          Entry_Number : Positive;
                                          Entry_Cnt    : in out Natural;
@@ -78,7 +78,7 @@ package body Partitions is
    -- Number_Of_Logical_Partitions --
    ----------------------------------
 
-   function Number_Of_Logical_Partitions (Disk        : not null Block_Driver_Ref;
+   function Number_Of_Logical_Partitions (Disk        : not null Any_Block_Driver;
                                           EBR_Address : Logical_Block_Address)
                                           return Natural
    is
@@ -111,7 +111,7 @@ package body Partitions is
    -- Get_Logical_Partition_Entry --
    ---------------------------------
 
-   function Get_Logical_Partition_Entry (Disk         : not null Block_Driver_Ref;
+   function Get_Logical_Partition_Entry (Disk         : not null Any_Block_Driver;
                                          EBR_Address  : Logical_Block_Address;
                                          Entry_Number : Positive;
                                          Entry_Cnt    : in out Natural;
@@ -149,7 +149,7 @@ package body Partitions is
    -- Get_Partition_Entry --
    -------------------------
 
-   function Get_Partition_Entry (Disk         : not null Block_Driver_Ref;
+   function Get_Partition_Entry (Disk         : not null Any_Block_Driver;
                                  Entry_Number : Positive;
                                  P_Entry      : out Partition_Entry)
                                  return Status_Code
@@ -199,7 +199,7 @@ package body Partitions is
    -- Number_Of_Partitions --
    --------------------------
 
-   function Number_Of_Partitions (Disk : Block_Driver_Ref) return Natural is
+   function Number_Of_Partitions (Disk : Any_Block_Driver) return Natural is
       MBR       : Block (0 .. 511);
       Entry_Cnt : Natural := 0;
       P_Entry   : Partition_Entry;

--- a/services/src/filesystems/partitions.ads
+++ b/services/src/filesystems/partitions.ads
@@ -69,12 +69,12 @@ package Partitions is
 
    type Status_Code is (Status_Ok, Disk_Error, Invalid_Parition);
 
-   function Get_Partition_Entry (Disk         : not null Block_Driver_Ref;
+   function Get_Partition_Entry (Disk         : not null Any_Block_Driver;
                                  Entry_Number : Positive;
                                  P_Entry      : out Partition_Entry)
                                  return Status_Code;
 
-   function Number_Of_Partitions (Disk : Block_Driver_Ref) return Natural;
+   function Number_Of_Partitions (Disk : Any_Block_Driver) return Natural;
 
    function Is_Valid (P_Entry : Partition_Entry) return Boolean is
      (P_Entry.Status = 16#00# or else P_Entry.Status = 16#80#);

--- a/services/src/filesystems/virtual_file_system.adb
+++ b/services/src/filesystems/virtual_file_system.adb
@@ -40,7 +40,7 @@ package body Virtual_File_System is
    function Find_FS (This                : in out VFS;
                      Path                : Pathname;
                      Path_Reminder_Start : out Integer)
-                     return FS_Driver_Ref
+                     return Any_FS_Driver
    is
       Start, Stop : Integer;
       Elt  : Mount_Point_Access := This.Mount_points;
@@ -72,7 +72,7 @@ package body Virtual_File_System is
 
    function Mount (This       : in out VFS;
                    Path       : Pathname;
-                   Filesystem : not null FS_Driver_Ref)
+                   Filesystem : not null Any_FS_Driver)
                    return Status_Kind
    is
       MP : constant Mount_Point_Access :=
@@ -109,7 +109,7 @@ package body Virtual_File_System is
                          return Status_Kind
    is
       Path_Reminder_Start : Integer;
-      FS : constant FS_Driver_Ref := This.Find_FS (Path, Path_Reminder_Start);
+      FS : constant Any_FS_Driver := This.Find_FS (Path, Path_Reminder_Start);
       Sub_Path : constant String := (if Path_Reminder_Start not in Path'Range
                                      then ""
                                      else Path (Path_Reminder_Start .. Path'Last));
@@ -131,7 +131,7 @@ package body Virtual_File_System is
                               return Status_Kind
    is
       Path_Reminder_Start : Integer;
-      FS : constant FS_Driver_Ref := This.Find_FS (Path, Path_Reminder_Start);
+      FS : constant Any_FS_Driver := This.Find_FS (Path, Path_Reminder_Start);
       Sub_Path : constant String := (if Path_Reminder_Start not in Path'Range
                                      then ""
                                      else Path (Path_Reminder_Start .. Path'Last));
@@ -153,7 +153,7 @@ package body Virtual_File_System is
                     return Status_Kind
    is
       Path_Reminder_Start : Integer;
-      FS : constant FS_Driver_Ref := This.Find_FS (Path, Path_Reminder_Start);
+      FS : constant Any_FS_Driver := This.Find_FS (Path, Path_Reminder_Start);
       Sub_Path : constant String := (if Path_Reminder_Start not in Path'Range
                                      then ""
                                      else Path (Path_Reminder_Start .. Path'Last));
@@ -175,7 +175,7 @@ package body Virtual_File_System is
                               return Status_Kind
    is
       Path_Reminder_Start : Integer;
-      FS : constant FS_Driver_Ref := This.Find_FS (Path, Path_Reminder_Start);
+      FS : constant Any_FS_Driver := This.Find_FS (Path, Path_Reminder_Start);
       Sub_Path : constant String := (if Path_Reminder_Start not in Path'Range
                                      then ""
                                      else Path (Path_Reminder_Start .. Path'Last));
@@ -213,7 +213,7 @@ package body Virtual_File_System is
                            return Status_Kind
    is
       Path_Reminder_Start : Integer;
-      FS : constant FS_Driver_Ref := This.Find_FS (Path, Path_Reminder_Start);
+      FS : constant Any_FS_Driver := This.Find_FS (Path, Path_Reminder_Start);
       Sub_Path : constant String := (if Path_Reminder_Start not in Path'Range
                                      then ""
                                      else Path (Path_Reminder_Start .. Path'Last));
@@ -233,11 +233,11 @@ package body Virtual_File_System is
    function Open (This    : in out VFS;
                   Path    : Pathname;
                   Mode    : File_Mode;
-                  Handler : out File_Handle_Ref)
+                  Handler : out Any_File_Handle)
                   return Status_Kind
    is
       Path_Reminder_Start : Integer;
-      FS : constant FS_Driver_Ref := This.Find_FS (Path, Path_Reminder_Start);
+      FS : constant Any_FS_Driver := This.Find_FS (Path, Path_Reminder_Start);
    begin
       if FS = null then
          return No_Such_File_Or_Directory;
@@ -253,11 +253,11 @@ package body Virtual_File_System is
    overriding
    function Open_Directory (This   : in out VFS;
                             Path   : Pathname;
-                            Handle : out Directory_Handle_Ref)
+                            Handle : out Any_Directory_Handle)
                             return Status_Kind
    is
       Path_Reminder_Start : Integer;
-      FS : constant FS_Driver_Ref := This.Find_FS (Path, Path_Reminder_Start);
+      FS : constant Any_FS_Driver := This.Find_FS (Path, Path_Reminder_Start);
       Sub_Path : constant String := (if Path_Reminder_Start not in Path'Range
                                      then ""
                                      else Path (Path_Reminder_Start .. Path'Last));

--- a/services/src/filesystems/virtual_file_system.ads
+++ b/services/src/filesystems/virtual_file_system.ads
@@ -34,11 +34,11 @@ with HAL.Filesystem; use HAL.Filesystem;
 package Virtual_File_System is
 
    type VFS is new HAL.Filesystem.FS_Driver with private;
-   type VFS_Ref is access all VFS'Class;
+   type Any_VFS is access all VFS'Class;
 
    function Mount (This       : in out VFS;
                    Path       : Pathname;
-                   Filesystem : not null FS_Driver_Ref)
+                   Filesystem : not null Any_FS_Driver)
                    return Status_Kind;
 
    function Umount (This       : in out VFS;
@@ -86,13 +86,13 @@ package Virtual_File_System is
    function Open (This    : in out VFS;
                   Path    : Pathname;
                   Mode    : File_Mode;
-                  Handler : out File_Handle_Ref)
+                  Handler : out Any_File_Handle)
                   return Status_Kind;
 
    overriding
    function Open_Directory (This   : in out VFS;
                             Path   : Pathname;
-                            Handle : out Directory_Handle_Ref)
+                            Handle : out Any_Directory_Handle)
                             return Status_Kind;
 
 private
@@ -123,7 +123,7 @@ private
 
    type Mount_Point is record
       Directory : not null access String;
-      FS        : not null FS_Driver_Ref;
+      FS        : not null Any_FS_Driver;
       Next      : Mount_Point_Access := null;
    end record;
 
@@ -135,7 +135,7 @@ private
    function Find_FS (This                : in out VFS;
                      Path                : Pathname;
                      Path_Reminder_Start : out Integer)
-                     return FS_Driver_Ref;
+                     return Any_FS_Driver;
    --  Find the mount point for a given path and return the index of the first
    --  character of the remaining path. Path_Reminder_Start will be out of
    --  Path'Range is there is no remaining characters.

--- a/services/src/ravenscar-common/ravenscar_time.adb
+++ b/services/src/ravenscar-common/ravenscar_time.adb
@@ -39,7 +39,7 @@ package body Ravenscar_Time is
    -- Delays --
    ------------
 
-   function Delays return not null HAL.Time.Delays_Ref is
+   function Delays return not null HAL.Time.Any_Delays is
    begin
       return Delay_Singleton'Access;
    end Delays;

--- a/services/src/ravenscar-common/ravenscar_time.ads
+++ b/services/src/ravenscar-common/ravenscar_time.ads
@@ -33,7 +33,7 @@ with HAL.Time;
 
 package Ravenscar_Time is
 
-   function Delays return not null HAL.Time.Delays_Ref;
+   function Delays return not null HAL.Time.Any_Delays;
 
 private
 

--- a/services/src/utils/file_block_drivers.ads
+++ b/services/src/utils/file_block_drivers.ads
@@ -37,7 +37,7 @@ with Interfaces;        use Interfaces;
 
 package File_Block_Drivers is
 
-   type File_Block_Driver (File : not null File_Handle_Ref) is new Block_Driver with private;
+   type File_Block_Driver (File : not null Any_File_Handle) is new Block_Driver with private;
 
    overriding
    function Read
@@ -54,5 +54,5 @@ package File_Block_Drivers is
       return Boolean;
 
 private
-   type File_Block_Driver (File : not null File_Handle_Ref) is new Block_Driver with null record;
+   type File_Block_Driver (File : not null Any_File_Handle) is new Block_Driver with null record;
 end File_Block_Drivers;

--- a/testsuite/tests/disk_partitions/src/tc_read_partitions.adb
+++ b/testsuite/tests/disk_partitions/src/tc_read_partitions.adb
@@ -23,7 +23,7 @@ procedure TC_Read_Partitions is
    procedure List_Partitions (FS : in out FS_Driver'Class;
                               Path_To_Disk_Image : Pathname)
    is
-      File : File_Handle_Ref;
+      File : Any_File_Handle;
    begin
       if FS.Open (Path_To_Disk_Image, Read_Only, File) /= Status_Ok then
          Put_Line ("Cannot open disk image '" & Path_To_Disk_Image & "'");

--- a/testsuite/tests/virtual_file_system/src/helpers.adb
+++ b/testsuite/tests/virtual_file_system/src/helpers.adb
@@ -128,7 +128,7 @@ package body Helpers is
    ----------
 
    procedure Dump (FS : in out FS_Driver'Class; Dir : Pathname) is
-      DH     : Directory_Handle_Ref;
+      DH     : Any_Directory_Handle;
       DE     : Directory_Entry;
       I      : Positive := 1;
       Status : Status_Kind;
@@ -149,7 +149,7 @@ package body Helpers is
                when Regular_File =>
                   Put_Line ("  File: " & Name);
                   declare
-                     File : File_Handle_Ref;
+                     File : Any_File_Handle;
                   begin
                      Test (FS.Open (Name, Read_Only, File));
                      declare

--- a/testsuite/tests/virtual_file_system/src/helpers.ads
+++ b/testsuite/tests/virtual_file_system/src/helpers.ads
@@ -30,8 +30,8 @@ package Helpers is
    --  Dump the content of the Dir directory in FS to the standard output
 
    procedure Destroy is new Ada.Unchecked_Deallocation
-     (FS_Driver'Class, FS_Driver_Ref);
+     (FS_Driver'Class, Any_FS_Driver);
    procedure Destroy is new Ada.Unchecked_Deallocation
-     (Virtual_File_System.VFS'Class, Virtual_File_System.VFS_Ref);
+     (Virtual_File_System.VFS'Class, Virtual_File_System.Any_VFS);
 
 end Helpers;

--- a/testsuite/tests/virtual_file_system/src/tc_nested_mount.adb
+++ b/testsuite/tests/virtual_file_system/src/tc_nested_mount.adb
@@ -11,7 +11,7 @@ procedure TC_Nested_Mount is
    --  calls that are more or less expected to fail.
 
    Root_VFS   : Virtual_File_System.VFS;
-   Child_VFS  : Virtual_File_System.VFS_Ref := new Virtual_File_System.VFS;
+   Child_VFS  : Virtual_File_System.Any_VFS := new Virtual_File_System.VFS;
    Empty_FS   : Native_FS_Driver_Ref :=
      Create ("empty", Create_If_Missing => True);
    Subdirs_FS : Native_FS_Driver_Ref := Create ("subdirs");


### PR DESCRIPTION
An access-to-classwide type is much like a pointer-to-baseclass in C++, in that the access values can designate any type in the derivation class. **Any** type. A good way to name such types then, and one that does not redundantly include the "_Access" or "_Ref", is to add the prefix "Any_" to the designated type name, eg Any_GPIO_Point or Any_I2C_Port. If we are consistent the reader will immediately know what they are getting.