### PR TITLE
Two new ADC demos

### DIFF
--- a/ARM/STM32/driver_demos/demo_adc_timer_dma/.gdbinit
+++ b/ARM/STM32/driver_demos/demo_adc_timer_dma/.gdbinit
@@ -1,0 +1,24 @@
+# This command file will cause a Cortex-M3 or -M4 board to automatically 
+# reset immediately after a GDB "load" command executes.  Note that GPS
+# issues that command as part of the Debug->Init menu invocation.  Manual
+# "load" command invocations will also trigger the action.
+#
+# The reset is achieved by writing to the "Application Interrupt and Reset
+# Control" register located at address 0xE000ED0C.  
+#
+# Both the processor and the peripherals can be reset by writing a value
+# of 0x05FA0004. That value will write to the SYSRESETREQ bit.  If you want
+# to avoid resetting the peripherals, change the value to 0x05FA0001.  That
+# value will write to the VECTRESET bit.  Do *not* use a value that sets both
+# bits.
+#
+# In both cases, any on-board debug hardware is not reset.
+#
+# See the book "The Definitive Guide to the ARM Cortex-M3 and Cortex-M4
+# Processors" by Joseph Yiu, 3rd edition, pp 262-263 for further details.
+
+define hookpost-load
+echo Resetting the processor and peripherals...\n
+set *0xE000ED0C := 0x05FA0004
+echo Reset complete\n
+end

--- a/ARM/STM32/driver_demos/demo_adc_timer_dma/demo_adc_timer_dma.gpr
+++ b/ARM/STM32/driver_demos/demo_adc_timer_dma/demo_adc_timer_dma.gpr
@@ -1,0 +1,18 @@
+with "../../../../boards/common_config.gpr";
+with "../../../../boards/stm32f429_discovery.gpr";
+
+project Demo_ADC_Timer_DMA extends "../../../../examples/common/common.gpr" is
+
+   for Main use ("demo_adc_timer_dma");
+
+   for Languages use ("Ada");
+   for Source_Dirs use ("src");
+   for Object_Dir use "obj/" & Common_Config.Build;
+   for Runtime ("Ada") use STM32F429_Discovery'Runtime("Ada");
+--   for Create_Missing_Dirs use "true";
+
+   package Builder is
+      for Global_Configuration_Pragmas use "gnat.adc";
+   end Builder;
+
+end Demo_ADC_Timer_DMA;

--- a/ARM/STM32/driver_demos/demo_adc_timer_dma/gnat.adc
+++ b/ARM/STM32/driver_demos/demo_adc_timer_dma/gnat.adc
@@ -1,0 +1,2 @@
+pragma Partition_Elaboration_Policy (Sequential);
+

--- a/ARM/STM32/driver_demos/demo_adc_timer_dma/obj/.gitignore
+++ b/ARM/STM32/driver_demos/demo_adc_timer_dma/obj/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/ARM/STM32/driver_demos/demo_adc_timer_dma/readme.md
+++ b/ARM/STM32/driver_demos/demo_adc_timer_dma/readme.md
@@ -1,0 +1,8 @@
+This program demonstrates reading the VBat (battery voltage) value from
+an ADC unit, using a timer to trigger the conversions and DMA to copy the
+sampled value from the ADC to the application variable.
+
+This program is expected to run on the STM32F429 Discovery boards because
+it uses the LCD to display results.  This display usage is entirely for
+convenience -- some other means for showing the results could be used, such
+as a serial port, or some other board with a different display.

