### PR TITLE
change boards' LED names to disambiguate from color names

### DIFF
--- a/ARM/STM32/driver_demos/demo_LIS3DSH_pwm/src/demo_lis3dsh_pwm.adb
+++ b/ARM/STM32/driver_demos/demo_LIS3DSH_pwm/src/demo_lis3dsh_pwm.adb
@@ -174,25 +174,25 @@ procedure Demo_LIS3DSH_PWM is
       Attach_PWM_Channel
         (PWM_Output_Green,
          Channel => Channel_1,
-         Point   => Green,
+         Point   => Green_LED,
          PWM_AF  => PWM_Output_AF);
 
       Attach_PWM_Channel
         (PWM_Output_Orange,
          Channel => Channel_2,
-         Point   => Orange,
+         Point   => Orange_LED,
          PWM_AF  => PWM_Output_AF);
 
       Attach_PWM_Channel
         (PWM_Output_Red,
          Channel => Channel_3,
-         Point   => Red,
+         Point   => Red_LED,
          PWM_AF  => PWM_Output_AF);
 
       Attach_PWM_Channel
         (PWM_Output_Blue,
          Channel => Channel_4,
-         Point   => Blue,
+         Point   => Blue_LED,
          PWM_AF  => PWM_Output_AF);
 
       Enable_Output (PWM_Output_Green);

--- a/ARM/STM32/driver_demos/demo_LIS3DSH_tilt/src/demo_lis3dsh_tilt.adb
+++ b/ARM/STM32/driver_demos/demo_LIS3DSH_tilt/src/demo_lis3dsh_tilt.adb
@@ -91,27 +91,27 @@ begin
       Accelerometer.Get_Accelerations (Axes);
 
       if Axes.X > Threshold then
-         Turn_On (Red);
+         Turn_On (Red_LED);
       else
-         Turn_Off (Red);
+         Turn_Off (Red_LED);
       end if;
 
       if Axes.X < -Threshold then
-         Turn_On (Green);
+         Turn_On (Green_LED);
       else
-         Turn_Off (Green);
+         Turn_Off (Green_LED);
       end if;
 
       if Axes.Y > Threshold then
-         Turn_On (Orange);
+         Turn_On (Orange_LED);
       else
-         Turn_Off (Orange);
+         Turn_Off (Orange_LED);
       end if;
 
       if Axes.Y < -Threshold then
-         Turn_On (Blue);
+         Turn_On (Blue_LED);
       else
-         Turn_Off (Blue);
+         Turn_Off (Blue_LED);
       end if;
    end loop;
 end Demo_LIS3DSH_Tilt;

--- a/ARM/STM32/driver_demos/demo_adc_dma/src/demo_adc_vbat_dma.adb
+++ b/ARM/STM32/driver_demos/demo_adc_dma/src/demo_adc_vbat_dma.adb
@@ -166,7 +166,7 @@ begin
 
       Print (0, 24, Voltage, "mv");
 
-      Green.Toggle;
+      Green_LED.Toggle;
 
       delay until Clock + Milliseconds (100);
    end loop;

--- a/ARM/STM32/driver_demos/demo_adc_interrupts/src/demo_adc_vbat_interrupts.adb
+++ b/ARM/STM32/driver_demos/demo_adc_interrupts/src/demo_adc_vbat_interrupts.adb
@@ -110,6 +110,6 @@ begin
 
       Print (0, 24, Voltage, "mv");
 
-      Green.Toggle;
+      Green_LED.Toggle;
    end loop;
 end Demo_ADC_VBat_Interrupts;

