### PR TITLE
correct descriptor comment for CRC units

### DIFF
--- a/ARM/STM32/svd/stm32f40x/stm32_svd-crc.ads
+++ b/ARM/STM32/svd/stm32f40x/stm32_svd-crc.ads
@@ -49,10 +49,10 @@ package STM32_SVD.CRC is
    -- Peripherals --
    -----------------
 
-   --  Cryptographic processor
+   --  Cyclic Redundancy Check (CRC) unit
    type CRC_Peripheral is record
       --  Data register
-      DR  : HAL.UInt32;
+      DR  : HAL.UInt32 with Volatile_Full_Access;
       --  Independent Data register
       IDR : IDR_Register;
       --  Control register
@@ -66,7 +66,7 @@ package STM32_SVD.CRC is
       CR  at 16#8# range 0 .. 31;
    end record;
 
-   --  Cryptographic processor
+   --  Cyclic Redundancy Check (CRC) unit
    CRC_Periph : aliased CRC_Peripheral
      with Import, Address => CRC_Base;
 

--- a/ARM/STM32/svd/stm32f429x/stm32_svd-crc.ads
+++ b/ARM/STM32/svd/stm32f429x/stm32_svd-crc.ads
@@ -49,7 +49,7 @@ package STM32_SVD.CRC is
    -- Peripherals --
    -----------------
 
-   --  Cryptographic processor
+   --  Cyclic Redundancy Check (CRC) unit
    type CRC_Peripheral is record
       --  Data register
       DR  : HAL.UInt32;
@@ -66,7 +66,7 @@ package STM32_SVD.CRC is
       CR  at 16#8# range 0 .. 31;
    end record;
 
-   --  Cryptographic processor
+   --  Cyclic Redundancy Check (CRC) unit
    CRC_Periph : aliased CRC_Peripheral
      with Import, Address => CRC_Base;
 

--- a/ARM/STM32/svd/stm32f46_79x/stm32_svd-crc.ads
+++ b/ARM/STM32/svd/stm32f46_79x/stm32_svd-crc.ads
@@ -49,7 +49,7 @@ package STM32_SVD.CRC is
    -- Peripherals --
    -----------------
 
-   --  Cryptographic processor
+   --  Cyclic Redundancy Check (CRC) unit
    type CRC_Peripheral is record
       --  Data register
       DR  : HAL.UInt32;
@@ -66,7 +66,7 @@ package STM32_SVD.CRC is
       CR  at 16#8# range 0 .. 31;
    end record;
 
-   --  Cryptographic processor
+   --  Cyclic Redundancy Check (CRC) unit
    CRC_Periph : aliased CRC_Peripheral
      with Import, Address => CRC_Base;
 

--- a/ARM/STM32/svd/stm32f7x/stm32_svd-crc.ads
+++ b/ARM/STM32/svd/stm32f7x/stm32_svd-crc.ads
@@ -49,10 +49,10 @@ package STM32_SVD.CRC is
    -- Peripherals --
    -----------------
 
-   --  Cryptographic processor
+   --  Cyclic Redundancy Check (CRC) unit
    type CRC_Peripheral is record
       --  Data register
-      DR   : HAL.UInt32;
+      DR  : HAL.UInt32;
       --  Independent Data register
       IDR  : IDR_Register;
       --  Control register
@@ -72,7 +72,7 @@ package STM32_SVD.CRC is
       POL  at 16#10# range 0 .. 31;
    end record;
 
-   --  Cryptographic processor
+   --  Cyclic Redundancy Check (CRC) unit
    CRC_Periph : aliased CRC_Peripheral
      with Import, Address => CRC_Base;
 

--- a/ARM/STM32/svd/stm32f7x9/stm32_svd-crc.ads
+++ b/ARM/STM32/svd/stm32f7x9/stm32_svd-crc.ads
@@ -49,10 +49,10 @@ package STM32_SVD.CRC is
    -- Peripherals --
    -----------------
 
-   --  Cryptographic processor
+   --  Cyclic Redundancy Check (CRC) unit
    type CRC_Peripheral is record
       --  Data register
-      DR   : HAL.UInt32;
+      DR  : HAL.UInt32;
       --  Independent Data register
       IDR  : IDR_Register;
       --  Control register
@@ -72,7 +72,7 @@ package STM32_SVD.CRC is
       POL  at 16#10# range 0 .. 31;
    end record;
 
-   --  Cryptographic processor
+   --  Cyclic Redundancy Check (CRC) unit
    CRC_Periph : aliased CRC_Peripheral
      with Import, Address => CRC_Base;
 


### PR DESCRIPTION
Minor fix to the comment lines indicating the peripheral. These comments match those committed elsewhere to the SVD files so this is what would be generated.