### PR TITLE
GPIO: mode and pull control

### DIFF
--- a/ARM/Nordic/drivers/nrf51-gpio.adb
+++ b/ARM/Nordic/drivers/nrf51-gpio.adb
@@ -33,6 +33,32 @@ with NRF51_SVD.GPIO; use NRF51_SVD.GPIO;
 
 package body nRF51.GPIO is
 
+   overriding
+   function Mode (This : GPIO_Point) return HAL.GPIO.GPIO_Mode is
+      CNF : PIN_CNF_Register renames GPIO_Periph.PIN_CNF (This.Pin);
+   begin
+      case CNF.DIR is
+         when Input => return HAL.GPIO.Input;
+         when Output => return HAL.GPIO.Output;
+      end case;
+   end Mode;
+
+   --------------
+   -- Set_Mode --
+   --------------
+
+   overriding
+   function Set_Mode (This : in out GPIO_Point;
+                      Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean
+   is
+      CNF : PIN_CNF_Register renames GPIO_Periph.PIN_CNF (This.Pin);
+   begin
+      CNF.DIR := (case Mode is
+                     when HAL.GPIO.Input  => Input,
+                     when HAL.GPIO.Output => Output);
+      return True;
+   end Set_Mode;
+
    ---------
    -- Set --
    ---------

--- a/ARM/Nordic/drivers/nrf51-gpio.adb
+++ b/ARM/Nordic/drivers/nrf51-gpio.adb
@@ -63,13 +63,46 @@ package body nRF51.GPIO is
    -- Set --
    ---------
 
-   overriding function Set
+   overriding
+   function Set
      (This : GPIO_Point)
       return Boolean
    is
    begin
       return GPIO_Periph.IN_k.Arr (This.Pin) = High;
    end Set;
+
+   ----------
+   -- Pull --
+   ----------
+
+   overriding
+   function Pull (This : GPIO_Point) return HAL.GPIO.GPIO_Pull is
+   begin
+      case GPIO_Periph.PIN_CNF (This.Pin).PULL is
+         when Disabled => return HAL.GPIO.Floating;
+         when Pulldown => return HAL.GPIO.Pull_Down;
+         when Pullup => return HAL.GPIO.Pull_Up;
+      end case;
+   end Pull;
+
+   --------------
+   -- Set_Pull --
+   --------------
+
+   overriding
+   function Set_Pull (This : in out GPIO_Point;
+                      Pull : HAL.GPIO.GPIO_Pull)
+                      return Boolean
+   is
+   begin
+      GPIO_Periph.PIN_CNF (This.Pin).PULL :=
+        (case Pull is
+            when HAL.GPIO.Floating  => Disabled,
+            when HAL.GPIO.Pull_Down => Pulldown,
+            when HAL.GPIO.Pull_Up   => Pullup);
+      return True;
+   end Set_Pull;
 
    ---------
    -- Set --

--- a/ARM/Nordic/drivers/nrf51-gpio.adb
+++ b/ARM/Nordic/drivers/nrf51-gpio.adb
@@ -56,6 +56,9 @@ package body nRF51.GPIO is
       CNF.DIR := (case Mode is
                      when HAL.GPIO.Input  => Input,
                      when HAL.GPIO.Output => Output);
+      CNF.INPUT := (case Mode is
+                       when HAL.GPIO.Input  => Connect,
+                       when HAL.GPIO.Output => Disconnect);
       return True;
    end Set_Mode;
 

--- a/ARM/Nordic/drivers/nrf51-gpio.adb
+++ b/ARM/Nordic/drivers/nrf51-gpio.adb
@@ -72,28 +72,30 @@ package body nRF51.GPIO is
       return GPIO_Periph.IN_k.Arr (This.Pin) = High;
    end Set;
 
-   ----------
-   -- Pull --
-   ----------
+   -------------------
+   -- Pull_Resistor --
+   -------------------
 
    overriding
-   function Pull (This : GPIO_Point) return HAL.GPIO.GPIO_Pull is
+   function Pull_Resistor (This : GPIO_Point)
+                           return HAL.GPIO.GPIO_Pull_Resistor
+   is
    begin
       case GPIO_Periph.PIN_CNF (This.Pin).PULL is
          when Disabled => return HAL.GPIO.Floating;
          when Pulldown => return HAL.GPIO.Pull_Down;
          when Pullup => return HAL.GPIO.Pull_Up;
       end case;
-   end Pull;
+   end Pull_Resistor;
 
-   --------------
-   -- Set_Pull --
-   --------------
+   -----------------------
+   -- Set_Pull_Resistor --
+   -----------------------
 
    overriding
-   function Set_Pull (This : in out GPIO_Point;
-                      Pull : HAL.GPIO.GPIO_Pull)
-                      return Boolean
+   function Set_Pull_Resistor (This : in out GPIO_Point;
+                               Pull : HAL.GPIO.GPIO_Pull_Resistor)
+                               return Boolean
    is
    begin
       GPIO_Periph.PIN_CNF (This.Pin).PULL :=
@@ -102,7 +104,7 @@ package body nRF51.GPIO is
             when HAL.GPIO.Pull_Down => Pulldown,
             when HAL.GPIO.Pull_Up   => Pullup);
       return True;
-   end Set_Pull;
+   end Set_Pull_Resistor;
 
    ---------
    -- Set --

--- a/ARM/Nordic/drivers/nrf51-gpio.ads
+++ b/ARM/Nordic/drivers/nrf51-gpio.ads
@@ -75,12 +75,13 @@ package nRF51.GPIO is
                       Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean;
 
    overriding
-   function Pull (This : GPIO_Point) return HAL.GPIO.GPIO_Pull;
+   function Pull_Resistor (This : GPIO_Point)
+                           return HAL.GPIO.GPIO_Pull_Resistor;
 
    overriding
-   function Set_Pull (This : in out GPIO_Point;
-                      Pull : HAL.GPIO.GPIO_Pull)
-                      return Boolean;
+   function Set_Pull_Resistor (This : in out GPIO_Point;
+                               Pull : HAL.GPIO.GPIO_Pull_Resistor)
+                               return Boolean;
 
    overriding
    function Set (This : GPIO_Point) return Boolean with

--- a/ARM/Nordic/drivers/nrf51-gpio.ads
+++ b/ARM/Nordic/drivers/nrf51-gpio.ads
@@ -75,6 +75,14 @@ package nRF51.GPIO is
                       Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean;
 
    overriding
+   function Pull (This : GPIO_Point) return HAL.GPIO.GPIO_Pull;
+
+   overriding
+   function Set_Pull (This : in out GPIO_Point;
+                      Pull : HAL.GPIO.GPIO_Pull)
+                      return Boolean;
+
+   overriding
    function Set (This : GPIO_Point) return Boolean with
      Inline;
    --  Returns True if the bit specified by This.Pin is set (not zero) in the