--- a/ARM/STM32/driver_demos/demo_adc_polling/src/demo_adc_gpio_polling.adb
+++ b/ARM/STM32/driver_demos/demo_adc_polling/src/demo_adc_gpio_polling.adb
@@ -142,7 +142,7 @@ begin
       Raw := UInt32 (Conversion_Value (Converter));
       Print (0, 0, Raw'Img);
 
-      Green.Toggle;
+      Green_LED.Toggle;
 
       delay until Clock + Milliseconds (200); -- slow it down to ease reading
    end loop;

--- a/ARM/STM32/driver_demos/demo_adc_polling/src/demo_adc_temperature_polling.adb
+++ b/ARM/STM32/driver_demos/demo_adc_polling/src/demo_adc_temperature_polling.adb
@@ -139,6 +139,6 @@ begin
 
       Print (0, 24, UInt32 (Temperature), " degrees C");
 
-      Green.Toggle;
+      Green_LED.Toggle;
    end loop;
 end Demo_ADC_Temperature_Polling;

--- a/ARM/STM32/driver_demos/demo_adc_polling/src/demo_adc_vbat_polling.adb
+++ b/ARM/STM32/driver_demos/demo_adc_polling/src/demo_adc_vbat_polling.adb
@@ -110,6 +110,6 @@ begin
 
       Print (0, 24, Voltage, "mv");
 
-      Green.Toggle;
+      Green_LED.Toggle;
    end loop;
 end Demo_ADC_VBat_Polling;

--- a/ARM/STM32/driver_demos/demo_adc_polling/src/demo_adc_vref_polling.adb
+++ b/ARM/STM32/driver_demos/demo_adc_polling/src/demo_adc_vref_polling.adb
@@ -107,6 +107,6 @@ begin
 
       Print (0, 24, VRefInt, "mv");
 
-      Green.Toggle;
+      Green_LED.Toggle;
    end loop;
 end Demo_ADC_VRef_Polling;

--- a/ARM/STM32/driver_demos/demo_dma_mem_to_mem/src/demo_dma_interrupts.adb
+++ b/ARM/STM32/driver_demos/demo_dma_mem_to_mem/src/demo_dma_interrupts.adb
@@ -99,15 +99,15 @@ begin
    if Event_Kind in Direct_Mode_Error_Interrupt | FIFO_Error_Interrupt | Transfer_Error_Interrupt then
       --  signal the problem and loop forever
       loop
-         Green.Toggle;
+         Green_LED.Toggle;
          delay until Clock + Milliseconds (200);
       end loop;
    end if;
 
    if Source_Block = Destination_Block then
-      Turn_On (Green);
+      Turn_On (Green_LED);
    else
-      Turn_On (Red);
+      Turn_On (Red_LED);
    end if;
 
    loop

--- a/ARM/STM32/driver_demos/demo_dma_mem_to_mem/src/demo_dma_polling.adb
+++ b/ARM/STM32/driver_demos/demo_dma_mem_to_mem/src/demo_dma_polling.adb
@@ -100,15 +100,15 @@ begin
    if Status /= DMA_No_Error then
       --  signal the problem
       loop
-         Green.Toggle;
+         Green_LED.Toggle;
          delay until Clock + Milliseconds (200);
       end loop;
    end if;
 
    if Source_Block = Destination_Block then
-      Turn_On (Green);
+      Turn_On (Green_LED);
    else
-      Turn_On (Red);
+      Turn_On (Red_LED);
    end if;
 
    loop

--- a/ARM/STM32/driver_demos/demo_dma_mem_to_peripheral/src/demo_usart_dma_continuous.adb
+++ b/ARM/STM32/driver_demos/demo_dma_mem_to_peripheral/src/demo_usart_dma_continuous.adb
@@ -167,7 +167,7 @@ begin
 
    --  at this point the characters will be coming continuously from the USART
 
-   Turn_On (Green);
+   Turn_On (Green_LED);
 
    loop
       null;

--- a/ARM/STM32/driver_demos/demo_independent_watchdog/src/demo_iwdg.adb
+++ b/ARM/STM32/driver_demos/demo_independent_watchdog/src/demo_iwdg.adb
@@ -80,13 +80,13 @@ procedure Demo_IWDG is
       Interval : constant Time_Span := Time_Required / 4;
       --  We divide so that we can blink more often
    begin
-      Turn_On (Green);
+      Turn_On (Green_LED);
       delay until Clock + Interval;
-      Turn_Off (Green);
+      Turn_Off (Green_LED);
       delay until Clock + Interval;
-      Turn_On (Green);
+      Turn_On (Green_LED);
       delay until Clock + Interval;
-      Turn_Off (Green);
+      Turn_Off (Green_LED);
       delay until Clock + Interval;
    end Do_Work;
 

--- a/ARM/STM32/driver_demos/demo_timer_interrupts_basic/src/stm32f4_timer_interrupts.adb
+++ b/ARM/STM32/driver_demos/demo_timer_interrupts_basic/src/stm32f4_timer_interrupts.adb
@@ -51,7 +51,7 @@ package body STM32F4_Timer_Interrupts is
          if Status (Timer_7, Timer_Update_Indicated) then
             if Interrupt_Enabled (Timer_7, Timer_Update_Interrupt) then
                Clear_Pending_Interrupt (Timer_7, Timer_Update_Interrupt);
-               Green.Toggle;
+               Green_LED.Toggle;
             end if;
          end if;
       end IRQ_Handler;

--- a/ARM/STM32/driver_demos/demo_timer_interrupts_multichannel/src/stm32f4_timer_interrupts.adb
+++ b/ARM/STM32/driver_demos/demo_timer_interrupts_multichannel/src/stm32f4_timer_interrupts.adb
@@ -50,7 +50,7 @@ package body STM32F4_Timer_Interrupts is
          if Status (Timer_3, Timer_CC1_Indicated) then
             Clear_Pending_Interrupt (Timer_3, Timer_CC1_Interrupt);
 
-            Blue.Toggle;
+            Blue_LED.Toggle;
 
             Current := Current_Capture_Value (Timer_3, Channel_1);
             Set_Compare_Value (Timer_3, Channel_1, Current + Channel_1_Period);
@@ -59,7 +59,7 @@ package body STM32F4_Timer_Interrupts is
          if Status (Timer_3, Timer_CC2_Indicated) then
             Clear_Pending_Interrupt (Timer_3, Timer_CC2_Interrupt);
 
-            Green.Toggle;
+            Green_LED.Toggle;
 
             Current := Current_Capture_Value (Timer_3, Channel_2);
             Set_Compare_Value (Timer_3, Channel_2, Current + Channel_2_Period);
@@ -68,7 +68,7 @@ package body STM32F4_Timer_Interrupts is
          if Status (Timer_3, Timer_CC3_Indicated) then
             Clear_Pending_Interrupt (Timer_3, Timer_CC3_Interrupt);
 
-            Orange.Toggle;
+            Orange_LED.Toggle;
 
             Current := Current_Capture_Value (Timer_3, Channel_3);
             Set_Compare_Value (Timer_3, Channel_3, Current + Channel_3_Period);
@@ -77,7 +77,7 @@ package body STM32F4_Timer_Interrupts is
          if Status (Timer_3, Timer_CC4_Indicated) then
             Clear_Pending_Interrupt (Timer_3, Timer_CC4_Interrupt);
 
-            Red.Toggle;
+            Red_LED.Toggle;
 
             Current := Current_Capture_Value (Timer_3, Channel_4);
             Set_Compare_Value (Timer_3, Channel_4, Current + Channel_4_Period);

--- a/ARM/STM32/driver_demos/demo_timer_pwm/src/demo_pwm_adt.adb
+++ b/ARM/STM32/driver_demos/demo_timer_pwm/src/demo_pwm_adt.adb
@@ -75,10 +75,10 @@ procedure Demo_PWM_ADT is  -- demo the higher-level PWM abstract data type
    --  Channel_3 is connected to the red LED.
    --  Channel_4 is connected to the blue LED.
    LED_For : constant array (Timer_Channel) of User_LED :=
-               (Channel_1 => Green,
-                Channel_2 => Orange,
-                Channel_3 => Red,
-                Channel_4 => Blue);
+               (Channel_1 => Green_LED,
+                Channel_2 => Orange_LED,
+                Channel_3 => Red_LED,
+                Channel_4 => Blue_LED);
 
    Requested_Frequency : constant Hertz := 30_000;  -- arbitrary
 

--- a/ARM/STM32/driver_demos/demo_timer_quad_encoder/src/demo_encoder.adb
+++ b/ARM/STM32/driver_demos/demo_timer_quad_encoder/src/demo_encoder.adb
@@ -82,11 +82,11 @@ procedure Demo_Encoder is
    begin
       case Motor.Current_Direction is
          when Motor.Forward =>
-            Turn_Off (Red);
-            Turn_On (Green);
+            Turn_Off (Red_LED);
+            Turn_On (Green_LED);
          when Motor.Backward =>
-            Turn_Off (Green);
-            Turn_On (Red);
+            Turn_Off (Green_LED);
+            Turn_On (Red_LED);
       end case;
    end Indicate_Direction;
 

--- a/boards/stm32f407_discovery/src/stm32-board.ads
+++ b/boards/stm32f407_discovery/src/stm32-board.ads
@@ -62,13 +62,13 @@ package STM32.Board is
 
    subtype User_LED is GPIO_Point;
 
-   Green  : User_LED renames PD12;
-   Orange : User_LED renames PD13;
-   Red    : User_LED renames PD14;
-   Blue   : User_LED renames PD15;
+   Green_LED  : User_LED renames PD12;
+   Orange_LED : User_LED renames PD13;
+   Red_LED    : User_LED renames PD14;
+   Blue_LED   : User_LED renames PD15;
 
-   All_LEDs : GPIO_Points := Green & Orange & Red & Blue;
-   LCH_LED  : GPIO_Point renames Red;
+   All_LEDs : GPIO_Points := Green_LED & Orange_LED & Red_LED & Blue_LED;
+   LCH_LED  : GPIO_Point renames Red_LED;
 
    procedure Initialize_LEDs;
    --  MUST be called prior to any use of the LEDs

--- a/boards/stm32f429_discovery/src/stm32-board.ads
+++ b/boards/stm32f429_discovery/src/stm32-board.ads
@@ -65,12 +65,12 @@ package STM32.Board is
 
    subtype User_LED is GPIO_Point;
 
-   Green : User_LED renames PG13;
-   Red   : User_LED renames PG14;
+   Green_LED : User_LED renames PG13;
+   Red_LED   : User_LED renames PG14;
 
-   LCH_LED : User_LED renames Red;
+   LCH_LED : User_LED renames Red_LED;
 
-   All_LEDs  : GPIO_Points := Green & Red;
+   All_LEDs  : GPIO_Points := Green_LED & Red_LED;
 
    procedure Initialize_LEDs;
    --  MUST be called prior to any use of the LEDs unless initialization is

--- a/boards/stm32f469_discovery/src/stm32-board.ads
+++ b/boards/stm32f469_discovery/src/stm32-board.ads
@@ -55,14 +55,14 @@ package STM32.Board is
 
    subtype User_LED is GPIO_Point;
 
-   Green     : User_LED renames PG6;
-   Orange    : User_LED renames PD4;
-   Red       : User_LED renames PD5;
-   Blue      : User_LED renames PK3;
+   Green_LED  : User_LED renames PG6;
+   Orange_LED : User_LED renames PD4;
+   Red_LED    : User_LED renames PD5;
+   Blue_LED   : User_LED renames PK3;
 
-   LCH_LED   : User_LED renames Red;
+   LCH_LED   : User_LED renames Red_LED;
 
-   All_LEDs  : GPIO_Points := Green & Orange & Red & Blue;
+   All_LEDs  : GPIO_Points := Green_LED & Orange_LED & Red_LED & Blue_LED;
 
    procedure Initialize_LEDs;
    --  MUST be called prior to any use of the LEDs

--- a/boards/stm32f746_discovery/src/stm32-board.ads
+++ b/boards/stm32f746_discovery/src/stm32-board.ads
@@ -53,11 +53,11 @@ package STM32.Board is
 
    subtype User_LED is GPIO_Point;
 
-   Green    : User_LED renames PI1;
-   LED1     : User_LED renames Green;
-   LCH_LED  : User_LED renames Green;
+   Green_LED : User_LED renames PI1;
+   LED1      : User_LED renames Green_LED;
+   LCH_LED   : User_LED renames Green_LED;
 
-   All_LEDs : GPIO_Points := (1 => Green);
+   All_LEDs : GPIO_Points := (1 => Green_LED);
 
    procedure Initialize_LEDs;
    --  MUST be called prior to any use of the LEDs

--- a/boards/stm32f769_discovery/src/stm32-board.ads
+++ b/boards/stm32f769_discovery/src/stm32-board.ads
@@ -53,15 +53,15 @@ package STM32.Board is
 
    subtype User_LED is GPIO_Point;
 
-   Red      : User_LED renames PJ13;
-   Green    : User_LED renames PJ5;
-   Green2   : User_LED renames PA12;
-   LED1     : User_LED renames Red;
-   LED2     : User_LED renames Green;
-   LED3     : User_LED renames Green2;
-   LCH_LED  : User_LED renames Red;
+   Red_LED    : User_LED renames PJ13;
+   Green_LED  : User_LED renames PJ5;
+   Green2_LED : User_LED renames PA12;
+   LED1       : User_LED renames Red_LED;
+   LED2       : User_LED renames Green_LED;
+   LED3       : User_LED renames Green2_LED;
+   LCH_LED    : User_LED renames Red_LED;
 
-   All_LEDs : GPIO_Points := (Red, Green, Green2);
+   All_LEDs : GPIO_Points := (Red_LED, Green_LED, Green2_LED);
 
    procedure Initialize_LEDs;
    --  MUST be called prior to any use of the LEDs

--- a/examples/accelerometer/src/main.adb
+++ b/examples/accelerometer/src/main.adb
@@ -95,16 +95,16 @@ begin
       Accelerometer.Get_Accelerations (Values);
       if abs Values.X > abs Values.Y then
          if Values.X > Threshold_High then
-            STM32.Board.Red.Set;
+            STM32.Board.Red_LED.Set;
          elsif Values.X < Threshold_Low then
-            STM32.Board.Green.Set;
+            STM32.Board.Green_LED.Set;
          end if;
          My_Delay (10);
       else
          if Values.Y > Threshold_High then
-            STM32.Board.Orange.Set;
+            STM32.Board.Orange_LED.Set;
          elsif Values.Y < Threshold_Low then
-            STM32.Board.Blue.Set;
+            STM32.Board.Blue_LED.Set;
          end if;
          My_Delay (10);
       end if;

--- a/examples/hello_world_tasking/src/driver.adb
+++ b/examples/hello_world_tasking/src/driver.adb
@@ -39,7 +39,7 @@ package body Driver is
 
    type Index is mod 4;
 
-   Pattern : array (Index) of User_LED := (Orange, Red, Blue, Green);
+   Pattern : array (Index) of User_LED := (Orange_LED, Red_LED, Blue_LED, Green_LED);
    --  The LEDs are not physically laid out "consecutively" in such a way that
    --  we can simply go in enumeral order to get circular rotation. Thus we
    --  define this mapping, using a consecutive index to get the physical LED


### PR DESCRIPTION
Otherwise the names clash. An annoyance we needn't perpetuate.