### PR TITLE
STM32 Inter-IC Sound support

### DIFF
--- a/ARM/STM32/devices/stm32f40x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f40x/stm32-device.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                     Copyright (C) 2015-2016, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -437,6 +437,43 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
+   procedure Enable_Clock (This : I2S_Port) is
+   begin
+      if This.Periph.all'Address = SPI1_Base then
+         RCC_Periph.APB2ENR.SPI1EN := True;
+      elsif This.Periph.all'Address = SPI2_Base then
+         RCC_Periph.APB1ENR.SPI2EN := True;
+      elsif This.Periph.all'Address = SPI3_Base then
+         RCC_Periph.APB1ENR.SPI3EN := True;
+      else
+         raise Unknown_Device;
+      end if;
+   end Enable_Clock;
+
+   -----------
+   -- Reset --
+   -----------
+
+   procedure Reset (This : in out I2S_Port) is
+   begin
+      if This.Periph.all'Address = SPI1_Base then
+         RCC_Periph.APB2RSTR.SPI1RST := True;
+         RCC_Periph.APB2RSTR.SPI1RST := False;
+      elsif This.Periph.all'Address = SPI2_Base then
+         RCC_Periph.APB1RSTR.SPI2RST := True;
+         RCC_Periph.APB1RSTR.SPI2RST := False;
+      elsif This.Periph.all'Address = SPI3_Base then
+         RCC_Periph.APB1RSTR.SPI3RST := True;
+         RCC_Periph.APB1RSTR.SPI3RST := False;
+      else
+         raise Unknown_Device;
+      end if;
+   end Reset;
+
+   ------------------
+   -- Enable_Clock --
+   ------------------
+
    procedure Enable_Clock (This : in out Timer) is
    begin
       if This'Address = TIM1_Base then
@@ -534,6 +571,8 @@ package body STM32.Device is
       Source       : constant UInt2 := RCC_Periph.CFGR.SWS;
       Result       : RCC_System_Clocks;
    begin
+      Result.I2SCLK := 0;
+
       case Source is
          when 0 =>
             --  HSI as source
@@ -556,10 +595,17 @@ package body STM32.Device is
                Pllvco     : UInt32;
             begin
                if not HSE_Source then
-                  Pllvco := (HSI_VALUE / Pllm) * Plln;
+                  Pllvco := HSI_VALUE;
                else
-                  Pllvco := (HSE_VALUE / Pllm) * Plln;
+                  Pllvco := HSE_VALUE;
                end if;
+
+               Pllvco := Pllvco / Pllm;
+
+               Result.I2SCLK := Pllvco;
+
+               Pllvco := Pllvco * Plln;
+
                Result.SYSCLK := Pllvco / Pllp;
             end;
          when others =>
@@ -593,8 +639,70 @@ package body STM32.Device is
          end if;
       end;
 
+      -- I2S Clock --
+
+      if RCC_Periph.CFGR.I2SSRC then
+         --  External clock source
+         Result.I2SCLK := 0;
+         raise Program_Error with "External I2S clock value is unknown";
+      else
+         --  Pll clock source
+         declare
+            Plli2sn : constant UInt32 :=
+              UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SNx);
+            Plli2sr : constant UInt32
+              := UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SRx);
+         begin
+            Result.I2SCLK := (Result.I2SCLK * Plli2sn) / Plli2sr;
+         end;
+      end if;
+
       return Result;
    end System_Clock_Frequencies;
+
+   --------------------
+   -- PLLI2S_Enabled --
+   --------------------
+
+   function PLLI2S_Enabled return Boolean is
+     (RCC_Periph.CR.PLLI2SRDY);
+
+   ------------------------
+   -- Set_PLLI2S_Factors --
+   ------------------------
+
+   procedure Set_PLLI2S_Factors (Pll_N : UInt9;
+                                 Pll_R : UInt3)
+
+   is
+   begin
+      RCC_Periph.PLLI2SCFGR.PLLI2SNx := Pll_N;
+      RCC_Periph.PLLI2SCFGR.PLLI2SRx := Pll_R;
+   end Set_PLLI2S_Factors;
+
+   -------------------
+   -- Enable_PLLI2S --
+   -------------------
+
+   procedure Enable_PLLI2S is
+   begin
+      RCC_Periph.CR.PLLI2SON := True;
+      loop
+         exit when PLLI2S_Enabled;
+      end loop;
+   end Enable_PLLI2S;
+
+   --------------------
+   -- Disable_PLLI2S --
+   --------------------
+
+   procedure Disable_PLLI2S is
+   begin
+      RCC_Periph.CR.PLLI2SON := False;
+      loop
+         exit when not PLLI2S_Enabled;
+      end loop;
+   end Disable_PLLI2S;
 
    -----------------------
    -- Enable_DCMI_Clock --

--- a/ARM/STM32/devices/stm32f40x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f40x/stm32-device.adb
@@ -419,13 +419,13 @@ package body STM32.Device is
 
    procedure Reset (This : in out SPI_Port) is
    begin
-      if This'Address = SPI1_Base then
+      if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2RSTR.SPI1RST := True;
          RCC_Periph.APB2RSTR.SPI1RST := False;
-      elsif This'Address = SPI2_Base then
+      elsif This.Periph.all'Address = SPI2_Base then
          RCC_Periph.APB1RSTR.SPI2RST := True;
          RCC_Periph.APB1RSTR.SPI2RST := False;
-      elsif This'Address = SPI3_Base then
+      elsif This.Periph.all'Address = SPI3_Base then
          RCC_Periph.APB1RSTR.SPI3RST := True;
          RCC_Periph.APB1RSTR.SPI3RST := False;
       else

--- a/ARM/STM32/devices/stm32f40x/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f40x/stm32-device.ads
@@ -329,7 +329,6 @@ package STM32.Device is
    DMA_2 : aliased DMA_Controller with Import, Volatile, Address => DMA2_Base;
 
    procedure Enable_Clock (This : aliased in out DMA_Controller);
-
    procedure Reset (This : aliased in out DMA_Controller);
 
    Internal_I2C_Port_1 : aliased Internal_I2C_Port with Import, Volatile, Address => I2C1_Base;

--- a/ARM/STM32/devices/stm32f40x/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f40x/stm32-device.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                     Copyright (C) 2015-2016, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -44,15 +44,16 @@
 
 with STM32_SVD;     use STM32_SVD;
 
-with STM32.DMA;     use STM32.DMA;
-with STM32.GPIO;    use STM32.GPIO;
-with STM32.ADC;     use STM32.ADC;
-with STM32.USARTs;  use STM32.USARTs;
-with STM32.SPI;     use STM32.SPI;
-with STM32.Timers;  use STM32.Timers;
-with STM32.DAC;     use STM32.DAC;
-with STM32.I2C;     use STM32.I2C;
-with STM32.RTC;     use STM32.RTC;
+with STM32.DMA;    use STM32.DMA;
+with STM32.GPIO;   use STM32.GPIO;
+with STM32.ADC;    use STM32.ADC;
+with STM32.USARTs; use STM32.USARTs;
+with STM32.SPI;    use STM32.SPI;
+with STM32.I2S;    use STM32.I2S;
+with STM32.Timers; use STM32.Timers;
+with STM32.DAC;    use STM32.DAC;
+with STM32.I2C;    use STM32.I2C;
+with STM32.RTC;    use STM32.RTC;
 
 package STM32.Device is
    pragma Elaborate_Body;
@@ -361,6 +362,17 @@ package STM32.Device is
 
    procedure Reset (This : in out SPI_Port);
 
+   Internal_I2S_1 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI1_Base;
+   Internal_I2S_2 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI2_Base;
+   Internal_I2S_3 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI3_Base;
+
+   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access);
+   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access);
+   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access);
+
+   procedure Enable_Clock (This : I2S_Port);
+   procedure Reset (This : in out I2S_Port);
+
    Timer_1  : aliased Timer with Import, Volatile, Address => TIM1_Base;
    Timer_2  : aliased Timer with Import, Volatile, Address => TIM2_Base;
    Timer_3  : aliased Timer with Import, Volatile, Address => TIM3_Base;
@@ -391,9 +403,21 @@ package STM32.Device is
       PCLK2   : UInt32;
       TIMCLK1 : UInt32;
       TIMCLK2 : UInt32;
+      I2SCLK  : UInt32;
    end record;
 
    function System_Clock_Frequencies return RCC_System_Clocks;
+
+   procedure Set_PLLI2S_Factors (Pll_N : UInt9;
+                                 Pll_R : UInt3);
+
+   function PLLI2S_Enabled return Boolean;
+
+   procedure Enable_PLLI2S
+     with Post => PLLI2S_Enabled;
+
+   procedure Disable_PLLI2S
+     with Post => not PLLI2S_Enabled;
 
    procedure Enable_DCMI_Clock;
 

--- a/ARM/STM32/devices/stm32f42x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f42x/stm32-device.adb
@@ -802,7 +802,7 @@ package body STM32.Device is
 
    -------------------
    -- Enable_PLLSAI --
-   -------------------;
+   -------------------
 
    procedure Enable_PLLSAI is
    begin
@@ -819,7 +819,7 @@ package body STM32.Device is
 
    -------------------
    -- Enable_PLLSAI --
-   -------------------;
+   -------------------
 
    procedure Disable_PLLSAI is
    begin

