### PR TITLE
[RFC] Tentative solution for the delay problem

### DIFF
--- a/boards/OpenMV2/src/openmv-lcd_shield.adb
+++ b/boards/OpenMV2/src/openmv-lcd_shield.adb
@@ -33,7 +33,6 @@ with STM32.GPIO;
 with STM32.Device;
 with OpenMV;
 with ST7735R; use ST7735R;
-with Ravenscar_Time;
 
 package body OpenMV.LCD_Shield is
 
@@ -45,8 +44,7 @@ package body OpenMV.LCD_Shield is
    LCD_Driver : ST7735R.ST7735R_Device (Shield_SPI'Access,
                                         LCD_CS'Access,
                                         LCD_RS'Access,
-                                        LCD_RST'Access,
-                                        Ravenscar_Time.Delays);
+                                        LCD_RST'Access);
    Is_Initialized : Boolean := False;
 
    -----------------

--- a/boards/OpenMV2/src/openmv.adb
+++ b/boards/OpenMV2/src/openmv.adb
@@ -30,6 +30,8 @@
 ------------------------------------------------------------------------------
 
 with HAL.SPI;
+with HAL.Time;
+with Ravenscar_Time;
 
 package body OpenMV is
 
@@ -175,4 +177,6 @@ package body OpenMV is
    function Get_Shield_USART return not null HAL.UART.Any_UART_Port is
       (USART_3'Access);
 
+begin
+   HAL.Time.Set_Global_Delay_Provider (Ravenscar_Time.Delay_Provider);
 end OpenMV;

--- a/boards/crazyflie/src/stm32-board.adb
+++ b/boards/crazyflie/src/stm32-board.adb
@@ -41,6 +41,9 @@
 --   COPYRIGHT(c) 2014 STMicroelectronics                                   --
 ------------------------------------------------------------------------------
 
+with HAL.Time;
+with Ravenscar_Time;
+
 package body STM32.Board is
 
    -------------
@@ -173,4 +176,6 @@ package body STM32.Board is
       end if;
    end Configure_I2C;
 
+begin
+   HAL.Time.Set_Global_Delay_Provider (Ravenscar_Time.Delay_Provider);
 end STM32.Board;

--- a/boards/stm32f407_discovery/src/stm32-board.adb
+++ b/boards/stm32f407_discovery/src/stm32-board.adb
@@ -44,6 +44,8 @@
 with Ada.Real_Time; use Ada.Real_Time;
 with HAL.SPI;
 with LIS3DSH;       use LIS3DSH;
+with HAL.Time;
+with Ravenscar_Time;
 
 package body STM32.Board is
 
@@ -280,5 +282,6 @@ package body STM32.Board is
       Init_SPI;
    end Initialize_Accelerometer;
 
-
+begin
+   HAL.Time.Set_Global_Delay_Provider (Ravenscar_Time.Delay_Provider);
 end STM32.Board;

--- a/boards/stm32f407_discovery/src/stm32-board.ads
+++ b/boards/stm32f407_discovery/src/stm32-board.ads
@@ -55,7 +55,6 @@ with STM32.I2C; use STM32.I2C;
 with STM32.I2S; use STM32.I2S;
 with HAL.Audio; use HAL.Audio;
 with CS43L22;
-with Ravenscar_Time;
 
 package STM32.Board is
    pragma Elaborate_Body;
@@ -90,8 +89,7 @@ package STM32.Board is
    Audio_I2S : I2S_Port renames I2S_3;
    Audio_Rate : constant Audio_Frequency := Audio_Freq_48kHz;
    DAC_Reset_Point : GPIO_Point renames PD4;
-   Audio_DAC : CS43L22.CS43L22_Device (Audio_I2C'Access,
-                                       Ravenscar_Time.Delays);
+   Audio_DAC : CS43L22.CS43L22_Device (Audio_I2C'Access);
 
    Acc_SPI    : SPI_Port renames SPI_1;
    Acc_SPI_AF : GPIO_Alternate_Function renames GPIO_AF_5_SPI1;

--- a/boards/stm32f429_discovery/src/framebuffer_ili9341.ads
+++ b/boards/stm32f429_discovery/src/framebuffer_ili9341.ads
@@ -31,7 +31,6 @@
 
 with HAL;             use HAL;
 with HAL.Framebuffer; use HAL.Framebuffer;
-with Ravenscar_Time;
 
 with Framebuffer_LTDC;
 private with ILI9341;
@@ -60,8 +59,7 @@ private
       Device : ILI9341.ILI9341_Device (STM32.Device.SPI_5'Access,
                                        Chip_Select => LCD_CSX'Access,
                                        WRX         => LCD_WRX_DCX'Access,
-                                       Reset       => LCD_RESET'Access,
-                                       Time        => Ravenscar_Time.Delays);
+                                       Reset       => LCD_RESET'Access);
    end record;
 
 end Framebuffer_ILI9341;

--- a/boards/stm32f429_discovery/src/stm32-board.adb
+++ b/boards/stm32f429_discovery/src/stm32-board.adb
@@ -42,6 +42,8 @@
 ------------------------------------------------------------------------------
 
 with HAL.SPI;
+with HAL.Time;
+with Ravenscar_Time;
 
 package body STM32.Board is
 
@@ -159,4 +161,6 @@ package body STM32.Board is
       User_Button_Point.Configure_IO (Config);
    end Configure_User_Button_GPIO;
 
+begin
+   HAL.Time.Set_Global_Delay_Provider (Ravenscar_Time.Delay_Provider);
 end STM32.Board;

--- a/boards/stm32f429_discovery/src/touch_panel_stmpe811.ads
+++ b/boards/stm32f429_discovery/src/touch_panel_stmpe811.ads
@@ -31,7 +31,6 @@
 
 with HAL.Touch_Panel;
 with HAL.Framebuffer;
-with Ravenscar_Time;
 
 private with STMPE811;
 private with STM32.Device;
@@ -62,7 +61,6 @@ private
 
    type Touch_Panel is limited new STMPE811.STMPE811_Device
      (Port     => TP_I2C'Access,
-      I2C_Addr => 16#82#,
-      Time     => Ravenscar_Time.Delays) with null record;
+      I2C_Addr => 16#82#) with null record;
 
 end Touch_Panel_STMPE811;

--- a/boards/stm32f469_discovery/src/stm32-board.adb
+++ b/boards/stm32f469_discovery/src/stm32-board.adb
@@ -30,6 +30,8 @@
 ------------------------------------------------------------------------------
 
 with Ada.Real_Time; use Ada.Real_Time;
+with HAL.Time;
+with Ravenscar_Time;
 
 package body STM32.Board is
 
@@ -153,4 +155,6 @@ package body STM32.Board is
       Configure_IO (User_Button_Point, Config);
    end Configure_User_Button_GPIO;
 
+begin
+   HAL.Time.Set_Global_Delay_Provider (Ravenscar_Time.Delay_Provider);
 end STM32.Board;

--- a/boards/stm32f746_discovery/src/audio.ads
+++ b/boards/stm32f746_discovery/src/audio.ads
@@ -34,7 +34,6 @@
 
 with HAL.Audio; use HAL.Audio;
 with HAL.I2C;   use HAL.I2C;
-with Ravenscar_Time;
 
 private with WM8994;
 
@@ -75,7 +74,7 @@ private
 
    type WM8994_Audio_Device (Port : not null Any_I2C_Port) is
      tagged limited record
-      Device : WM8994.WM8994_Device (Port, Audio_I2C_Addr, Ravenscar_Time.Delays);
+      Device : WM8994.WM8994_Device (Port, Audio_I2C_Addr);
    end record;
 
 end Audio;

--- a/boards/stm32f746_discovery/src/stm32-board.adb
+++ b/boards/stm32f746_discovery/src/stm32-board.adb
@@ -29,6 +29,9 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
+with HAL.Time;
+with Ravenscar_Time;
+
 package body STM32.Board is
 
    ------------------
@@ -134,4 +137,6 @@ package body STM32.Board is
       Configure_IO (User_Button_Point, Config);
    end Configure_User_Button_GPIO;
 
+begin
+   HAL.Time.Set_Global_Delay_Provider (Ravenscar_Time.Delay_Provider);
 end STM32.Board;

--- a/boards/stm32f769_discovery/src/audio.ads
+++ b/boards/stm32f769_discovery/src/audio.ads
@@ -34,7 +34,6 @@
 
 with HAL.Audio;      use HAL.Audio;
 with HAL.I2C;        use HAL.I2C;
-with Ravenscar_Time;
 
 private with WM8994;
 
@@ -75,7 +74,7 @@ private
 
    type WM8994_Audio_Device (Port : not null Any_I2C_Port) is
      tagged limited record
-      Device : WM8994.WM8994_Device (Port, Audio_I2C_Addr, Ravenscar_Time.Delays);
+      Device : WM8994.WM8994_Device (Port, Audio_I2C_Addr);
    end record;
 
 end Audio;

--- a/boards/stm32f769_discovery/src/framebuffer_otm8009a.ads
+++ b/boards/stm32f769_discovery/src/framebuffer_otm8009a.ads
@@ -32,7 +32,6 @@
 with HAL;             use HAL;
 with HAL.Framebuffer; use HAL.Framebuffer;
 with HAL.Bitmap;
-with Ravenscar_Time;
 
 private with STM32.Device;
 private with STM32.DMA2D_Bitmap;
@@ -138,8 +137,7 @@ private
       record
          Device  : OTM8009A.OTM8009A_Device
                     (DSI_Host   => STM32.Device.DSIHOST'Access,
-                     Channel_Id => LCD_Channel,
-                     Time       => Ravenscar_Time.Delays);
+                     Channel_Id => LCD_Channel);
          Swapped : Boolean;
          Buffers : FB_Array := (others => STM32.DMA2D_Bitmap.Null_Buffer);
       end record;

--- a/boards/stm32f769_discovery/src/stm32-board.adb
+++ b/boards/stm32f769_discovery/src/stm32-board.adb
@@ -29,6 +29,9 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
+with HAL.Time;
+with Ravenscar_Time;
+
 package body STM32.Board is
 
    ------------------
@@ -142,4 +145,6 @@ package body STM32.Board is
       Configure_IO (User_Button_Point, Config);
    end Configure_User_Button_GPIO;
 
+begin
+   HAL.Time.Set_Global_Delay_Provider (Ravenscar_Time.Delay_Provider);
 end STM32.Board;

--- a/components/src/audio/CS43L22/cs43l22.adb
+++ b/components/src/audio/CS43L22/cs43l22.adb
@@ -29,6 +29,8 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
+with HAL.Time;
+
 package body CS43L22 is
 
    ---------------
@@ -182,7 +184,7 @@ package body CS43L22 is
       --  Unmute the output first
       This.Set_Mute (Mute_Off);
 
-      This.Time.Delay_Milliseconds (1);
+      HAL.Time.Delay_Milliseconds (1);
 
       This.I2C_Write (CS43L22_REG_POWER_CTL2, This.Output_Dev);
 

--- a/components/src/audio/CS43L22/cs43l22.ads
+++ b/components/src/audio/CS43L22/cs43l22.ads
@@ -35,7 +35,6 @@ with Interfaces; use Interfaces;
 with HAL;        use HAL;
 with HAL.I2C;    use HAL.I2C;
 with HAL.Audio;  use HAL.Audio;
-with HAL.Time;
 
 package CS43L22 is
 
@@ -57,8 +56,7 @@ package CS43L22 is
 
    subtype Volume_Level is Unsigned_8 range 0 .. 100;
 
-   type CS43L22_Device (Port : not null Any_I2C_Port;
-                        Time : not null HAL.Time.Any_Delays) is
+   type CS43L22_Device (Port : not null Any_I2C_Port) is
      tagged limited private;
 
    procedure Init (This      : in out CS43L22_Device;
@@ -120,8 +118,7 @@ private
    CS43L22_REG_THERMAL_FOLDBACK    : constant := 16#33#;
    CS43L22_REG_CHARGE_PUMP_FREQ    : constant := 16#34#;
 
-   type CS43L22_Device (Port : not null Any_I2C_Port;
-                        Time : not null HAL.Time.Any_Delays) is
+   type CS43L22_Device (Port : not null Any_I2C_Port) is
      tagged limited record
       Output_Enabled : Boolean := False;
       Output_Dev     : Byte := 0;

--- a/components/src/audio/W8994/wm8994.adb
+++ b/components/src/audio/W8994/wm8994.adb
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 with Ada.Text_IO;
+with HAL.Time;
 
 package body WM8994 is
 
@@ -122,7 +123,7 @@ package body WM8994 is
       --  Enable BIAS generator, Enable VMID
       I2C_Write (This, 16#01#, 16#0003#);
 
-      This.Time.Delay_Milliseconds (50);
+      HAL.Time.Delay_Milliseconds (50);
 
       Output_Enabled := Output /= No_Output;
       Input_Enabled  := Input /= No_Input;
@@ -223,7 +224,7 @@ package body WM8994 is
          I2C_Write (This, 16#4C#, 16#9F25#);
 
          --  Add Delay
-         This.Time.Delay_Milliseconds (15);
+         HAL.Time.Delay_Milliseconds (15);
 
          --  Select DAC1 (Left) to Left Headphone Output PGA (HPOUT1LVOL) path
          I2C_Write (This, 16#2D#, 16#0001#);
@@ -241,7 +242,7 @@ package body WM8994 is
          I2C_Write (This, 16#54#, 16#0033#);
 
          --  Add Delay
-         This.Time.Delay_Milliseconds (250);
+         HAL.Time.Delay_Milliseconds (250);
 
          --  Enable HPOUT1 (Left) and HPOUT1 (Right) intermediate and output
          --  stages. Remove clamps.

--- a/components/src/audio/W8994/wm8994.ads
+++ b/components/src/audio/W8994/wm8994.ads
@@ -34,7 +34,6 @@
 with Interfaces; use Interfaces;
 with HAL;        use HAL;
 with HAL.I2C;    use HAL.I2C;
-with HAL.Time;
 
 package WM8994 is
 
@@ -89,8 +88,7 @@ package WM8994 is
 
    type WM8994_Device
      (Port     : not null Any_I2C_Port;
-      I2C_Addr : UInt10;
-      Time     : not null HAL.Time.Any_Delays)
+      I2C_Addr : UInt10)
    is tagged limited private;
 
    procedure Init (This      : in out WM8994_Device;
@@ -114,8 +112,7 @@ package WM8994 is
 
 private
    type WM8994_Device (Port     : not null Any_I2C_Port;
-                       I2C_Addr : UInt10;
-                       Time     : not null HAL.Time.Any_Delays) is tagged limited null record;
+                       I2C_Addr : UInt10) is tagged limited null record;
 
    procedure I2C_Write (This   : in out WM8994_Device;
                         Reg   : UInt16;

--- a/components/src/motion/ak8963/ak8963.adb
+++ b/components/src/motion/ak8963/ak8963.adb
@@ -33,6 +33,7 @@ with Ada.Unchecked_Conversion;
 with Interfaces;    use Interfaces;
 
 with HAL.I2C;       use HAL.I2C;
+with HAL.Time;
 
 package body AK8963 is
 
@@ -236,7 +237,7 @@ package body AK8963 is
       while Retry > 0 loop
          exit when Get_Data_Ready (Device);
          Retry := Retry - 1;
-         Device.Time.Delay_Milliseconds (10);
+         HAL.Time.Delay_Milliseconds (10);
       end loop;
 
       if Retry = 0 then

--- a/components/src/motion/ak8963/ak8963.ads
+++ b/components/src/motion/ak8963/ak8963.ads
@@ -32,7 +32,6 @@
 --  AK8963 I2C device class package
 
 with HAL.I2C;    use HAL;
-with HAL.Time;
 
 package AK8963 is
 
@@ -52,8 +51,7 @@ package AK8963 is
       Fuse_ROM_Access);
 
    type AK8963_Device (I2C_Port         : not null HAL.I2C.Any_I2C_Port;
-                       Address_Selector : AK8963_Address_Selector;
-                        Time            : not null HAL.Time.Any_Delays) is private;
+                       Address_Selector : AK8963_Address_Selector) is private;
 
    procedure Initialize (Device : in out AK8963_Device);
 
@@ -81,8 +79,7 @@ package AK8963 is
 private
 
    type AK8963_Device (I2C_Port         : not null HAL.I2C.Any_I2C_Port;
-                       Address_Selector : AK8963_Address_Selector;
-                        Time            : not null HAL.Time.Any_Delays)
+                       Address_Selector : AK8963_Address_Selector)
    is record
       Address : UInt10;
       Is_Init : Boolean := False;

--- a/components/src/motion/mpu9250/mpu9250.adb
+++ b/components/src/motion/mpu9250/mpu9250.adb
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 with Ada.Unchecked_Conversion;
+with HAL.Time;
 
 package body MPU9250 is
 
@@ -57,7 +58,7 @@ package body MPU9250 is
       end if;
 
       --  Wait for MPU9250 startup
-      Device.Time.Delay_Milliseconds (MPU9250_STARTUP_TIME_MS);
+      HAL.Time.Delay_Milliseconds (MPU9250_STARTUP_TIME_MS);
 
       --  Set the device address
       Device.Address :=
@@ -242,7 +243,7 @@ package body MPU9250 is
         (Device, MPU9250_RA_GYRO_CONFIG, 16#E0#);
 
       --  Delay a while to let the device stabilize
-      Device.Time.Delay_Milliseconds (25);
+      HAL.Time.Delay_Milliseconds (25);
 
       --  Get average self-test values of gyro and accelerometer
       for I in 1 .. 200 loop
@@ -288,7 +289,7 @@ package body MPU9250 is
         (Device, MPU9250_RA_GYRO_CONFIG, 16#00#);
 
       --  Delay a while to let the device stabilize
-      Device.Time.Delay_Milliseconds (25);
+      HAL.Time.Delay_Milliseconds (25);
 
       --  Retrieve Accelerometer and Gyro Factory Self - Test Code From USR_Reg
       MPU9250_Read_Byte_At_Register

--- a/components/src/motion/mpu9250/mpu9250.ads
+++ b/components/src/motion/mpu9250/mpu9250.ads
@@ -35,7 +35,6 @@ with Interfaces;          use Interfaces;
 
 with HAL;                 use HAL;
 with HAL.I2C;             use HAL.I2C;
-with HAL.Time;
 
 package MPU9250 is
 
@@ -45,8 +44,7 @@ package MPU9250 is
 
    --  Types and subtypes
    type MPU9250_Device (Port        : HAL.I2C.Any_I2C_Port;
-                        I2C_AD0_Pin : MPU9250_AD0_Pin_State;
-                        Time        : not null HAL.Time.Any_Delays) is private;
+                        I2C_AD0_Pin : MPU9250_AD0_Pin_State) is private;
 
    --  Type reprensnting all the different clock sources of the MPU9250.
    --  See the MPU9250 register map section 4.4 for more details.
@@ -223,8 +221,7 @@ private
 
    type MPU9250_Device
      (Port        : HAL.I2C.Any_I2C_Port;
-      I2C_AD0_Pin : MPU9250_AD0_Pin_State;
-      Time        : not null HAL.Time.Any_Delays)
+      I2C_AD0_Pin : MPU9250_AD0_Pin_State)
    is record
       Is_Init : Boolean := False;
       Address : UInt10;

--- a/components/src/printer/adafruit_thermal_printer/adafruit-thermal_printer.adb
+++ b/components/src/printer/adafruit_thermal_printer/adafruit-thermal_printer.adb
@@ -30,8 +30,10 @@
 ------------------------------------------------------------------------------
 
 with Ada.Unchecked_Conversion;
-with HAL.UART; use HAL.UART;
-with Interfaces; use Interfaces;
+with HAL.Time;
+with HAL.UART;                 use HAL.UART;
+with Interfaces;               use Interfaces;
+
 
 package body AdaFruit.Thermal_Printer is
 
@@ -225,7 +227,7 @@ package body AdaFruit.Thermal_Printer is
          Write (This, Str);
 
          --  delay until Clock + Microseconds (10000 * Str'Length);
-         This.Time.Delay_Microseconds (600 * Str'Length);
+         HAL.Time.Delay_Microseconds (600 * Str'Length);
       end loop;
    end Print_Bitmap;
 
@@ -245,12 +247,12 @@ package body AdaFruit.Thermal_Printer is
    procedure Reset (This : in out TP_Device) is
    begin
       Write (This, "" & To_Char (16#FF#));
-      This.Time.Delay_Milliseconds (50);
+      HAL.Time.Delay_Milliseconds (50);
 
       Write (This, ASCII.ESC & '8' & ASCII.NUL & ASCII.NUL);
 
       for X in 1 .. 10 loop
-         This.Time.Delay_Microseconds (10_000);
+         HAL.Time.Delay_Microseconds (10_000);
          Write (This, "" & ASCII.NUL);
       end loop;
 

--- a/components/src/printer/adafruit_thermal_printer/adafruit-thermal_printer.ads
+++ b/components/src/printer/adafruit_thermal_printer/adafruit-thermal_printer.ads
@@ -29,14 +29,12 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with HAL; use HAL;
+with HAL;     use HAL;
 with HAL.UART;
-with HAL.Time;
 
 package AdaFruit.Thermal_Printer is
 
-   type TP_Device (Port : not null HAL.UART.Any_UART_Port;
-                   Time : not null HAL.Time.Any_Delays) is
+   type TP_Device (Port : not null HAL.UART.Any_UART_Port) is
      tagged private;
 
    --  The baud rate for this printers is usually 19_200 but some printers
@@ -103,8 +101,7 @@ package AdaFruit.Thermal_Printer is
    procedure Print_Test_Page (This : in out TP_Device);
 
 private
-   type TP_Device (Port : not null HAL.UART.Any_UART_Port;
-                   Time : not null HAL.Time.Any_Delays) is
+   type TP_Device (Port : not null HAL.UART.Any_UART_Port) is
      tagged null record;
 
 end AdaFruit.Thermal_Printer;

--- a/components/src/screen/ST7735R/st7735r.adb
+++ b/components/src/screen/ST7735R/st7735r.adb
@@ -31,7 +31,8 @@
 
 with Ada.Unchecked_Conversion;
 with System;
-with Interfaces; use Interfaces;
+with Interfaces;               use Interfaces;
+with HAL.Time;
 
 package body ST7735R is
 
@@ -226,14 +227,14 @@ package body ST7735R is
       LCD.Initialized := True;
 
       LCD.RST.Clear;
-      LCD.Time.Delay_Milliseconds (100);
+      HAL.Time.Delay_Milliseconds (100);
       LCD.RST.Set;
-      LCD.Time.Delay_Milliseconds (100);
+      HAL.Time.Delay_Milliseconds (100);
 
       --  Sleep Exit
       Write_Command (LCD, 16#11#);
 
-      LCD.Time.Delay_Milliseconds (100);
+      HAL.Time.Delay_Milliseconds (100);
    end Initialize;
 
    -----------------

--- a/components/src/screen/ST7735R/st7735r.ads
+++ b/components/src/screen/ST7735R/st7735r.ads
@@ -34,7 +34,6 @@ with HAL.SPI;         use HAL.SPI;
 with HAL.GPIO;        use HAL.GPIO;
 with HAL.Framebuffer; use HAL.Framebuffer;
 with HAL.Bitmap;      use HAL.Bitmap;
-with HAL.Time;
 
 package ST7735R is
 
@@ -42,8 +41,7 @@ package ST7735R is
      (Port : not null Any_SPI_Port;
       CS   : not null Any_GPIO_Point;
       RS   : not null Any_GPIO_Point;
-      RST  : not null Any_GPIO_Point;
-      Time : not null HAL.Time.Any_Delays)
+      RST  : not null Any_GPIO_Point)
    is limited new HAL.Framebuffer.Frame_Buffer_Display with private;
 
    procedure Initialize (LCD : in out ST7735R_Device);
@@ -272,8 +270,7 @@ private
      (Port : not null Any_SPI_Port;
       CS   : not null Any_GPIO_Point;
       RS   : not null Any_GPIO_Point;
-      RST  : not null Any_GPIO_Point;
-      Time : not null HAL.Time.Any_Delays)
+      RST  : not null Any_GPIO_Point)
    is limited new HAL.Framebuffer.Frame_Buffer_Display with record
       Initialized : Boolean := True;
       Layer : aliased Bitmap_Buffer;

--- a/components/src/screen/ili9341/ili9341.adb
+++ b/components/src/screen/ili9341/ili9341.adb
@@ -42,9 +42,9 @@
 ------------------------------------------------------------------------------
 
 with Ada.Unchecked_Conversion;
-with Interfaces;   use Interfaces;
-
-with ILI9341_Regs; use ILI9341_Regs;
+with Interfaces;               use Interfaces;
+with ILI9341_Regs;             use ILI9341_Regs;
+with HAL.Time;
 
 package body ILI9341 is
 
@@ -278,7 +278,7 @@ package body ILI9341 is
    begin
       This.Reset.Set;
       This.Send_Command (ILI9341_RESET);
-      This.Time.Delay_Milliseconds (5);
+      HAL.Time.Delay_Milliseconds (5);
 
       This.Send_Command (ILI9341_POWERA);
       This.Send_Data (16#39#);
@@ -389,9 +389,9 @@ package body ILI9341 is
 
       case Mode is
          when RGB_Mode =>
-            This.Time.Delay_Milliseconds (150);
+            HAL.Time.Delay_Milliseconds (150);
          when SPI_Mode =>
-            This.Time.Delay_Milliseconds (20);
+            HAL.Time.Delay_Milliseconds (20);
       end case;
       --  document ILI9341_DS_V1.02, section 11.2, pg 205 says we need
       --  either 120ms or 5ms, depending on the mode, but seems incorrect.

--- a/components/src/screen/ili9341/ili9341.ads
+++ b/components/src/screen/ili9341/ili9341.ads
@@ -48,7 +48,6 @@
 with HAL;      use HAL;
 with HAL.SPI;  use HAL.SPI;
 with HAL.GPIO; use HAL.GPIO;
-with HAL.Time;
 
 package ILI9341 is
 
@@ -56,8 +55,7 @@ package ILI9341 is
      (Port        : not null access SPI_Port'Class;
       Chip_Select : not null Any_GPIO_Point;
       WRX         : not null Any_GPIO_Point;
-      Reset       : not null Any_GPIO_Point;
-      Time        : not null HAL.Time.Any_Delays)
+      Reset       : not null Any_GPIO_Point)
    is tagged limited private;
 
    type ILI9341_Mode is
@@ -154,8 +152,7 @@ private
      (Port        : not null access SPI_Port'Class;
       Chip_Select : not null Any_GPIO_Point;
       WRX         : not null Any_GPIO_Point;
-      Reset       : not null Any_GPIO_Point;
-      Time        : not null HAL.Time.Any_Delays)
+      Reset       : not null Any_GPIO_Point)
    is tagged limited record
       Selected_Orientation : Orientations;
 

--- a/components/src/screen/otm8009a/otm8009a.adb
+++ b/components/src/screen/otm8009a/otm8009a.adb
@@ -29,6 +29,8 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
+with HAL.Time;
+
 package body OTM8009A is
 
    ADDR_SHIFT_CMD : constant := 16#00#;
@@ -90,11 +92,11 @@ package body OTM8009A is
       --  -> Source output level during porch and non-display area to GND --
       This.Write (Address => 16#C480#,
                   Data    => (1 => 16#30#));
-      This.Time.Delay_Milliseconds (10);
+      HAL.Time.Delay_Milliseconds (10);
       --  Not documented...
       This.Write (Address => 16#C48A#,
                   Data    => (1 => 16#40#));
-      This.Time.Delay_Milliseconds (10);
+      HAL.Time.Delay_Milliseconds (10);
       ----------------------------------------------------------------------
 
       ----------------------------------------------------------------------
@@ -300,7 +302,7 @@ package body OTM8009A is
                   Data   => (1 .. 0 => <>));
 
       --  Wait for Sleep Out exit
-      This.Time.Delay_Milliseconds (120);
+      HAL.Time.Delay_Milliseconds (120);
 
       case Color_Mode is
          when RGB565 =>

--- a/components/src/screen/otm8009a/otm8009a.ads
+++ b/components/src/screen/otm8009a/otm8009a.ads
@@ -32,7 +32,6 @@
 with Interfaces; use Interfaces;
 with HAL;        use HAL;
 with HAL.DSI;    use HAL.DSI;
-with HAL.Time;
 
 package OTM8009A is
 
@@ -88,8 +87,7 @@ package OTM8009A is
 
    type OTM8009A_Device
      (DSI_Host   : not null Any_DSI_Port;
-      Channel_ID : DSI_Virtual_Channel_ID;
-      Time       : not null HAL.Time.Any_Delays)
+      Channel_ID : DSI_Virtual_Channel_ID)
    is tagged limited private;
 
    procedure Initialize
@@ -101,8 +99,7 @@ private
 
    type OTM8009A_Device
      (DSI_Host   : not null Any_DSI_Port;
-      Channel_ID : DSI_Virtual_Channel_ID;
-      Time       : not null HAL.Time.Any_Delays)
+      Channel_ID : DSI_Virtual_Channel_ID)
    is tagged limited record
       Current_Shift : Byte := 0;
    end record;

--- a/components/src/touch_panel/stmpe811/stmpe811.adb
+++ b/components/src/touch_panel/stmpe811/stmpe811.adb
@@ -42,6 +42,7 @@
 ------------------------------------------------------------------------------
 
 with Interfaces; use Interfaces;
+with HAL.Time;
 
 package body STMPE811 is
 
@@ -194,7 +195,7 @@ package body STMPE811 is
       This.Write_Register (IOE_REG_SYS_CTRL1, 16#02#);
 
       --  Give some time for the reset
-      This.Time.Delay_Milliseconds (2);
+      HAL.Time.Delay_Milliseconds (2);
 
       This.Write_Register (IOE_REG_SYS_CTRL1, 16#00#);
    end IOE_Reset;
@@ -256,7 +257,7 @@ package body STMPE811 is
    is
    begin
 
-      This.Time.Delay_Milliseconds (100);
+      HAL.Time.Delay_Milliseconds (100);
 
       if This.Get_IOE_ID /= 16#0811# then
          return False;
@@ -269,7 +270,7 @@ package body STMPE811 is
 
       This.Write_Register (IOE_REG_ADC_CTRL1, 16#49#);
 
-      This.Time.Delay_Milliseconds (2);
+      HAL.Time.Delay_Milliseconds (2);
 
       This.Write_Register (IOE_REG_ADC_CTRL2, 16#01#);
 

--- a/components/src/touch_panel/stmpe811/stmpe811.ads
+++ b/components/src/touch_panel/stmpe811/stmpe811.ads
@@ -30,15 +30,13 @@
 ------------------------------------------------------------------------------
 
 with HAL;             use HAL;
-with HAL.Time;        use HAL.Time;
 with HAL.I2C;         use HAL.I2C;
 with HAL.Touch_Panel; use HAL.Touch_Panel;
 
 package STMPE811 is
 
    type STMPE811_Device (Port     : not null Any_I2C_Port;
-                         I2C_Addr : I2C_Address;
-                         Time     : not null HAL.Time.Any_Delays) is
+                         I2C_Addr : I2C_Address) is
      limited new Touch_Panel_Device with private;
 
    function Initialize (This : in out STMPE811_Device) return Boolean;
@@ -72,8 +70,7 @@ package STMPE811 is
 private
 
    type STMPE811_Device (Port     : not null Any_I2C_Port;
-                         I2C_Addr : I2C_Address;
-                         Time     : not null HAL.Time.Any_Delays) is
+                         I2C_Addr : I2C_Address) is
      limited new Touch_Panel_Device with record
       LCD_Natural_Width  : Natural := 0;
       LCD_Natural_Height : Natural := 0;

--- a/examples/accelerometer/src/main.adb
+++ b/examples/accelerometer/src/main.adb
@@ -35,12 +35,12 @@
 --  blue button to enter sound mode where a two tone audio is played in the
 --  headphone jack. Press the black button to reset.
 
-with Ada.Real_Time;      use Ada.Real_Time;
 with HAL;                use HAL;
 with STM32.Board;        use STM32.Board;
 with STM32.User_Button;
 with LIS3DSH;            use LIS3DSH;
 with HAL.Audio;          use HAL.Audio;
+with HAL.Time;
 with Simple_Synthesizer;
 with CS43L22;
 
@@ -51,13 +51,6 @@ procedure Main is
 
    Threshold_High : constant LIS3DSH.Axis_Acceleration :=  200;
    Threshold_Low  : constant LIS3DSH.Axis_Acceleration := -200;
-
-   procedure My_Delay (Milli : Natural);
-
-   procedure My_Delay (Milli : Natural) is
-   begin
-      delay until Clock + Milliseconds (Milli);
-   end My_Delay;
 
    Synth : Simple_Synthesizer.Synthesizer;
    Audio_Data : Audio_Buffer (1 .. 128);
@@ -84,9 +77,9 @@ begin
    if Accelerometer.Device_Id /= I_Am_LIS3DSH then
       loop
          All_LEDs_On;
-         My_Delay (100);
+         HAL.Time.Delay_Milliseconds (100);
          All_LEDs_Off;
-         My_Delay (100);
+         HAL.Time.Delay_Milliseconds (100);
       end loop;
    end if;
 
@@ -99,14 +92,14 @@ begin
          elsif Values.X < Threshold_Low then
             STM32.Board.Green.Set;
          end if;
-         My_Delay (10);
+         HAL.Time.Delay_Milliseconds (10);
       else
          if Values.Y > Threshold_High then
             STM32.Board.Orange.Set;
          elsif Values.Y < Threshold_Low then
             STM32.Board.Blue.Set;
          end if;
-         My_Delay (10);
+         HAL.Time.Delay_Milliseconds (10);
       end if;
 
       if STM32.User_Button.Has_Been_Pressed then

--- a/hal/src/hal-time.adb
+++ b/hal/src/hal-time.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                        Copyright (C) 2017, AdaCore                       --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -29,32 +29,59 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-package HAL.Time is
+package body HAL.Time is
 
-   function Delay_Provided return Boolean;
+   Global_Delay_Provider : Any_Delay_Provider := null;
 
-   procedure Delay_Seconds (S : Natural)
-     with Pre => Delay_Provided;
+   --------------------
+   -- Delay_Provided --
+   --------------------
 
-   procedure Delay_Milliseconds (Ms : Natural)
-     with Pre => Delay_Provided;
+   function Delay_Provided return Boolean is
+     (Global_Delay_Provider /= null);
 
-   procedure Delay_Microseconds (Us : Natural)
-     with Pre => Delay_Provided;
+   -------------------
+   -- Delay_Seconds --
+   -------------------
 
-   type Delay_Provider is limited interface;
+   procedure Delay_Seconds (S : Natural) is
+   begin
+      if Global_Delay_Provider /= null then
+         Global_Delay_Provider.Delay_Seconds (S);
+      end if;
+   end Delay_Seconds;
 
-   type Any_Delay_Provider is access all Delay_Provider'Class;
+   ------------------------
+   -- Delay_Milliseconds --
+   ------------------------
 
-   procedure Delay_Microseconds (This : in out Delay_Provider;
-                                 Us   : Natural) is abstract;
+   procedure Delay_Milliseconds (Ms : Natural) is
+   begin
+      if Global_Delay_Provider /= null then
+         Global_Delay_Provider.Delay_Milliseconds (Ms);
+      end if;
+   end Delay_Milliseconds;
 
-   procedure Delay_Milliseconds (This : in out Delay_Provider;
-                                 Ms   : Natural) is abstract;
+   ------------------------
+   -- Delay_Microseconds --
+   ------------------------
 
-   procedure Delay_Seconds      (This : in out Delay_Provider;
-                                 S    : Natural) is abstract;
+   procedure Delay_Microseconds (Us : Natural) is
+   begin
+      if Global_Delay_Provider /= null then
+         Global_Delay_Provider.Delay_Microseconds (Us);
+      end if;
+   end Delay_Microseconds;
 
-   procedure Set_Global_Delay_Provider (Provider : not null Any_Delay_Provider);
+   -------------------------------
+   -- Set_Global_Delay_Provider --
+   -------------------------------
+
+   procedure Set_Global_Delay_Provider
+     (Provider : not null Any_Delay_Provider)
+   is
+   begin
+      Global_Delay_Provider := Provider;
+   end Set_Global_Delay_Provider;
 
 end HAL.Time;

--- a/services/src/ravenscar-common/ravenscar_time.adb
+++ b/services/src/ravenscar-common/ravenscar_time.adb
@@ -33,24 +33,22 @@ with Ada.Real_Time; use Ada.Real_Time;
 
 package body Ravenscar_Time is
 
-   Delay_Singleton : aliased Ravenscar_Delays;
+   Delay_Singleton : aliased Ravenscar_Delay_Provider;
 
-   ------------
-   -- Delays --
-   ------------
+   --------------------
+   -- Delay_Provider --
+   --------------------
 
-   function Delays return not null HAL.Time.Any_Delays is
-   begin
-      return Delay_Singleton'Access;
-   end Delays;
+   function Delay_Provider return not null HAL.Time.Any_Delay_Provider is
+      (Delay_Singleton'Access);
 
    ------------------------
    -- Delay_Microseconds --
    ------------------------
 
    overriding procedure Delay_Microseconds
-     (This : in out Ravenscar_Delays;
-      Us   : Integer)
+     (This : in out Ravenscar_Delay_Provider;
+      Us   : Natural)
    is
       pragma Unreferenced (This);
    begin
@@ -62,8 +60,8 @@ package body Ravenscar_Time is
    ------------------------
 
    overriding procedure Delay_Milliseconds
-     (This : in out Ravenscar_Delays;
-      Ms   : Integer)
+     (This : in out Ravenscar_Delay_Provider;
+      Ms   : Natural)
    is
       pragma Unreferenced (This);
    begin
@@ -75,8 +73,8 @@ package body Ravenscar_Time is
    -------------------
 
    overriding procedure Delay_Seconds
-     (This : in out Ravenscar_Delays;
-      S    : Integer)
+     (This : in out Ravenscar_Delay_Provider;
+      S    : Natural)
    is
       pragma Unreferenced (This);
    begin

--- a/services/src/ravenscar-common/ravenscar_time.ads
+++ b/services/src/ravenscar-common/ravenscar_time.ads
@@ -33,21 +33,21 @@ with HAL.Time;
 
 package Ravenscar_Time is
 
-   function Delays return not null HAL.Time.Any_Delays;
+   function Delay_Provider return not null HAL.Time.Any_Delay_Provider;
 
 private
 
-   type Ravenscar_Delays is new HAL.Time.Delays with null record;
+   type Ravenscar_Delay_Provider is new HAL.Time.Delay_Provider with null record;
 
    overriding
-   procedure Delay_Microseconds (This : in out Ravenscar_Delays;
-                                 Us   : Integer);
+   procedure Delay_Microseconds (This : in out Ravenscar_Delay_Provider;
+                                 Us   : Natural);
 
    overriding
-   procedure Delay_Milliseconds (This : in out Ravenscar_Delays;
-                                 Ms   : Integer);
+   procedure Delay_Milliseconds (This : in out Ravenscar_Delay_Provider;
+                                 Ms   : Natural);
 
    overriding
-   procedure Delay_Seconds      (This : in out Ravenscar_Delays;
-                                 S    : Integer);
+   procedure Delay_Seconds      (This : in out Ravenscar_Delay_Provider;
+                                 S    : Natural);
 end Ravenscar_Time;


### PR DESCRIPTION
The idea here is that some piece of code is holds an access to an object
(Delay_Provider) that provides delay for the entire library.

The main drawback of course is that someone has to set the
Delay_Provider, in this patch I do it in the elaboration of the board
packages.

I'm not very convince myself about this solution but I though I'd try
and share it.