### PR TITLE
Don't disable those interrupts not specified to be enabled. 

### DIFF
--- a/ARM/STM32/drivers/dma/stm32-dma.adb
+++ b/ARM/STM32/drivers/dma/stm32-dma.adb
@@ -295,8 +295,6 @@ package body STM32.DMA is
       for Selected_Interrupt in Enabled_Interrupts'Range loop
          if Enabled_Interrupts (Selected_Interrupt) then
             Enable_Interrupt (This, Stream, Selected_Interrupt);
-         else
-            Disable_Interrupt (This, Stream, Selected_Interrupt);
          end if;
       end loop;
 

--- a/ARM/STM32/drivers/dma_stm32f769/stm32-dma.adb
+++ b/ARM/STM32/drivers/dma_stm32f769/stm32-dma.adb
@@ -254,8 +254,6 @@ package body STM32.DMA is
       for Selected_Interrupt in Enabled_Interrupts'Range loop
          if Enabled_Interrupts (Selected_Interrupt) then
             Enable_Interrupt (This, Stream, Selected_Interrupt);
-         else
-            Disable_Interrupt (This, Stream, Selected_Interrupt);
          end if;
       end loop;
 


### PR DESCRIPTION
The intent is only to enable those requested, not disable the others, so the code did too much.