--- a/ARM/STM32/devices/stm32f42x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f42x/stm32-device.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                     Copyright (C) 2015-2016, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -488,6 +488,58 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
+   procedure Enable_Clock (This : I2S_Port) is
+   begin
+      if This.Periph.all'Address = SPI1_Base then
+         RCC_Periph.APB2ENR.SPI1EN := True;
+      elsif This.Periph.all'Address = SPI2_Base then
+         RCC_Periph.APB1ENR.SPI2EN := True;
+      elsif This.Periph.all'Address = SPI3_Base then
+         RCC_Periph.APB1ENR.SPI3EN := True;
+      elsif This.Periph.all'Address = SPI4_Base then
+         RCC_Periph.APB2ENR.SPI5ENR := True;
+      elsif This.Periph.all'Address = SPI5_Base then
+         RCC_Periph.APB2ENR.SPI5ENR := True;
+      elsif This.Periph.all'Address = SPI6_Base then
+         RCC_Periph.APB2ENR.SPI6ENR := True;
+      else
+         raise Unknown_Device;
+      end if;
+   end Enable_Clock;
+
+   -----------
+   -- Reset --
+   -----------
+
+   procedure Reset (This : in out I2S_Port) is
+   begin
+      if This.Periph.all'Address = SPI1_Base then
+         RCC_Periph.APB2RSTR.SPI1RST := True;
+         RCC_Periph.APB2RSTR.SPI1RST := False;
+      elsif This.Periph.all'Address = SPI2_Base then
+         RCC_Periph.APB1RSTR.SPI2RST := True;
+         RCC_Periph.APB1RSTR.SPI2RST := False;
+      elsif This.Periph.all'Address = SPI3_Base then
+         RCC_Periph.APB1RSTR.SPI3RST := True;
+         RCC_Periph.APB1RSTR.SPI3RST := False;
+      elsif This.Periph.all'Address = SPI4_Base then
+         RCC_Periph.APB2RSTR.SPI4RST := True;
+         RCC_Periph.APB2RSTR.SPI4RST := False;
+      elsif This.Periph.all'Address = SPI5_Base then
+         RCC_Periph.APB2RSTR.SPI5RST := True;
+         RCC_Periph.APB2RSTR.SPI5RST := False;
+      elsif This.Periph.all'Address = SPI6_Base then
+         RCC_Periph.APB2RSTR.SPI6RST := True;
+         RCC_Periph.APB2RSTR.SPI6RST := False;
+      else
+         raise Unknown_Device;
+      end if;
+   end Reset;
+
+   ------------------
+   -- Enable_Clock --
+   ------------------
+
    procedure Enable_Clock (This : in out Timer) is
    begin
       if This'Address = TIM1_Base then
@@ -585,6 +637,8 @@ package body STM32.Device is
       Source       : constant UInt2 := RCC_Periph.CFGR.SWS;
       Result       : RCC_System_Clocks;
    begin
+      Result.I2SCLK := 0;
+
       case Source is
          when 0 =>
             --  HSI as source
@@ -605,10 +659,17 @@ package body STM32.Device is
                Pllvco     : UInt32;
             begin
                if not HSE_Source then
-                  Pllvco := (HSI_VALUE / Pllm) * Plln;
+                  Pllvco := HSI_VALUE;
                else
-                  Pllvco := (HSE_VALUE / Pllm) * Plln;
+                  Pllvco := HSE_VALUE;
                end if;
+
+               Pllvco := Pllvco / Pllm;
+
+               Result.I2SCLK := Pllvco;
+
+               Pllvco := Pllvco * Plln;
+
                Result.SYSCLK := Pllvco / Pllp;
             end;
          when others =>
@@ -663,8 +724,70 @@ package body STM32.Device is
          end if;
       end;
 
+      -- I2S Clock --
+
+      if RCC_Periph.CFGR.I2SSRC then
+         --  External clock source
+         Result.I2SCLK := 0;
+         raise Program_Error with "External I2S clock value is unknown";
+      else
+         --  Pll clock source
+         declare
+            Plli2sn : constant UInt32 :=
+              UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SN);
+            Plli2sr : constant UInt32
+              := UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SR);
+         begin
+            Result.I2SCLK := (Result.I2SCLK * Plli2sn) / Plli2sr;
+         end;
+      end if;
+
       return Result;
    end System_Clock_Frequencies;
+
+   --------------------
+   -- PLLI2S_Enabled --
+   --------------------
+
+   function PLLI2S_Enabled return Boolean is
+     (RCC_Periph.CR.PLLI2SRDY);
+
+   ------------------------
+   -- Set_PLLI2S_Factors --
+   ------------------------
+
+   procedure Set_PLLI2S_Factors (Pll_N : UInt9;
+                                 Pll_R : UInt3)
+
+   is
+   begin
+      RCC_Periph.PLLI2SCFGR.PLLI2SN := Pll_N;
+      RCC_Periph.PLLI2SCFGR.PLLI2SR := Pll_R;
+   end Set_PLLI2S_Factors;
+
+   -------------------
+   -- Enable_PLLI2S --
+   -------------------
+
+   procedure Enable_PLLI2S is
+   begin
+      RCC_Periph.CR.PLLI2SON := True;
+      loop
+         exit when PLLI2S_Enabled;
+      end loop;
+   end Enable_PLLI2S;
+
+   --------------------
+   -- Disable_PLLI2S --
+   --------------------
+
+   procedure Disable_PLLI2S is
+   begin
+      RCC_Periph.CR.PLLI2SON := False;
+      loop
+         exit when not PLLI2S_Enabled;
+      end loop;
+   end Disable_PLLI2S;
 
    ------------------
    -- PLLSAI_Ready --

--- a/ARM/STM32/devices/stm32f42x/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f42x/stm32-device.ads
@@ -69,7 +69,6 @@ package STM32.Device is
    procedure Enable_Clock (Points : GPIO_Points)
      with Inline;
 
-
    procedure Reset (This : aliased in out GPIO_Port)
      with Inline;
    procedure Reset (Point : GPIO_Point)

--- a/ARM/STM32/devices/stm32f42x/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f42x/stm32-device.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                     Copyright (C) 2015-2016, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -49,6 +49,7 @@ with STM32.GPIO;    use STM32.GPIO;
 with STM32.ADC;     use STM32.ADC;
 with STM32.USARTs;  use STM32.USARTs;
 with STM32.SPI;     use STM32.SPI;
+with STM32.I2S;     use STM32.I2S;
 with STM32.I2C;     use STM32.I2C;
 with STM32.Timers;  use STM32.Timers;
 with STM32.DAC;     use STM32.DAC;
@@ -408,6 +409,23 @@ package STM32.Device is
    procedure Enable_Clock (This : SPI_Port);
    procedure Reset (This : SPI_Port);
 
