### PR TITLE
More illustrative demo and improved facility implementation.

### DIFF
--- a/ARM/STM32/drivers/crc_stm32f4/stm32-crc-dma.ads
+++ b/ARM/STM32/drivers/crc_stm32f4/stm32-crc-dma.ads
@@ -35,9 +35,34 @@
 --  Note this API is for the STM32 F4x family. Other STM MCUs have additional
 --  CRC capabilities.
 
---  See app note AN4187 "Using CRC through DMA"
+--  See also app note AN4187 "Using CRC through DMA"
+
+--  Example usage, assuming prior clock enabling for the CRC unit:
+
+--     Checksum_DMA : UInt32 := 0;
+--
+--     Data : constant Block_32 := ( .... );
+--
+--     ...
+--
+--     Enable_Clock (Controller);
+--
+--     Reset (Controller);
+--
+--     Reset_Calculator (CRC_Unit);  --  if need be
+--
+--     Update_CRC (CRC_Unit, Controller'Access, Stream, Input => Data);
+--
+--     DMA_IRQ_Handler.Await_Event (Next_DMA_Interrupt);
+--
+--     if Next_DMA_Interrupt /= Transfer_Complete_Interrupt then
+--        Panic;
+--     end if;
+--
+--     Checksum_DMA := Value (CRC_Unit);
 
 with STM32.DMA; use STM32.DMA;
+with System;
 
 package STM32.CRC.DMA is
    pragma Elaborate_Body;
@@ -45,13 +70,18 @@ package STM32.CRC.DMA is
    --  These routines use the specified controller and stream to transfer
    --  all of the Input data components to This CRC unit, updating the
    --  CRC value accordingly. At the end of the transfer the DMA interrupt
-   --  Transfer_Complete_Indicated is triggered. Clients are expected to have
+   --  Transfer_Complete_Interrupt is triggered. Clients are expected to have
    --  an application-defined handler for that interrupt, in order to await
    --  completion of the transfer.
 
-   --  Note that you can use a slice if the entire array is not intended for
+   --  These routines can be called multiple times, back-to-back, presumably
+   --  with different input blocks, in order to update the value of the
+   --  calculated CRC checksum within the CRC processor. Each call will
+   --  result in a Transfer_Complete_Interrupt event.
+
+   --  Note that you can use a slice if the entire block is not intended for
    --  transfer, but beware alignment boundaries to prevent copying of the
-   --  actual parameter.
+   --  actual parameter into a temporary.
 
    procedure Update_CRC
      (This       : in out CRC_32;
@@ -59,7 +89,7 @@ package STM32.CRC.DMA is
       Stream     : DMA_Stream_Selector;
       Input      : Block_32);
    --  Update the calculated CRC value based on all of the 32-bit components
-   --  of Input. Triggers DMA.Transfer_Complete_Indicated on completion.
+   --  of Input. Triggers the Transfer_Complete_Interrupt on completion.
 
    procedure Update_CRC
      (This       : in out CRC_32;
@@ -67,7 +97,7 @@ package STM32.CRC.DMA is
       Stream     : DMA_Stream_Selector;
       Input      : Block_16);
    --  Update the calculated CRC value based on all of the 16-bit components
-   --  of Input. Triggers DMA.Transfer_Complete_Indicated on completion.
+   --  of Input. Triggers the Transfer_Complete_Interrupt on completion.
 
    procedure Update_CRC
      (This       : in out CRC_32;
@@ -75,6 +105,23 @@ package STM32.CRC.DMA is
       Stream     : DMA_Stream_Selector;
       Input      : Block_8);
    --  Update the calculated CRC value based on all of the 8-bit components
-   --  of Input. Triggers DMA.Transfer_Complete_Indicated on completion.
+   --  of Input. Triggers the Transfer_Complete_Interrupt on completion.
+
+private
+
+   procedure Transfer_Input_To_CRC
+     (This          : in out CRC_32;
+      Controller    : access DMA_Controller;
+      Stream        : DMA_Stream_Selector;
+      Input_Address : System.Address;
+      Input_Length  : UInt16;
+      Data_Width    : DMA_Data_Transfer_Widths);
+   --  Configures the DMA controller and stream for transfering memory blocks,
+   --  of the width specified by Data_Width, to This CRC processor. Then uses
+   --  the controller and stream to transfer the data starting at Input_Address
+   --  to This CRC unit, updating the CRC value accordingly. The number of
+   --  Input memory items (of Data_Width size) to be transferred is specified
+   --  by Input_Length. At the end of the transfer the DMA interrupt
+   --  Transfer_Complete_Interrupt is triggered.
 
 end STM32.CRC.DMA;

--- a/ARM/STM32/drivers/crc_stm32f4/stm32-crc.adb
+++ b/ARM/STM32/drivers/crc_stm32f4/stm32-crc.adb
@@ -31,20 +31,20 @@
 
 package body STM32.CRC is
 
-   ---------------
-   -- Reset_CRC --
-   ---------------
+   ----------------------
+   -- Reset_Calculator --
+   ----------------------
 
-   procedure Reset_CRC (This : in out CRC_32) is
+   procedure Reset_Calculator (This : in out CRC_32) is
    begin
       This.CR.CR := True;
-   end Reset_CRC;
+   end Reset_Calculator;
 
-   ---------------
-   -- CRC_Value --
-   ---------------
+   -----------
+   -- Value --
+   -----------
 
-   function CRC_Value (This : CRC_32) return UInt32 is
+   function Value (This : CRC_32) return UInt32 is
       (This.DR);
 
    ----------------

--- a/ARM/STM32/drivers/crc_stm32f4/stm32-crc.ads
+++ b/ARM/STM32/drivers/crc_stm32f4/stm32-crc.ads
@@ -29,8 +29,8 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
---  A driver for the Cyclic Redundancy Check CRC-32 calculation processor. Note
---  the CPU transfers the data to the CRC processor.
+--  A driver for the Cyclic Redundancy Check CRC-32 calculation processor. 
+--  The CPU transfers the data to the CRC processor.
 
 --  Note this API is for the STM32 F4x family. Other STM MCUs have additional
 --  CRC capabilities.
@@ -42,21 +42,28 @@ package STM32.CRC is
 
    type CRC_32 is limited private;
 
-   procedure Reset_CRC (This : in out CRC_32);
-   --  Reset the unit's calculator to 16#FFFF_FFFF#. Does not affect the
-   --  contents of the unit's independent data.
+   procedure Reset_Calculator (This : in out CRC_32) with
+     Post => Value (This) = 16#FFFF_FFFF#;
+   --  Reset the unit's calculator value to 16#FFFF_FFFF#. All previous
+   --  calculations due to calls to Update_CRC are lost. Does not affect
+   --  the contents of the unit's independent data.
 
-   function CRC_Value (This : CRC_32) return UInt32;
+   function Value (This : CRC_32) return UInt32;
    --  Returns the currently calculated CRC value, reflecting any prior calls
    --  to Update_CRC. This is the same value returned via the Update_CRC.Output
-   --  parameter in calls to that routine.
+   --  parameter.
+
+   --  The Update_CRC routines can be called multiple times, back-to-back,
+   --  presumably with different input blocks, in order to update the value
+   --  of the calculated CRC checksum within the CRC processor with differing
+   --  input values.
 
    procedure Update_CRC
      (This   : in out CRC_32;
       Input  : UInt32;
       Output : out UInt32);
-   --  Updates the 32-bit CRC value in This from the 32-bit Input value.
-   --  Output is the resulting CRC-32 value.
+   --  Updates the 32-bit CRC value in This from the 32-bit Input value and any
+   --  previously-calculated CRC value. Output is the resulting CRC-32 value.
 
    type Block_32 is array (Positive range <>) of UInt32
      with Component_Size => 32;
@@ -65,8 +72,9 @@ package STM32.CRC is
      (This   : in out CRC_32;
       Input  : Block_32;
       Output : out UInt32);
-   --  Updates the 32-bit CRC value in This from the 32-bit Input values.
-   --  Output is the resulting CRC-32 value.
+   --  Updates the 32-bit CRC value in This from the 32-bit Input values and
+   --  any previously-calculated CRC value. Output is the resulting CRC-32
+   --  value.
 
    type Block_16 is array (Positive range <>) of UInt16
      with Component_Size => 16;
@@ -75,8 +83,8 @@ package STM32.CRC is
      (This   : in out CRC_32;
       Input  : Block_16;
       Output : out UInt32);
-   --  Updates the 32-bit CRC value in This from the 16-bit Input values.
-   --  Output is the resulting CRC-32 value.
+   --  Updates the 32-bit CRC value in This from the 16-bit Input values and any
+   --  previously-calculated CRC value. Output is the resulting CRC-32 value.
 
    type Block_8 is array (Positive range <>) of UInt8
      with Component_Size => 8;
@@ -85,8 +93,8 @@ package STM32.CRC is
      (This   : in out CRC_32;
       Input  : Block_8;
       Output : out UInt32);
-   --  Updates the 32-bit CRC value in This from the 8-bit Input values.
-   --  Output is the resulting CRC-32 value.
+   --  Updates the 32-bit CRC value in This from the 8-bit Input values and any
+   --  previously-calculated CRC value. Output is the resulting CRC-32 value.
 
    procedure Set_Independent_Data
      (This  : in out CRC_32;


### PR DESCRIPTION
STM32.CRC.DMA:
Make Update_CRC routines efficient when called back-to-back.
We don't reset the DMA controller each time now, in particular.

Correct name of interrupt triggered in comments.
Add comment header showing usage.

Refactor so that we can use one common routine in the package body.
Export it to any further child packages. This common routine clears all
DMA status flags explicitly since the Config routine does only that now
(configures the controller).

STM32.CRC:
Refactor subprogram names for better readability.
Add and revise comments.

demo_crc:
Show back-to-back calls to Update_CRC.
Show how to use the facility for arbitrary memory sections.
Add checks that individual calls are working as expected.
Various formatting and comment improvements.