### PR TITLE
Indicate BUILD is for the platform

### DIFF
--- a/boards/common_config.gpr
+++ b/boards/common_config.gpr
@@ -7,7 +7,7 @@ abstract project Common_Config is
 
    type BUILD_TYPE is
       ("Debug", "Production");
-   Build : BUILD_Type := external ("BUILD", "Debug");
+   Build : BUILD_Type := external ("PLATFORM_BUILD", "Debug");
 
    package Compiler is
       case Build is


### PR DESCRIPTION
So can have another build scenario var for the app, separately. Otherwise we cannot build the RTS and drivers for "production" and the app for "debugging", and vice versa.