### PR TITLE
add complementary PWM output capability

### DIFF
--- a/ARM/STM32/driver_demos/demo_timer_pwm/src/demo_pwm_adt.adb
+++ b/ARM/STM32/driver_demos/demo_timer_pwm/src/demo_pwm_adt.adb
@@ -147,7 +147,7 @@ begin
       LED_For (Output_Channel),
       Timer_AF);
 
-   Enable_PWM (Power_Control);
+   Enable_Output (Power_Control);
 
    declare
       Arg       : Long_Float := 0.0;


### PR DESCRIPTION
Additional routines for complementary outputs for sake of some kinds of motor control.
Refactoring some routine names as a result.
Somewhat lighter wrapping of timers (no need for local polarity type)