+   Internal_I2S_1 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI1_Base;
+   Internal_I2S_2 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI2_Base;
+   Internal_I2S_3 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI3_Base;
+   Internal_I2S_4 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI4_Base;
+   Internal_I2S_5 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI5_Base;
+   Internal_I2S_6 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI6_Base;
+
+   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access);
+   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access);
+   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access);
+   I2S_4 : aliased I2S_Port (Internal_I2S_4'Access);
+   I2S_5 : aliased I2S_Port (Internal_I2S_5'Access);
+   I2S_6 : aliased I2S_Port (Internal_I2S_6'Access);
+
+   procedure Enable_Clock (This : I2S_Port);
+   procedure Reset (This : in out I2S_Port);
+
    Timer_1  : aliased Timer with Import, Volatile, Address => TIM1_Base;
    Timer_2  : aliased Timer with Import, Volatile, Address => TIM2_Base;
    Timer_3  : aliased Timer with Import, Volatile, Address => TIM3_Base;
@@ -438,9 +456,21 @@ package STM32.Device is
       PCLK2   : UInt32;
       TIMCLK1 : UInt32;
       TIMCLK2 : UInt32;
+      I2SCLK  : UInt32;
    end record;
 
    function System_Clock_Frequencies return RCC_System_Clocks;
+
+   procedure Set_PLLI2S_Factors (Pll_N : UInt9;
+                                 Pll_R : UInt3);
+
+   function PLLI2S_Enabled return Boolean;
+
+   procedure Enable_PLLI2S
+     with Post => PLLI2S_Enabled;
+
+   procedure Disable_PLLI2S
+     with Post => not PLLI2S_Enabled;
 
    type PLLSAI_DivR is new UInt2;
 

--- a/ARM/STM32/devices/stm32f46_79x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f46_79x/stm32-device.adb
@@ -896,7 +896,7 @@ package body STM32.Device is
 
    -------------------
    -- Enable_PLLSAI --
-   -------------------;
+   -------------------
 
    procedure Enable_PLLSAI is
    begin
@@ -910,7 +910,7 @@ package body STM32.Device is
 
    -------------------
    -- Enable_PLLSAI --
-   -------------------;
+   -------------------
 
    procedure Disable_PLLSAI is
    begin

--- a/ARM/STM32/devices/stm32f46_79x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f46_79x/stm32-device.adb
@@ -462,22 +462,22 @@ package body STM32.Device is
 
    procedure Reset (This : in out SPI_Port) is
    begin
-      if This'Address = SPI1_Base then
+      if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2RSTR.SPI1RST := True;
          RCC_Periph.APB2RSTR.SPI1RST := False;
-      elsif This'Address = SPI2_Base then
+      elsif This.Periph.all'Address = SPI2_Base then
          RCC_Periph.APB1RSTR.SPI2RST := True;
          RCC_Periph.APB1RSTR.SPI2RST := False;
-      elsif This'Address = SPI3_Base then
+      elsif This.Periph.all'Address = SPI3_Base then
          RCC_Periph.APB1RSTR.SPI3RST := True;
          RCC_Periph.APB1RSTR.SPI3RST := False;
-      elsif This'Address = SPI4_Base then
+      elsif This.Periph.all'Address = SPI4_Base then
          RCC_Periph.APB2RSTR.SPI4RST := True;
          RCC_Periph.APB2RSTR.SPI4RST := False;
-      elsif This'Address = SPI5_Base then
+      elsif This.Periph.all'Address = SPI5_Base then
          RCC_Periph.APB2RSTR.SPI5RST := True;
          RCC_Periph.APB2RSTR.SPI5RST := False;
-      elsif This'Address = SPI6_Base then
+      elsif This.Periph.all'Address = SPI6_Base then
          RCC_Periph.APB2RSTR.SPI6RST := True;
          RCC_Periph.APB2RSTR.SPI6RST := False;
       else

--- a/ARM/STM32/devices/stm32f46_79x/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f46_79x/stm32-device.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                     Copyright (C) 2015-2016, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -45,6 +45,7 @@ with STM32.GPIO;        use STM32.GPIO;
 with STM32.I2C;         use STM32.I2C;
 with STM32.SDMMC;       use STM32.SDMMC;
 with STM32.SPI;         use STM32.SPI;
+with STM32.I2S;         use STM32.I2S;
 with STM32.Timers;      use STM32.Timers;
 with STM32.USARTs;      use STM32.USARTs;
 with STM32.RTC;         use STM32.RTC;
@@ -460,6 +461,23 @@ package STM32.Device is
    procedure Enable_Clock (This : aliased in out SPI_Port);
    procedure Reset (This : in out SPI_Port);
 
+   Internal_I2S_1 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI1_Base;
+   Internal_I2S_2 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI2_Base;
+   Internal_I2S_3 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI3_Base;
+   Internal_I2S_4 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI4_Base;
+   Internal_I2S_5 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI5_Base;
+   Internal_I2S_6 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI6_Base;
+
+   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access);
+   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access);
+   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access);
+   I2S_4 : aliased I2S_Port (Internal_I2S_4'Access);
+   I2S_5 : aliased I2S_Port (Internal_I2S_5'Access);
+   I2S_6 : aliased I2S_Port (Internal_I2S_6'Access);
+
+   procedure Enable_Clock (This : I2S_Port);
+   procedure Reset (This : in out I2S_Port);
+
    Timer_1 : aliased Timer with Volatile, Address => TIM1_Base;
    pragma Import (Ada, Timer_1);
    Timer_2 : aliased Timer with Volatile, Address => TIM2_Base;
@@ -530,9 +548,21 @@ package STM32.Device is
       PCLK2   : UInt32;
       TIMCLK1 : UInt32;
       TIMCLK2 : UInt32;
+      I2SCLK  : UInt32;
    end record;
 
    function System_Clock_Frequencies return RCC_System_Clocks;
+
+   procedure Set_PLLI2S_Factors (Pll_N : UInt9;
+                                 Pll_R : UInt3);
+
+   function PLLI2S_Enabled return Boolean;
+
+   procedure Enable_PLLI2S
+     with Post => PLLI2S_Enabled;
+
+   procedure Disable_PLLI2S
+     with Post => not PLLI2S_Enabled;
 
    type PLLSAI_DivR is new UInt2;
    PLLSAI_DIV2  : constant PLLSAI_DivR := 0;

--- a/ARM/STM32/devices/stm32f7x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f7x/stm32-device.adb
@@ -852,7 +852,7 @@ package body STM32.Device is
 
    -------------------
    -- Enable_PLLSAI --
-   -------------------;
+   -------------------
 
    procedure Enable_PLLSAI is
    begin
@@ -866,7 +866,7 @@ package body STM32.Device is
 
    -------------------
    -- Enable_PLLSAI --
-   -------------------;
+   -------------------
 
    procedure Disable_PLLSAI is
    begin

--- a/ARM/STM32/devices/stm32f7x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f7x/stm32-device.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                     Copyright (C) 2015-2016, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -428,6 +428,58 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
+   procedure Enable_Clock (This : I2S_Port) is
+   begin
+      if This.Periph.all'Address = SPI1_Base then
+         RCC_Periph.APB2ENR.SPI1EN := True;
+      elsif This.Periph.all'Address = SPI2_Base then
+         RCC_Periph.APB1ENR.SPI2EN := True;
+      elsif This.Periph.all'Address = SPI3_Base then
+         RCC_Periph.APB1ENR.SPI3EN := True;
+      elsif This.Periph.all'Address = SPI4_Base then
+         RCC_Periph.APB2ENR.SPI5ENR := True;
+      elsif This.Periph.all'Address = SPI5_Base then
+         RCC_Periph.APB2ENR.SPI5ENR := True;
+      elsif This.Periph.all'Address = SPI6_Base then
+         RCC_Periph.APB2ENR.SPI6ENR := True;
+      else
+         raise Unknown_Device;
+      end if;
+   end Enable_Clock;
+
+   -----------
+   -- Reset --
+   -----------
+
+   procedure Reset (This : in out I2S_Port) is
+   begin
+      if This.Periph.all'Address = SPI1_Base then
+         RCC_Periph.APB2RSTR.SPI1RST := True;
+         RCC_Periph.APB2RSTR.SPI1RST := False;
+      elsif This.Periph.all'Address = SPI2_Base then
+         RCC_Periph.APB1RSTR.SPI2RST := True;
+         RCC_Periph.APB1RSTR.SPI2RST := False;
+      elsif This.Periph.all'Address = SPI3_Base then
+         RCC_Periph.APB1RSTR.SPI3RST := True;
+         RCC_Periph.APB1RSTR.SPI3RST := False;
+      elsif This.Periph.all'Address = SPI4_Base then
+         RCC_Periph.APB2RSTR.SPI4RST := True;
+         RCC_Periph.APB2RSTR.SPI4RST := False;
+      elsif This.Periph.all'Address = SPI5_Base then
+         RCC_Periph.APB2RSTR.SPI5RST := True;
+         RCC_Periph.APB2RSTR.SPI5RST := False;
+      elsif This.Periph.all'Address = SPI6_Base then
+         RCC_Periph.APB2RSTR.SPI6RST := True;
+         RCC_Periph.APB2RSTR.SPI6RST := False;
+      else
+         raise Unknown_Device;
+      end if;
+   end Reset;
+
+   ------------------
+   -- Enable_Clock --
+   ------------------
+
    procedure Enable_Clock (This : in out Timer) is
    begin
       if This'Address = TIM1_Base then
@@ -643,6 +695,8 @@ package body STM32.Device is
       Source       : constant UInt2 := RCC_Periph.CFGR.SWS;
       Result       : RCC_System_Clocks;
    begin
+      Result.I2SCLK := 0;
+
       case Source is
          when 0 =>
             --  HSI as source
@@ -663,10 +717,17 @@ package body STM32.Device is
                Pllvco     : UInt32;
             begin
                if not HSE_Source then
-                  Pllvco := (HSI_VALUE / Pllm) * Plln;
+                  Pllvco := HSI_VALUE;
                else
-                  Pllvco := (HSE_VALUE / Pllm) * Plln;
+                  Pllvco := HSE_VALUE;
                end if;
+
+               Pllvco := Pllvco / Pllm;
+
+               Result.I2SCLK := Pllvco;
+
+               Pllvco := Pllvco * Plln;
+
                Result.SYSCLK := Pllvco / Pllp;
             end;
          when others =>
@@ -715,8 +776,70 @@ package body STM32.Device is
          end if;
       end;
 
+      -- I2S Clock --
+
+      if RCC_Periph.CFGR.I2SSRC then
+         --  External clock source
+         Result.I2SCLK := 0;
+         raise Program_Error with "External I2S clock value is unknown";
+      else
+         --  Pll clock source
+         declare
+            Plli2sn : constant UInt32 :=
+              UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SN);
+            Plli2sr : constant UInt32
+              := UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SR);
+         begin
+            Result.I2SCLK := (Result.I2SCLK * Plli2sn) / Plli2sr;
+         end;
+      end if;
+
       return Result;
    end System_Clock_Frequencies;
+
+   --------------------
+   -- PLLI2S_Enabled --
+   --------------------
+
+   function PLLI2S_Enabled return Boolean is
+     (RCC_Periph.CR.PLLI2SRDY);
+
+   ------------------------
+   -- Set_PLLI2S_Factors --
+   ------------------------
+
+   procedure Set_PLLI2S_Factors (Pll_N : UInt9;
+                                 Pll_R : UInt3)
+
+   is
+   begin
+      RCC_Periph.PLLI2SCFGR.PLLI2SN := Pll_N;
+      RCC_Periph.PLLI2SCFGR.PLLI2SR := Pll_R;
+   end Set_PLLI2S_Factors;
+
+   -------------------
+   -- Enable_PLLI2S --
+   -------------------
+
+   procedure Enable_PLLI2S is
+   begin
+      RCC_Periph.CR.PLLI2SON := True;
+      loop
+         exit when PLLI2S_Enabled;
+      end loop;
+   end Enable_PLLI2S;
+
+   --------------------
+   -- Disable_PLLI2S --
+   --------------------
+
+   procedure Disable_PLLI2S is
+   begin
+      RCC_Periph.CR.PLLI2SON := False;
+      loop
+         exit when not PLLI2S_Enabled;
+      end loop;
+   end Disable_PLLI2S;
 
    ------------------
    -- PLLSAI_Ready --

--- a/ARM/STM32/devices/stm32f7x/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f7x/stm32-device.adb
@@ -378,17 +378,17 @@ package body STM32.Device is
 
    procedure Enable_Clock (This : SPI_Port) is
    begin
-      if This'Address = SPI1_Base then
+      if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2ENR.SPI1EN := True;
-      elsif This'Address = SPI2_Base then
+      elsif This.Periph.all'Address = SPI2_Base then
          RCC_Periph.APB1ENR.SPI2EN := True;
-      elsif This'Address = SPI3_Base then
+      elsif This.Periph.all'Address = SPI3_Base then
          RCC_Periph.APB1ENR.SPI3EN := True;
-      elsif This'Address = SPI4_Base then
+      elsif This.Periph.all'Address = SPI4_Base then
          RCC_Periph.APB2ENR.SPI4ENR := True;
-      elsif This'Address = SPI5_Base then
+      elsif This.Periph.all'Address = SPI5_Base then
          RCC_Periph.APB2ENR.SPI5ENR := True;
-      elsif This'Address = SPI6_Base then
+      elsif This.Periph.all'Address = SPI6_Base then
          RCC_Periph.APB2ENR.SPI6ENR := True;
       else
          raise Unknown_Device;
@@ -401,22 +401,22 @@ package body STM32.Device is
 
    procedure Reset (This : SPI_Port) is
    begin
-      if This'Address = SPI1_Base then
+      if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2RSTR.SPI1RST := True;
          RCC_Periph.APB2RSTR.SPI1RST := False;
-      elsif This'Address = SPI2_Base then
+      elsif This.Periph.all'Address = SPI2_Base then
          RCC_Periph.APB1RSTR.SPI2RST := True;
          RCC_Periph.APB1RSTR.SPI2RST := False;
-      elsif This'Address = SPI3_Base then
+      elsif This.Periph.all'Address = SPI3_Base then
          RCC_Periph.APB1RSTR.SPI3RST := True;
          RCC_Periph.APB1RSTR.SPI3RST := False;
-      elsif This'Address = SPI4_Base then
+      elsif This.Periph.all'Address = SPI4_Base then
          RCC_Periph.APB2RSTR.SPI4RST := True;
          RCC_Periph.APB2RSTR.SPI4RST := False;
-      elsif This'Address = SPI5_Base then
+      elsif This.Periph.all'Address = SPI5_Base then
          RCC_Periph.APB2RSTR.SPI5RST := True;
          RCC_Periph.APB2RSTR.SPI5RST := False;
-      elsif This'Address = SPI6_Base then
+      elsif This.Periph.all'Address = SPI6_Base then
          RCC_Periph.APB2RSTR.SPI6RST := True;
          RCC_Periph.APB2RSTR.SPI6RST := False;
       else

--- a/ARM/STM32/devices/stm32f7x/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f7x/stm32-device.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                     Copyright (C) 2015-2016, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -58,6 +58,7 @@ with STM32.GPIO;    use STM32.GPIO;
 with STM32.I2C;     use STM32.I2C;
 with STM32.SDMMC;   use STM32.SDMMC;
 with STM32.SPI;     use STM32.SPI;
+with STM32.I2S;     use STM32.I2S;
 with STM32.Timers;  use STM32.Timers;
 with STM32.RTC;     use STM32.RTC;
 
@@ -458,6 +459,29 @@ package STM32.Device is
    procedure Enable_Clock (This : SPI_Port);
    procedure Reset (This : SPI_Port);
 
+   Internal_I2S_1 : aliased Internal_I2S_Port
+     with Import, Volatile, Address => SPI1_Base;
+   Internal_I2S_2 : aliased Internal_I2S_Port
+     with Import, Volatile, Address => SPI2_Base;
+   Internal_I2S_3 : aliased Internal_I2S_Port
+     with Import, Volatile, Address => SPI3_Base;
+   Internal_I2S_4 : aliased Internal_I2S_Port
+     with Import, Volatile, Address => SPI4_Base;
+   Internal_I2S_5 : aliased Internal_I2S_Port
+     with Import, Volatile, Address => SPI5_Base;
+   Internal_I2S_6 : aliased Internal_I2S_Port
+     with Import, Volatile, Address => SPI6_Base;
+
+   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access);
+   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access);
+   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access);
+   I2S_4 : aliased I2S_Port (Internal_I2S_4'Access);
+   I2S_5 : aliased I2S_Port (Internal_I2S_5'Access);
+   I2S_6 : aliased I2S_Port (Internal_I2S_6'Access);
+
+   procedure Enable_Clock (This : I2S_Port);
+   procedure Reset (This : in out I2S_Port);
+
    ------------
    -- Timers --
    ------------
@@ -527,9 +551,21 @@ package STM32.Device is
       PCLK2   : UInt32;
       TIMCLK1 : UInt32;
       TIMCLK2 : UInt32;
+      I2SCLK  : UInt32;
    end record;
 
    function System_Clock_Frequencies return RCC_System_Clocks;
+
+   procedure Set_PLLI2S_Factors (Pll_N : UInt9;
+                                 Pll_R : UInt3);
+
+   function PLLI2S_Enabled return Boolean;
+
+   procedure Enable_PLLI2S
+     with Post => PLLI2S_Enabled;
+
+   procedure Disable_PLLI2S
+     with Post => not PLLI2S_Enabled;
 
    type PLLSAI_DivR is new UInt2;
    PLLSAI_DIV2  : constant PLLSAI_DivR := 0;

--- a/ARM/STM32/devices/stm32f7x9/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f7x9/stm32-device.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                     Copyright (C) 2015-2016, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -485,6 +485,58 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
+   procedure Enable_Clock (This : I2S_Port) is
+   begin
+      if This.Periph.all'Address = SPI1_Base then
+         RCC_Periph.APB2ENR.SPI1EN := True;
+      elsif This.Periph.all'Address = SPI2_Base then
+         RCC_Periph.APB1ENR.SPI2EN := True;
+      elsif This.Periph.all'Address = SPI3_Base then
+         RCC_Periph.APB1ENR.SPI3EN := True;
+      elsif This.Periph.all'Address = SPI4_Base then
+         RCC_Periph.APB2ENR.SPI5ENR := True;
+      elsif This.Periph.all'Address = SPI5_Base then
+         RCC_Periph.APB2ENR.SPI5ENR := True;
+      elsif This.Periph.all'Address = SPI6_Base then
+         RCC_Periph.APB2ENR.SPI6ENR := True;
+      else
+         raise Unknown_Device;
+      end if;
+   end Enable_Clock;
+
+   -----------
+   -- Reset --
+   -----------
+
+   procedure Reset (This : in out I2S_Port) is
+   begin
+      if This.Periph.all'Address = SPI1_Base then
+         RCC_Periph.APB2RSTR.SPI1RST := True;
+         RCC_Periph.APB2RSTR.SPI1RST := False;
+      elsif This.Periph.all'Address = SPI2_Base then
+         RCC_Periph.APB1RSTR.SPI2RST := True;
+         RCC_Periph.APB1RSTR.SPI2RST := False;
+      elsif This.Periph.all'Address = SPI3_Base then
+         RCC_Periph.APB1RSTR.SPI3RST := True;
+         RCC_Periph.APB1RSTR.SPI3RST := False;
+      elsif This.Periph.all'Address = SPI4_Base then
+         RCC_Periph.APB2RSTR.SPI4RST := True;
+         RCC_Periph.APB2RSTR.SPI4RST := False;
+      elsif This.Periph.all'Address = SPI5_Base then
+         RCC_Periph.APB2RSTR.SPI5RST := True;
+         RCC_Periph.APB2RSTR.SPI5RST := False;
+      elsif This.Periph.all'Address = SPI6_Base then
+         RCC_Periph.APB2RSTR.SPI6RST := True;
+         RCC_Periph.APB2RSTR.SPI6RST := False;
+      else
+         raise Unknown_Device;
+      end if;
+   end Reset;
+
+   ------------------
+   -- Enable_Clock --
+   ------------------
+
    procedure Enable_Clock (This : in out Timer) is
    begin
       if This'Address = TIM1_Base then
@@ -706,6 +758,8 @@ package body STM32.Device is
       Source       : constant UInt2 := RCC_Periph.CFGR.SWS;
       Result       : RCC_System_Clocks;
    begin
+      Result.I2SCLK := 0;
+
       case Source is
          when 0 =>
             --  HSI as source
@@ -726,10 +780,17 @@ package body STM32.Device is
                Pllvco     : UInt32;
             begin
                if not HSE_Source then
-                  Pllvco := (HSI_VALUE / Pllm) * Plln;
+                  Pllvco := HSI_VALUE;
                else
-                  Pllvco := (HSE_VALUE / Pllm) * Plln;
+                  Pllvco := HSE_VALUE;
                end if;
+
+               Pllvco := Pllvco / Pllm;
+
+               Result.I2SCLK := Pllvco;
+
+               Pllvco := Pllvco * Plln;
+
                Result.SYSCLK := Pllvco / Pllp;
             end;
          when others =>
@@ -778,8 +839,70 @@ package body STM32.Device is
          end if;
       end;
 
+      -- I2S Clock --
+
+      if RCC_Periph.CFGR.I2SSRC then
+         --  External clock source
+         Result.I2SCLK := 0;
+         raise Program_Error with "External I2S clock value is unknown";
+      else
+         --  Pll clock source
+         declare
+            Plli2sn : constant UInt32 :=
+              UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SN);
+            Plli2sr : constant UInt32
+              := UInt32 (RCC_Periph.PLLI2SCFGR.PLLI2SR);
+         begin
+            Result.I2SCLK := (Result.I2SCLK * Plli2sn) / Plli2sr;
+         end;
+      end if;
+
       return Result;
    end System_Clock_Frequencies;
+
+   --------------------
+   -- PLLI2S_Enabled --
+   --------------------
+
+   function PLLI2S_Enabled return Boolean is
+     (RCC_Periph.CR.PLLI2SRDY);
+
+   ------------------------
+   -- Set_PLLI2S_Factors --
+   ------------------------
+
+   procedure Set_PLLI2S_Factors (Pll_N : UInt9;
+                                 Pll_R : UInt3)
+
+   is
+   begin
+      RCC_Periph.PLLI2SCFGR.PLLI2SN := Pll_N;
+      RCC_Periph.PLLI2SCFGR.PLLI2SR := Pll_R;
+   end Set_PLLI2S_Factors;
+
+   -------------------
+   -- Enable_PLLI2S --
+   -------------------
+
+   procedure Enable_PLLI2S is
+   begin
+      RCC_Periph.CR.PLLI2SON := True;
+      loop
+         exit when PLLI2S_Enabled;
+      end loop;
+   end Enable_PLLI2S;
+
+   --------------------
+   -- Disable_PLLI2S --
+   --------------------
+
+   procedure Disable_PLLI2S is
+   begin
+      RCC_Periph.CR.PLLI2SON := False;
+      loop
+         exit when not PLLI2S_Enabled;
+      end loop;
+   end Disable_PLLI2S;
 
    ------------------
    -- PLLSAI_Ready --

--- a/ARM/STM32/devices/stm32f7x9/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f7x9/stm32-device.adb
@@ -435,17 +435,17 @@ package body STM32.Device is
 
    procedure Enable_Clock (This : SPI_Port) is
    begin
-      if This'Address = SPI1_Base then
+      if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2ENR.SPI1EN := True;
-      elsif This'Address = SPI2_Base then
+      elsif This.Periph.all'Address = SPI2_Base then
          RCC_Periph.APB1ENR.SPI2EN := True;
-      elsif This'Address = SPI3_Base then
+      elsif This.Periph.all'Address = SPI3_Base then
          RCC_Periph.APB1ENR.SPI3EN := True;
-      elsif This'Address = SPI4_Base then
+      elsif This.Periph.all'Address = SPI4_Base then
          RCC_Periph.APB2ENR.SPI4ENR := True;
-      elsif This'Address = SPI5_Base then
+      elsif This.Periph.all'Address = SPI5_Base then
          RCC_Periph.APB2ENR.SPI5ENR := True;
-      elsif This'Address = SPI6_Base then
+      elsif This.Periph.all'Address = SPI6_Base then
          RCC_Periph.APB2ENR.SPI6ENR := True;
       else
          raise Unknown_Device;
@@ -458,22 +458,22 @@ package body STM32.Device is
 
    procedure Reset (This : SPI_Port) is
    begin
-      if This'Address = SPI1_Base then
+      if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2RSTR.SPI1RST := True;
          RCC_Periph.APB2RSTR.SPI1RST := False;
-      elsif This'Address = SPI2_Base then
+      elsif This.Periph.all'Address = SPI2_Base then
          RCC_Periph.APB1RSTR.SPI2RST := True;
          RCC_Periph.APB1RSTR.SPI2RST := False;
-      elsif This'Address = SPI3_Base then
+      elsif This.Periph.all'Address = SPI3_Base then
          RCC_Periph.APB1RSTR.SPI3RST := True;
          RCC_Periph.APB1RSTR.SPI3RST := False;
-      elsif This'Address = SPI4_Base then
+      elsif This.Periph.all'Address = SPI4_Base then
          RCC_Periph.APB2RSTR.SPI4RST := True;
          RCC_Periph.APB2RSTR.SPI4RST := False;
-      elsif This'Address = SPI5_Base then
+      elsif This.Periph.all'Address = SPI5_Base then
          RCC_Periph.APB2RSTR.SPI5RST := True;
          RCC_Periph.APB2RSTR.SPI5RST := False;
-      elsif This'Address = SPI6_Base then
+      elsif This.Periph.all'Address = SPI6_Base then
          RCC_Periph.APB2RSTR.SPI6RST := True;
          RCC_Periph.APB2RSTR.SPI6RST := False;
       else

--- a/ARM/STM32/devices/stm32f7x9/stm32-device.adb
+++ b/ARM/STM32/devices/stm32f7x9/stm32-device.adb
@@ -915,7 +915,7 @@ package body STM32.Device is
 
    -------------------
    -- Enable_PLLSAI --
-   -------------------;
+   -------------------
 
    procedure Enable_PLLSAI is
    begin
@@ -929,7 +929,7 @@ package body STM32.Device is
 
    -------------------
    -- Enable_PLLSAI --
-   -------------------;
+   -------------------
 
    procedure Disable_PLLSAI is
    begin

--- a/ARM/STM32/devices/stm32f7x9/stm32-device.ads
+++ b/ARM/STM32/devices/stm32f7x9/stm32-device.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                     Copyright (C) 2015-2016, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -60,6 +60,7 @@ with STM32.GPIO;    use STM32.GPIO;
 with STM32.I2C;     use STM32.I2C;
 with STM32.SDMMC;   use STM32.SDMMC;
 with STM32.SPI;     use STM32.SPI;
+with STM32.I2S;     use STM32.I2S;
 with STM32.Timers;  use STM32.Timers;
 with STM32.RTC;     use STM32.RTC;
 
@@ -476,6 +477,29 @@ package STM32.Device is
    procedure Enable_Clock (This : SPI_Port);
    procedure Reset (This : SPI_Port);
 
+   Internal_I2S_1 : aliased Internal_I2S_Port
+     with Import, Volatile, Address => SPI1_Base;
+   Internal_I2S_2 : aliased Internal_I2S_Port
+     with Import, Volatile, Address => SPI2_Base;
+   Internal_I2S_3 : aliased Internal_I2S_Port
+     with Import, Volatile, Address => SPI3_Base;
+   Internal_I2S_4 : aliased Internal_I2S_Port
+     with Import, Volatile, Address => SPI4_Base;
+   Internal_I2S_5 : aliased Internal_I2S_Port
+     with Import, Volatile, Address => SPI5_Base;
+   Internal_I2S_6 : aliased Internal_I2S_Port
+     with Import, Volatile, Address => SPI6_Base;
+
+   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access);
+   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access);
+   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access);
+   I2S_4 : aliased I2S_Port (Internal_I2S_4'Access);
+   I2S_5 : aliased I2S_Port (Internal_I2S_5'Access);
+   I2S_6 : aliased I2S_Port (Internal_I2S_6'Access);
+
+   procedure Enable_Clock (This : I2S_Port);
+   procedure Reset (This : in out I2S_Port);
+
    Timer_1 : aliased Timer with Volatile, Address => TIM1_Base;
    pragma Import (Ada, Timer_1);
    Timer_2 : aliased Timer with Volatile, Address => TIM2_Base;
@@ -548,9 +572,21 @@ package STM32.Device is
       PCLK2   : UInt32;
       TIMCLK1 : UInt32;
       TIMCLK2 : UInt32;
+      I2SCLK  : UInt32;
    end record;
 
    function System_Clock_Frequencies return RCC_System_Clocks;
+
+   procedure Set_PLLI2S_Factors (Pll_N : UInt9;
+                                 Pll_R : UInt3);
+
+   function PLLI2S_Enabled return Boolean;
+
+   procedure Enable_PLLI2S
+     with Post => PLLI2S_Enabled;
+
+   procedure Disable_PLLI2S
+     with Post => not PLLI2S_Enabled;
 
    type PLLSAI_DivR is new UInt2;
    PLLSAI_DIV2  : constant PLLSAI_DivR := 0;

--- a/ARM/STM32/drivers/stm32-i2s.adb
+++ b/ARM/STM32/drivers/stm32-i2s.adb
@@ -1,0 +1,210 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                    Copyright (C) 2016, AdaCore                           --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of STMicroelectronics nor the names of its       --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+--                                                                          --
+--  This file is based on:                                                  --
+--                                                                          --
+--   @file    stm32f4xx_hal_i2s.c                                           --
+--   @author  MCD Application Team                                          --
+--   @version V1.0.0                                                        --
+--   @date    18-February-2014                                              --
+--   @brief   I2S HAL module driver.                                        --
+--                                                                          --
+--   COPYRIGHT(c) 2014 STMicroelectronics                                   --
+------------------------------------------------------------------------------
+
+with Ada.Unchecked_Conversion;
+with STM32.Device; use STM32.Device;
+
+package body STM32.I2S is
+
+   function To_Unsigned_16 is new Ada.Unchecked_Conversion (Integer_16,
+                                                            Unsigned_16);
+   function To_Integer_16 is new Ada.Unchecked_Conversion (Unsigned_16,
+                                                           Integer_16);
+   ---------------
+   -- Configure --
+   ---------------
+
+   procedure Configure (This : in out I2S_Port; Conf : I2S_Configuration) is
+   begin
+      This.Periph.I2SCFGR.I2SCFG := (case Conf.Mode is
+                                        when Slave_Transmit  => 2#00#,
+                                        when Slave_Receive   => 2#01#,
+                                        when Master_Transmit => 2#10#,
+                                        when Master_Receive  => 2#11#);
+
+      This.Periph.I2SCFGR.PCMSYNC := Conf.Syncho = Long_Frame_Synchro;
+
+      This.Periph.I2SCFGR.I2SSTD := (case Conf.Standard is
+                                        when I2S_Philips_Standard   => 2#00#,
+                                        when MSB_Justified_Standard => 2#01#,
+                                        when LSB_Justified_Standard => 2#10#,
+                                        when PCM_Standard           => 2#11#);
+
+      This.Periph.I2SCFGR.CKPOL := Conf.Clock_Polarity = Steady_State_High;
+
+      This.Periph.I2SCFGR.DATLEN := (case Conf.Data_Length is
+                                        when Data_16bits => 2#00#,
+                                        when Data_24bits => 2#01#,
+                                        when Data_32bits => 2#10#);
+
+      This.Periph.I2SCFGR.CHLEN := Conf.Chan_Length = Channel_32bits;
+
+      This.Periph.I2SPR.MCKOE := Conf.Master_Clock_Out_Enabled;
+
+      This.Periph.CR2.TXDMAEN := Conf.Transmit_DMA_Enabled;
+      This.Periph.CR2.RXDMAEN := Conf.Receive_DMA_Enabled;
+   end Configure;
+
+   -----------------
+   -- In_I2S_Mode --
+   -----------------
+
+   function In_I2S_Mode (This : in out I2S_Port) return Boolean is
+     (This.Periph.I2SCFGR.I2SMOD);
+
+   ------------
+   -- Enable --
+   ------------
+
+   procedure Enable (This : in out I2S_Port) is
+   begin
+      if This.Periph.CR1.SPE then
+         raise Program_Error with "Device already enabled in SPI mode";
+      end if;
+      This.Periph.I2SCFGR.I2SMOD := True;
+      This.Periph.I2SCFGR.I2SE   := True;
+   end Enable;
+
+   -------------
+   -- Disable --
+   -------------
+
+   procedure Disable (This : in out I2S_Port) is
+   begin
+      This.Periph.I2SCFGR.I2SE := False;
+   end Disable;
+
+   -------------
+   -- Enabled --
+   -------------
+
+   function Enabled (This : I2S_Port) return Boolean is
+   begin
+      return This.Periph.I2SCFGR.I2SE;
+   end Enabled;
+
+   ---------------------------
+   -- Data_Register_Address --
+   ---------------------------
+
+   function Data_Register_Address (This : I2S_Port)
+                                   return System.Address
+   is
+   begin
+      return This.Periph.DR'Address;
+   end Data_Register_Address;
+
+   -------------------
+   -- Set_Frequency --
+   -------------------
+
+   overriding
+   procedure Set_Frequency (This      : in out I2S_Port;
+                            Frequency : Audio_Frequency)
+   is
+      I2SCLK       : constant UInt32 := System_Clock_Frequencies.I2SCLK;
+      Real_Divider : UInt32;
+      Packet_Len   : constant UInt32 := (if This.Periph.I2SCFGR.DATLEN = 0
+                                         then 1 else 2);
+      Is_Odd       : Boolean;
+      Divider      : UInt32;
+   begin
+      if This.Periph.I2SPR.MCKOE then
+         Real_Divider := (I2SCLK / 256) * 10;
+      else
+         Real_Divider := (I2SCLK / (32 * Packet_Len)) * 10;
+      end if;
+
+      Real_Divider := ((Real_Divider / Frequency'Enum_Rep) + 5) / 10;
+
+      Is_Odd := Real_Divider mod 2 = 1;
+
+      if Is_Odd then
+         Divider := (Real_Divider - 1) / 2;
+      else
+         Divider := Real_Divider / 2;
+      end if;
+
+      if Divider < 2 or else Divider > 255 then
+         --  Value out of bounds, use default value
+         Divider := 2;
+         Is_Odd  := False;
+      end if;
+
+      This.Periph.I2SPR.ODD    := Is_Odd;
+      This.Periph.I2SPR.I2SDIV := Byte (Divider);
+   end Set_Frequency;
+
+   -------------
+   -- Receive --
+   -------------
+
+   overriding procedure Receive
+     (This : in out I2S_Port;
+      Data : out Audio_Buffer)
+   is
+   begin
+      for Elt of Data loop
+         while not This.Periph.SR.RXNE loop
+            null;
+         end loop;
+         Elt := To_Integer_16 (This.Periph.DR.DR);
+      end loop;
+   end Receive;
+
+   --------------
+   -- Transmit --
+   --------------
+
+   overriding procedure Transmit
+     (This : in out I2S_Port;
+      Data : Audio_Buffer)
+   is
+   begin
+      for Elt of Data loop
+         while not This.Periph.SR.TXE loop
+            null;
+         end loop;
+         This.Periph.DR.DR := To_Unsigned_16 (Elt);
+      end loop;
+   end Transmit;
+
+end STM32.I2S;

--- a/ARM/STM32/drivers/stm32-i2s.ads
+++ b/ARM/STM32/drivers/stm32-i2s.ads
@@ -1,0 +1,131 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                    Copyright (C) 2016, AdaCore                           --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of STMicroelectronics nor the names of its       --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+--                                                                          --
+--  This file is based on:                                                  --
+--                                                                          --
+--   @file    stm32f4xx_hal_i2s.h                                           --
+--   @author  MCD Application Team                                          --
+--   @version V1.0.0                                                        --
+--   @date    18-February-2014                                              --
+--   @brief   Header file of I2S HAL module.                                --
+--                                                                          --
+--   COPYRIGHT(c) 2014 STMicroelectronics                                   --
+------------------------------------------------------------------------------
+
+--  This file provides definitions for the STM32F4 (ARM Cortex M4F
+--  from ST Microelectronics) Inter-IC Sound (I2S) facility.
+
+private with STM32_SVD.SPI;
+with HAL.Audio; use HAL.Audio;
+with System;
+
+package STM32.I2S is
+
+   type I2S_Mode is (Slave_Transmit,
+                     Slave_Receive,
+                     Master_Transmit,
+                     Master_Receive);
+
+   type I2S_Standard is (I2S_Philips_Standard,
+                         MSB_Justified_Standard,
+                         LSB_Justified_Standard,
+                         PCM_Standard);
+
+   type I2S_Synchronization is (Short_Frame_Syncrho,
+                                Long_Frame_Synchro);
+
+   type I2S_Clock_Polarity is (Steady_State_Low,
+                               Steady_State_High);
+
+   type I2S_Data_Length is (Data_16bits, Data_24bits, Data_32bits);
+   type I2S_Channel_Length is (Channel_16bits, Channel_32bits);
+
+   type I2S_Linear_Prescaler is range 2 .. 255;
+
+   type I2S_Configuration is record
+      Mode                     : I2S_Mode;
+      Standard                 : I2S_Standard;
+      Syncho                   : I2S_Synchronization;
+      Clock_Polarity           : I2S_Clock_Polarity;
+      Data_Length              : I2S_Data_Length;
+      Chan_Length              : I2S_Channel_Length;
+      Master_Clock_Out_Enabled : Boolean;
+      Transmit_DMA_Enabled     : Boolean;
+      Receive_DMA_Enabled      : Boolean;
+   end record;
+
+   type Internal_I2S_Port is private;
+
+   type I2S_Port (Periph : not null access Internal_I2S_Port) is
+      limited new Audio_Stream with private;
+
+   function In_I2S_Mode (This : in out I2S_Port) return Boolean;
+   --  I2S peripherals are shared with SPI, this function returns True only if
+   --  the periperal is configure in I2S mode.
+
+   procedure Configure (This : in out I2S_Port; Conf : I2S_Configuration)
+     with Pre  => not This.Enabled,
+          Post => not This.Enabled;
+
+   procedure Enable (This : in out I2S_Port)
+     with Post => This.Enabled and This.In_I2S_Mode;
+
+   procedure Disable (This : in out I2S_Port)
+     with Pre => This.In_I2S_Mode;
+
+   function Enabled (This : I2S_Port) return Boolean;
+
+   function Data_Register_Address (This : I2S_Port)
+                                   return System.Address;
+   --  For DMA transfer
+
+   overriding
+   procedure Set_Frequency (This      : in out I2S_Port;
+                            Frequency : Audio_Frequency)
+     with Pre  => not This.Enabled;
+
+   overriding
+   procedure Transmit (This : in out I2S_Port;
+                       Data : Audio_Buffer)
+     with Pre => This.In_I2S_Mode;
+
+      overriding
+   procedure Receive (This : in out I2S_Port;
+                      Data : out Audio_Buffer)
+     with Pre => This.In_I2S_Mode;
+
+private
+
+   type Internal_I2S_Port is new STM32_SVD.SPI.SPI_Peripheral;
+
+   type I2S_Port (Periph : not null access Internal_I2S_Port) is
+     limited new Audio_Stream with null record;
+
+end STM32.I2S;

--- a/boards/stm32f407_discovery/src/stm32-board.ads
+++ b/boards/stm32f407_discovery/src/stm32-board.ads
@@ -51,6 +51,11 @@ with LIS3DSH.SPI;   use LIS3DSH.SPI;
 
 with Ada.Interrupts.Names; use Ada.Interrupts;
 with STM32.SPI; use STM32.SPI;
+with STM32.I2C; use STM32.I2C;
+with STM32.I2S; use STM32.I2S;
+with HAL.Audio; use HAL.Audio;
+with CS43L22;
+with Ravenscar_Time;
 
 package STM32.Board is
    pragma Elaborate_Body;
@@ -77,6 +82,16 @@ package STM32.Board is
    procedure Toggle_LEDs (These : in out GPIO_Points)
      renames STM32.GPIO.Toggle;
 
+   procedure Initialize_Audio;
+
+   Audio_I2C : I2C_Port renames I2C_1;
+   Audio_I2C_Points : constant GPIO_Points (1 .. 2) := (PB6, PB9);
+   Audio_I2S_Points : constant GPIO_Points (1 .. 4) := (PC7, PC10, PC12, PA4);
+   Audio_I2S : I2S_Port renames I2S_3;
+   Audio_Rate : constant Audio_Frequency := Audio_Freq_48kHz;
+   DAC_Reset_Point : GPIO_Point renames PD4;
+   Audio_DAC : CS43L22.CS43L22_Device (Audio_I2C'Access,
+                                       Ravenscar_Time.Delays);
 
    Acc_SPI    : SPI_Port renames SPI_1;
    Acc_SPI_AF : GPIO_Alternate_Function renames GPIO_AF_5_SPI1;

--- a/boards/stm32f469_discovery/src/audio.adb
+++ b/boards/stm32f469_discovery/src/audio.adb
@@ -229,7 +229,7 @@ package body Audio is
         (Output    => CS43L22.Auto,
          Volume    => Unsigned_8 (Volume),
          Frequency =>
-           CS43L22.Audio_Frequency'Enum_Val
+           HAL.Audio.Audio_Frequency'Enum_Val
              (Audio_Frequency'Enum_Rep (Frequency)));
    end Initialize_Audio_Out;
 

--- a/boards/stm32f469_discovery/src/audio.adb
+++ b/boards/stm32f469_discovery/src/audio.adb
@@ -203,7 +203,7 @@ package body Audio is
    -- Initialize --
    ----------------
 
-   overriding procedure Initialize_Audio_Out
+   procedure Initialize_Audio_Out
      (This      : in out CS43L22_Audio_Device;
       Volume    : Audio_Volume;
       Frequency : Audio_Frequency)
@@ -251,7 +251,7 @@ package body Audio is
    -- Play --
    ----------
 
-   overriding procedure Play
+   procedure Play
      (This   : in out CS43L22_Audio_Device;
       Buffer : Audio_Buffer)
    is
@@ -275,7 +275,7 @@ package body Audio is
    -- Pause --
    -----------
 
-   overriding procedure Pause (This : in out CS43L22_Audio_Device) is
+   procedure Pause (This : in out CS43L22_Audio_Device) is
    begin
       This.Device.Pause;
       DMA_Pause (Audio_SAI, SAI_Out_Block);
@@ -285,7 +285,7 @@ package body Audio is
    -- Resume --
    ------------
 
-   overriding procedure Resume (This : in out CS43L22_Audio_Device)
+   procedure Resume (This : in out CS43L22_Audio_Device)
    is
    begin
       This.Device.Resume;
@@ -296,7 +296,7 @@ package body Audio is
    -- Stop --
    ----------
 
-   overriding procedure Stop (This : in out CS43L22_Audio_Device)
+   procedure Stop (This : in out CS43L22_Audio_Device)
    is
    begin
       This.Device.Stop;
@@ -310,7 +310,7 @@ package body Audio is
    -- Set_Volume --
    ----------------
 
-   overriding procedure Set_Volume
+   procedure Set_Volume
      (This   : in out CS43L22_Audio_Device;
       Volume : Audio_Volume)
    is
@@ -322,7 +322,7 @@ package body Audio is
    -- Set_Frequency --
    -------------------
 
-   overriding procedure Set_Frequency
+   procedure Set_Frequency
      (This      : in out CS43L22_Audio_Device;
       Frequency : Audio_Frequency)
    is

--- a/boards/stm32f469_discovery/src/audio.ads
+++ b/boards/stm32f469_discovery/src/audio.ads
@@ -40,39 +40,39 @@ private with CS43L22;
 
 package Audio is
 
-   type CS43L22_Audio_Device (Port : not null I2C_Port_Ref) is limited
-     new HAL.Audio.Audio_Device with private;
+   type CS43L22_Audio_Device (Port : not null I2C_Port_Ref) is
+     tagged limited private;
 
-   overriding procedure Initialize_Audio_Out
+   procedure Initialize_Audio_Out
      (This      : in out CS43L22_Audio_Device;
       Volume    : Audio_Volume;
       Frequency : Audio_Frequency);
 
-   overriding procedure Play
+   procedure Play
      (This   : in out CS43L22_Audio_Device;
       Buffer : Audio_Buffer);
 
-   overriding procedure Pause
+   procedure Pause
      (This : in out CS43L22_Audio_Device);
 
-   overriding procedure Resume
+   procedure Resume
      (This : in out CS43L22_Audio_Device);
 
-   overriding procedure Stop
+   procedure Stop
      (This : in out CS43L22_Audio_Device);
 
-   overriding procedure Set_Volume
+   procedure Set_Volume
      (This   : in out CS43L22_Audio_Device;
       Volume : Audio_Volume);
 
-   overriding procedure Set_Frequency
+   procedure Set_Frequency
      (This      : in out CS43L22_Audio_Device;
       Frequency : Audio_Frequency);
 
 private
 
-   type CS43L22_Audio_Device (Port : not null I2C_Port_Ref) is limited
-   new HAL.Audio.Audio_Device with record
+   type CS43L22_Audio_Device (Port : not null I2C_Port_Ref) is
+     tagged limited record
       Device : CS43L22.CS43L22_Device (Port, Ravenscar_Time.Delays);
    end record;
 

--- a/boards/stm32f746_discovery/src/audio.adb
+++ b/boards/stm32f746_discovery/src/audio.adb
@@ -190,7 +190,7 @@ package body Audio is
    -- Initialize --
    ----------------
 
-   overriding procedure Initialize_Audio_Out
+   procedure Initialize_Audio_Out
      (This      : in out WM8994_Audio_Device;
       Volume    : Audio_Volume;
       Frequency : Audio_Frequency)
@@ -225,7 +225,7 @@ package body Audio is
    -- Play --
    ----------
 
-   overriding procedure Play
+   procedure Play
      (This   : in out WM8994_Audio_Device;
       Buffer : Audio_Buffer)
    is
@@ -253,7 +253,7 @@ package body Audio is
    -- Pause --
    -----------
 
-   overriding procedure Pause (This : in out WM8994_Audio_Device) is
+   procedure Pause (This : in out WM8994_Audio_Device) is
    begin
       This.Device.Pause;
       DMA_Pause (Audio_SAI, SAI_Out_Block);
@@ -263,7 +263,7 @@ package body Audio is
    -- Resume --
    ------------
 
-   overriding procedure Resume (This : in out WM8994_Audio_Device)
+   procedure Resume (This : in out WM8994_Audio_Device)
    is
    begin
       This.Device.Resume;
@@ -274,7 +274,7 @@ package body Audio is
    -- Stop --
    ----------
 
-   overriding procedure Stop (This : in out WM8994_Audio_Device)
+   procedure Stop (This : in out WM8994_Audio_Device)
    is
    begin
       This.Device.Stop (WM8994.Stop_Power_Down_Sw);
@@ -288,7 +288,7 @@ package body Audio is
    -- Set_Volume --
    ----------------
 
-   overriding procedure Set_Volume
+   procedure Set_Volume
      (This   : in out WM8994_Audio_Device;
       Volume : Audio_Volume)
    is
@@ -300,7 +300,7 @@ package body Audio is
    -- Set_Frequency --
    -------------------
 
-   overriding procedure Set_Frequency
+   procedure Set_Frequency
      (This      : in out WM8994_Audio_Device;
       Frequency : Audio_Frequency)
    is

--- a/boards/stm32f746_discovery/src/audio.ads
+++ b/boards/stm32f746_discovery/src/audio.ads
@@ -40,41 +40,41 @@ private with WM8994;
 
 package Audio is
 
-   type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is limited new
-     Audio_Device with private;
+   type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is
+     tagged limited private;
 
-   overriding procedure Initialize_Audio_Out
+   procedure Initialize_Audio_Out
      (This      : in out WM8994_Audio_Device;
       Volume    : Audio_Volume;
       Frequency : Audio_Frequency);
 
-   overriding procedure Set_Volume
+   procedure Set_Volume
      (This   : in out WM8994_Audio_Device;
       Volume : Audio_Volume);
 
-   overriding procedure Set_Frequency
+   procedure Set_Frequency
      (This   : in out WM8994_Audio_Device;
       Frequency : Audio_Frequency);
 
-   overriding procedure Play
+   procedure Play
      (This   : in out WM8994_Audio_Device;
       Buffer : Audio_Buffer);
 
-   overriding procedure Pause
+   procedure Pause
      (This : in out WM8994_Audio_Device);
 
-   overriding procedure Resume
+   procedure Resume
      (This : in out WM8994_Audio_Device);
 
-   overriding procedure Stop
+   procedure Stop
      (This : in out WM8994_Audio_Device);
 
 private
 
    Audio_I2C_Addr  : constant I2C_Address := 16#34#;
 
-   type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is limited new
-     Audio_Device with record
+   type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is
+     tagged limited record
       Device : WM8994.WM8994_Device (Port, Audio_I2C_Addr, Ravenscar_Time.Delays);
    end record;
 

--- a/boards/stm32f769_discovery/src/audio.adb
+++ b/boards/stm32f769_discovery/src/audio.adb
@@ -192,7 +192,7 @@ package body Audio is
    -- Initialize --
    ----------------
 
-   overriding procedure Initialize_Audio_Out
+   procedure Initialize_Audio_Out
      (This      : in out WM8994_Audio_Device;
       Volume    : Audio_Volume;
       Frequency : Audio_Frequency)
@@ -227,7 +227,7 @@ package body Audio is
    -- Play --
    ----------
 
-   overriding procedure Play
+   procedure Play
      (This   : in out WM8994_Audio_Device;
       Buffer : Audio_Buffer)
    is
@@ -255,7 +255,7 @@ package body Audio is
    -- Pause --
    -----------
 
-   overriding procedure Pause (This : in out WM8994_Audio_Device) is
+   procedure Pause (This : in out WM8994_Audio_Device) is
    begin
       This.Device.Pause;
       DMA_Pause (Audio_SAI, SAI_Out_Block);
@@ -265,7 +265,7 @@ package body Audio is
    -- Resume --
    ------------
 
-   overriding procedure Resume (This : in out WM8994_Audio_Device)
+   procedure Resume (This : in out WM8994_Audio_Device)
    is
    begin
       This.Device.Resume;
@@ -276,7 +276,7 @@ package body Audio is
    -- Stop --
    ----------
 
-   overriding procedure Stop (This : in out WM8994_Audio_Device)
+   procedure Stop (This : in out WM8994_Audio_Device)
    is
    begin
       This.Device.Stop (WM8994.Stop_Power_Down_Sw);
@@ -290,7 +290,7 @@ package body Audio is
    -- Set_Volume --
    ----------------
 
-   overriding procedure Set_Volume
+   procedure Set_Volume
      (This   : in out WM8994_Audio_Device;
       Volume : Audio_Volume)
    is
@@ -302,7 +302,7 @@ package body Audio is
    -- Set_Frequency --
    -------------------
 
-   overriding procedure Set_Frequency
+   procedure Set_Frequency
      (This      : in out WM8994_Audio_Device;
       Frequency : Audio_Frequency)
    is

--- a/boards/stm32f769_discovery/src/audio.ads
+++ b/boards/stm32f769_discovery/src/audio.ads
@@ -40,41 +40,39 @@ private with WM8994;
 
 package Audio is
 
-   type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is limited new
-     Audio_Device with private;
+   type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is limited private;
 
-   overriding procedure Initialize_Audio_Out
+   procedure Initialize_Audio_Out
      (This      : in out WM8994_Audio_Device;
       Volume    : Audio_Volume;
       Frequency : Audio_Frequency);
 
-   overriding procedure Set_Volume
+   procedure Set_Volume
      (This   : in out WM8994_Audio_Device;
       Volume : Audio_Volume);
 
-   overriding procedure Set_Frequency
+   procedure Set_Frequency
      (This   : in out WM8994_Audio_Device;
       Frequency : Audio_Frequency);
 
-   overriding procedure Play
+   procedure Play
      (This   : in out WM8994_Audio_Device;
       Buffer : Audio_Buffer);
 
-   overriding procedure Pause
+   procedure Pause
      (This : in out WM8994_Audio_Device);
 
-   overriding procedure Resume
+   procedure Resume
      (This : in out WM8994_Audio_Device);
 
-   overriding procedure Stop
+   procedure Stop
      (This : in out WM8994_Audio_Device);
 
 private
 
    Audio_I2C_Addr  : constant I2C_Address := 16#34#;
 
-   type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is limited new
-     Audio_Device with record
+   type WM8994_Audio_Device (Port : not null I2C_Port_Ref) is limited record
       Device : WM8994.WM8994_Device (Port, Audio_I2C_Addr, Ravenscar_Time.Delays);
    end record;
 

--- a/components/src/audio/CS43L22/cs43l22.ads
+++ b/components/src/audio/CS43L22/cs43l22.ads
@@ -34,6 +34,7 @@
 with Interfaces; use Interfaces;
 with HAL;        use HAL;
 with HAL.I2C;    use HAL.I2C;
+with HAL.Audio;  use HAL.Audio;
 with HAL.Time;
 
 package CS43L22 is
@@ -49,28 +50,6 @@ package CS43L22 is
 
    CS43L22_ID       : constant := 16#E0#;
    CS43L22_ID_MASK  : constant := 16#F8#;
-
-   type Audio_Frequency is
-     (Audio_Freq_8kHz,
-      Audio_Freq_11kHz,
-      Audio_Freq_16kHz,
-      Audio_Freq_22kHz,
-      Audio_Freq_32kHz,
-      Audio_Freq_44kHz,
-      Audio_Freq_48kHz,
-      Audio_Freq_96kHz,
-      Audio_Freq_192kHz)
-     with Size => 32;
-   for Audio_Frequency use
-     (Audio_Freq_8kHz   =>  8_000,
-      Audio_Freq_11kHz  => 11_025,
-      Audio_Freq_16kHz  => 16_000,
-      Audio_Freq_22kHz  => 22_050,
-      Audio_Freq_32kHz  => 32_000,
-      Audio_Freq_44kHz  => 44_100,
-      Audio_Freq_48kHz  => 48_000,
-      Audio_Freq_96kHz  => 96_000,
-      Audio_Freq_192kHz => 192_000);
 
    type Mute is
      (Mute_On,

--- a/examples/accelerometer/src/main.adb
+++ b/examples/accelerometer/src/main.adb
@@ -29,10 +29,20 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Ada.Real_Time; use Ada.Real_Time;
-with HAL;           use HAL;
-with STM32.Board;   use STM32.Board;
-with LIS3DSH;       use LIS3DSH;
+--  This is a demo of the features available on the STM32F4-DISCOVERY board.
+--
+--  Tilt the board and the LED closer to the ground will light up. Press the
+--  blue button to enter sound mode where a two tone audio is played in the
+--  headphone jack. Press the black button to reset.
+
+with Ada.Real_Time;      use Ada.Real_Time;
+with HAL;                use HAL;
+with STM32.Board;        use STM32.Board;
+with STM32.User_Button;
+with LIS3DSH;            use LIS3DSH;
+with HAL.Audio;          use HAL.Audio;
+with Simple_Synthesizer;
+with CS43L22;
 
 procedure Main is
    use type Byte;
@@ -49,8 +59,17 @@ procedure Main is
       delay until Clock + Milliseconds (Milli);
    end My_Delay;
 
+   Synth : Simple_Synthesizer.Synthesizer;
+   Audio_Data : Audio_Buffer (1 .. 128);
+
 begin
    Initialize_LEDs;
+
+   STM32.User_Button.Initialize;
+
+   Initialize_Audio;
+   Synth.Set_Frequency (STM32.Board.Audio_Rate);
+   STM32.Board.Audio_DAC.Set_Volume (60);
 
    Initialize_Accelerometer;
 
@@ -71,23 +90,46 @@ begin
       end loop;
    end if;
 
+
    loop
       Accelerometer.Get_Accelerations (Values);
       if abs Values.X > abs Values.Y then
          if Values.X > Threshold_High then
-               STM32.Board.Red.Set;
+            STM32.Board.Red.Set;
          elsif Values.X < Threshold_Low then
-               STM32.Board.Green.Set;
+            STM32.Board.Green.Set;
          end if;
          My_Delay (10);
       else
          if Values.Y > Threshold_High then
-               STM32.Board.Orange.Set;
+            STM32.Board.Orange.Set;
          elsif Values.Y < Threshold_Low then
-               STM32.Board.Blue.Set;
+            STM32.Board.Blue.Set;
          end if;
          My_Delay (10);
       end if;
+
+      if STM32.User_Button.Has_Been_Pressed then
+         --  Go to the sound loop
+         exit;
+      end if;
+
       All_LEDs_Off;
+   end loop;
+
+   STM32.Board.Audio_DAC.Play;
+   loop
+      for Cnt in 1 .. 1_000 loop
+         if Cnt < 500 then
+            Synth.Set_Note_Frequency (440.0);
+            All_LEDs_On;
+         else
+            Synth.Set_Note_Frequency (880.0);
+            All_LEDs_Off;
+         end if;
+
+         Synth.Receive (Audio_Data);
+         STM32.Board.Audio_I2S.Transmit (Audio_Data);
+      end loop;
    end loop;
 end Main;

--- a/hal/src/hal-audio.ads
+++ b/hal/src/hal-audio.ads
@@ -34,7 +34,7 @@ with Interfaces; use Interfaces;
 package HAL.Audio is
 
    type Audio_Buffer is array (Natural range <>) of Integer_16
-     with Component_Size => 16, Alignment => 32;
+     with Component_Size => 16, Alignment => 16;
 
    type Audio_Volume is new Natural range 0 .. 100;
 
@@ -56,35 +56,16 @@ package HAL.Audio is
       Audio_Freq_48kHz => 48_000,
       Audio_Freq_96kHz => 96_000);
 
-   type Audio_Buffer_Completion_Level is
-     (Half, Full);
-
-   type Audio_Device is limited interface;
-
-   procedure Initialize_Audio_Out
-     (This      : in out Audio_Device;
-      Volume    : Audio_Volume;
-      Frequency : Audio_Frequency) is abstract;
-
-   procedure Play
-     (This   : in out Audio_Device;
-      Buffer : Audio_Buffer) is abstract;
-
-   procedure Pause
-     (This : in out Audio_Device) is abstract;
-
-   procedure Resume
-     (This : in out Audio_Device) is abstract;
-
-   procedure Stop
-     (This : in out Audio_Device) is abstract;
-
-   procedure Set_Volume
-     (This   : in out Audio_Device;
-      Volume : Audio_Volume) is abstract;
+   type Audio_Stream is limited interface;
 
    procedure Set_Frequency
-     (This      : in out Audio_Device;
+     (This      : in out Audio_Stream;
       Frequency : Audio_Frequency) is abstract;
+
+   procedure Transmit (This : in out Audio_Stream;
+                       Data : Audio_Buffer) is abstract;
+
+   procedure Receive (This : in out Audio_Stream;
+                      Data : out Audio_Buffer) is abstract;
 
 end HAL.Audio;

--- a/hal/src/hal-audio.ads
+++ b/hal/src/hal-audio.ads
@@ -58,9 +58,8 @@ package HAL.Audio is
 
    type Audio_Stream is limited interface;
 
-   procedure Set_Frequency
-     (This      : in out Audio_Stream;
-      Frequency : Audio_Frequency) is abstract;
+   procedure Set_Frequency (This      : in out Audio_Stream;
+                            Frequency : Audio_Frequency) is abstract;
 
    procedure Transmit (This : in out Audio_Stream;
                        Data : Audio_Buffer) is abstract;

--- a/services/services.gpr
+++ b/services/services.gpr
@@ -5,7 +5,8 @@ library project Services is
 
    Src_Dirs := ("src/filesystems",
                 "src/BLE",
-                "src/utils");
+                "src/utils",
+                "src/audio");
 
    case Config.RTS is
       when "ravenscar-sfp" | "ravenscar-full" =>

--- a/services/src/audio/simple_synthesizer.adb
+++ b/services/src/audio/simple_synthesizer.adb
@@ -1,0 +1,122 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                        Copyright (C) 2016, AdaCore                       --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with Interfaces; use Interfaces;
+
+package body Simple_Synthesizer is
+
+   ------------------------
+   -- Set_Note_Frequency --
+   ------------------------
+
+   procedure Set_Note_Frequency
+     (This : in out Synthesizer;
+      Note : Float)
+   is
+   begin
+      This.Note := Note;
+   end Set_Note_Frequency;
+
+   -------------------
+   -- Set_Frequency --
+   -------------------
+
+   overriding procedure Set_Frequency
+     (This      : in out Synthesizer;
+      Frequency : Audio_Frequency)
+   is
+   begin
+      This.Frequency := Frequency;
+   end Set_Frequency;
+
+   --------------
+   -- Transmit --
+   --------------
+
+   overriding procedure Transmit
+     (This : in out Synthesizer;
+      Data : Audio_Buffer)
+   is
+   begin
+      raise Program_Error with "This Synthesizer doesn't take input";
+   end Transmit;
+
+   -------------
+   -- Receive --
+   -------------
+
+   overriding procedure Receive
+     (This : in out Synthesizer;
+      Data : out Audio_Buffer)
+   is
+      function Next_Sample return Integer_16;
+
+      Rate      : constant Float :=
+        Float (Audio_Frequency'Enum_Rep (This.Frequency));
+      Note      : constant Float := This.Note;
+      Amplitude : constant Float := Float (This.Amplitude);
+      Delt      : constant Float := 2.0 / (Rate * (1.0 / Note));
+
+
+      -----------------
+      -- Next_Sample --
+      -----------------
+
+      function Next_Sample return Integer_16 is
+      begin
+         This.Last_Sample := This.Last_Sample + Delt;
+         if This.Last_Sample >  1.0 then
+            This.Last_Sample := -1.0;
+         end if;
+         return Integer_16 (This.Last_Sample * Amplitude);
+      end Next_Sample;
+
+      Tmp : Integer_16;
+   begin
+      if This.Stereo then
+         if Data'Length mod 2 /= 0 then
+            raise Program_Error with
+              "Audio buffer for stereo output should have even length";
+         end if;
+
+         for Index in 0 .. (Data'Length / 2) - 1 loop
+            Tmp := Next_Sample;
+            Data ((Index * 2) + Data'First) := Tmp;
+            Data ((Index * 2) + Data'First + 1) := Tmp;
+         end loop;
+      else
+         for Elt of Data loop
+            Elt := Next_Sample;
+         end loop;
+      end if;
+   end Receive;
+
+end Simple_Synthesizer;

--- a/services/src/audio/simple_synthesizer.ads
+++ b/services/src/audio/simple_synthesizer.ads
@@ -1,0 +1,65 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                        Copyright (C) 2016, AdaCore                       --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This package provides a simple software synthesizer that can be used to try
+--  audio streams and DACs.
+
+with HAL.Audio;  use HAL.Audio;
+
+package Simple_Synthesizer is
+
+   type Synthesizer (Stereo    : Boolean := True;
+                     Amplitude : Natural := 500) is
+     limited new Audio_Stream with private;
+
+   procedure Set_Note_Frequency (This : in out Synthesizer;
+                                 Note : Float);
+
+   overriding
+   procedure Set_Frequency (This      : in out Synthesizer;
+                            Frequency : Audio_Frequency);
+
+   overriding
+   procedure Transmit (This : in out Synthesizer;
+                       Data : Audio_Buffer);
+
+   overriding
+   procedure Receive (This : in out Synthesizer;
+                      Data : out Audio_Buffer);
+private
+   type Synthesizer (Stereo    : Boolean := True;
+                     Amplitude : Natural := 500) is
+     limited new Audio_Stream with record
+      Frequency   : Audio_Frequency;
+      Note        : Float := 0.0;
+      Last_Sample : Float := 0.0;
+   end record;
+end Simple_Synthesizer;


### PR DESCRIPTION
This patch series add support for I2S in STM32F4/7 drives and use it in a example.