--- a/ARM/Nordic/drivers/nrf51-gpio.ads
+++ b/ARM/Nordic/drivers/nrf51-gpio.ads
@@ -68,6 +68,13 @@ package nRF51.GPIO is
    end record;
 
    overriding
+   function Mode (This : GPIO_Point) return HAL.GPIO.GPIO_Mode;
+
+   overriding
+   function Set_Mode (This : in out GPIO_Point;
+                      Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean;
+
+   overriding
    function Set (This : GPIO_Point) return Boolean with
      Inline;
    --  Returns True if the bit specified by This.Pin is set (not zero) in the

--- a/ARM/STM32/drivers/stm32-gpio.adb
+++ b/ARM/STM32/drivers/stm32-gpio.adb
@@ -104,12 +104,13 @@ package body STM32.GPIO is
       return True;
    end Set_Mode;
 
-   ----------
-   -- Pull --
-   ----------
+   -------------------
+   -- Pull_Resistor --
+   -------------------
 
    overriding
-   function Pull (This : GPIO_Point) return HAL.GPIO.GPIO_Pull is
+   function Pull_Resistor (This : GPIO_Point)
+                           return HAL.GPIO.GPIO_Pull_Resistor is
    begin
       if  This.Periph.PUPDR.Arr (This.Pin) = 0 then
          return HAL.GPIO.Floating;
@@ -118,16 +119,16 @@ package body STM32.GPIO is
       else
          return HAL.GPIO.Pull_Down;
       end if;
-   end Pull;
+   end Pull_Resistor;
 
-   --------------
-   -- Set_Pull --
-   --------------
+   -----------------------
+   -- Set_Pull_Resistor --
+   -----------------------
 
    overriding
-   function Set_Pull (This : in out GPIO_Point;
-                      Pull : HAL.GPIO.GPIO_Pull)
-                      return Boolean
+   function Set_Pull_Resistor (This : in out GPIO_Point;
+                               Pull : HAL.GPIO.GPIO_Pull_Resistor)
+                               return Boolean
    is
    begin
       case Pull is
@@ -139,7 +140,7 @@ package body STM32.GPIO is
             This.Periph.PUPDR.Arr (This.Pin) := 2;
       end case;
       return True;
-   end Set_Pull;
+   end Set_Pull_Resistor;
 
    ---------
    -- Set --

--- a/ARM/STM32/drivers/stm32-gpio.adb
+++ b/ARM/STM32/drivers/stm32-gpio.adb
@@ -104,6 +104,43 @@ package body STM32.GPIO is
       return True;
    end Set_Mode;
 
+   ----------
+   -- Pull --
+   ----------
+
+   overriding
+   function Pull (This : GPIO_Point) return HAL.GPIO.GPIO_Pull is
+   begin
+      if  This.Periph.PUPDR.Arr (This.Pin) = 0 then
+         return HAL.GPIO.Floating;
+      elsif This.Periph.PUPDR.Arr (This.Pin) = 1 then
+         return HAL.GPIO.Pull_Up;
+      else
+         return HAL.GPIO.Pull_Down;
+      end if;
+   end Pull;
+
+   --------------
+   -- Set_Pull --
+   --------------
+
+   overriding
+   function Set_Pull (This : in out GPIO_Point;
+                      Pull : HAL.GPIO.GPIO_Pull)
+                      return Boolean
+   is
+   begin
+      case Pull is
+         when HAL.GPIO.Floating =>
+            This.Periph.PUPDR.Arr (This.Pin) := 0;
+         when HAL.GPIO.Pull_Up =>
+            This.Periph.PUPDR.Arr (This.Pin) := 1;
+         when HAL.GPIO.Pull_Down =>
+            This.Periph.PUPDR.Arr (This.Pin) := 2;
+      end case;
+      return True;
+   end Set_Pull;
+
    ---------
    -- Set --
    ---------

--- a/ARM/STM32/drivers/stm32-gpio.adb
+++ b/ARM/STM32/drivers/stm32-gpio.adb
@@ -72,6 +72,38 @@ package body STM32.GPIO is
       return False;
    end Any_Set;
 
+   ----------
+   -- Mode --
+   ----------
+
+   overriding
+   function Mode (This : GPIO_Point) return HAL.GPIO.GPIO_Mode is
+   begin
+      case This.Periph.MODER.Arr (This.Pin) is
+         when Pin_IO_Modes'Enum_Rep (Mode_Out) => return HAL.GPIO.Output;
+         when Pin_IO_Modes'Enum_Rep (Mode_In) => return HAL.GPIO.Input;
+         when others => return HAL.GPIO.Unknown;
+      end case;
+   end Mode;
+
+   --------------
+   -- Set_Mode --
+   --------------
+
+   overriding
+   function Set_Mode (This : in out GPIO_Point;
+                      Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean
+   is
+   begin
+      case Mode is
+         when HAL.GPIO.Output =>
+            This.Periph.MODER.Arr (This.Pin) := Pin_IO_Modes'Enum_Rep (Mode_Out);
+         when HAL.GPIO.Input =>
+            This.Periph.MODER.Arr (This.Pin) := Pin_IO_Modes'Enum_Rep (Mode_In);
+      end case;
+      return True;
+   end Set_Mode;
+
    ---------
    -- Set --
    ---------

--- a/ARM/STM32/drivers/stm32-gpio.ads
+++ b/ARM/STM32/drivers/stm32-gpio.ads
@@ -141,12 +141,13 @@ package STM32.GPIO is
                       Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean;
 
    overriding
-   function Pull (This : GPIO_Point) return HAL.GPIO.GPIO_Pull;
+   function Pull_Resistor (This : GPIO_Point)
+                           return HAL.GPIO.GPIO_Pull_Resistor;
 
    overriding
-   function Set_Pull (This : in out GPIO_Point;
-                      Pull : HAL.GPIO.GPIO_Pull)
-                      return Boolean;
+   function Set_Pull_Resistor (This : in out GPIO_Point;
+                               Pull : HAL.GPIO.GPIO_Pull_Resistor)
+                               return Boolean;
 
    overriding
    function Set (This : GPIO_Point) return Boolean with

--- a/ARM/STM32/drivers/stm32-gpio.ads
+++ b/ARM/STM32/drivers/stm32-gpio.ads
@@ -134,6 +134,12 @@ package STM32.GPIO is
    end record;
 
    overriding
+   function Mode (This : GPIO_Point) return HAL.GPIO.GPIO_Mode;
+
+   overriding
+   function Set_Mode (This : in out GPIO_Point;
+                      Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean;
+   overriding
    function Set (This : GPIO_Point) return Boolean with
      Inline;
    --  Returns True if the bit specified by This.Pin is set (not zero) in the

--- a/ARM/STM32/drivers/stm32-gpio.ads
+++ b/ARM/STM32/drivers/stm32-gpio.ads
@@ -139,6 +139,15 @@ package STM32.GPIO is
    overriding
    function Set_Mode (This : in out GPIO_Point;
                       Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean;
+
+   overriding
+   function Pull (This : GPIO_Point) return HAL.GPIO.GPIO_Pull;
+
+   overriding
+   function Set_Pull (This : in out GPIO_Point;
+                      Pull : HAL.GPIO.GPIO_Pull)
+                      return Boolean;
+
    overriding
    function Set (This : GPIO_Point) return Boolean with
      Inline;

--- a/components/src/io_expander/MCP23xxx/mcp23x08.adb
+++ b/components/src/io_expander/MCP23xxx/mcp23x08.adb
@@ -324,27 +324,29 @@ package body MCP23x08 is
       return True;
    end Set_Mode;
 
-   ----------
-   -- Pull --
-   ----------
+   -------------------
+   -- Pull_Resistor --
+   -------------------
 
    overriding
-   function Pull (This : MCP23_GPIO_Point) return HAL.GPIO.GPIO_Pull is
+   function Pull_Resistor (This : MCP23_GPIO_Point)
+                           return HAL.GPIO.GPIO_Pull_Resistor
+   is
    begin
       return (if This.Device.Pull_Up (This.Pin) then
                  HAL.GPIO.Pull_Up
               else
                  HAL.GPIO.Floating);
-   end Pull;
+   end Pull_Resistor;
 
-   --------------
-   -- Set_Pull --
-   --------------
+   -----------------------
+   -- Set_Pull_Resistor --
+   -----------------------
 
    overriding
-   function Set_Pull (This : in out MCP23_GPIO_Point;
-                      Pull : HAL.GPIO.GPIO_Pull)
-                      return Boolean
+   function Set_Pull_Resistor (This : in out MCP23_GPIO_Point;
+                               Pull : HAL.GPIO.GPIO_Pull_Resistor)
+                               return Boolean
    is
    begin
       if Pull = HAL.GPIO.Pull_Down then
@@ -353,7 +355,7 @@ package body MCP23x08 is
          This.Device.Configure_Pull (This.Pin, Pull = HAL.GPIO.Pull_Up);
          return True;
       end if;
-   end Set_Pull;
+   end Set_Pull_Resistor;
 
    ---------
    -- Set --

--- a/components/src/io_expander/MCP23xxx/mcp23x08.adb
+++ b/components/src/io_expander/MCP23xxx/mcp23x08.adb
@@ -237,9 +237,9 @@ package body MCP23x08 is
    ---------
 
    overriding
-   function Set (Point : MCP23_GPIO_Point) return Boolean is
+   function Set (This : MCP23_GPIO_Point) return Boolean is
    begin
-      return Point.Device.Set (Point.Pin);
+      return This.Device.Set (This.Pin);
    end Set;
 
    ---------
@@ -247,9 +247,9 @@ package body MCP23x08 is
    ---------
 
    overriding
-   procedure Set (Point : in out MCP23_GPIO_Point) is
+   procedure Set (This : in out MCP23_GPIO_Point) is
    begin
-      Point.Device.Set (Point.Pin);
+      This.Device.Set (This.Pin);
    end Set;
 
    -----------
@@ -257,9 +257,9 @@ package body MCP23x08 is
    -----------
 
    overriding
-   procedure Clear (Point : in out MCP23_GPIO_Point) is
+   procedure Clear (This : in out MCP23_GPIO_Point) is
    begin
-      Point.Device.Clear (Point.Pin);
+      This.Device.Clear (This.Pin);
    end Clear;
 
    ------------
@@ -267,9 +267,9 @@ package body MCP23x08 is
    ------------
 
    overriding
-   procedure Toggle (Point : in out MCP23_GPIO_Point) is
+   procedure Toggle (This : in out MCP23_GPIO_Point) is
    begin
-      Point.Device.Toggle (Point.Pin);
+      This.Device.Toggle (This.Pin);
    end Toggle;
 
 end MCP23x08;

--- a/components/src/io_expander/MCP23xxx/mcp23x08.ads
+++ b/components/src/io_expander/MCP23xxx/mcp23x08.ads
@@ -103,16 +103,16 @@ private
    --  Internal implementation of HAL.GPIO interface
 
    overriding
-   function Set (Point : MCP23_GPIO_Point) return Boolean;
+   function Set (This : MCP23_GPIO_Point) return Boolean;
 
    overriding
-   procedure Set (Point : in out MCP23_GPIO_Point);
+   procedure Set (This : in out MCP23_GPIO_Point);
 
    overriding
-   procedure Clear (Point : in out MCP23_GPIO_Point);
+   procedure Clear (This : in out MCP23_GPIO_Point);
 
    overriding
-   procedure Toggle (Point : in out MCP23_GPIO_Point);
+   procedure Toggle (This : in out MCP23_GPIO_Point);
 
    type MCP23_GPIO_Point_Array is array (MCP23x08_Pin) of
      aliased MCP23_GPIO_Point;

--- a/components/src/io_expander/MCP23xxx/mcp23x08.ads
+++ b/components/src/io_expander/MCP23xxx/mcp23x08.ads
@@ -67,6 +67,10 @@ package MCP23x08 is
                              Pull_Up : Boolean);
    --  Configure single pin pull up resistor
 
+   function Pull_Up (This : MCP23x08_IO_Expander;
+                     Pin  : MCP23x08_Pin) return Boolean;
+   --  Return True if the internal pull-up resistor in enabled
+
    function Set (This  : MCP23x08_IO_Expander;
                  Pin   : MCP23x08_Pin) return Boolean;
    --  Return the curent status of Pin
@@ -123,6 +127,13 @@ private
    function Set_Mode (This : in out MCP23_GPIO_Point;
                       Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean;
 
+   overriding
+   function Pull (This : MCP23_GPIO_Point) return HAL.GPIO.GPIO_Pull;
+
+   overriding
+   function Set_Pull (This : in out MCP23_GPIO_Point;
+                      Pull : HAL.GPIO.GPIO_Pull)
+                      return Boolean;
    overriding
    function Set (This : MCP23_GPIO_Point) return Boolean;
 

--- a/components/src/io_expander/MCP23xxx/mcp23x08.ads
+++ b/components/src/io_expander/MCP23xxx/mcp23x08.ads
@@ -53,6 +53,20 @@ package MCP23x08 is
    --  Configure single pin as input or output and optinaly enable the pull-up
    --  resistor.
 
+   procedure Configure_Mode (This    : in out MCP23x08_IO_Expander;
+                             Pin     : MCP23x08_Pin;
+                             Output  : Boolean);
+   --  Configure single pin as input or output
+
+   function Is_Output (This : in out MCP23x08_IO_Expander;
+                       Pin  : MCP23x08_Pin)
+                       return Boolean;
+
+   procedure Configure_Pull (This    : in out MCP23x08_IO_Expander;
+                             Pin     : MCP23x08_Pin;
+                             Pull_Up : Boolean);
+   --  Configure single pin pull up resistor
+
    function Set (This  : MCP23x08_IO_Expander;
                  Pin   : MCP23x08_Pin) return Boolean;
    --  Return the curent status of Pin
@@ -101,6 +115,13 @@ private
       Pin    : MCP23x08_Pin;
    end record;
    --  Internal implementation of HAL.GPIO interface
+
+   overriding
+   function Mode (This : MCP23_GPIO_Point) return HAL.GPIO.GPIO_Mode;
+
+   overriding
+   function Set_Mode (This : in out MCP23_GPIO_Point;
+                      Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean;
 
    overriding
    function Set (This : MCP23_GPIO_Point) return Boolean;

--- a/components/src/io_expander/MCP23xxx/mcp23x08.ads
+++ b/components/src/io_expander/MCP23xxx/mcp23x08.ads
@@ -128,12 +128,13 @@ private
                       Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean;
 
    overriding
-   function Pull (This : MCP23_GPIO_Point) return HAL.GPIO.GPIO_Pull;
+   function Pull_Resistor (This : MCP23_GPIO_Point)
+                           return HAL.GPIO.GPIO_Pull_Resistor;
 
    overriding
-   function Set_Pull (This : in out MCP23_GPIO_Point;
-                      Pull : HAL.GPIO.GPIO_Pull)
-                      return Boolean;
+   function Set_Pull_Resistor (This : in out MCP23_GPIO_Point;
+                               Pull : HAL.GPIO.GPIO_Pull_Resistor)
+                               return Boolean;
    overriding
    function Set (This : MCP23_GPIO_Point) return Boolean;
 

--- a/components/src/io_expander/stmpe1600/stmpe1600.adb
+++ b/components/src/io_expander/stmpe1600/stmpe1600.adb
@@ -349,7 +349,6 @@ package body STMPE1600 is
       return True;
    end Set_Mode;
 
-
    ---------
    -- Set --
    ---------

--- a/components/src/io_expander/stmpe1600/stmpe1600.ads
+++ b/components/src/io_expander/stmpe1600/stmpe1600.ads
@@ -38,15 +38,15 @@ package STMPE1600 is
                             Addr : HAL.I2C.I2C_Address) is limited private;
    type Any_STMPE1600_Expander is access all STMPE1600_Expander;
 
-   type Pin_Polarity is (Low, High) with Size => 1;
-   type Pin_Direction is (Input, Output) with Size => 1;
+   type STMPE1600_Pin_Polarity is (Low, High) with Size => 1;
+   type STMPE1600_Pin_Direction is (Input, Output) with Size => 1;
    type STMPE1600_Pin_Number is range 0 .. 15;
 
    type STMPE1600_Pins is array (STMPE1600_Pin_Number) of Boolean
      with Pack, Size => 16;
 
    type STMPE1600_Pins_Direction is
-     array (STMPE1600_Pin_Number) of Pin_Direction
+     array (STMPE1600_Pin_Number) of STMPE1600_Pin_Direction
      with Pack, Size => 16;
 
    procedure Check_Id
@@ -56,7 +56,7 @@ package STMPE1600 is
    procedure Set_Interrupt_Enable
      (This     : in out STMPE1600_Expander;
       Enable   : Boolean;
-      Polarity : Pin_Polarity;
+      Polarity : STMPE1600_Pin_Polarity;
       Status   : out Boolean);
    --  Enables/Disables the interrupt to the host.
    --  Allows also to set whether the interrupt is active High or Low.
@@ -101,7 +101,12 @@ package STMPE1600 is
    procedure Set_Pin_Direction
      (This      : STMPE1600_Expander;
       Pin       : STMPE1600_Pin_Number;
-      Direction : Pin_Direction);
+      Direction : STMPE1600_Pin_Direction);
+
+   function Pin_Direction
+     (This : STMPE1600_Expander;
+      Pin  : STMPE1600_Pin_Number)
+      return STMPE1600_Pin_Direction;
 
    procedure Set_Pin_Polarity_Inversion
      (This            : STMPE1600_Expander;
@@ -117,7 +122,7 @@ package STMPE1600 is
 private
 
    type STMPE1600_SYS_CTRL is record
-      INT_Polarity : Pin_Polarity := Low;
+      INT_Polarity : STMPE1600_Pin_Polarity := Low;
       Reserved_1   : HAL.Bit := 0;
       INT_Enable   : Boolean := False;
       Reserved_3_4 : HAL.UInt2 := 0;
@@ -141,16 +146,29 @@ private
       Port : Any_STMPE1600_Expander;
       Pin  : STMPE1600_Pin_Number;
    end record;
+
    type STMPE1600_Pin_Array is
      array (STMPE1600_Pin_Number) of aliased STMPE1600_Pin;
 
-   overriding function Set (This : STMPE1600_Pin) return Boolean;
 
-   overriding procedure Set (This : in out STMPE1600_Pin);
+   overriding
+   function Mode (This : STMPE1600_Pin) return HAL.GPIO.GPIO_Mode;
 
-   overriding procedure Clear (This : in out STMPE1600_Pin);
+   overriding
+   function Set_Mode (This : in out STMPE1600_Pin;
+                      Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean;
 
-   overriding procedure Toggle (This : in out STMPE1600_Pin);
+   overriding
+   function Set (This : STMPE1600_Pin) return Boolean;
+
+   overriding
+   procedure Set (This : in out STMPE1600_Pin);
+
+   overriding
+   procedure Clear (This : in out STMPE1600_Pin);
+
+   overriding
+   procedure Toggle (This : in out STMPE1600_Pin);
 
    type STMPE1600_Expander (Port : not null HAL.I2C.Any_I2C_Port;
                             Addr : HAL.I2C.I2C_Address)

--- a/components/src/io_expander/stmpe1600/stmpe1600.ads
+++ b/components/src/io_expander/stmpe1600/stmpe1600.ads
@@ -121,6 +121,8 @@ package STMPE1600 is
 
 private
 
+   use type HAL.GPIO.GPIO_Pull;
+
    type STMPE1600_SYS_CTRL is record
       INT_Polarity : STMPE1600_Pin_Polarity := Low;
       Reserved_1   : HAL.Bit := 0;
@@ -157,6 +159,16 @@ private
    overriding
    function Set_Mode (This : in out STMPE1600_Pin;
                       Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean;
+
+   overriding
+   function Pull (This : STMPE1600_Pin) return HAL.GPIO.GPIO_Pull is
+     (HAL.GPIO.Floating);
+
+   overriding
+   function Set_Pull (This : in out STMPE1600_Pin;
+                      Pull : HAL.GPIO.GPIO_Pull)
+                      return Boolean is (Pull = HAL.GPIO.Floating);
+   --  STMPE1600 doesn't have internal pull resistors
 
    overriding
    function Set (This : STMPE1600_Pin) return Boolean;

--- a/components/src/io_expander/stmpe1600/stmpe1600.ads
+++ b/components/src/io_expander/stmpe1600/stmpe1600.ads
@@ -121,7 +121,7 @@ package STMPE1600 is
 
 private
 
-   use type HAL.GPIO.GPIO_Pull;
+   use type HAL.GPIO.GPIO_Pull_Resistor;
 
    type STMPE1600_SYS_CTRL is record
       INT_Polarity : STMPE1600_Pin_Polarity := Low;
@@ -161,13 +161,14 @@ private
                       Mode : HAL.GPIO.GPIO_Config_Mode) return Boolean;
 
    overriding
-   function Pull (This : STMPE1600_Pin) return HAL.GPIO.GPIO_Pull is
+   function Pull_Resistor (This : STMPE1600_Pin)
+                           return HAL.GPIO.GPIO_Pull_Resistor is
      (HAL.GPIO.Floating);
 
    overriding
-   function Set_Pull (This : in out STMPE1600_Pin;
-                      Pull : HAL.GPIO.GPIO_Pull)
-                      return Boolean is (Pull = HAL.GPIO.Floating);
+   function Set_Pull_Resistor (This : in out STMPE1600_Pin;
+                               Pull : HAL.GPIO.GPIO_Pull_Resistor)
+                               return Boolean is (Pull = HAL.GPIO.Floating);
    --  STMPE1600 doesn't have internal pull resistors
 
    overriding

--- a/hal/src/hal-gpio.ads
+++ b/hal/src/hal-gpio.ads
@@ -32,7 +32,9 @@
 package HAL.GPIO is
 
    type GPIO_Mode is (Unknown, Input, Output);
-   --  Possible modes for a GPIO point
+   --  Possible modes for a GPIO point. Unknown means that the point is
+   --  configured in a mode that is not described in this interface. For
+   --  instance alternate function mode on an STM32 micro-controller.
 
    subtype GPIO_Config_Mode is GPIO_Mode range Input .. Output;
    --  Modes a GPIO point can be configured in
@@ -57,8 +59,17 @@ package HAL.GPIO is
                                return Boolean is abstract;
    --  Return False if pull is not available for this GPIO point
 
-   function Set (This : GPIO_Point) return Boolean is abstract
-     with Pre'Class => This.Mode = Input;
+   function Set (This : GPIO_Point) return Boolean is abstract;
+   --  Read actual state of the GPIO_Point.
+   --
+   --  So far all the GPIO supported by this library have the ability to read
+   --  the state even when they are configured as output.
+
+
+   --  For the output control procedures below, depending on configuration
+   --  and/or other devices conected to the IO line, these procedures may have
+   --  no actual effect on the line. For example trying to set the IO when
+   --  another device is pulling the line to low.
 
    procedure Set (This : in out GPIO_Point) is abstract
      with Pre'Class => This.Mode = Output;

--- a/hal/src/hal-gpio.ads
+++ b/hal/src/hal-gpio.ads
@@ -31,16 +31,32 @@
 
 package HAL.GPIO is
 
+   type GPIO_Mode is (Unknown, Input, Output);
+   --  Possible modes for a GPIO point
+
+   subtype GPIO_Config_Mode is GPIO_Mode range Input .. Output;
+   --  Modes a GPIO point can be configured in
+
    type GPIO_Point is limited interface;
 
    type Any_GPIO_Point is access all GPIO_Point'Class;
 
-   function Set (This : GPIO_Point) return Boolean is abstract;
+   function Mode (This : GPIO_Point) return GPIO_Mode is abstract;
 
-   procedure Set (This : in out GPIO_Point) is abstract;
+   function Set_Mode (This : in out GPIO_Point;
+                      Mode : GPIO_Config_Mode) return Boolean is abstract;
+   --  Return False if the mode is not available
 
-   procedure Clear (This : in out GPIO_Point) is abstract;
+   function Set (This : GPIO_Point) return Boolean is abstract
+     with Pre'Class => This.Mode = Input;
 
-   procedure Toggle (This : in out GPIO_Point) is abstract;
+   procedure Set (This : in out GPIO_Point) is abstract
+     with Pre'Class => This.Mode = Output;
+
+   procedure Clear (This : in out GPIO_Point) is abstract
+     with Pre'Class => This.Mode = Output;
+
+   procedure Toggle (This : in out GPIO_Point) is abstract
+     with Pre'Class => This.Mode = Output;
 
 end HAL.GPIO;

--- a/hal/src/hal-gpio.ads
+++ b/hal/src/hal-gpio.ads
@@ -37,7 +37,7 @@ package HAL.GPIO is
    subtype GPIO_Config_Mode is GPIO_Mode range Input .. Output;
    --  Modes a GPIO point can be configured in
 
-   type GPIO_Pull is (Floating, Pull_Up, Pull_Down);
+   type GPIO_Pull_Resistor is (Floating, Pull_Up, Pull_Down);
 
    type GPIO_Point is limited interface;
 
@@ -49,11 +49,12 @@ package HAL.GPIO is
                       Mode : GPIO_Config_Mode) return Boolean is abstract;
    --  Return False if the mode is not available
 
-   function Pull (This : GPIO_Point) return GPIO_Pull is abstract;
+   function Pull_Resistor (This : GPIO_Point)
+                           return GPIO_Pull_Resistor is abstract;
 
-   function Set_Pull (This : in out GPIO_Point;
-                      Pull : GPIO_Pull)
-                      return Boolean is abstract;
+   function Set_Pull_Resistor (This : in out GPIO_Point;
+                               Pull : GPIO_Pull_Resistor)
+                               return Boolean is abstract;
    --  Return False if pull is not available for this GPIO point
 
    function Set (This : GPIO_Point) return Boolean is abstract

--- a/hal/src/hal-gpio.ads
+++ b/hal/src/hal-gpio.ads
@@ -37,6 +37,8 @@ package HAL.GPIO is
    subtype GPIO_Config_Mode is GPIO_Mode range Input .. Output;
    --  Modes a GPIO point can be configured in
 
+   type GPIO_Pull is (Floating, Pull_Up, Pull_Down);
+
    type GPIO_Point is limited interface;
 
    type Any_GPIO_Point is access all GPIO_Point'Class;
@@ -46,6 +48,13 @@ package HAL.GPIO is
    function Set_Mode (This : in out GPIO_Point;
                       Mode : GPIO_Config_Mode) return Boolean is abstract;
    --  Return False if the mode is not available
+
+   function Pull (This : GPIO_Point) return GPIO_Pull is abstract;
+
+   function Set_Pull (This : in out GPIO_Point;
+                      Pull : GPIO_Pull)
+                      return Boolean is abstract;
+   --  Return False if pull is not available for this GPIO point
 
    function Set (This : GPIO_Point) return Boolean is abstract
      with Pre'Class => This.Mode = Input;

--- a/testsuite/tests/bitmap_drawing/src/tc_bitmap_drawing.adb
+++ b/testsuite/tests/bitmap_drawing/src/tc_bitmap_drawing.adb
@@ -1,3 +1,4 @@
+with Test_Directories;     use Test_Directories;
 with Ada.Text_IO;          use Ada.Text_IO;
 with Native.Filesystem;    use Native.Filesystem;
 with HAL;                  use HAL;
@@ -5,16 +6,9 @@ with HAL.Filesystem;       use HAL.Filesystem;
 with HAL.Bitmap;           use HAL.Bitmap;
 with Memory_Mapped_Bitmap; use Memory_Mapped_Bitmap;
 with Bitmap_File_Output;   use Bitmap_File_Output;
-with Ada.Command_Line;
-with Ada.Directories;
 with Compare_Files;
 
 procedure TC_Bitmap_Drawing is
-
-   Program_Abspath : constant Pathname := Native.Filesystem.Join
-     (Ada.Directories.Current_Directory, Ada.Command_Line.Command_Name, False);
-   Test_Dir : constant Pathname := Ada.Directories.Containing_Directory
-     (Ada.Directories.Containing_Directory (Program_Abspath));
 
    BM_Width  : constant := 100;
    BM_Height : constant := 100;

--- a/testsuite/tests/bitmap_drawing/tc.gpr
+++ b/testsuite/tests/bitmap_drawing/tc.gpr
@@ -1,11 +1,10 @@
 with "../../../boards/native";
 with "../../../boards/native/config";
-with "../../utils/test_utils";
 
-project TC is
+project TC extends "../../utils/test_utils.gpr" is
 
    for Languages use ("Ada");
-   for Source_Dirs use ("src");
+   for Source_Dirs use Test_Utils'Source_Dirs & ("src");
    for Main use
        ("tc_bitmap_drawing.adb");
    for Object_Dir use "obj";

--- a/testsuite/tests/disk_partitions/src/tc_read_partitions.adb
+++ b/testsuite/tests/disk_partitions/src/tc_read_partitions.adb
@@ -3,15 +3,9 @@ with Native.Filesystem;  use Native.Filesystem;
 with HAL.Filesystem;     use HAL.Filesystem;
 with Partitions;         use Partitions;
 with File_Block_Drivers; use File_Block_Drivers;
-with Ada.Command_Line;
-with Ada.Directories;
+with Test_Directories;   use Test_Directories;
 
 procedure TC_Read_Partitions is
-
-   Program_Abspath : constant Pathname := Native.Filesystem.Join
-     (Ada.Directories.Current_Directory, Ada.Command_Line.Command_Name, False);
-   Test_Dir : constant Pathname := Ada.Directories.Containing_Directory
-     (Ada.Directories.Containing_Directory (Program_Abspath));
 
    procedure List_Partitions (FS : in out FS_Driver'Class;
                               Path_To_Disk_Image : Pathname);

--- a/testsuite/tests/disk_partitions/tc.gpr
+++ b/testsuite/tests/disk_partitions/tc.gpr
@@ -1,7 +1,7 @@
 with "../../../boards/native";
 with "../../../boards/native/config";
 
-project TC is
+project TC extends "../../utils/test_utils.gpr" is
 
    for Languages use ("Ada");
    for Source_Dirs use ("src");

--- a/testsuite/tests/virtual_file_system/tc.gpr
+++ b/testsuite/tests/virtual_file_system/tc.gpr
@@ -1,7 +1,7 @@
 with "../../../boards/native";
 with "../../../boards/native/config";
 
-project TC is
+project TC extends "../../utils/test_utils.gpr" is
 
    for Languages use ("Ada");
    for Source_Dirs use ("src");

--- a/testsuite/tests/wire_simulation/src/tc_virtual_wire.adb
+++ b/testsuite/tests/wire_simulation/src/tc_virtual_wire.adb
@@ -1,0 +1,151 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                        Copyright (C) 2017, AdaCore                       --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with HAL.GPIO; use HAL.GPIO;
+
+with Wire_Simulation; use Wire_Simulation;
+with Ada.Text_IO;   use Ada.Text_IO;
+
+procedure TC_Virtual_Wire is
+   pragma Assertion_Policy (Assert => Check);
+
+   No_Pull_Wire : Virtual_Wire (Default_Pull => Floating,
+                                Max_Points   => 2);
+
+   Pull_Up_Wire : Virtual_Wire (Default_Pull => Pull_Up,
+                                Max_Points   => 2);
+
+   Pull_Down_Wire : Virtual_Wire (Default_Pull => Pull_Down,
+                                  Max_Points   => 2);
+
+   Unref : Boolean with Unreferenced;
+begin
+
+   -- Default mode --
+
+   pragma Assert (No_Pull_Wire.Point (1).Mode = Input,
+                  "Default point mode should be input");
+
+   -- State with only inputs and a wire pull resistor --
+
+   pragma Assert (Pull_Up_Wire.Point (1).Set,
+                  "Default state of pull up wire should be high");
+   pragma Assert (not Pull_Down_Wire.Point (1).Set,
+                  "Default state of pull down wire should be low");
+
+   -- State with only inputs and a point pull resistor --
+
+   pragma Assert (No_Pull_Wire.Point (1).Set_Pull_Resistor (Pull_Up),
+                  "It should be possible to change the pull resitor");
+
+   pragma Assert (No_Pull_Wire.Point (1).Set,
+                  "State of wire with one pull up point should be high");
+
+
+   Unref := No_Pull_Wire.Point (1).Set_Pull_Resistor (Pull_Down);
+   pragma Assert (not No_Pull_Wire.Point (1).Set,
+                  "State of wire with one pull down point should be low");
+
+   -- State with one input one output and no pull resistor --
+
+   pragma Assert (No_Pull_Wire.Point (1).Set_Mode (Input),
+                  "It should be possible to change the mode");
+   Unref := No_Pull_Wire.Point (1).Set_Pull_Resistor (Pull_Down);
+
+   Unref := No_Pull_Wire.Point (2).Set_Mode (Output);
+   Unref := No_Pull_Wire.Point (2).Set_Pull_Resistor (Floating);
+
+   No_Pull_Wire.Point (2).Set;
+   pragma Assert (No_Pull_Wire.Point (1).Set, "Should be high");
+   No_Pull_Wire.Point (2).Clear;
+   pragma Assert (not No_Pull_Wire.Point (1).Set, "Should be low");
+
+   -- State with one input one output and point pull resistor --
+
+   Unref := No_Pull_Wire.Point (1).Set_Mode (Input);
+   Unref := No_Pull_Wire.Point (1).Set_Pull_Resistor (Pull_Up);
+
+   Unref := No_Pull_Wire.Point (2).Set_Mode (Output);
+   Unref := No_Pull_Wire.Point (2).Set_Pull_Resistor (Floating);
+
+   No_Pull_Wire.Point (2).Set;
+   pragma Assert (No_Pull_Wire.Point (1).Set, "Should be high");
+   No_Pull_Wire.Point (2).Clear;
+   pragma Assert (not No_Pull_Wire.Point (1).Set, "Should be low");
+
+   Unref := No_Pull_Wire.Point (1).Set_Pull_Resistor (Pull_Down);
+
+   No_Pull_Wire.Point (2).Set;
+   pragma Assert (No_Pull_Wire.Point (1).Set, "Should be high");
+   No_Pull_Wire.Point (2).Clear;
+   pragma Assert (not No_Pull_Wire.Point (1).Set, "Should be low");
+
+   -- Opposite pull on the same wire --
+   declare
+   begin
+      Unref := Pull_Down_Wire.Point (1).Set_Pull_Resistor (Pull_Up);
+   exception
+      when Invalid_Configuration =>
+         Put_Line ("Expected exception on oppposite pull (1)");
+   end;
+
+   declare
+   begin
+      Unref := Pull_Up_Wire.Point (1).Set_Pull_Resistor (Pull_Down);
+   exception
+      when Invalid_Configuration =>
+         Put_Line ("Expected exception on oppposite pull (2)");
+   end;
+
+   -- Two output point on a wire --
+   declare
+   begin
+      Unref := Pull_Up_Wire.Point (1).Set_Mode (Output);
+      Unref := Pull_Up_Wire.Point (2).Set_Mode (Output);
+   exception
+      when Invalid_Configuration =>
+         Put_Line ("Expected exception on multiple output points");
+   end;
+
+   -- Unknon state --
+   declare
+   begin
+      Unref := No_Pull_Wire.Point (1).Set_Mode (Input);
+      Unref := No_Pull_Wire.Point (1).Set_Pull_Resistor (Floating);
+      Unref := No_Pull_Wire.Point (2).Set_Mode (Input);
+      Unref := No_Pull_Wire.Point (2).Set_Pull_Resistor (Floating);
+      Unref := No_Pull_Wire.Point (2).Set;
+   exception
+      when Unknown_State =>
+         Put_Line ("Expected exception on unknown state");
+   end;
+
+end TC_Virtual_Wire;

--- a/testsuite/tests/wire_simulation/tc.gpr
+++ b/testsuite/tests/wire_simulation/tc.gpr
@@ -1,0 +1,15 @@
+with "../../../boards/native";
+with "../../../boards/native/config";
+
+project TC extends "../../utils/test_utils.gpr" is
+
+   for Languages use ("Ada");
+   for Source_Dirs use ("src");
+   for Main use ("tc_virtual_wire.adb");
+   for Object_Dir use "obj";
+   for Exec_Dir use "bin";
+
+   package Compiler renames Config.Compiler;
+   package Builder renames Config.Builder;
+
+end TC;

--- a/testsuite/tests/wire_simulation/tc_virtual_wire.out
+++ b/testsuite/tests/wire_simulation/tc_virtual_wire.out
@@ -1,0 +1,4 @@
+Expected exception on oppposite pull (1)
+Expected exception on oppposite pull (2)
+Expected exception on multiple output points
+Expected exception on unknown state

--- a/testsuite/utils/src/test_directories.ads
+++ b/testsuite/utils/src/test_directories.ads
@@ -1,0 +1,45 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                        Copyright (C) 2017, AdaCore                       --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Command_Line;
+with Ada.Directories;
+with HAL.Filesystem;    use HAL.Filesystem;
+with Native.Filesystem; use Native.Filesystem;
+
+package Test_Directories is
+   Program_Abspath : constant Pathname := Native.Filesystem.Join
+     (Ada.Directories.Current_Directory, Ada.Command_Line.Command_Name, False);
+   --  Absolute path of the test executable
+
+   Test_Dir : constant Pathname := Ada.Directories.Containing_Directory
+     (Ada.Directories.Containing_Directory (Program_Abspath));
+   --  Absolute path to the test directory
+end Test_Directories;

--- a/testsuite/utils/src/wire_simulation.adb
+++ b/testsuite/utils/src/wire_simulation.adb
@@ -1,0 +1,210 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                        Copyright (C) 2017, AdaCore                       --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+package body Wire_Simulation is
+
+   -----------
+   -- Point --
+   -----------
+
+   function Point
+     (This : in out Virtual_Wire;
+      Id   : Positive)
+      return Any_GPIO_Point
+   is
+   begin
+      This.Points (Id).Wire := This'Unchecked_Access;
+      return This.Points (Id)'Unchecked_Access;
+   end Point;
+
+   --------------
+   -- Set_Mode --
+   --------------
+
+   overriding function Set_Mode
+     (This : in out Wire_Point;
+      Mode : GPIO_Config_Mode)
+      return Boolean
+   is
+   begin
+      This.Current_Mode := Input;
+      if Mode = Output and then This.Wire.At_Least_One_Output then
+         raise Invalid_Configuration;
+      end if;
+      This.Current_Mode := Mode;
+      This.Wire.Update_Wire_State;
+      return True;
+   end Set_Mode;
+
+   -----------------------
+   -- Set_Pull_Resistor --
+   -----------------------
+
+   overriding function Set_Pull_Resistor
+     (This : in out Wire_Point;
+      Pull : GPIO_Pull_Resistor)
+      return Boolean
+   is
+   begin
+      This.Current_Pull := Floating;
+
+      if Pull = Pull_Down
+        and then
+          (This.Wire.At_Least_One_Pull_Up
+           or else
+           This.Wire.Default_Pull = Pull_Up)
+      then
+         raise Invalid_Configuration;
+      elsif Pull = Pull_Up
+        and then
+          (This.Wire.At_Least_One_Pull_Down
+           or else
+           This.Wire.Default_Pull = Pull_Down)
+      then
+         raise Invalid_Configuration;
+      else
+         This.Current_Pull := Pull;
+         This.Wire.Update_Wire_State;
+         return True;
+      end if;
+   end Set_Pull_Resistor;
+
+   ---------
+   -- Set --
+   ---------
+
+   overriding function Set
+     (This : Wire_Point)
+      return Boolean
+   is
+   begin
+      case This.Wire.State is
+         when Unknown =>
+            raise Unknown_State;
+         when High =>
+            return True;
+         when Low =>
+            return False;
+      end case;
+   end Set;
+
+   ---------
+   -- Set --
+   ---------
+
+   overriding procedure Set
+     (This : in out Wire_Point)
+   is
+   begin
+      This.Current_State := True;
+      This.Wire.Update_Wire_State;
+   end Set;
+
+   -----------
+   -- Clear --
+   -----------
+
+   overriding procedure Clear
+     (This : in out Wire_Point)
+   is
+   begin
+      This.Current_State := False;
+      This.Wire.Update_Wire_State;
+   end Clear;
+
+   ------------
+   -- Toggle --
+   ------------
+
+   overriding procedure Toggle
+     (This : in out Wire_Point)
+   is
+   begin
+      This.Current_State := not This.Current_State;
+      This.Wire.Update_Wire_State;
+   end Toggle;
+
+   -----------------------
+   -- Update_Wire_State --
+   -----------------------
+
+   procedure Update_Wire_State (This : in out Virtual_Wire) is
+      Has_Pull_Up : constant Boolean :=
+        This.At_Least_One_Pull_Up or This.Default_Pull = Pull_Up;
+      Has_Pull_Down : constant Boolean :=
+        This.At_Least_One_Pull_Down  or This.Default_Pull = Pull_Down;
+
+      State : Wire_State := Unknown;
+   begin
+      pragma Assert ((Has_Pull_Down /= Has_Pull_Up) or else not Has_Pull_Up,
+                     "Invalid config. This should've been caught before");
+
+      if Has_Pull_Down then
+         State := Low;
+      elsif Has_Pull_Up then
+         State := High;
+      end if;
+
+      for Pt of This.Points loop
+         if Pt.Current_Mode = Output then
+            if Pt.Current_State then
+               State := High;
+            else
+               State := Low;
+            end if;
+            exit;
+         end if;
+      end loop;
+      This.State := State;
+   end Update_Wire_State;
+
+   -------------------------
+   -- At_Least_One_Output --
+   -------------------------
+
+   function At_Least_One_Output (This : Virtual_Wire) return Boolean is
+     (for some Pt of This.Points => Pt.Current_Mode = Output);
+
+   --------------------------
+   -- At_Least_One_Pull_Up --
+   --------------------------
+
+   function At_Least_One_Pull_Up (This : Virtual_Wire) return Boolean is
+     (for some Pt of This.Points => Pt.Current_Pull = Pull_Up);
+
+   ----------------------------
+   -- At_Least_One_Pull_Down --
+   ----------------------------
+
+   function At_Least_One_Pull_Down (This : Virtual_Wire) return Boolean is
+     (for some Pt of This.Points => Pt.Current_Pull = Pull_Down);
+
+end Wire_Simulation;

--- a/testsuite/utils/src/wire_simulation.ads
+++ b/testsuite/utils/src/wire_simulation.ads
@@ -1,0 +1,120 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                        Copyright (C) 2017, AdaCore                       --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This package provides a simulation of digital signals on an electric wire.
+--  It can be used to test algorithms using GPIO_Point like protocol bit
+--  banging.
+
+with HAL.GPIO; use HAL.GPIO;
+
+package Wire_Simulation is
+
+   Unknown_State : exception;
+   Invalid_Configuration : exception;
+
+   type Virtual_Wire (Default_Pull : GPIO_Pull_Resistor;
+                      Max_Points   : Positive) is
+     tagged limited private;
+
+   type Any_Virtual_Wire is access all Virtual_Wire'Class;
+
+   function Point (This : in out Virtual_Wire;
+                   Id   : Positive)
+                   return Any_GPIO_Point
+     with Pre => Id <= This.Max_Points;
+   --  Return the GPIO_Point coresponding to the Id
+
+private
+
+   type Wire_State is (High, Low, Unknown);
+
+   type Wire_Point is new HAL.GPIO.GPIO_Point with record
+      Current_Mode  : GPIO_Mode := Input;
+      Current_Pull  : GPIO_Pull_Resistor := Floating;
+      Current_State : Boolean := False;
+      Wire          : Any_Virtual_Wire := null;
+   end record;
+
+   overriding
+   function Mode (This : Wire_Point) return GPIO_Mode is (This.Current_Mode);
+
+   overriding
+   function Set_Mode (This : in out Wire_Point;
+                      Mode : GPIO_Config_Mode) return Boolean;
+   --  Return False if the mode is not available
+
+   overriding
+   function Pull_Resistor (This : Wire_Point)
+                           return GPIO_Pull_Resistor is (This.Current_Pull);
+
+   overriding
+   function Set_Pull_Resistor (This : in out Wire_Point;
+                               Pull : GPIO_Pull_Resistor)
+                               return Boolean;
+
+   overriding
+   function Set (This : Wire_Point) return Boolean;
+
+   overriding
+   procedure Set (This : in out Wire_Point);
+
+   overriding
+   procedure Clear (This : in out Wire_Point);
+
+   overriding
+   procedure Toggle (This : in out Wire_Point);
+
+
+   type Wire_Point_Array is array (Natural range <>) of aliased Wire_Point;
+
+   type Virtual_Wire (Default_Pull : GPIO_Pull_Resistor;
+                      Max_Points   : Positive) is
+     tagged limited record
+
+      State  : Wire_State := (case Default_Pull is
+                                 when Pull_Down => Low,
+                                 when Pull_Up   => High,
+                                 when Floating  => Unknown);
+      Points : aliased Wire_Point_Array (1 .. Max_Points);
+   end record;
+
+   procedure Update_Wire_State (This : in out Virtual_Wire);
+
+   function At_Least_One_Output (This : Virtual_Wire) return Boolean;
+   --  Return True if at least one GPIO point is configured as output
+
+   function At_Least_One_Pull_Up (This : Virtual_Wire) return Boolean;
+   --  Return True if at least one GPIO point is configured as pull up
+
+   function At_Least_One_Pull_Down (This : Virtual_Wire) return Boolean;
+   --  Return True if at least one GPIO point is configured as pull down
+
+end Wire_Simulation;

--- a/testsuite/utils/test_utils.gpr
+++ b/testsuite/utils/test_utils.gpr
@@ -1,13 +1,8 @@
-library project Test_Utils extends "../../boards/common_config.gpr" is
 
-   Src_Dirs := ("src");
+project Test_Utils extends "../../boards/common_config.gpr" is
 
-   for Source_Dirs use Src_Dirs;
-
+   for Source_Dirs use ("src");
    for Languages use ("Ada");
-   for Library_Name use "test_utils";
-   for Library_Kind use "static";
-   for Library_Dir use "lib/";
    for Object_Dir use "obj/";
 
    package Compiler renames Common_Config.Compiler;


### PR DESCRIPTION
Add primitives to control the mode (input/output) and pull resistors of GPIO points.