--- a/ARM/STM32/driver_demos/demo_adc_timer_dma/src/demo_adc_timer_dma.adb
+++ b/ARM/STM32/driver_demos/demo_adc_timer_dma/src/demo_adc_timer_dma.adb
@@ -1,0 +1,225 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                     Copyright (C) 2017, AdaCore                          --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This program demonstrates reading the VBat (battery voltage) value from
+--  an ADC unit, using a timer to drive the ADC conversions and DMA
+--  to transfer the raw counts from the ADC unit to the application variable.
+
+with Last_Chance_Handler;  pragma Unreferenced (Last_Chance_Handler);
+
+with STM32.Device;  use STM32.Device;
+with STM32.Board;   use STM32.Board;
+with Interfaces;    use Interfaces;
+with HAL;           use HAL;
+with STM32.ADC;     use STM32.ADC;
+with STM32.DMA;     use STM32.DMA;
+with STM32.GPIO;    use STM32.GPIO;
+with STM32.Timers;  use STM32.Timers;
+with STM32.PWM;     use STM32.PWM;
+with Ada.Real_Time; use Ada.Real_Time;
+with LCD_Std_Out;
+
+procedure Demo_ADC_Timer_DMA is
+
+   Selected_Timer : Timer renames Timer_1;
+
+   Triggering_Signal : PWM_Modulator (Selected_Timer'Access);
+   --  the PWM modulator used to generate the square wave that triggers the ADC
+   --  conversions
+
+   Controller : DMA_Controller renames DMA_2;
+   Stream     : constant DMA_Stream_Selector := Stream_0;
+
+   Counts : UInt32 with Volatile;
+   --  The raw counts from the ADC sampling the VBat channel. The value is
+   --  updated by the DMA controller.
+
+   procedure Configure_ADC;
+   --  Set up ADC1 to read the VBat voltage value. Note that only ADC1 can
+   --  do this. Conversions are not triggered by software but are instead
+   --  triggered by Timer1. Each conversion generates an interrupt signalling
+   --  conversion complete.
+
+   procedure Configure_Timer;
+   --  Set up Timer1 to generare a square wave of arbitrary frequency, in
+   --  order to trigger the ADC conversions. The timer is configured as a PWM
+   --  generator since that is the waveform required. The duty cycle determines
+   --  the number of rising/falling edges, and it is the edge(s) that triggers
+   --  the ADC, so the frequency and duty cycle are significant.
+
+   procedure Configure_DMA;
+
+   function Voltage return UInt32;
+
+   procedure Print (X, Y : Natural; Value : UInt32; Suffix : String := "")
+     with Inline;
+   --  Print the image of Value at the location indicated, with the suffix
+   --  appended
+
+   function Voltage return UInt32 is
+      Result : UInt32;
+   begin
+      Result := ((Counts * VBat_Bridge_Divisor) * ADC_Supply_Voltage) / 16#FFF#;
+      --  16#FFF# because we are using 12-bit conversion resolution
+      return Result;
+   end Voltage;
+
+   -----------
+   -- Print --
+   -----------
+
+   procedure Print (X, Y : Natural; Value : UInt32; Suffix : String := "") is
+      Value_Image : constant String := Value'Img;
+   begin
+      LCD_Std_Out.Put (X, Y, Value_Image (2 .. Value_Image'Last) & Suffix);
+   end Print;
+
+   -------------------
+   -- Configure_ADC --
+   -------------------
+
+   procedure Configure_ADC is
+      All_Regular_Conversions : constant Regular_Channel_Conversions :=
+         (1 => (Channel     => VBat.Channel,
+                Sample_Time => Sample_3_Cycles));  -- arbitrary
+   begin
+      Enable_Clock (VBat.ADC.all);
+
+      Configure_Common_Properties
+        (Mode           => Independent,
+         Prescalar      => PCLK2_Div_2,
+         DMA_Mode       => Disabled,
+         Sampling_Delay => Sampling_Delay_5_Cycles);  -- arbitrary
+
+      Configure_Unit
+        (VBat.ADC.all,
+         Resolution => ADC_Resolution_12_Bits,
+         Alignment  => Right_Aligned);
+
+      Configure_Regular_Conversions
+        (VBat.ADC.all,
+         Continuous  => False,  -- False is ESSENTIAL when externally triggered!
+         Trigger     => (Trigger_Rising_Edge, Event => Timer1_CC1_Event),
+         Enable_EOC  => True,
+         Conversions => All_Regular_Conversions);
+      --  Either rising or falling edge should work. Note that the Event must
+      --  match the timer used!
+
+      Enable_DMA (VBat.ADC.all);
+
+      Enable_DMA_After_Last_Transfer (VBat.ADC.all);
+   end Configure_ADC;
+
+   ---------------------
+   -- Configure_Timer --
+   ---------------------
+
+   procedure Configure_Timer is
+      Timer_AF       : constant STM32.GPIO_Alternate_Function := GPIO_AF_1_TIM1;
+      Output_Channel : constant Timer_Channel := Channel_1; --  must match ADC trigger
+      Frequency      : constant Hertz := 10_000;  -- arbitrary
+      Output_Pin     : constant GPIO_Point := PA8;  -- timer 1, channel 1
+      --  note that the output pin is not used since we are reading the
+      --  internal VBat channel, which is ADC1_IN18
+   begin
+      Configure_PWM_Timer (Triggering_Signal.Generator, Frequency);
+
+      Attach_PWM_Channel
+        (Triggering_Signal,
+         Output_Channel,
+         Output_Pin,
+         Timer_AF);
+
+      Set_Duty_Cycle (Triggering_Signal, Value => 10);
+      --  An arbitrary percentage, but determines the number of rising/falling
+      --  transitions
+   end Configure_Timer;
+
+   -------------------
+   -- Configure_DMA --
+   -------------------
+
+   procedure Configure_DMA is
+      Config : DMA_Stream_Configuration;
+   begin
+      Enable_Clock (Controller);
+
+      Reset (Controller, Stream);
+
+      Config.Channel                      := Channel_0;
+      Config.Direction                    := Peripheral_To_Memory;
+      Config.Memory_Data_Format           := HalfWords;
+      Config.Peripheral_Data_Format       := HalfWords;
+      Config.Increment_Peripheral_Address := False;
+      Config.Increment_Memory_Address     := False;
+      Config.Operation_Mode               := Circular_Mode;
+      Config.Priority                     := Priority_Very_High;
+      Config.FIFO_Enabled                 := False;
+      Config.Memory_Burst_Size            := Memory_Burst_Single;
+      Config.Peripheral_Burst_Size        := Peripheral_Burst_Single;
+
+      Configure (Controller, Stream, Config);
+
+      Clear_All_Status (Controller, Stream);
+   end Configure_DMA;
+
+begin
+   Initialize_LEDs;
+
+   delay until Clock + Milliseconds (1000);
+   --  Give the LCD time to get ready after the unit's elaboration-based
+   --  initialization. This is only necessary when the display prints garbage,
+   --  as if out of synch somehow. After it starts printing junk the full
+   --  second is apparently required. But once it starts working correctly the
+   --  delay can be reduced to nothing but don't be foooled by that, it can
+   --  come back. TODO: fix the LCD driver...
+
+   LCD_Std_Out.Clear_Screen;
+
+   Configure_ADC;
+   Configure_Timer;
+   Configure_DMA;
+
+   Start_Transfer
+     (Controller,
+      Stream,
+      Source      => Data_Register_Address (VBat.ADC.all),
+      Destination => Counts'Address,
+      Data_Count  => 1);  -- ie, 1 halfword
+
+   Enable (VBat.ADC.all);
+   Enable_Output (Triggering_Signal);
+
+   loop
+      Print (0, 24, Voltage, "mv");
+      delay until Clock + Milliseconds (100);  -- arbitrary
+   end loop;
+end Demo_ADC_Timer_DMA;

--- a/ARM/STM32/driver_demos/demo_adc_timer_triggered/.gdbinit
+++ b/ARM/STM32/driver_demos/demo_adc_timer_triggered/.gdbinit
@@ -1,0 +1,24 @@
+# This command file will cause a Cortex-M3 or -M4 board to automatically 
+# reset immediately after a GDB "load" command executes.  Note that GPS
+# issues that command as part of the Debug->Init menu invocation.  Manual
+# "load" command invocations will also trigger the action.
+#
+# The reset is achieved by writing to the "Application Interrupt and Reset
+# Control" register located at address 0xE000ED0C.  
+#
+# Both the processor and the peripherals can be reset by writing a value
+# of 0x05FA0004. That value will write to the SYSRESETREQ bit.  If you want
+# to avoid resetting the peripherals, change the value to 0x05FA0001.  That
+# value will write to the VECTRESET bit.  Do *not* use a value that sets both
+# bits.
+#
+# In both cases, any on-board debug hardware is not reset.
+#
+# See the book "The Definitive Guide to the ARM Cortex-M3 and Cortex-M4
+# Processors" by Joseph Yiu, 3rd edition, pp 262-263 for further details.
+
+define hookpost-load
+echo Resetting the processor and peripherals...\n
+set *0xE000ED0C := 0x05FA0004
+echo Reset complete\n
+end

--- a/ARM/STM32/driver_demos/demo_adc_timer_triggered/demo_adc_timer_triggered.gpr
+++ b/ARM/STM32/driver_demos/demo_adc_timer_triggered/demo_adc_timer_triggered.gpr
@@ -1,0 +1,18 @@
+with "../../../../boards/common_config.gpr";
+with "../../../../boards/stm32f429_discovery.gpr";
+
+project Demo_ADC_Timer_Triggered extends "../../../../examples/common/common.gpr" is
+
+   for Main use ("demo_adc_timer_triggered");
+
+   for Languages use ("Ada");
+   for Source_Dirs use ("src");
+   for Object_Dir use "obj/" & Common_Config.Build;
+   for Runtime ("Ada") use STM32F429_Discovery'Runtime("Ada");
+--   for Create_Missing_Dirs use "true";
+
+   package Builder is
+      for Global_Configuration_Pragmas use "gnat.adc";
+   end Builder;
+
+end Demo_ADC_Timer_Triggered;

--- a/ARM/STM32/driver_demos/demo_adc_timer_triggered/gnat.adc
+++ b/ARM/STM32/driver_demos/demo_adc_timer_triggered/gnat.adc
@@ -1,0 +1,2 @@
+pragma Partition_Elaboration_Policy (Sequential);
+

--- a/ARM/STM32/driver_demos/demo_adc_timer_triggered/obj/.gitignore
+++ b/ARM/STM32/driver_demos/demo_adc_timer_triggered/obj/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/ARM/STM32/driver_demos/demo_adc_timer_triggered/readme.md
+++ b/ARM/STM32/driver_demos/demo_adc_timer_triggered/readme.md
@@ -1,0 +1,7 @@
+This program demonstrates reading the VBat (battery voltage) value from
+an ADC unit, using a timer to trigger the conversions.
+
+This program is expected to run on the STM32F429 Discovery boards because
+it uses the LCD to display results.  This display usage is entirely for
+convenience -- some other means for showing the results could be used, such
+as a serial port, or some other board with a different display.

--- a/ARM/STM32/driver_demos/demo_adc_timer_triggered/src/adc_interrupt_handling.adb
+++ b/ARM/STM32/driver_demos/demo_adc_timer_triggered/src/adc_interrupt_handling.adb
@@ -1,0 +1,68 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                     Copyright (C) 2017, AdaCore                          --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with STM32.Device; use STM32.Device;
+with STM32.ADC;    use STM32.ADC;
+with Interfaces;   use Interfaces;
+
+package body ADC_Interrupt_Handling is
+
+   protected body VBat_Reader is
+
+      -------------
+      -- Voltage --
+      -------------
+
+      function Voltage return UInt32 is
+         Result : UInt32;
+      begin
+         Result := ((Counts * VBat_Bridge_Divisor) * ADC_Supply_Voltage) / 16#FFF#;
+         --  16#FFF# because we are using 12-bit conversion resolution
+         return Result;
+      end Voltage;
+
+      -----------------
+      -- IRQ_Handler --
+      -----------------
+
+      procedure IRQ_Handler is
+      begin
+         if Status (VBat.ADC.all, Regular_Channel_Conversion_Complete) then
+            if Interrupt_Enabled (VBat.ADC.all, Regular_Channel_Conversion_Complete) then
+               Clear_Interrupt_Pending (VBat.ADC.all, Regular_Channel_Conversion_Complete);
+               Counts := UInt32 (Conversion_Value (VBat.ADC.all));
+            end if;
+         end if;
+      end IRQ_Handler;
+
+   end VBat_Reader;
+
+end ADC_Interrupt_Handling;

--- a/ARM/STM32/driver_demos/demo_adc_timer_triggered/src/adc_interrupt_handling.ads
+++ b/ARM/STM32/driver_demos/demo_adc_timer_triggered/src/adc_interrupt_handling.ads
@@ -1,0 +1,54 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                     Copyright (C) 2017, AdaCore                          --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This file provides an interrupt handler for ADC interrupts.
+
+with Ada.Interrupts.Names;
+with HAL;  use HAL;
+
+package ADC_Interrupt_Handling is
+
+   protected VBat_Reader is
+      pragma Interrupt_Priority;
+
+      function Voltage return UInt32;
+      --  in millivolts
+
+   private
+
+      procedure IRQ_Handler with
+        Attach_Handler => Ada.Interrupts.Names.ADC_Interrupt;
+
+      Counts : UInt32;
+
+   end VBat_Reader;
+
+end ADC_Interrupt_Handling;

--- a/ARM/STM32/driver_demos/demo_adc_timer_triggered/src/demo_adc_timer_triggered.adb
+++ b/ARM/STM32/driver_demos/demo_adc_timer_triggered/src/demo_adc_timer_triggered.adb
@@ -1,0 +1,168 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                     Copyright (C) 2017, AdaCore                          --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This program demonstrates reading the VBat (battery voltage) value from
+--  an ADC unit, using a timer to drive the ADC conversions and an interrupt
+--  handler to read the converted values.
+
+with ADC_Interrupt_Handling; use ADC_Interrupt_Handling;
+
+with Last_Chance_Handler;  pragma Unreferenced (Last_Chance_Handler);
+
+with STM32.Device;  use STM32.Device;
+with STM32.Board;   use STM32.Board;
+
+with HAL;           use HAL;
+with STM32.ADC;     use STM32.ADC;
+with STM32.GPIO;    use STM32.GPIO;
+with STM32.Timers;  use STM32.Timers;
+with STM32.PWM;     use STM32.PWM;
+with Ada.Real_Time; use Ada.Real_Time;
+
+with LCD_Std_Out;
+
+procedure Demo_ADC_Timer_Triggered is
+
+   Selected_Timer : Timer renames Timer_1;
+
+   Power_Control : PWM_Modulator (Selected_Timer'Access);
+
+   procedure Configure_ADC;
+   --  Set up ADC1 to read the VBat voltage value. Note that only ADC1 can
+   --  do this. Conversions are not triggered by software but are instead
+   --  triggered by Timer1. Each conversion generates an interrupt signalling
+   --  conversion complete.
+
+   procedure Configure_Timer;
+   --  Set up Timer1 to generare a square wave of arbitrary frequency, in
+   --  order to trigger the ADC conversions. The timer is configured as a PWM
+   --  generator since that is the waveform required. The duty cycle determines
+   --  the number of rising/falling edges, and it is the edge(s) that triggers
+   --  the ADC, so the frequency and duty cycle are significant.
+
+   procedure Print (X, Y : Natural; Value : UInt32; Suffix : String := "")
+     with Inline;
+   --  Print the image of Value at the location indicated, with the suffix
+   --  appended
+
+   -----------
+   -- Print --
+   -----------
+
+   procedure Print (X, Y : Natural; Value : UInt32; Suffix : String := "") is
+      Value_Image : constant String := Value'Img;
+   begin
+      LCD_Std_Out.Put (X, Y, Value_Image (2 .. Value_Image'Last) & Suffix);
+   end Print;
+
+   -------------------
+   -- Configure_ADC --
+   -------------------
+
+   procedure Configure_ADC is
+      All_Regular_Conversions : constant Regular_Channel_Conversions :=
+         (1 => (Channel     => VBat.Channel,
+                Sample_Time => Sample_3_Cycles));  -- arbitrary
+   begin
+      Enable_Clock (VBat.ADC.all);
+
+      Configure_Common_Properties
+        (Mode           => Independent,
+         Prescalar      => PCLK2_Div_2,
+         DMA_Mode       => Disabled,
+         Sampling_Delay => Sampling_Delay_5_Cycles);  -- arbitrary
+
+      Configure_Unit
+        (VBat.ADC.all,
+         Resolution => ADC_Resolution_12_Bits,
+         Alignment  => Right_Aligned);
+
+      Configure_Regular_Conversions
+        (VBat.ADC.all,
+         Continuous  => False,  -- False is ESSENTIAL when externally triggered!
+         Trigger     => (Trigger_Rising_Edge, Event => Timer1_CC1_Event),
+         Enable_EOC  => True,
+         Conversions => All_Regular_Conversions);
+      --  Either rising or falling edge should work. Note that the Event must
+      --  match the timer used!
+
+      Enable_Interrupts (VBat.ADC.all, Regular_Channel_Conversion_Complete);
+   end Configure_ADC;
+
+   ---------------------
+   -- Configure_Timer --
+   ---------------------
+
+   procedure Configure_Timer is
+      Timer_AF       : constant STM32.GPIO_Alternate_Function := GPIO_AF_1_TIM1;
+      Output_Channel : constant Timer_Channel := Channel_1;
+      Frequency      : constant Hertz := 10_000;  -- arbitrary
+      Output_Pin     : constant GPIO_Point := PA8;  -- timer 1, channel 1
+      --  note that the output pin is not used since we are reading the
+      --  internal VBat channel, which is ADC1_IN18
+   begin
+      Configure_PWM_Timer (Power_Control.Generator, Frequency);
+
+      Attach_PWM_Channel
+        (Power_Control,
+         Output_Channel,
+         Output_Pin,
+         Timer_AF);
+
+      Set_Duty_Cycle (Power_Control, Value => 10);
+      --  An arbitrary percentage, but determines the number of rising/falling
+      --  transitions
+   end Configure_Timer;
+
+begin
+   Initialize_LEDs;
+
+   delay until Clock + Milliseconds (1000);
+   --  Give the LCD time to get ready after the unit's elaboration-based
+   --  initialization. This is only necessary when the display prints garbage,
+   --  as if out of synch somehow. After it starts printing junk the full
+   --  second is apparently required. But once it starts working correctly the
+   --  delay can be reduced to nothing but don't be foooled by that, it can
+   --  come back. TODO: fix the LCD driver...
+
+   LCD_Std_Out.Clear_Screen;
+
+   Configure_ADC;
+   Configure_Timer;
+
+   Enable (VBat.ADC.all);
+   Enable_Output (Power_Control);
+
+   loop
+      Print (0, 24, VBat_Reader.Voltage, "mv");
+      delay until Clock + Milliseconds (100);  -- arbitrary
+   end loop;
+end Demo_ADC_Timer_Triggered;

--- a/ARM/STM32/driver_demos/demo_adc_timer_triggered/src/demo_adc_timer_triggered.adb
+++ b/ARM/STM32/driver_demos/demo_adc_timer_triggered/src/demo_adc_timer_triggered.adb
@@ -53,7 +53,9 @@ procedure Demo_ADC_Timer_Triggered is
 
    Selected_Timer : Timer renames Timer_1;
 
-   Power_Control : PWM_Modulator (Selected_Timer'Access);
+   Triggering_Signal : PWM_Modulator (Selected_Timer'Access);
+   --  the PWM modulator used to generate the square wave that triggers the ADC
+   --  conversions
 
    procedure Configure_ADC;
    --  Set up ADC1 to read the VBat voltage value. Note that only ADC1 can
@@ -123,21 +125,21 @@ procedure Demo_ADC_Timer_Triggered is
 
    procedure Configure_Timer is
       Timer_AF       : constant STM32.GPIO_Alternate_Function := GPIO_AF_1_TIM1;
-      Output_Channel : constant Timer_Channel := Channel_1;
+      Output_Channel : constant Timer_Channel := Channel_1; --  must match ADC trigger
       Frequency      : constant Hertz := 10_000;  -- arbitrary
       Output_Pin     : constant GPIO_Point := PA8;  -- timer 1, channel 1
       --  note that the output pin is not used since we are reading the
       --  internal VBat channel, which is ADC1_IN18
    begin
-      Configure_PWM_Timer (Power_Control.Generator, Frequency);
+      Configure_PWM_Timer (Triggering_Signal.Generator, Frequency);
 
       Attach_PWM_Channel
-        (Power_Control,
+        (Triggering_Signal,
          Output_Channel,
          Output_Pin,
          Timer_AF);
 
-      Set_Duty_Cycle (Power_Control, Value => 10);
+      Set_Duty_Cycle (Triggering_Signal, Value => 10);
       --  An arbitrary percentage, but determines the number of rising/falling
       --  transitions
    end Configure_Timer;
@@ -159,7 +161,7 @@ begin
    Configure_Timer;
 
    Enable (VBat.ADC.all);
-   Enable_Output (Power_Control);
+   Enable_Output (Triggering_Signal);
 
    loop
       Print (0, 24, VBat_Reader.Voltage, "mv");


### PR DESCRIPTION
Two new ADC demos, plus a refinement to an existing ADC demo to prevent overruns.
One new demo uses a timer to trigger the ADC conversions with interrupts to capture the sampled data.
One new demo uses a timer to trigger the ADC conversions with DMA to capture the sampled data.
