### PR TITLE
HAL: Make UInt8|16|32 derived from Interfaces types rather than subtypes

### DIFF
--- a/arch/ARM/Nordic/drivers/nrf51-radio.adb
+++ b/arch/ARM/Nordic/drivers/nrf51-radio.adb
@@ -298,7 +298,7 @@ package body nRF51.Radio is
    ----------------------
 
    procedure Configure_Packet
-     (S0_Field_Size_In_Byte        : UInt1;
+     (S0_Field_Size_In_Byte        : Bit;
       S1_Field_Size_In_Bit         : UInt4;
       Length_Field_Size_In_Bit     : UInt4;
       Max_Packet_Length_In_Byte    : Packet_Len;

--- a/arch/ARM/Nordic/drivers/nrf51-radio.adb
+++ b/arch/ARM/Nordic/drivers/nrf51-radio.adb
@@ -31,7 +31,6 @@
 
 with NRF51_SVD.RADIO; use NRF51_SVD.RADIO;
 with System.Storage_Elements; use System.Storage_Elements;
-with Interfaces; use Interfaces;
 
 package body nRF51.Radio is
 
@@ -299,7 +298,7 @@ package body nRF51.Radio is
    ----------------------
 
    procedure Configure_Packet
-     (S0_Field_Size_In_Byte        : Bit;
+     (S0_Field_Size_In_Byte        : UInt1;
       S1_Field_Size_In_Bit         : UInt4;
       Length_Field_Size_In_Bit     : UInt4;
       Max_Packet_Length_In_Byte    : Packet_Len;

--- a/arch/ARM/Nordic/drivers/nrf51-radio.ads
+++ b/arch/ARM/Nordic/drivers/nrf51-radio.ads
@@ -159,7 +159,7 @@ package nRF51.Radio is
    type Length_Field_Endianness is (Little_Endian, Big_Endian);
 
    procedure Configure_Packet
-     (S0_Field_Size_In_Byte        : UInt1;
+     (S0_Field_Size_In_Byte        : Bit;
       S1_Field_Size_In_Bit         : UInt4;
       Length_Field_Size_In_Bit     : UInt4;
       Max_Packet_Length_In_Byte    : Packet_Len;

--- a/arch/ARM/Nordic/drivers/nrf51-radio.ads
+++ b/arch/ARM/Nordic/drivers/nrf51-radio.ads
@@ -69,7 +69,7 @@ package nRF51.Radio is
    --  Setup shortcuts for the radio device. Shortcuts will start a task when
    --  the associated event is triggered.
 
-   subtype Packet_Len is Byte;
+   subtype Packet_Len is UInt8;
 
    type Radio_Frequency_MHz is range 2400 .. 2527;
 
@@ -159,7 +159,7 @@ package nRF51.Radio is
    type Length_Field_Endianness is (Little_Endian, Big_Endian);
 
    procedure Configure_Packet
-     (S0_Field_Size_In_Byte        : Bit;
+     (S0_Field_Size_In_Byte        : UInt1;
       S1_Field_Size_In_Bit         : UInt4;
       Length_Field_Size_In_Bit     : UInt4;
       Max_Packet_Length_In_Byte    : Packet_Len;

--- a/arch/ARM/Nordic/drivers/nrf51-rng.adb
+++ b/arch/ARM/Nordic/drivers/nrf51-rng.adb
@@ -56,7 +56,7 @@ package body nRF51.RNG is
    -- Read --
    ----------
 
-   function Read return Byte is
+   function Read return UInt8 is
    begin
       --  Clear event
       RNG_Periph.EVENTS_VALRDY := 0;

--- a/arch/ARM/Nordic/drivers/nrf51-rng.ads
+++ b/arch/ARM/Nordic/drivers/nrf51-rng.ads
@@ -37,6 +37,6 @@ package nRF51.RNG is
 
    procedure Disable_Digital_Error_Correction;
 
-   function Read return Byte;
+   function Read return UInt8;
 
 end nRF51.RNG;

--- a/arch/ARM/Nordic/drivers/nrf51-temperature.adb
+++ b/arch/ARM/Nordic/drivers/nrf51-temperature.adb
@@ -30,7 +30,7 @@
 ------------------------------------------------------------------------------
 
 with NRF51_SVD.TEMP; use NRF51_SVD.TEMP;
-with Interfaces;     use Interfaces;
+with HAL;            use HAL;
 
 package body nRF51.Temperature is
 

--- a/arch/ARM/Nordic/drivers/nrf51-twi.adb
+++ b/arch/ARM/Nordic/drivers/nrf51-twi.adb
@@ -30,7 +30,6 @@
 ------------------------------------------------------------------------------
 
 with NRF51_SVD.TWI; use NRF51_SVD.TWI;
-with Interfaces;    use Interfaces;
 
 package body nRF51.TWI is
 
@@ -251,13 +250,13 @@ package body nRF51.TWI is
       case Mem_Addr_Size is
          when Memory_Size_8b =>
             This.Master_Transmit (Addr    => Addr,
-                                  Data    => (0 => Byte (Mem_Addr)),
+                                  Data    => (0 => UInt8 (Mem_Addr)),
                                   Status  => Status,
                                   Timeout => Timeout);
          when Memory_Size_16b =>
             This.Master_Transmit (Addr    => Addr,
-                                  Data    => (Byte (Shift_Right (Mem_Addr, 8)),
-                                              Byte (Mem_Addr and 16#FF#)),
+                                  Data    => (UInt8 (Shift_Right (Mem_Addr, 8)),
+                                              UInt8 (Mem_Addr and 16#FF#)),
                                   Status  => Status,
                                   Timeout => Timeout);
       end case;
@@ -294,13 +293,13 @@ package body nRF51.TWI is
       case Mem_Addr_Size is
          when Memory_Size_8b =>
             This.Master_Transmit (Addr    => Addr,
-                                  Data    => (0 => Byte (Mem_Addr)),
+                                  Data    => (0 => UInt8 (Mem_Addr)),
                                   Status  => Status,
                                   Timeout => Timeout);
          when Memory_Size_16b =>
             This.Master_Transmit (Addr    => Addr,
-                                  Data    => (Byte (Shift_Right (Mem_Addr, 8)),
-                                              Byte (Mem_Addr and 16#FF#)),
+                                  Data    => (UInt8 (Shift_Right (Mem_Addr, 8)),
+                                              UInt8 (Mem_Addr and 16#FF#)),
                                   Status  => Status,
                                   Timeout => Timeout);
       end case;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-aar.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-aar.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -378,6 +379,6 @@ package NRF51_SVD.AAR is
 
    --  Accelerated Address Resolver.
    AAR_Periph : aliased AAR_Peripheral
-     with Import, Address => AAR_Base;
+     with Import, Address => System'To_Address (16#4000F000#);
 
 end NRF51_SVD.AAR;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-aar.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-aar.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-adc.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-adc.ads
@@ -295,7 +295,7 @@ package NRF51_SVD.ADC is
       --  ADC reference selection.
       REFSEL         : CONFIG_REFSEL_Field := NRF51_SVD.ADC.Vbg;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  ADC analog pin selection.
       PSEL           : CONFIG_PSEL_Field := NRF51_SVD.ADC.Disabled;
       --  ADC external reference pin selection.

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-adc.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-adc.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -294,7 +295,7 @@ package NRF51_SVD.ADC is
       --  ADC reference selection.
       REFSEL         : CONFIG_REFSEL_Field := NRF51_SVD.ADC.Vbg;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  ADC analog pin selection.
       PSEL           : CONFIG_PSEL_Field := NRF51_SVD.ADC.Disabled;
       --  ADC external reference pin selection.
@@ -403,6 +404,6 @@ package NRF51_SVD.ADC is
 
    --  Analog to digital converter.
    ADC_Periph : aliased ADC_Peripheral
-     with Import, Address => ADC_Base;
+     with Import, Address => System'To_Address (16#40007000#);
 
 end NRF51_SVD.ADC;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-adc.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-adc.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-amli.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-amli.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -419,6 +420,6 @@ package NRF51_SVD.AMLI is
 
    --  AHB Multi-Layer Interface.
    AMLI_Periph : aliased AMLI_Peripheral
-     with Import, Address => AMLI_Base;
+     with Import, Address => System'To_Address (16#40000000#);
 
 end NRF51_SVD.AMLI;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-amli.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-amli.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ccm.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ccm.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -436,6 +437,6 @@ package NRF51_SVD.CCM is
 
    --  AES CCM Mode Encryption.
    CCM_Periph : aliased CCM_Peripheral
-     with Import, Address => CCM_Base;
+     with Import, Address => System'To_Address (16#4000F000#);
 
 end NRF51_SVD.CCM;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ccm.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ccm.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-clock.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-clock.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -147,7 +148,7 @@ package NRF51_SVD.CLOCK is
       LFCLKSTARTED  : INTENSET_LFCLKSTARTED_Field_1 :=
                        Intenset_Lfclkstarted_Field_Reset;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Enable interrupt on DONE event.
       DONE          : INTENSET_DONE_Field_1 := Intenset_Done_Field_Reset;
       --  Enable interrupt on CTTO event.
@@ -272,7 +273,7 @@ package NRF51_SVD.CLOCK is
       LFCLKSTARTED  : INTENCLR_LFCLKSTARTED_Field_1 :=
                        Intenclr_Lfclkstarted_Field_Reset;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Disable interrupt on DONE event.
       DONE          : INTENCLR_DONE_Field_1 := Intenclr_Done_Field_Reset;
       --  Disable interrupt on CTTO event.
@@ -626,6 +627,6 @@ package NRF51_SVD.CLOCK is
 
    --  Clock control.
    CLOCK_Periph : aliased CLOCK_Peripheral
-     with Import, Address => CLOCK_Base;
+     with Import, Address => System'To_Address (16#40000000#);
 
 end NRF51_SVD.CLOCK;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-clock.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-clock.ads
@@ -148,7 +148,7 @@ package NRF51_SVD.CLOCK is
       LFCLKSTARTED  : INTENSET_LFCLKSTARTED_Field_1 :=
                        Intenset_Lfclkstarted_Field_Reset;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Enable interrupt on DONE event.
       DONE          : INTENSET_DONE_Field_1 := Intenset_Done_Field_Reset;
       --  Enable interrupt on CTTO event.
@@ -273,7 +273,7 @@ package NRF51_SVD.CLOCK is
       LFCLKSTARTED  : INTENCLR_LFCLKSTARTED_Field_1 :=
                        Intenclr_Lfclkstarted_Field_Reset;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Disable interrupt on DONE event.
       DONE          : INTENCLR_DONE_Field_1 := Intenclr_Done_Field_Reset;
       --  Disable interrupt on CTTO event.

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-clock.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-clock.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ecb.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ecb.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ecb.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ecb.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -244,6 +245,6 @@ package NRF51_SVD.ECB is
 
    --  AES ECB Mode Encryption.
    ECB_Periph : aliased ECB_Peripheral
-     with Import, Address => ECB_Base;
+     with Import, Address => System'To_Address (16#4000E000#);
 
 end NRF51_SVD.ECB;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ficr.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ficr.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -69,8 +70,7 @@ package NRF51_SVD.FICR is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   --  Deprecated array of size of RAM block in bytes. This name is kept for
-   --  backward compatinility purposes. Use SIZERAMBLOCKS instead.
+   --  Deprecated array of size of RAM block in bytes. This name is kept for backward compatinility purposes. Use SIZERAMBLOCKS instead.
 
    --  Deprecated array of size of RAM block in bytes. This name is kept for
    --  backward compatinility purposes. Use SIZERAMBLOCKS instead.
@@ -273,6 +273,6 @@ package NRF51_SVD.FICR is
 
    --  Factory Information Configuration.
    FICR_Periph : aliased FICR_Peripheral
-     with Import, Address => FICR_Base;
+     with Import, Address => System'To_Address (16#10000000#);
 
 end NRF51_SVD.FICR;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ficr.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ficr.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-gpio.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-gpio.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -507,6 +508,6 @@ package NRF51_SVD.GPIO is
 
    --  General purpose input and output.
    GPIO_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIO_Base;
+     with Import, Address => System'To_Address (16#50000000#);
 
 end NRF51_SVD.GPIO;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-gpio.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-gpio.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-gpiote.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-gpiote.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -381,6 +382,6 @@ package NRF51_SVD.GPIOTE is
 
    --  GPIO tasks and events.
    GPIOTE_Periph : aliased GPIOTE_Peripheral
-     with Import, Address => GPIOTE_Base;
+     with Import, Address => System'To_Address (16#40006000#);
 
 end NRF51_SVD.GPIOTE;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-gpiote.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-gpiote.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-lpcomp.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-lpcomp.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -664,6 +665,6 @@ package NRF51_SVD.LPCOMP is
 
    --  Low power comparator.
    LPCOMP_Periph : aliased LPCOMP_Peripheral
-     with Import, Address => LPCOMP_Base;
+     with Import, Address => System'To_Address (16#40013000#);
 
 end NRF51_SVD.LPCOMP;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-lpcomp.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-lpcomp.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-mpu.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-mpu.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -307,7 +308,7 @@ package NRF51_SVD.MPU is
       --  SPI1 and TWI1 region configuration.
       SPI1_TWI1      : PERR0_SPI1_TWI1_Field := NRF51_SVD.MPU.Inregion1;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  GPIOTE region configuration.
       GPIOTE         : PERR0_GPIOTE_Field := NRF51_SVD.MPU.Inregion1;
       --  ADC region configuration.
@@ -551,6 +552,6 @@ package NRF51_SVD.MPU is
 
    --  Memory Protection Unit.
    MPU_Periph : aliased MPU_Peripheral
-     with Import, Address => MPU_Base;
+     with Import, Address => System'To_Address (16#40000000#);
 
 end NRF51_SVD.MPU;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-mpu.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-mpu.ads
@@ -308,7 +308,7 @@ package NRF51_SVD.MPU is
       --  SPI1 and TWI1 region configuration.
       SPI1_TWI1      : PERR0_SPI1_TWI1_Field := NRF51_SVD.MPU.Inregion1;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  GPIOTE region configuration.
       GPIOTE         : PERR0_GPIOTE_Field := NRF51_SVD.MPU.Inregion1;
       --  ADC region configuration.

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-mpu.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-mpu.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-nvmc.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-nvmc.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -200,6 +201,6 @@ package NRF51_SVD.NVMC is
 
    --  Non Volatile Memory Controller.
    NVMC_Periph : aliased NVMC_Peripheral
-     with Import, Address => NVMC_Base;
+     with Import, Address => System'To_Address (16#4001E000#);
 
 end NRF51_SVD.NVMC;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-nvmc.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-nvmc.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-power.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-power.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -403,7 +404,7 @@ package NRF51_SVD.POWER is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype GPREGRET_GPREGRET_Field is HAL.Byte;
+   subtype GPREGRET_GPREGRET_Field is HAL.UInt8;
 
    --  General purpose retention register. This register is a retained
    --  register.
@@ -729,6 +730,6 @@ package NRF51_SVD.POWER is
 
    --  Power Control.
    POWER_Periph : aliased POWER_Peripheral
-     with Import, Address => POWER_Base;
+     with Import, Address => System'To_Address (16#40000000#);
 
 end NRF51_SVD.POWER;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-power.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-power.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ppi.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ppi.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -583,6 +584,6 @@ package NRF51_SVD.PPI is
 
    --  PPI controller.
    PPI_Periph : aliased PPI_Peripheral
-     with Import, Address => PPI_Base;
+     with Import, Address => System'To_Address (16#4001F000#);
 
 end NRF51_SVD.PPI;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ppi.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-ppi.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-qdec.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-qdec.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -618,6 +619,6 @@ package NRF51_SVD.QDEC is
 
    --  Rotary decoder.
    QDEC_Periph : aliased QDEC_Peripheral
-     with Import, Address => QDEC_Base;
+     with Import, Address => System'To_Address (16#40012000#);
 
 end NRF51_SVD.QDEC;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-qdec.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-qdec.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-radio.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-radio.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -161,7 +162,7 @@ package NRF51_SVD.RADIO is
       ADDRESS_BCSTART   : SHORTS_ADDRESS_BCSTART_Field :=
                            NRF51_SVD.RADIO.Disabled;
       --  unspecified
-      Reserved_7_7      : HAL.Bit := 16#0#;
+      Reserved_7_7      : HAL.UInt1 := 16#0#;
       --  Shortcut between DISABLED event and RSSISTOP task.
       DISABLED_RSSISTOP : SHORTS_DISABLED_RSSISTOP_Field :=
                            NRF51_SVD.RADIO.Disabled;
@@ -765,7 +766,7 @@ package NRF51_SVD.RADIO is
       --  Read-only. CRC field of previously received packet.
       RXCRC          : RXCRC_RXCRC_Field;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -922,8 +923,8 @@ package NRF51_SVD.RADIO is
       Reserved_20_31 at 0 range 20 .. 31;
    end record;
 
-   subtype PCNF1_MAXLEN_Field is HAL.Byte;
-   subtype PCNF1_STATLEN_Field is HAL.Byte;
+   subtype PCNF1_MAXLEN_Field is HAL.UInt8;
+   subtype PCNF1_STATLEN_Field is HAL.UInt8;
    subtype PCNF1_BALEN_Field is HAL.UInt3;
 
    --  On air endianness of packet length field. Decision point: START task.
@@ -981,7 +982,7 @@ package NRF51_SVD.RADIO is
    end record;
 
    --  PREFIX0_AP array element
-   subtype PREFIX0_AP_Element is HAL.Byte;
+   subtype PREFIX0_AP_Element is HAL.UInt8;
 
    --  PREFIX0_AP array
    type PREFIX0_AP_Field_Array is array (0 .. 3) of PREFIX0_AP_Element
@@ -1009,7 +1010,7 @@ package NRF51_SVD.RADIO is
    end record;
 
    --  PREFIX1_AP array element
-   subtype PREFIX1_AP_Element is HAL.Byte;
+   subtype PREFIX1_AP_Element is HAL.UInt8;
 
    --  PREFIX1_AP array
    type PREFIX1_AP_Field_Array is array (4 .. 7) of PREFIX1_AP_Element
@@ -1078,7 +1079,7 @@ package NRF51_SVD.RADIO is
       case As_Array is
          when False =>
             --  ADDR as a value
-            Val : HAL.Byte;
+            Val : HAL.UInt8;
          when True =>
             --  ADDR as an array
             Arr : RXADDRESSES_ADDR_Field_Array;
@@ -1168,7 +1169,7 @@ package NRF51_SVD.RADIO is
       --  CRC polynomial. Decision point: START task.
       CRCPOLY        : CRCPOLY_CRCPOLY_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1185,7 +1186,7 @@ package NRF51_SVD.RADIO is
       --  Initial value for CRC calculation. Decision point: START task.
       CRCINIT        : CRCINIT_CRCINIT_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1237,7 +1238,7 @@ package NRF51_SVD.RADIO is
       Reserved_2_31 at 0 range 2 .. 31;
    end record;
 
-   subtype TIFS_TIFS_Field is HAL.Byte;
+   subtype TIFS_TIFS_Field is HAL.UInt8;
 
    --  Inter Frame Spacing in microseconds.
    type TIFS_Register is record
@@ -1386,7 +1387,7 @@ package NRF51_SVD.RADIO is
       case As_Array is
          when False =>
             --  ENA as a value
-            Val : HAL.Byte;
+            Val : HAL.UInt8;
          when True =>
             --  ENA as an array
             Arr : DACNF_ENA_Field_Array;
@@ -1410,7 +1411,7 @@ package NRF51_SVD.RADIO is
       case As_Array is
          when False =>
             --  TXADD as a value
-            Val : HAL.Byte;
+            Val : HAL.UInt8;
          when True =>
             --  TXADD as an array
             Arr : DACNF_TXADD_Field_Array;
@@ -1680,6 +1681,6 @@ package NRF51_SVD.RADIO is
 
    --  The radio.
    RADIO_Periph : aliased RADIO_Peripheral
-     with Import, Address => RADIO_Base;
+     with Import, Address => System'To_Address (16#40001000#);
 
 end NRF51_SVD.RADIO;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-radio.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-radio.ads
@@ -162,7 +162,7 @@ package NRF51_SVD.RADIO is
       ADDRESS_BCSTART   : SHORTS_ADDRESS_BCSTART_Field :=
                            NRF51_SVD.RADIO.Disabled;
       --  unspecified
-      Reserved_7_7      : HAL.UInt1 := 16#0#;
+      Reserved_7_7      : HAL.Bit := 16#0#;
       --  Shortcut between DISABLED event and RSSISTOP task.
       DISABLED_RSSISTOP : SHORTS_DISABLED_RSSISTOP_Field :=
                            NRF51_SVD.RADIO.Disabled;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-radio.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-radio.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-rng.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-rng.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -174,7 +175,7 @@ package NRF51_SVD.RNG is
       Reserved_1_31 at 0 range 1 .. 31;
    end record;
 
-   subtype VALUE_VALUE_Field is HAL.Byte;
+   subtype VALUE_VALUE_Field is HAL.UInt8;
 
    --  RNG random number.
    type VALUE_Register is record
@@ -259,6 +260,6 @@ package NRF51_SVD.RNG is
 
    --  Random Number Generator.
    RNG_Periph : aliased RNG_Peripheral
-     with Import, Address => RNG_Base;
+     with Import, Address => System'To_Address (16#4000D000#);
 
 end NRF51_SVD.RNG;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-rng.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-rng.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-rtc.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-rtc.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -629,7 +630,7 @@ package NRF51_SVD.RTC is
       --  Read-only. Counter value.
       COUNTER        : COUNTER_COUNTER_Field;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -664,7 +665,7 @@ package NRF51_SVD.RTC is
       --  Compare value.
       COMPARE        : CC_COMPARE_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -769,10 +770,10 @@ package NRF51_SVD.RTC is
 
    --  Real time counter 0.
    RTC0_Periph : aliased RTC_Peripheral
-     with Import, Address => RTC0_Base;
+     with Import, Address => System'To_Address (16#4000B000#);
 
    --  Real time counter 1.
    RTC1_Periph : aliased RTC_Peripheral
-     with Import, Address => RTC1_Base;
+     with Import, Address => System'To_Address (16#40011000#);
 
 end NRF51_SVD.RTC;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-rtc.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-rtc.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spi.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spi.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -153,7 +154,7 @@ package NRF51_SVD.SPI is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype RXD_RXD_Field is HAL.Byte;
+   subtype RXD_RXD_Field is HAL.UInt8;
 
    --  RX data.
    type RXD_Register is record
@@ -171,7 +172,7 @@ package NRF51_SVD.SPI is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype TXD_TXD_Field is HAL.Byte;
+   subtype TXD_TXD_Field is HAL.UInt8;
 
    --  TX data.
    type TXD_Register is record
@@ -324,10 +325,10 @@ package NRF51_SVD.SPI is
 
    --  SPI master 0.
    SPI0_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI0_Base;
+     with Import, Address => System'To_Address (16#40003000#);
 
    --  SPI master 1.
    SPI1_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI1_Base;
+     with Import, Address => System'To_Address (16#40004000#);
 
 end NRF51_SVD.SPI;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spi.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spi.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spim.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spim.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -141,7 +142,7 @@ package NRF51_SVD.SPIM is
    --  Interrupt enable set register.
    type INTENSET_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  Enable interrupt on STOPPED event.
       STOPPED        : INTENSET_STOPPED_Field_1 :=
                         Intenset_Stopped_Field_Reset;
@@ -275,7 +276,7 @@ package NRF51_SVD.SPIM is
    --  Interrupt enable clear register.
    type INTENCLR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  Disable interrupt on STOPPED event.
       STOPPED        : INTENCLR_STOPPED_Field_1 :=
                         Intenclr_Stopped_Field_Reset;
@@ -362,7 +363,7 @@ package NRF51_SVD.SPIM is
    -- SPIM_RXD cluster's Registers --
    ----------------------------------
 
-   subtype MAXCNT_RXD_MAXCNT_Field is HAL.Byte;
+   subtype MAXCNT_RXD_MAXCNT_Field is HAL.UInt8;
 
    --  Maximum number of buffer bytes to receive.
    type MAXCNT_RXD_Register is record
@@ -379,7 +380,7 @@ package NRF51_SVD.SPIM is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype AMOUNT_RXD_AMOUNT_Field is HAL.Byte;
+   subtype AMOUNT_RXD_AMOUNT_Field is HAL.UInt8;
 
    --  Number of bytes received in the last transaction.
    type AMOUNT_RXD_Register is record
@@ -417,7 +418,7 @@ package NRF51_SVD.SPIM is
    -- SPIM_TXD cluster's Registers --
    ----------------------------------
 
-   subtype MAXCNT_TXD_MAXCNT_Field is HAL.Byte;
+   subtype MAXCNT_TXD_MAXCNT_Field is HAL.UInt8;
 
    --  Maximum number of buffer bytes to send.
    type MAXCNT_TXD_Register is record
@@ -434,7 +435,7 @@ package NRF51_SVD.SPIM is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype AMOUNT_TXD_AMOUNT_Field is HAL.Byte;
+   subtype AMOUNT_TXD_AMOUNT_Field is HAL.UInt8;
 
    --  Number of bytes sent in the last transaction.
    type AMOUNT_TXD_Register is record
@@ -527,7 +528,7 @@ package NRF51_SVD.SPIM is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype ORC_ORC_Field is HAL.Byte;
+   subtype ORC_ORC_Field is HAL.UInt8;
 
    --  Over-read character.
    type ORC_Register is record
@@ -639,6 +640,6 @@ package NRF51_SVD.SPIM is
 
    --  SPI master with easyDMA 1.
    SPIM1_Periph : aliased SPIM_Peripheral
-     with Import, Address => SPIM1_Base;
+     with Import, Address => System'To_Address (16#40004000#);
 
 end NRF51_SVD.SPIM;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spim.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spim.ads
@@ -142,7 +142,7 @@ package NRF51_SVD.SPIM is
    --  Interrupt enable set register.
    type INTENSET_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  Enable interrupt on STOPPED event.
       STOPPED        : INTENSET_STOPPED_Field_1 :=
                         Intenset_Stopped_Field_Reset;
@@ -276,7 +276,7 @@ package NRF51_SVD.SPIM is
    --  Interrupt enable clear register.
    type INTENCLR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  Disable interrupt on STOPPED event.
       STOPPED        : INTENCLR_STOPPED_Field_1 :=
                         Intenclr_Stopped_Field_Reset;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spim.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spim.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spis.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spis.ads
@@ -124,7 +124,7 @@ package NRF51_SVD.SPIS is
    --  Interrupt enable set register.
    type INTENSET_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  Enable interrupt on END event.
       END_k          : INTENSET_END_Field_1 := Intenset_End_Field_Reset;
       --  unspecified
@@ -197,7 +197,7 @@ package NRF51_SVD.SPIS is
    --  Interrupt enable clear register.
    type INTENCLR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  Disable interrupt on END event.
       END_k          : INTENCLR_END_Field_1 := Intenclr_End_Field_Reset;
       --  unspecified

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spis.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spis.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -123,11 +124,11 @@ package NRF51_SVD.SPIS is
    --  Interrupt enable set register.
    type INTENSET_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  Enable interrupt on END event.
       END_k          : INTENSET_END_Field_1 := Intenset_End_Field_Reset;
       --  unspecified
-      Reserved_2_9   : HAL.Byte := 16#0#;
+      Reserved_2_9   : HAL.UInt8 := 16#0#;
       --  Enable interrupt on ACQUIRED event.
       ACQUIRED       : INTENSET_ACQUIRED_Field_1 :=
                         Intenset_Acquired_Field_Reset;
@@ -196,11 +197,11 @@ package NRF51_SVD.SPIS is
    --  Interrupt enable clear register.
    type INTENCLR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  Disable interrupt on END event.
       END_k          : INTENCLR_END_Field_1 := Intenclr_End_Field_Reset;
       --  unspecified
-      Reserved_2_9   : HAL.Byte := 16#0#;
+      Reserved_2_9   : HAL.UInt8 := 16#0#;
       --  Disable interrupt on ACQUIRED event.
       ACQUIRED       : INTENCLR_ACQUIRED_Field_1 :=
                         Intenclr_Acquired_Field_Reset;
@@ -345,7 +346,7 @@ package NRF51_SVD.SPIS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype MAXRX_MAXRX_Field is HAL.Byte;
+   subtype MAXRX_MAXRX_Field is HAL.UInt8;
 
    --  Maximum number of bytes in the receive buffer.
    type MAXRX_Register is record
@@ -362,7 +363,7 @@ package NRF51_SVD.SPIS is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype AMOUNTRX_AMOUNTRX_Field is HAL.Byte;
+   subtype AMOUNTRX_AMOUNTRX_Field is HAL.UInt8;
 
    --  Number of bytes received in last granted transaction.
    type AMOUNTRX_Register is record
@@ -379,7 +380,7 @@ package NRF51_SVD.SPIS is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype MAXTX_MAXTX_Field is HAL.Byte;
+   subtype MAXTX_MAXTX_Field is HAL.UInt8;
 
    --  Maximum number of bytes in the transmit buffer.
    type MAXTX_Register is record
@@ -396,7 +397,7 @@ package NRF51_SVD.SPIS is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype AMOUNTTX_AMOUNTTX_Field is HAL.Byte;
+   subtype AMOUNTTX_AMOUNTTX_Field is HAL.UInt8;
 
    --  Number of bytes transmitted in last granted transaction.
    type AMOUNTTX_Register is record
@@ -472,7 +473,7 @@ package NRF51_SVD.SPIS is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype DEF_DEF_Field is HAL.Byte;
+   subtype DEF_DEF_Field is HAL.UInt8;
 
    --  Default character.
    type DEF_Register is record
@@ -489,7 +490,7 @@ package NRF51_SVD.SPIS is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype ORC_ORC_Field is HAL.Byte;
+   subtype ORC_ORC_Field is HAL.UInt8;
 
    --  Over-read character.
    type ORC_Register is record
@@ -619,6 +620,6 @@ package NRF51_SVD.SPIS is
 
    --  SPI slave 1.
    SPIS1_Periph : aliased SPIS_Peripheral
-     with Import, Address => SPIS1_Base;
+     with Import, Address => System'To_Address (16#40004000#);
 
 end NRF51_SVD.SPIS;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spis.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-spis.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-swi.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-swi.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,14 +25,16 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
+with System;
 
 package NRF51_SVD.SWI is
    pragma Preelaborate;
@@ -58,6 +60,6 @@ package NRF51_SVD.SWI is
 
    --  SW Interrupts.
    SWI_Periph : aliased SWI_Peripheral
-     with Import, Address => SWI_Base;
+     with Import, Address => System'To_Address (16#40014000#);
 
 end NRF51_SVD.SWI;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-swi.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-swi.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-temp.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-temp.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -184,6 +185,6 @@ package NRF51_SVD.TEMP is
 
    --  Temperature Sensor.
    TEMP_Periph : aliased TEMP_Peripheral
-     with Import, Address => TEMP_Base;
+     with Import, Address => System'To_Address (16#4000C000#);
 
 end NRF51_SVD.TEMP;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-temp.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-temp.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-timer.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-timer.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -500,14 +501,14 @@ package NRF51_SVD.TIMER is
 
    --  Timer 0.
    TIMER0_Periph : aliased TIMER_Peripheral
-     with Import, Address => TIMER0_Base;
+     with Import, Address => System'To_Address (16#40008000#);
 
    --  Timer 1.
    TIMER1_Periph : aliased TIMER_Peripheral
-     with Import, Address => TIMER1_Base;
+     with Import, Address => System'To_Address (16#40009000#);
 
    --  Timer 2.
    TIMER2_Periph : aliased TIMER_Peripheral
-     with Import, Address => TIMER2_Base;
+     with Import, Address => System'To_Address (16#4000A000#);
 
 end NRF51_SVD.TIMER;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-timer.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-timer.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-twi.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-twi.ads
@@ -232,7 +232,7 @@ package NRF51_SVD.TWI is
    --  Interrupt enable set register.
    type INTENSET_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  Enable interrupt on STOPPED event.
       STOPPED        : INTENSET_STOPPED_Field_1 :=
                         Intenset_Stopped_Field_Reset;
@@ -245,7 +245,7 @@ package NRF51_SVD.TWI is
       TXDSENT        : INTENSET_TXDSENT_Field_1 :=
                         Intenset_Txdsent_Field_Reset;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  Enable interrupt on ERROR event.
       ERROR          : INTENSET_ERROR_Field_1 := Intenset_Error_Field_Reset;
       --  unspecified
@@ -425,7 +425,7 @@ package NRF51_SVD.TWI is
    --  Interrupt enable clear register.
    type INTENCLR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  Disable interrupt on STOPPED event.
       STOPPED        : INTENCLR_STOPPED_Field_1 :=
                         Intenclr_Stopped_Field_Reset;
@@ -438,7 +438,7 @@ package NRF51_SVD.TWI is
       TXDSENT        : INTENCLR_TXDSENT_Field_1 :=
                         Intenclr_Txdsent_Field_Reset;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  Disable interrupt on ERROR event.
       ERROR          : INTENCLR_ERROR_Field_1 := Intenclr_Error_Field_Reset;
       --  unspecified

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-twi.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-twi.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-twi.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-twi.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -231,7 +232,7 @@ package NRF51_SVD.TWI is
    --  Interrupt enable set register.
    type INTENSET_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  Enable interrupt on STOPPED event.
       STOPPED        : INTENSET_STOPPED_Field_1 :=
                         Intenset_Stopped_Field_Reset;
@@ -244,7 +245,7 @@ package NRF51_SVD.TWI is
       TXDSENT        : INTENSET_TXDSENT_Field_1 :=
                         Intenset_Txdsent_Field_Reset;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  Enable interrupt on ERROR event.
       ERROR          : INTENSET_ERROR_Field_1 := Intenset_Error_Field_Reset;
       --  unspecified
@@ -424,7 +425,7 @@ package NRF51_SVD.TWI is
    --  Interrupt enable clear register.
    type INTENCLR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  Disable interrupt on STOPPED event.
       STOPPED        : INTENCLR_STOPPED_Field_1 :=
                         Intenclr_Stopped_Field_Reset;
@@ -437,7 +438,7 @@ package NRF51_SVD.TWI is
       TXDSENT        : INTENCLR_TXDSENT_Field_1 :=
                         Intenclr_Txdsent_Field_Reset;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  Disable interrupt on ERROR event.
       ERROR          : INTENCLR_ERROR_Field_1 := Intenclr_Error_Field_Reset;
       --  unspecified
@@ -594,7 +595,7 @@ package NRF51_SVD.TWI is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype RXD_RXD_Field is HAL.Byte;
+   subtype RXD_RXD_Field is HAL.UInt8;
 
    --  RX data register.
    type RXD_Register is record
@@ -612,7 +613,7 @@ package NRF51_SVD.TWI is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype TXD_TXD_Field is HAL.Byte;
+   subtype TXD_TXD_Field is HAL.UInt8;
 
    --  TX data register.
    type TXD_Register is record
@@ -756,10 +757,10 @@ package NRF51_SVD.TWI is
 
    --  Two-wire interface master 0.
    TWI0_Periph : aliased TWI_Peripheral
-     with Import, Address => TWI0_Base;
+     with Import, Address => System'To_Address (16#40003000#);
 
    --  Two-wire interface master 1.
    TWI1_Periph : aliased TWI_Peripheral
-     with Import, Address => TWI1_Base;
+     with Import, Address => System'To_Address (16#40004000#);
 
 end NRF51_SVD.TWI;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-uart.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-uart.ads
@@ -245,7 +245,7 @@ package NRF51_SVD.UART is
       --  Enable interrupt on TXRDY event.
       TXDRDY         : INTENSET_TXDRDY_Field_1 := Intenset_Txdrdy_Field_Reset;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  Enable interrupt on ERROR event.
       ERROR          : INTENSET_ERROR_Field_1 := Intenset_Error_Field_Reset;
       --  unspecified
@@ -428,7 +428,7 @@ package NRF51_SVD.UART is
       --  Disable interrupt on TXRDY event.
       TXDRDY         : INTENCLR_TXDRDY_Field_1 := Intenclr_Txdrdy_Field_Reset;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  Disable interrupt on ERROR event.
       ERROR          : INTENCLR_ERROR_Field_1 := Intenclr_Error_Field_Reset;
       --  unspecified

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-uart.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-uart.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -244,7 +245,7 @@ package NRF51_SVD.UART is
       --  Enable interrupt on TXRDY event.
       TXDRDY         : INTENSET_TXDRDY_Field_1 := Intenset_Txdrdy_Field_Reset;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  Enable interrupt on ERROR event.
       ERROR          : INTENSET_ERROR_Field_1 := Intenset_Error_Field_Reset;
       --  unspecified
@@ -427,7 +428,7 @@ package NRF51_SVD.UART is
       --  Disable interrupt on TXRDY event.
       TXDRDY         : INTENCLR_TXDRDY_Field_1 := Intenclr_Txdrdy_Field_Reset;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  Disable interrupt on ERROR event.
       ERROR          : INTENCLR_ERROR_Field_1 := Intenclr_Error_Field_Reset;
       --  unspecified
@@ -612,7 +613,7 @@ package NRF51_SVD.UART is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype RXD_RXD_Field is HAL.Byte;
+   subtype RXD_RXD_Field is HAL.UInt8;
 
    --  RXD register. On read action the buffer pointer is displaced. Once read
    --  the character is consumed. If read when no character available, the UART
@@ -632,7 +633,7 @@ package NRF51_SVD.UART is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype TXD_TXD_Field is HAL.Byte;
+   subtype TXD_TXD_Field is HAL.UInt8;
 
    --  TXD register.
    type TXD_Register is record
@@ -809,6 +810,6 @@ package NRF51_SVD.UART is
 
    --  Universal Asynchronous Receiver/Transmitter.
    UART0_Periph : aliased UART_Peripheral
-     with Import, Address => UART0_Base;
+     with Import, Address => System'To_Address (16#40002000#);
 
 end NRF51_SVD.UART;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-uart.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-uart.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-uicr.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-uicr.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -196,6 +197,6 @@ package NRF51_SVD.UICR is
 
    --  User Information Configuration.
    UICR_Periph : aliased UICR_Peripheral
-     with Import, Address => UICR_Base;
+     with Import, Address => System'To_Address (16#10001000#);
 
 end NRF51_SVD.UICR;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-uicr.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-uicr.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-wdt.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-wdt.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -539,6 +540,6 @@ package NRF51_SVD.WDT is
 
    --  Watchdog Timer.
    WDT_Periph : aliased WDT_Peripheral
-     with Import, Address => WDT_Base;
+     with Import, Address => System'To_Address (16#40010000#);
 
 end NRF51_SVD.WDT;

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd-wdt.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd-wdt.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd.ads
@@ -1,20 +1,20 @@
 --    Copyright (c) 2013, Nordic Semiconductor ASA
 --    All rights reserved.
---
+--  
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions are met:
---
+--  
 --    * Redistributions of source code must retain the above copyright notice, this
 --      list of conditions and the following disclaimer.
---
+--  
 --    * Redistributions in binary form must reproduce the above copyright notice,
 --      this list of conditions and the following disclaimer in the documentation
 --      and/or other materials provided with the distribution.
---
+--  
 --    * Neither the name of Nordic Semiconductor ASA nor the names of its
 --      contributors may be used to endorse or promote products derived from
 --      this software without specific prior written permission.
---
+--  
 --    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 --    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 --    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,12 +25,13 @@
 --    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 --    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 --    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---
+--  
 
 --  This spec has been automatically generated from nrf51.svd
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with System;
 

--- a/arch/ARM/Nordic/svd/nrf51/nrf51_svd.ads
+++ b/arch/ARM/Nordic/svd/nrf51/nrf51_svd.ads
@@ -1,31 +1,31 @@
---    Copyright (c) 2013, Nordic Semiconductor ASA
---    All rights reserved.
---  
---    Redistribution and use in source and binary forms, with or without
---    modification, are permitted provided that the following conditions are met:
---  
---    * Redistributions of source code must retain the above copyright notice, this
---      list of conditions and the following disclaimer.
---  
---    * Redistributions in binary form must reproduce the above copyright notice,
---      this list of conditions and the following disclaimer in the documentation
---      and/or other materials provided with the distribution.
---  
---    * Neither the name of Nordic Semiconductor ASA nor the names of its
---      contributors may be used to endorse or promote products derived from
---      this software without specific prior written permission.
---  
---    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
---    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
---    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
---    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
---    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
---    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
---    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
---    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
---    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
---    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---  
+--  Copyright (c) 2013, Nordic Semiconductor ASA
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--
+--  * Redistributions of source code must retain the above copyright notice, this
+--  list of conditions and the following disclaimer.
+--
+--  * Redistributions in binary form must reproduce the above copyright notice,
+--  this list of conditions and the following disclaimer in the documentation
+--  and/or other materials provided with the distribution.
+--
+--  * Neither the name of Nordic Semiconductor ASA nor the names of its
+--  contributors may be used to endorse or promote products derived from
+--  this software without specific prior written permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+--  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+--  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+--  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+--  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+--  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+--  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
 
 --  This spec has been automatically generated from nrf51.svd
 

--- a/arch/ARM/STM32/driver_demos/demo_L3GD20_dataready_int/demo_l3gd20_dataready_int.gpr
+++ b/arch/ARM/STM32/driver_demos/demo_L3GD20_dataready_int/demo_l3gd20_dataready_int.gpr
@@ -1,7 +1,7 @@
-with "../../../../boards/common_config.gpr";
-with "../../../../boards/stm32f429_discovery.gpr";
+with "../../../../../boards/common_config.gpr";
+with "../../../../../boards/stm32f429_discovery.gpr";
 
-project Demo_L3GD20_Dataready_Int extends "../../../../examples/common/common.gpr" is
+project Demo_L3GD20_Dataready_Int extends "../../../../../examples/common/common.gpr" is
 
   for Main use ("demo_l3gd20.adb");
 

--- a/arch/ARM/STM32/driver_demos/demo_L3GD20_polling/demo_l3gd20.gpr
+++ b/arch/ARM/STM32/driver_demos/demo_L3GD20_polling/demo_l3gd20.gpr
@@ -1,7 +1,7 @@
-with "../../../../boards/common_config.gpr";
-with "../../../../boards/stm32f429_discovery.gpr";
+with "../../../../../boards/common_config.gpr";
+with "../../../../../boards/stm32f429_discovery.gpr";
 
-project Demo_L3GD20 extends "../../../../examples/common/common.gpr" is
+project Demo_L3GD20 extends "../../../../../examples/common/common.gpr" is
 
    for Source_Dirs use ("src");   for Target use "arm-eabi";
    for Main use ("demo_l3gd20.adb");

--- a/arch/ARM/STM32/driver_demos/demo_LIS3DSH_pwm/src/demo_lis3dsh_pwm.adb
+++ b/arch/ARM/STM32/driver_demos/demo_LIS3DSH_pwm/src/demo_lis3dsh_pwm.adb
@@ -49,15 +49,15 @@
 
 with Last_Chance_Handler;  pragma Unreferenced (Last_Chance_Handler);
 
-with Interfaces;        use Interfaces;
-with Ada.Real_Time;     use Ada.Real_Time;
+with HAL;           use HAL;
+with Ada.Real_Time; use Ada.Real_Time;
 
-with STM32.Board;       use STM32.Board;
-with LIS3DSH;           use LIS3DSH;  -- on the F4 Disco board
+with STM32.Board;   use STM32.Board;
+with LIS3DSH;       use LIS3DSH;  -- on the F4 Disco board
 
-with STM32.GPIO;        use STM32.GPIO;
-with STM32.Timers;      use STM32.Timers;
-with STM32.PWM;         use STM32.PWM;
+with STM32.GPIO;    use STM32.GPIO;
+with STM32.Timers;  use STM32.Timers;
+with STM32.PWM;     use STM32.PWM;
 
 use STM32;
 

--- a/arch/ARM/STM32/driver_demos/demo_LIS3DSH_tilt/demo_lis3dsh_tilt.gpr
+++ b/arch/ARM/STM32/driver_demos/demo_LIS3DSH_tilt/demo_lis3dsh_tilt.gpr
@@ -1,7 +1,7 @@
-with "../../../../boards/common_config.gpr";
-with "../../../../boards/stm32f407_discovery.gpr";
+with "../../../../../boards/common_config.gpr";
+with "../../../../../boards/stm32f407_discovery.gpr";
 
-project Demo_LIS3DSH_Tilt extends "../../../../examples/common/common.gpr" is
+project Demo_LIS3DSH_Tilt extends "../../../../../examples/common/common.gpr" is
 
    for Languages use ("Ada");
    for Main use ("demo_lis3dsh_tilt.adb");

--- a/arch/ARM/STM32/driver_demos/demo_LIS3DSH_tilt/src/demo_lis3dsh_tilt.adb
+++ b/arch/ARM/STM32/driver_demos/demo_LIS3DSH_tilt/src/demo_lis3dsh_tilt.adb
@@ -39,7 +39,7 @@
 
 with Last_Chance_Handler;  pragma Unreferenced (Last_Chance_Handler);
 
-with Interfaces;    use Interfaces;
+with HAL;           use HAL;
 with Ada.Real_Time; use Ada.Real_Time;
 with STM32.Board;   use STM32.Board;
 with LIS3DSH;       use LIS3DSH;

--- a/arch/ARM/STM32/driver_demos/demo_adc_interrupts/demo_adc_interrupts.gpr
+++ b/arch/ARM/STM32/driver_demos/demo_adc_interrupts/demo_adc_interrupts.gpr
@@ -1,7 +1,7 @@
-with "../../../../boards/common_config.gpr";
-with "../../../../boards/stm32f429_discovery.gpr";
+with "../../../../../boards/common_config.gpr";
+with "../../../../../boards/stm32f429_discovery.gpr";
 
-project Demo_ADC_Interrupts extends "../../../../examples/common/common.gpr" is
+project Demo_ADC_Interrupts extends "../../../../../examples/common/common.gpr" is
 
    for Main use ("demo_adc_vbat_interrupts");
 

--- a/arch/ARM/STM32/driver_demos/demo_adc_timer_dma/demo_adc_timer_dma.gpr
+++ b/arch/ARM/STM32/driver_demos/demo_adc_timer_dma/demo_adc_timer_dma.gpr
@@ -1,7 +1,7 @@
-with "../../../../boards/common_config.gpr";
-with "../../../../boards/stm32f429_discovery.gpr";
+with "../../../../../boards/common_config.gpr";
+with "../../../../../boards/stm32f429_discovery.gpr";
 
-project Demo_ADC_Timer_DMA extends "../../../../examples/common/common.gpr" is
+project Demo_ADC_Timer_DMA extends "../../../../../examples/common/common.gpr" is
 
    for Main use ("demo_adc_timer_dma");
 

--- a/arch/ARM/STM32/driver_demos/demo_crc/demo_crc.gpr
+++ b/arch/ARM/STM32/driver_demos/demo_crc/demo_crc.gpr
@@ -1,7 +1,7 @@
-with "../../../../boards/common_config.gpr";
-with "../../../../boards/stm32f429_discovery.gpr";
+with "../../../../../boards/common_config.gpr";
+with "../../../../../boards/stm32f429_discovery.gpr";
 
-project Demo_CRC extends "../../../../examples/common/common.gpr" is
+project Demo_CRC extends "../../../../../examples/common/common.gpr" is
 
    for Runtime ("Ada") use STM32F429_Discovery'Runtime ("Ada");
 

--- a/arch/ARM/STM32/driver_demos/demo_dac_dma/demo_dac_dma.gpr
+++ b/arch/ARM/STM32/driver_demos/demo_dac_dma/demo_dac_dma.gpr
@@ -1,7 +1,7 @@
-with "../../../../boards/common_config.gpr";
-with "../../../../boards/stm32f429_discovery.gpr";
+with "../../../../../boards/common_config.gpr";
+with "../../../../../boards/stm32f429_discovery.gpr";
 
-project Demo_DAC_DMA extends "../../../../examples/common/common.gpr" is
+project Demo_DAC_DMA extends "../../../../../examples/common/common.gpr" is
 
    for Main use ("demo_dac_dma");
    for Languages use ("Ada");

--- a/arch/ARM/STM32/driver_demos/demo_dma_mem_to_peripheral/demo_usart_dma_continuous.gpr
+++ b/arch/ARM/STM32/driver_demos/demo_dma_mem_to_peripheral/demo_usart_dma_continuous.gpr
@@ -1,7 +1,7 @@
-with "../../../../boards/common_config.gpr";
-with "../../../../boards/stm32f407_discovery.gpr";
+with "../../../../../boards/common_config.gpr";
+with "../../../../../boards/stm32f407_discovery.gpr";
 
-project Demo_USART_DMA_Continuous extends "../../../../examples/common/common.gpr" is
+project Demo_USART_DMA_Continuous extends "../../../../../examples/common/common.gpr" is
 
    for Main use ("demo_usart_dma_continuous.adb");
    for Languages use ("Ada");

--- a/arch/ARM/STM32/driver_demos/demo_timer_interrupts_basic/demo_basic_timer_interrupts.gpr
+++ b/arch/ARM/STM32/driver_demos/demo_timer_interrupts_basic/demo_basic_timer_interrupts.gpr
@@ -1,7 +1,7 @@
-with "../../../../boards/common_config.gpr";
-with "../../../../boards/stm32f407_discovery.gpr";
+with "../../../../../boards/common_config.gpr";
+with "../../../../../boards/stm32f407_discovery.gpr";
 
-project demo_basic_timer_interrupts extends "../../../../examples/common/common.gpr" is
+project demo_basic_timer_interrupts extends "../../../../../examples/common/common.gpr" is
 
    for Languages use ("Ada");
    for Main use ("demo.adb");

--- a/arch/ARM/STM32/driver_demos/demo_timer_pwm/demo_timer_pwm.gpr
+++ b/arch/ARM/STM32/driver_demos/demo_timer_pwm/demo_timer_pwm.gpr
@@ -1,7 +1,7 @@
-with "../../../../boards/common_config.gpr";
-with "../../../../boards/stm32f407_discovery.gpr";
+with "../../../../../boards/common_config.gpr";
+with "../../../../../boards/stm32f407_discovery.gpr";
 
-project Demo_Timer_PWM extends "../../../../examples/common/common.gpr" is
+project Demo_Timer_PWM extends "../../../../../examples/common/common.gpr" is
 
    for Languages use ("Ada");
    for Main use ("demo_pwm_adt", "demo_timer_pwm");

--- a/arch/ARM/STM32/driver_demos/demo_usart_interrupts/demo_usart_interrupts.gpr
+++ b/arch/ARM/STM32/driver_demos/demo_usart_interrupts/demo_usart_interrupts.gpr
@@ -1,7 +1,7 @@
-with "../../../../boards/common_config.gpr";
-with "../../../../boards/stm32f407_discovery.gpr";
+with "../../../../../boards/common_config.gpr";
+with "../../../../../boards/stm32f407_discovery.gpr";
 
-project Demo_USART_Interrupts extends "../../../../examples/common/common.gpr" is
+project Demo_USART_Interrupts extends "../../../../../examples/common/common.gpr" is
 
    for Main use ("demo_usart_interrupts.adb");
    for Languages use ("Ada");

--- a/arch/ARM/STM32/driver_demos/demo_usart_interrupts/src/serial_port.ads
+++ b/arch/ARM/STM32/driver_demos/demo_usart_interrupts/src/serial_port.ads
@@ -54,7 +54,7 @@ package Serial_Port is
    --  convenience routine
 
 
-   type Error_Conditions is new Byte;
+   type Error_Conditions is new UInt8;
 
    No_Error_Detected      : constant Error_Conditions := 2#0000_0000#;
    Parity_Error_Detected  : constant Error_Conditions := 2#0000_0001#;

--- a/arch/ARM/STM32/drivers/crc_stm32f4/stm32-crc.ads
+++ b/arch/ARM/STM32/drivers/crc_stm32f4/stm32-crc.ads
@@ -29,7 +29,7 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
---  A driver for the Cyclic Redundancy Check CRC-32 calculation processor. 
+--  A driver for the Cyclic Redundancy Check CRC-32 calculation processor.
 --  The CPU transfers the data to the CRC processor.
 
 --  Note this API is for the STM32 F4x family. Other STM MCUs have additional

--- a/arch/ARM/STM32/drivers/dma/stm32-dma.adb
+++ b/arch/ARM/STM32/drivers/dma/stm32-dma.adb
@@ -743,8 +743,8 @@ package body STM32.DMA is
       Stream : DMA_Stream_Selector)
       return UInt16
    is
-      ndt : constant Unsigned_16 := Current_NDT (This, Stream);
-      items : Unsigned_16;
+      ndt : constant UInt16 := Current_NDT (This, Stream);
+      items : UInt16;
    begin
       if Operating_Mode (This, Stream) = Peripheral_Flow_Control_Mode then
          items := 16#ffff# - ndt;

--- a/arch/ARM/STM32/drivers/dma/stm32-dma.ads
+++ b/arch/ARM/STM32/drivers/dma/stm32-dma.ads
@@ -189,7 +189,7 @@ package STM32.DMA with SPARK_Mode => Off is
    --  In contrast, on a memory-to-memory transfer the most efficient approach
    --  is to work in units of words. One would therefore specify word units for
    --  the source and destination formats and then specify 1/4 the total number
-   --  of bytes involved (assuming a four-byte word).
+   --  of bytes involved (assuming a four-UInt8 word).
 
    procedure Start_Transfer
      (This        : DMA_Controller;
@@ -596,7 +596,7 @@ package STM32.DMA with SPARK_Mode => Off is
 
    function Aligned (This : Address;  Width : DMA_Data_Transfer_Widths)
       return Boolean with Inline;
-   --  Returns whether the address is aligned on a word, half-word, or byte
+   --  Returns whether the address is aligned on a word, half-word, or UInt8
    --  boundary
 
    function Compatible_Alignments

--- a/arch/ARM/STM32/drivers/dma2d/stm32-dma2d.ads
+++ b/arch/ARM/STM32/drivers/dma2d/stm32-dma2d.ads
@@ -35,10 +35,10 @@ with Ada.Unchecked_Conversion;
 package STM32.DMA2D is
 
    type DMA2D_Color is record
-      Alpha : Byte;
-      Red   : Byte;
-      Green : Byte;
-      Blue  : Byte;
+      Alpha : UInt8;
+      Red   : UInt8;
+      Green : UInt8;
+      Blue  : UInt8;
    end record;
 
    for DMA2D_Color use record
@@ -138,7 +138,7 @@ package STM32.DMA2D is
    subtype Background_Color_Mode is DMA2D_Color_Mode;
    subtype Output_Color_Mode is DMA2D_Color_Mode range ARGB8888 .. ARGB4444;
 
---     function Bytes_Per_Pixel (CM : DMA2D_Color_Mode) return Positive
+--     function UInt8s_Per_Pixel (CM : DMA2D_Color_Mode) return Positive
 --     is (case CM is
 --            when ARGB8888 => 4,
 --            when RGB888 => 3,

--- a/arch/ARM/STM32/drivers/dma_stm32f769/stm32-dma.adb
+++ b/arch/ARM/STM32/drivers/dma_stm32f769/stm32-dma.adb
@@ -702,8 +702,8 @@ package body STM32.DMA is
       Stream : DMA_Stream_Selector)
       return UInt16
    is
-      ndt : constant Unsigned_16 := Current_NDT (This, Stream);
-      items : Unsigned_16;
+      ndt : constant UInt16 := Current_NDT (This, Stream);
+      items : UInt16;
    begin
       if Operating_Mode (This, Stream) = Peripheral_Flow_Control_Mode then
          items := 16#ffff# - ndt;

--- a/arch/ARM/STM32/drivers/dsi/stm32-dsi.adb
+++ b/arch/ARM/STM32/drivers/dsi/stm32-dsi.adb
@@ -68,8 +68,8 @@ package body STM32.DSI is
      (This       : in out DSI_Host;
       Channel_ID : DSI_Virtual_Channel_ID;
       Data_Type  : DSI_Pkt_Data_Type;
-      Data0      : Byte;
-      Data1      : Byte);
+      Data0      : UInt8;
+      Data1      : UInt8);
 
    ------------------------------
    -- DSI_Config_Packet_Header --
@@ -79,8 +79,8 @@ package body STM32.DSI is
      (This       : in out DSI_Host;
       Channel_ID : DSI_Virtual_Channel_ID;
       Data_Type  : DSI_Pkt_Data_Type;
-      Data0      : Byte;
-      Data1      : Byte)
+      Data0      : UInt8;
+      Data1      : UInt8)
    is
    begin
       This.Periph.DSI_GHCR :=
@@ -101,7 +101,7 @@ package body STM32.DSI is
       PLL_IN_Div               : DSI_PLL_IDF;
       PLL_OUT_Div              : DSI_PLL_ODF;
       Auto_Clock_Lane_Control  : Boolean;
-      TX_Escape_Clock_Division : Byte;
+      TX_Escape_Clock_Division : UInt8;
       --  The TX_ESC clock division. 0 or 1 stops the clock.
       Number_Of_Lanes          : DSI_Number_Of_Lanes)
    is
@@ -237,8 +237,8 @@ package body STM32.DSI is
       Vertical_FrontPorch         : UInt10;
       Vertical_Active             : UInt14;
       LP_Command_Enabled          : Boolean;
-      LP_Largest_Packet_Size      : Byte;
-      LP_VACT_Largest_Packet_Size : Byte;
+      LP_Largest_Packet_Size      : UInt8;
+      LP_VACT_Largest_Packet_Size : UInt8;
       LP_H_Front_Porch_Enable     : Boolean;
       LP_H_Back_Porch_Enable      : Boolean;
       LP_V_Active_Enable          : Boolean;
@@ -284,7 +284,7 @@ package body STM32.DSI is
          This.Periph.DSI_LCOLCR.LPE := Loosely_Packed;
       end if;
 
-      --  Set the Horizontal Synchronization Active (HSA) in lane byte clock
+      --  Set the Horizontal Synchronization Active (HSA) in lane UInt8 clock
       --  cycles
       This.Periph.DSI_VHSACR.HSA := HSync_Active_Duration;
       --  Set the Horizontal Back Porch
@@ -500,8 +500,8 @@ package body STM32.DSI is
      (This       : in out DSI_Host;
       Channel_ID : DSI_Virtual_Channel_ID;
       Mode       : DSI_Short_Write_Packet_Data_Type;
-      Param1     : Byte;
-      Param2     : Byte)
+      Param1     : UInt8;
+      Param2     : UInt8)
    is
       Start : Time;
    begin
@@ -528,7 +528,7 @@ package body STM32.DSI is
      (This       : in out DSI_Host;
       Channel_Id : DSI_Virtual_Channel_ID;
       Mode       : DSI_Long_Write_Packet_Data_Type;
-      Param1     : Byte;
+      Param1     : UInt8;
       Parameters : DSI_Data)
    is
       Start : Time;
@@ -567,7 +567,7 @@ package body STM32.DSI is
       Val1 := UInt32 (Parameters'Length + 1) and 16#FF#;
       Val2 := Shift_Right (UInt32 (Parameters'Length + 1) and 16#FF00#, 8);
       This.DSI_Config_Packet_Header
-        (Channel_Id, Mode, Byte (Val1), Byte (Val2));
+        (Channel_Id, Mode, UInt8 (Val1), UInt8 (Val2));
    end DSI_Long_Write;
 
 end STM32.DSI;

--- a/arch/ARM/STM32/drivers/dsi/stm32-dsi.ads
+++ b/arch/ARM/STM32/drivers/dsi/stm32-dsi.ads
@@ -119,7 +119,7 @@ package STM32.DSI is
       PLL_IN_Div               : DSI_PLL_IDF;
       PLL_OUT_Div              : DSI_PLL_ODF;
       Auto_Clock_Lane_Control  : Boolean;
-      TX_Escape_Clock_Division : Byte;
+      TX_Escape_Clock_Division : UInt8;
       --  The TX_ESC clock division. 0 or 1 stops the clock.
       Number_Of_Lanes          : DSI_Number_Of_Lanes);
 
@@ -145,8 +145,8 @@ package STM32.DSI is
       Vertical_FrontPorch         : UInt10;
       Vertical_Active             : UInt14;
       LP_Command_Enabled          : Boolean;
-      LP_Largest_Packet_Size      : Byte;
-      LP_VACT_Largest_Packet_Size : Byte;
+      LP_Largest_Packet_Size      : UInt8;
+      LP_VACT_Largest_Packet_Size : UInt8;
       LP_H_Front_Porch_Enable     : Boolean;
       LP_H_Back_Porch_Enable      : Boolean;
       LP_V_Active_Enable          : Boolean;
@@ -200,15 +200,15 @@ package STM32.DSI is
      (This       : in out DSI_Host;
       Channel_ID : HAL.DSI.DSI_Virtual_Channel_ID;
       Mode       : HAL.DSI.DSI_Short_Write_Packet_Data_Type;
-      Param1     : Byte;
-      Param2     : Byte);
+      Param1     : UInt8;
+      Param2     : UInt8);
 
    overriding
    procedure DSI_Long_Write
      (This       : in out DSI_Host;
       Channel_Id : HAL.DSI.DSI_Virtual_Channel_ID;
       Mode       : HAL.DSI.DSI_Long_Write_Packet_Data_Type;
-      Param1     : Byte;
+      Param1     : UInt8;
       Parameters : HAL.DSI.DSI_Data);
 private
    type DSI_Host (Periph : not null access SVD_DSI.DSI_Peripheral) is

--- a/arch/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
+++ b/arch/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
@@ -51,7 +51,7 @@ package body STM32.I2C is
    type I2C_Status_Flag is
      (Start_Bit,
       Address_Sent,
-      Byte_Transfer_Finished,
+      UInt8_Transfer_Finished,
       Address_Sent_10bit,
       Stop_Detection,
       Rx_Data_Register_Not_Empty,
@@ -242,7 +242,7 @@ package body STM32.I2C is
             return This.Periph.SR1.SB;
          when Address_Sent =>
             return This.Periph.SR1.ADDR;
-         when Byte_Transfer_Finished =>
+         when UInt8_Transfer_Finished =>
             return This.Periph.SR1.BTF;
          when Address_Sent_10bit =>
             return This.Periph.SR1.ADD10;
@@ -416,13 +416,13 @@ package body STM32.I2C is
       end if;
 
       if This.Config.Addressing_Mode = Addressing_Mode_7bit then
-         This.Periph.DR.DR := Byte (Addr) and not 2#1#;
+         This.Periph.DR.DR := UInt8 (Addr) and not 2#1#;
       else
          declare
-            MSB : constant Byte :=
-                    Byte (Shift_Right (UInt16 (Addr) and 16#300#, 7));
-            LSB : constant Byte :=
-                    Byte (Addr and 16#FF#);
+            MSB : constant UInt8 :=
+                    UInt8 (Shift_Right (UInt16 (Addr) and 16#300#, 7));
+            LSB : constant UInt8 :=
+                    UInt8 (Addr and 16#FF#);
          begin
             --  We need to send 2#1111_MSB0# when MSB are the 3 most
             --  significant bits of the address
@@ -462,13 +462,13 @@ package body STM32.I2C is
       end if;
 
       if This.Config.Addressing_Mode = Addressing_Mode_7bit then
-         This.Periph.DR.DR := Byte (Addr) or 2#1#;
+         This.Periph.DR.DR := UInt8 (Addr) or 2#1#;
       else
          declare
-            MSB : constant Byte :=
-                    Byte (Shift_Right (UInt16 (Addr) and 16#300#, 7));
-            LSB : constant Byte :=
-                    Byte (Addr and 16#FF#);
+            MSB : constant UInt8 :=
+                    UInt8 (Shift_Right (UInt16 (Addr) and 16#300#, 7));
+            LSB : constant UInt8 :=
+                    UInt8 (Addr and 16#FF#);
          begin
             --  We need to write the address bit. So let's start with a
             --  write header
@@ -531,7 +531,7 @@ package body STM32.I2C is
       end if;
 
       --  Send slave address
-      This.Periph.DR.DR := Byte (Addr) and not 2#1#;
+      This.Periph.DR.DR := UInt8 (Addr) and not 2#1#;
       Wait_Master_Flag (This, Address_Sent, Timeout, Status);
 
       if Status /= HAL.I2C.Ok then
@@ -549,9 +549,9 @@ package body STM32.I2C is
 
       case Mem_Addr_Size is
          when HAL.I2C.Memory_Size_8b =>
-            This.Periph.DR.DR := Byte (Mem_Addr);
+            This.Periph.DR.DR := UInt8 (Mem_Addr);
          when HAL.I2C.Memory_Size_16b =>
-            This.Periph.DR.DR := Byte (Shift_Right (Mem_Addr, 8));
+            This.Periph.DR.DR := UInt8 (Shift_Right (Mem_Addr, 8));
 
             Wait_Flag (This, Tx_Data_Register_Empty, False, Timeout, Status);
 
@@ -559,7 +559,7 @@ package body STM32.I2C is
                return;
             end if;
 
-            This.Periph.DR.DR := Byte (Mem_Addr and 16#FF#);
+            This.Periph.DR.DR := UInt8 (Mem_Addr and 16#FF#);
       end case;
    end Mem_Request_Write;
 
@@ -586,7 +586,7 @@ package body STM32.I2C is
       end if;
 
       --  Send slave address in write mode
-      This.Periph.DR.DR := Byte (Addr) and not 16#1#;
+      This.Periph.DR.DR := UInt8 (Addr) and not 16#1#;
 
       Wait_Master_Flag (This, Address_Sent, Timeout, Status);
 
@@ -605,9 +605,9 @@ package body STM32.I2C is
 
       case Mem_Addr_Size is
          when HAL.I2C.Memory_Size_8b =>
-            This.Periph.DR.DR := Byte (Mem_Addr);
+            This.Periph.DR.DR := UInt8 (Mem_Addr);
          when HAL.I2C.Memory_Size_16b =>
-            This.Periph.DR.DR := Byte (Shift_Right (Mem_Addr, 8));
+            This.Periph.DR.DR := UInt8 (Shift_Right (Mem_Addr, 8));
 
             Wait_Flag (This, Tx_Data_Register_Empty, False, Timeout, Status);
 
@@ -615,7 +615,7 @@ package body STM32.I2C is
                return;
             end if;
 
-            This.Periph.DR.DR := Byte (Mem_Addr and 16#FF#);
+            This.Periph.DR.DR := UInt8 (Mem_Addr and 16#FF#);
       end case;
 
       --  We now need to reset and send the slave address in read mode
@@ -628,7 +628,7 @@ package body STM32.I2C is
       end if;
 
       --  Send slave address in read mode
-      This.Periph.DR.DR := Byte (Addr) or 16#1#;
+      This.Periph.DR.DR := UInt8 (Addr) or 16#1#;
 
       Wait_Master_Flag (This, Address_Sent, Timeout, Status);
    end Mem_Request_Read;
@@ -692,7 +692,7 @@ package body STM32.I2C is
          Idx := Idx + 1;
 
          if Idx <= Data'Last then
-            Wait_Flag (This, Byte_Transfer_Finished, True, Timeout, Status);
+            Wait_Flag (This, UInt8_Transfer_Finished, True, Timeout, Status);
 
             if Status = HAL.I2C.Ok then
                This.Periph.DR.DR := Data (Idx);
@@ -776,7 +776,7 @@ package body STM32.I2C is
 
       while Idx <= Data'Last loop
          if Idx = Data'Last then
-            --  One byte to read
+            --  One UInt8 to read
             Wait_Flag
               (This,
                Rx_Data_Register_Not_Empty,
@@ -791,11 +791,11 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
          elsif Idx + 1 = Data'Last then
-            --  Two bytes to read
+            --  Two UInt8s to read
             This.Periph.CR1.ACK := False;
 
             Wait_Flag (This,
-                       Byte_Transfer_Finished,
+                       UInt8_Transfer_Finished,
                        False,
                        Timeout,
                        Status);
@@ -812,9 +812,9 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
          elsif Idx + 2 = Data'Last then
-            --  Three bytes to read
+            --  Three UInt8s to read
             Wait_Flag (This,
-                       Byte_Transfer_Finished,
+                       UInt8_Transfer_Finished,
                        False,
                        Timeout,
                        Status);
@@ -829,7 +829,7 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
             Wait_Flag (This,
-                       Byte_Transfer_Finished,
+                       UInt8_Transfer_Finished,
                        False,
                        Timeout,
                        Status);
@@ -846,7 +846,7 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
          else
-            --  One byte to read
+            --  One UInt8 to read
             Wait_Flag
               (This,
                Rx_Data_Register_Not_Empty,
@@ -861,7 +861,7 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
             Wait_Flag (This,
-                       Byte_Transfer_Finished,
+                       UInt8_Transfer_Finished,
                        False,
                        Timeout,
                        Status);
@@ -941,7 +941,7 @@ package body STM32.I2C is
 
          if Idx <= Data'Last then
             Wait_Flag (This,
-                       Byte_Transfer_Finished,
+                       UInt8_Transfer_Finished,
                        True,
                        Timeout,
                        Status);
@@ -1035,7 +1035,7 @@ package body STM32.I2C is
 
       while Idx <= Data'Last loop
          if Idx = Data'Last then
-            --  One byte to read
+            --  One UInt8 to read
             Wait_Flag
               (This, Rx_Data_Register_Not_Empty, False, Timeout, Status);
             if Status /= HAL.I2C.Ok then
@@ -1046,10 +1046,10 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
          elsif Idx + 1 = Data'Last then
-            --  Two bytes to read
+            --  Two UInt8s to read
             This.Periph.CR1.ACK := False;
 
-            Wait_Flag (This, Byte_Transfer_Finished, False, Timeout, Status);
+            Wait_Flag (This, UInt8_Transfer_Finished, False, Timeout, Status);
             if Status /= HAL.I2C.Ok then
                return;
             end if;
@@ -1063,8 +1063,8 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
          elsif Idx + 2 = Data'Last then
-            --  Three bytes to read
-            Wait_Flag (This, Byte_Transfer_Finished, False, Timeout, Status);
+            --  Three UInt8s to read
+            Wait_Flag (This, UInt8_Transfer_Finished, False, Timeout, Status);
             if Status /= HAL.I2C.Ok then
                return;
             end if;
@@ -1075,7 +1075,7 @@ package body STM32.I2C is
             Data (Idx) := This.Periph.DR.DR;
             Idx := Idx + 1;
 
-            Wait_Flag (This, Byte_Transfer_Finished, False, Timeout, Status);
+            Wait_Flag (This, UInt8_Transfer_Finished, False, Timeout, Status);
             if Status /= HAL.I2C.Ok then
                return;
             end if;
@@ -1089,7 +1089,7 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
          else
-            --  One byte to read
+            --  One UInt8 to read
             Wait_Flag
               (This, Rx_Data_Register_Not_Empty, False, Timeout, Status);
             if Status /= HAL.I2C.Ok then
@@ -1099,7 +1099,7 @@ package body STM32.I2C is
             Data (Idx) := This.Periph.DR.DR;
             Idx := Idx + 1;
 
-            Wait_Flag (This, Byte_Transfer_Finished, False, Timeout, Status);
+            Wait_Flag (This, UInt8_Transfer_Finished, False, Timeout, Status);
 
             if Status = HAL.I2C.Ok then
                Data (Idx) := This.Periph.DR.DR;

--- a/arch/ARM/STM32/drivers/i2c_stm32f7/stm32-i2c.adb
+++ b/arch/ARM/STM32/drivers/i2c_stm32f7/stm32-i2c.adb
@@ -54,7 +54,7 @@ package body STM32.I2C is
    procedure Config_Transfer
      (Port    : in out I2C_Port;
       Addr    : I2C_Address;
-      Size    : Byte;
+      Size    : UInt8;
       Mode    : I2C_Transfer_Mode;
       Request : I2C_Request);
 
@@ -171,7 +171,7 @@ package body STM32.I2C is
    procedure Config_Transfer
      (Port    : in out I2C_Port;
       Addr    : I2C_Address;
-      Size    : Byte;
+      Size    : UInt8;
       Mode    : I2C_Transfer_Mode;
       Request : I2C_Request)
    is
@@ -436,7 +436,7 @@ package body STM32.I2C is
                Size_Temp := 255;
             else
                Config_Transfer
-                 (This, Addr, Byte (Data'Length - Transmitted), Autoend_Mode,
+                 (This, Addr, UInt8 (Data'Length - Transmitted), Autoend_Mode,
                   No_Start_Stop);
                Size_Temp := Data'Length - Transmitted;
             end if;
@@ -521,7 +521,7 @@ package body STM32.I2C is
                Size_Temp := 255;
             else
                Config_Transfer
-                 (This, Addr, Byte (Data'Length - Transmitted), Autoend_Mode,
+                 (This, Addr, UInt8 (Data'Length - Transmitted), Autoend_Mode,
                   No_Start_Stop);
                Size_Temp := Data'Length - Transmitted;
             end if;
@@ -598,12 +598,12 @@ package body STM32.I2C is
 
       case Mem_Addr_Size is
          when Memory_Size_8b =>
-            This.Periph.TXDR.TXDATA := Byte (Mem_Addr);
+            This.Periph.TXDR.TXDATA := UInt8 (Mem_Addr);
 
          when Memory_Size_16b =>
             declare
-               MSB : constant Byte := Byte (Shift_Right (Mem_Addr, 8));
-               LSB : constant Byte := Byte (Mem_Addr and 16#FF#);
+               MSB : constant UInt8 := UInt8 (Shift_Right (Mem_Addr, 8));
+               LSB : constant UInt8 := UInt8 (Mem_Addr and 16#FF#);
             begin
                This.Periph.TXDR.TXDATA := MSB;
 
@@ -661,7 +661,7 @@ package body STM32.I2C is
             else
                Config_Transfer
                  (This, Addr,
-                  Byte (Data'Length - Transmitted),
+                  UInt8 (Data'Length - Transmitted),
                   Autoend_Mode,
                   No_Start_Stop);
                Size_Temp := Data'Length - Transmitted;
@@ -738,12 +738,12 @@ package body STM32.I2C is
 
       case Mem_Addr_Size is
          when Memory_Size_8b =>
-            This.Periph.TXDR.TXDATA := Byte (Mem_Addr);
+            This.Periph.TXDR.TXDATA := UInt8 (Mem_Addr);
 
          when Memory_Size_16b =>
             declare
-               MSB : constant Byte := Byte (Shift_Right (Mem_Addr, 8));
-               LSB : constant Byte := Byte (Mem_Addr and 16#FF#);
+               MSB : constant UInt8 := UInt8 (Shift_Right (Mem_Addr, 8));
+               LSB : constant UInt8 := UInt8 (Mem_Addr and 16#FF#);
             begin
                This.Periph.TXDR.TXDATA := MSB;
 
@@ -798,7 +798,7 @@ package body STM32.I2C is
             else
                Config_Transfer
                  (This, Addr,
-                  Byte (Data'Length - Transmitted),
+                  UInt8 (Data'Length - Transmitted),
                   Autoend_Mode,
                   No_Start_Stop);
                Size_Temp := Data'Length - Transmitted;

--- a/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.adb
+++ b/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.adb
@@ -372,7 +372,7 @@ package body STM32.LTDC is
       Buffer         : System.Address;
       X, Y           : Natural;
       W, H           : Positive;
-      Constant_Alpha : Byte := 255;
+      Constant_Alpha : UInt8 := 255;
       BF             : Blending_Factor := BF_Pixel_Alpha_X_Constant_Alpha)
    is
       L        : constant Layer_Access := Get_Layer (Layer);
@@ -407,8 +407,8 @@ package body STM32.LTDC is
             L.LBFCR.BF2 := BF2_Pixel_Alpha;
       end case;
 
-      CFBL.CFBLL := UInt13 (W * Bytes_Per_Pixel (Config)) + 3;
-      CFBL.CFBP := UInt13 (W * Bytes_Per_Pixel (Config));
+      CFBL.CFBLL := UInt13 (W * UInt8s_Per_Pixel (Config)) + 3;
+      CFBL.CFBP := UInt13 (W * UInt8s_Per_Pixel (Config));
       L.LCFBLR := CFBL;
 
       L.LCFBLNR.CFBLNBR := UInt11 (H);
@@ -455,7 +455,7 @@ package body STM32.LTDC is
    -- Set_Background --
    --------------------
 
-   procedure Set_Background (R, G, B : Byte) is
+   procedure Set_Background (R, G, B : UInt8) is
       RShift : constant UInt32 := Shift_Left (UInt32 (R), 16);
       GShift : constant UInt32 := Shift_Left (UInt32 (G), 8);
    begin

--- a/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.ads
+++ b/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.ads
@@ -60,7 +60,7 @@ package STM32.LTDC is
       Pixel_Fmt_AL88) --  8-bit Alpha, 8-bit Luniunance
      with Size => 3;
 
-   function Bytes_Per_Pixel (Fmt : Pixel_Format) return Natural
+   function UInt8s_Per_Pixel (Fmt : Pixel_Format) return Natural
      with Inline;
 
    subtype Frame_Buffer_Access is System.Address;
@@ -85,7 +85,7 @@ package STM32.LTDC is
    procedure Start;
    procedure Stop;
 
-   procedure Set_Background (R, G, B : Byte);
+   procedure Set_Background (R, G, B : UInt8);
 
    procedure Layer_Init
      (Layer          : LCD_Layer;
@@ -93,7 +93,7 @@ package STM32.LTDC is
       Buffer         : System.Address;
       X, Y           : Natural;
       W, H           : Positive;
-      Constant_Alpha : Byte := 255;
+      Constant_Alpha : UInt8 := 255;
       BF             : Blending_Factor := BF_Pixel_Alpha_X_Constant_Alpha);
 
    procedure Set_Layer_State
@@ -111,7 +111,7 @@ package STM32.LTDC is
 
 private
 
-   function Bytes_Per_Pixel (Fmt : Pixel_Format) return Natural
+   function UInt8s_Per_Pixel (Fmt : Pixel_Format) return Natural
    is (case Fmt is
           when Pixel_Fmt_ARGB8888 => 4,
           when Pixel_Fmt_RGB888 => 3,

--- a/arch/ARM/STM32/drivers/sai/stm32-sai.adb
+++ b/arch/ARM/STM32/drivers/sai/stm32-sai.adb
@@ -314,7 +314,7 @@ package body STM32.SAI is
    procedure Configure_Block_Frame
      (This       : SAI_Controller;
       Block        : SAI_Block;
-      Frame_Length : Byte;
+      Frame_Length : UInt8;
       Frame_Active : UInt7;
       Frame_Sync   : SAI_Frame_Synchronization;
       FS_Polarity  : SAI_Frame_Sync_Polarity;

--- a/arch/ARM/STM32/drivers/sai/stm32-sai.ads
+++ b/arch/ARM/STM32/drivers/sai/stm32-sai.ads
@@ -315,7 +315,7 @@ package STM32.SAI is
    procedure Configure_Block_Frame
      (This            : SAI_Controller;
       Block           : SAI_Block;
-      Frame_Length    : Byte;
+      Frame_Length    : UInt8;
       Frame_Active    : UInt7;
       Frame_Sync      : SAI_Frame_Synchronization;
       FS_Polarity     : SAI_Frame_Sync_Polarity;

--- a/arch/ARM/STM32/drivers/sd/sdio/stm32-sdmmc.ads
+++ b/arch/ARM/STM32/drivers/sd/sdio/stm32-sdmmc.ads
@@ -88,43 +88,43 @@ package STM32.SDMMC is
       High_Capacity_MMC_Card);
 
    type Card_Specific_Data_Register is record
-      CSD_Structure                    : Byte;
-      System_Specification_Version     : Byte;
-      Reserved                         : Byte;
-      Data_Read_Access_Time_1          : Byte;
-      Data_Read_Access_Time_2          : Byte; --  In CLK Cycles
-      Max_Bus_Clock_Frequency          : Byte;
+      CSD_Structure                    : UInt8;
+      System_Specification_Version     : UInt8;
+      Reserved                         : UInt8;
+      Data_Read_Access_Time_1          : UInt8;
+      Data_Read_Access_Time_2          : UInt8; --  In CLK Cycles
+      Max_Bus_Clock_Frequency          : UInt8;
       Card_Command_Class               : UInt16;
-      Max_Read_Data_Block_Length       : Byte; -- ld (blocksize in bytes)
+      Max_Read_Data_Block_Length       : UInt8; -- ld (blocksize in bytes)
       Partial_Block_For_Read_Allowed   : Boolean;
       Write_Block_Missalignment        : Boolean;
       Read_Block_Missalignment         : Boolean;
       DSR_Implemented                  : Boolean;
-      Reserved_2                       : Byte;
+      Reserved_2                       : UInt8;
       Device_Size                      : UInt32;
-      Max_Read_Current_At_VDD_Min      : Byte;
-      Max_Read_Current_At_VDD_Max      : Byte;
-      Max_Write_Current_At_VDD_Min     : Byte;
-      Max_Write_Current_At_VDD_Max     : Byte;
-      Device_Size_Multiplier           : Byte;
-      Erase_Group_Size                 : Byte;
-      Erase_Group_Size_Multiplier      : Byte;
-      Write_Protect_Group_Size         : Byte;
+      Max_Read_Current_At_VDD_Min      : UInt8;
+      Max_Read_Current_At_VDD_Max      : UInt8;
+      Max_Write_Current_At_VDD_Min     : UInt8;
+      Max_Write_Current_At_VDD_Max     : UInt8;
+      Device_Size_Multiplier           : UInt8;
+      Erase_Group_Size                 : UInt8;
+      Erase_Group_Size_Multiplier      : UInt8;
+      Write_Protect_Group_Size         : UInt8;
       Write_Protect_Group_Enable       : Boolean;
-      Manufacturer_Default_ECC         : Byte;
-      Write_Speed_Factor               : Byte;
-      Max_Write_Data_Block_Length      : Byte; -- =Max_Read_Data_Block_Length
+      Manufacturer_Default_ECC         : UInt8;
+      Write_Speed_Factor               : UInt8;
+      Max_Write_Data_Block_Length      : UInt8; -- =Max_Read_Data_Block_Length
       Partial_Blocks_For_Write_Allowed : Boolean;
-      Reserved_3                       : Byte;
+      Reserved_3                       : UInt8;
       Content_Protection_Application   : Boolean;
       File_Format_Group                : Boolean;
       Copy_Flag                        : Boolean;
       Permanent_Write_Protection       : Boolean;
       Temporary_Write_Protection       : Boolean;
-      File_Format                      : Byte;
-      ECC_Code                         : Byte;
-      CSD_CRC                          : Byte;
-      Reserved_4                       : Byte; --  Always 1
+      File_Format                      : UInt8;
+      ECC_Code                         : UInt8;
+      CSD_CRC                          : UInt8;
+      Reserved_4                       : UInt8; --  Always 1
    end record;
 
    type Card_Revision is record
@@ -153,15 +153,15 @@ package STM32.SDMMC is
    end record;
 
    type Card_Identification_Data_Register is record
-      Manufacturer_ID       : Byte;
+      Manufacturer_ID       : UInt8;
       OEM_Application_ID    : String (1 .. 2);
       Product_Name          : String (1 .. 5);
       Product_Revision      : Card_Revision;
       Product_Serial_Number : UInt32;
-      Reserved_1            : Byte;
+      Reserved_1            : UInt8;
       Manufacturing_Date    : Manufacturing_Date_Type;
-      CID_CRC               : Byte;
-      Reserved_2            : Byte; --  Always 1
+      CID_CRC               : UInt8;
+      Reserved_2            : UInt8; --  Always 1
    end record;
 
    type Card_Information is record
@@ -203,7 +203,7 @@ package STM32.SDMMC is
      (This      : in out SDMMC_Controller;
       Wide_Mode : Wide_Bus_Mode) return SD_Error;
 
-   type SD_Data is array (Unsigned_16 range <>) of Byte
+   type SD_Data is array (Unsigned_16 range <>) of UInt8
    with Pack;
 
    function Read_Blocks
@@ -291,7 +291,7 @@ package STM32.SDMMC is
 
 private
 
-   type SDMMC_Command is new Byte;
+   type SDMMC_Command is new UInt8;
 
    --  Resets the SD memory card
    Go_Idle_State        : constant SDMMC_Command := 0;

--- a/arch/ARM/STM32/drivers/sd/sdmmc/stm32-sdmmc.ads
+++ b/arch/ARM/STM32/drivers/sd/sdmmc/stm32-sdmmc.ads
@@ -87,43 +87,43 @@ package STM32.SDMMC is
       High_Capacity_MMC_Card);
 
    type Card_Specific_Data_Register is record
-      CSD_Structure                    : Byte;
-      System_Specification_Version     : Byte;
-      Reserved                         : Byte;
-      Data_Read_Access_Time_1          : Byte;
-      Data_Read_Access_Time_2          : Byte; --  In CLK Cycles
-      Max_Bus_Clock_Frequency          : Byte;
+      CSD_Structure                    : UInt8;
+      System_Specification_Version     : UInt8;
+      Reserved                         : UInt8;
+      Data_Read_Access_Time_1          : UInt8;
+      Data_Read_Access_Time_2          : UInt8; --  In CLK Cycles
+      Max_Bus_Clock_Frequency          : UInt8;
       Card_Command_Class               : UInt16;
-      Max_Read_Data_Block_Length       : Byte;
+      Max_Read_Data_Block_Length       : UInt8;
       Partial_Block_For_Read_Allowed   : Boolean;
       Write_Block_Missalignment        : Boolean;
       Read_Block_Missalignment         : Boolean;
       DSR_Implemented                  : Boolean;
-      Reserved_2                       : Byte;
+      Reserved_2                       : UInt8;
       Device_Size                      : UInt32;
-      Max_Read_Current_At_VDD_Min      : Byte;
-      Max_Read_Current_At_VDD_Max      : Byte;
-      Max_Write_Current_At_VDD_Min     : Byte;
-      Max_Write_Current_At_VDD_Max     : Byte;
-      Device_Size_Multiplier           : Byte;
-      Erase_Group_Size                 : Byte;
-      Erase_Group_Size_Multiplier      : Byte;
-      Write_Protect_Group_Size         : Byte;
+      Max_Read_Current_At_VDD_Min      : UInt8;
+      Max_Read_Current_At_VDD_Max      : UInt8;
+      Max_Write_Current_At_VDD_Min     : UInt8;
+      Max_Write_Current_At_VDD_Max     : UInt8;
+      Device_Size_Multiplier           : UInt8;
+      Erase_Group_Size                 : UInt8;
+      Erase_Group_Size_Multiplier      : UInt8;
+      Write_Protect_Group_Size         : UInt8;
       Write_Protect_Group_Enable       : Boolean;
-      Manufacturer_Default_ECC         : Byte;
-      Write_Speed_Factor               : Byte;
-      Max_Write_Data_Block_Length      : Byte;
+      Manufacturer_Default_ECC         : UInt8;
+      Write_Speed_Factor               : UInt8;
+      Max_Write_Data_Block_Length      : UInt8;
       Partial_Blocks_For_Write_Allowed : Boolean;
-      Reserved_3                       : Byte;
+      Reserved_3                       : UInt8;
       Content_Protection_Application   : Boolean;
       File_Format_Group                : Boolean;
       Copy_Flag                        : Boolean;
       Permanent_Write_Protection       : Boolean;
       Temporary_Write_Protection       : Boolean;
-      File_Format                      : Byte;
-      ECC_Code                         : Byte;
-      CSD_CRC                          : Byte;
-      Reserved_4                       : Byte; --  Always 1
+      File_Format                      : UInt8;
+      ECC_Code                         : UInt8;
+      CSD_CRC                          : UInt8;
+      Reserved_4                       : UInt8; --  Always 1
    end record;
 
    type Card_Revision is record
@@ -152,15 +152,15 @@ package STM32.SDMMC is
    end record;
 
    type Card_Identification_Data_Register is record
-      Manufacturer_ID       : Byte;
+      Manufacturer_ID       : UInt8;
       OEM_Application_ID    : String (1 .. 2);
       Product_Name          : String (1 .. 5);
       Product_Revision      : Card_Revision;
       Product_Serial_Number : UInt32;
-      Reserved_1            : Byte;
+      Reserved_1            : UInt8;
       Manufacturing_Date    : Manufacturing_Date_Type;
-      CID_CRC               : Byte;
-      Reserved_2            : Byte; --  Always 1
+      CID_CRC               : UInt8;
+      Reserved_2            : UInt8; --  Always 1
    end record;
 
    type Card_Information is record
@@ -202,7 +202,7 @@ package STM32.SDMMC is
      (This       : in out SDMMC_Controller;
       Wide_Mode  : Wide_Bus_Mode) return SD_Error;
 
-   type SD_Data is array (Unsigned_16 range <>) of Byte
+   type SD_Data is array (Unsigned_16 range <>) of UInt8
    with Pack;
 
    function Read_Blocks
@@ -287,7 +287,7 @@ package STM32.SDMMC is
 
 private
 
-   type SDMMC_Command is new Byte;
+   type SDMMC_Command is new UInt8;
 
    --  Resets the SD memory card
    Go_Idle_State        : constant SDMMC_Command := 0;

--- a/arch/ARM/STM32/drivers/sd/stm32-sdmmc.adb
+++ b/arch/ARM/STM32/drivers/sd/stm32-sdmmc.adb
@@ -875,38 +875,38 @@ package body STM32.SDMMC is
      (Controller : in out SDMMC_Controller;
       Info       :    out Card_Information) return SD_Error
    is
-      Tmp : Byte;
+      Tmp : UInt8;
    begin
       Info.Card_Type := Controller.Card_Type;
       Info.RCA       := UInt16 (Shift_Right (Controller.RCA, 16));
 
       --  Analysis of CSD Byte 0
-      Tmp := Byte (Shift_Right (Controller.CSD (0) and 16#FF00_0000#, 24));
+      Tmp := UInt8 (Shift_Right (Controller.CSD (0) and 16#FF00_0000#, 24));
       Info.SD_CSD.CSD_Structure := Shift_Right (Tmp and 16#C0#, 6);
       Info.SD_CSD.System_Specification_Version :=
         Shift_Right (Tmp and 16#3C#, 2);
       Info.SD_CSD.Reserved := Tmp and 16#03#;
 
       --  Byte 1
-      Tmp := Byte (Shift_Right (Controller.CSD (0) and 16#00FF_0000#, 16));
+      Tmp := UInt8 (Shift_Right (Controller.CSD (0) and 16#00FF_0000#, 16));
       Info.SD_CSD.Data_Read_Access_Time_1 := Tmp;
 
       --  Byte 2
-      Tmp := Byte (Shift_Right (Controller.CSD (0) and 16#0000_FF00#, 8));
+      Tmp := UInt8 (Shift_Right (Controller.CSD (0) and 16#0000_FF00#, 8));
       Info.SD_CSD.Data_Read_Access_Time_2 := Tmp;
 
       --  Byte 3
-      Tmp := Byte (Controller.CSD (0) and 16#0000_00FF#);
+      Tmp := UInt8 (Controller.CSD (0) and 16#0000_00FF#);
       Info.SD_CSD.Max_Bus_Clock_Frequency := Tmp;
 
       --  Byte 4 & 5
       Info.SD_CSD.Card_Command_Class :=
         UInt16 (Shift_Right (Controller.CSD (1) and 16#FFF0_0000#, 20));
       Info.SD_CSD.Max_Read_Data_Block_Length :=
-        Byte (Shift_Right (Controller.CSD (1) and 16#000F_0000#, 16));
+        UInt8 (Shift_Right (Controller.CSD (1) and 16#000F_0000#, 16));
 
       --  Byte 6
-      Tmp := Byte (Shift_Right (Controller.CSD (1) and 16#0000_FF00#, 8));
+      Tmp := UInt8 (Shift_Right (Controller.CSD (1) and 16#0000_FF00#, 8));
       Info.SD_CSD.Partial_Block_For_Read_Allowed := (Tmp and 16#80#) /= 0;
       Info.SD_CSD.Write_Block_Missalignment := (Tmp and 16#40#) /= 0;
       Info.SD_CSD.Read_Block_Missalignment := (Tmp and 16#20#) /= 0;
@@ -919,12 +919,12 @@ package body STM32.SDMMC is
          Info.SD_CSD.Device_Size := Shift_Left (UInt32 (Tmp) and 16#03#, 10);
 
          --  Byte 7
-         Tmp := Byte (Controller.CSD (1) and 16#0000_00FF#);
+         Tmp := UInt8 (Controller.CSD (1) and 16#0000_00FF#);
          Info.SD_CSD.Device_Size := Info.SD_CSD.Device_Size or
            Shift_Left (UInt32 (Tmp), 2);
 
          --  Byte 8
-         Tmp := Byte (Shift_Right (Controller.CSD (2) and 16#FF00_0000#, 24));
+         Tmp := UInt8 (Shift_Right (Controller.CSD (2) and 16#FF00_0000#, 24));
          Info.SD_CSD.Device_Size := Info.SD_CSD.Device_Size or
            Shift_Right (UInt32 (Tmp and 16#C0#), 6);
          Info.SD_CSD.Max_Read_Current_At_VDD_Min :=
@@ -933,7 +933,7 @@ package body STM32.SDMMC is
            Tmp and 16#07#;
 
          --  Byte 9
-         Tmp := Byte (Shift_Right (Controller.CSD (2) and 16#00FF_0000#, 16));
+         Tmp := UInt8 (Shift_Right (Controller.CSD (2) and 16#00FF_0000#, 16));
          Info.SD_CSD.Max_Write_Current_At_VDD_Min :=
            Shift_Right (Tmp and 16#E0#, 5);
          Info.SD_CSD.Max_Write_Current_At_VDD_Max :=
@@ -942,7 +942,7 @@ package body STM32.SDMMC is
            Shift_Left (Tmp and 16#03#, 2);
 
          --  Byte 10
-         Tmp := Byte (Shift_Right (Controller.CSD (2) and 16#0000_FF00#, 8));
+         Tmp := UInt8 (Shift_Right (Controller.CSD (2) and 16#0000_FF00#, 8));
          Info.SD_CSD.Device_Size_Multiplier :=
            Info.SD_CSD.Device_Size_Multiplier or
            Shift_Right (Tmp and 16#80#, 7);
@@ -956,7 +956,7 @@ package body STM32.SDMMC is
 
       elsif Controller.Card_Type = High_Capacity_SD_Card then
          --  Byte 7
-         Tmp := Byte (Controller.CSD (1) and 16#0000_00FF#);
+         Tmp := UInt8 (Controller.CSD (1) and 16#0000_00FF#);
          Info.SD_CSD.Device_Size := Shift_Left (UInt32 (Tmp), 16);
 
          --  Byte 8 & 9
@@ -968,7 +968,7 @@ package body STM32.SDMMC is
          Info.Card_Block_Size := 512;
 
          --  Byte 10
-         Tmp := Byte (Shift_Right (Controller.CSD (2) and 16#0000_FF00#, 8));
+         Tmp := UInt8 (Shift_Right (Controller.CSD (2) and 16#0000_FF00#, 8));
       else
          return Unsupported_Card;
       end if;
@@ -978,14 +978,14 @@ package body STM32.SDMMC is
         Shift_Left (Tmp and 16#3F#, 1);
 
       --  Byte 11
-      Tmp := Byte (Controller.CSD (2) and 16#0000_00FF#);
+      Tmp := UInt8 (Controller.CSD (2) and 16#0000_00FF#);
       Info.SD_CSD.Erase_Group_Size_Multiplier :=
         Info.SD_CSD.Erase_Group_Size_Multiplier or
         Shift_Right (Tmp and 16#80#, 7);
       Info.SD_CSD.Write_Protect_Group_Size := Tmp and 16#7F#;
 
       --  Byte 12
-      Tmp := Byte (Shift_Right (Controller.CSD (3) and 16#FF00_0000#, 24));
+      Tmp := UInt8 (Shift_Right (Controller.CSD (3) and 16#FF00_0000#, 24));
       Info.SD_CSD.Write_Protect_Group_Enable := (Tmp and 16#80#) /= 0;
       Info.SD_CSD.Manufacturer_Default_ECC := Shift_Right (Tmp and 16#60#, 5);
       Info.SD_CSD.Write_Speed_Factor := Shift_Right (Tmp and 16#1C#, 2);
@@ -993,7 +993,7 @@ package body STM32.SDMMC is
         Shift_Left (Tmp and 16#03#, 2);
 
       --  Byte 13
-      Tmp := Byte (Shift_Right (Controller.CSD (3) and 16#00FF_0000#, 16));
+      Tmp := UInt8 (Shift_Right (Controller.CSD (3) and 16#00FF_0000#, 16));
       Info.SD_CSD.Max_Write_Data_Block_Length :=
         Info.SD_CSD.Max_Read_Data_Block_Length or
         Shift_Right (Tmp and 16#C0#, 6);
@@ -1002,7 +1002,7 @@ package body STM32.SDMMC is
       Info.SD_CSD.Content_Protection_Application := (Tmp and 16#01#) /= 0;
 
       --  Byte 14
-      Tmp := Byte (Shift_Right (Controller.CSD (3) and 16#0000_FF00#, 8));
+      Tmp := UInt8 (Shift_Right (Controller.CSD (3) and 16#0000_FF00#, 8));
       Info.SD_CSD.File_Format_Group := (Tmp and 16#80#) /= 0;
       Info.SD_CSD.Copy_Flag := (Tmp and 16#40#) /= 0;
       Info.SD_CSD.Permanent_Write_Protection := (Tmp and 16#20#) /= 0;
@@ -1011,34 +1011,34 @@ package body STM32.SDMMC is
       Info.SD_CSD.ECC_Code := Tmp and 16#03#;
 
       --  Byte 15
-      Tmp := Byte (Controller.CSD (3) and 16#0000_00FF#);
+      Tmp := UInt8 (Controller.CSD (3) and 16#0000_00FF#);
       Info.SD_CSD.CSD_CRC := Shift_Right (Tmp and 16#FE#, 1);
       Info.SD_CSD.Reserved_4 := 0;
 
       --  Byte 0
-      Tmp := Byte (Shift_Right (Controller.CID (0) and 16#FF00_0000#, 24));
+      Tmp := UInt8 (Shift_Right (Controller.CID (0) and 16#FF00_0000#, 24));
       Info.SD_CID.Manufacturer_ID := Tmp;
 
       --  Byte 1 & 2
-      Tmp := Byte (Shift_Right (Controller.CID (0) and 16#00FF_0000#, 16));
+      Tmp := UInt8 (Shift_Right (Controller.CID (0) and 16#00FF_0000#, 16));
       Info.SD_CID.OEM_Application_ID (1) := Character'Val (Tmp);
-      Tmp := Byte (Shift_Right (Controller.CID (0) and 16#0000_FF00#, 8));
+      Tmp := UInt8 (Shift_Right (Controller.CID (0) and 16#0000_FF00#, 8));
       Info.SD_CID.OEM_Application_ID (2) := Character'Val (Tmp);
 
       --  Byte 3-7
-      Tmp := Byte (Controller.CID (0) and 16#0000_00FF#);
+      Tmp := UInt8 (Controller.CID (0) and 16#0000_00FF#);
       Info.SD_CID.Product_Name (1) := Character'Val (Tmp);
-      Tmp := Byte (Shift_Right (Controller.CID (1) and 16#FF00_0000#, 24));
+      Tmp := UInt8 (Shift_Right (Controller.CID (1) and 16#FF00_0000#, 24));
       Info.SD_CID.Product_Name (2) := Character'Val (Tmp);
-      Tmp := Byte (Shift_Right (Controller.CID (1) and 16#00FF_0000#, 16));
+      Tmp := UInt8 (Shift_Right (Controller.CID (1) and 16#00FF_0000#, 16));
       Info.SD_CID.Product_Name (3) := Character'Val (Tmp);
-      Tmp := Byte (Shift_Right (Controller.CID (1) and 16#0000_FF00#, 8));
+      Tmp := UInt8 (Shift_Right (Controller.CID (1) and 16#0000_FF00#, 8));
       Info.SD_CID.Product_Name (4) := Character'Val (Tmp);
-      Tmp := Byte (Controller.CID (1) and 16#0000_00FF#);
+      Tmp := UInt8 (Controller.CID (1) and 16#0000_00FF#);
       Info.SD_CID.Product_Name (5) := Character'Val (Tmp);
 
       --  Byte 8
-      Tmp := Byte (Shift_Right (Controller.CID (2) and 16#FF00_0000#, 24));
+      Tmp := UInt8 (Shift_Right (Controller.CID (2) and 16#FF00_0000#, 24));
       Info.SD_CID.Product_Revision.Major := UInt4 (Shift_Right (Tmp, 4));
       Info.SD_CID.Product_Revision.Minor := UInt4 (Tmp and 16#0F#);
 
@@ -1056,7 +1056,7 @@ package body STM32.SDMMC is
           (2000 + Shift_Right (Controller.CID (3) and 16#000F_F000#, 12));
 
       --  Byte 15
-      Tmp := Byte (Controller.CID (3) and 16#0000_00FF#);
+      Tmp := UInt8 (Controller.CID (3) and 16#0000_00FF#);
       Info.SD_CID.CID_CRC := Shift_Right (Tmp and 16#FE#, 1);
 
       return OK;
@@ -1073,7 +1073,7 @@ package body STM32.SDMMC is
       Err  : SD_Error;
       Idx  : Natural;
       Tmp  : SD_SCR;
-      Dead : Unsigned_32 with Unreferenced;
+      Dead : UInt32 with Unreferenced;
 
    begin
       Send_Command
@@ -1605,7 +1605,7 @@ package body STM32.SDMMC is
          Stream             => Stream,
          Source             => This.Periph.FIFO'Address,
          Destination        => Data_Addr,
-         Data_Count         => Unsigned_16 (Data_Len_Words), -- because DMA is set up with words
+         Data_Count         => UInt16 (Data_Len_Words), -- because DMA is set up with words
          Enabled_Interrupts => (Transfer_Error_Interrupt    => True,
                                 FIFO_Error_Interrupt        => True,
                                 Transfer_Complete_Interrupt => True,
@@ -1744,7 +1744,7 @@ package body STM32.SDMMC is
          Stream             => Stream,
          Destination        => This.Periph.FIFO'Address,
          Source             => Data_Addr,
-         Data_Count         => Unsigned_16 (Data_Len_Words), -- DMA uses words
+         Data_Count         => UInt16 (Data_Len_Words), -- DMA uses words
          Enabled_Interrupts => (Transfer_Error_Interrupt    => True,
                                 FIFO_Error_Interrupt        => True,
                                 Transfer_Complete_Interrupt => True,

--- a/arch/ARM/STM32/drivers/stm32-dac.adb
+++ b/arch/ARM/STM32/drivers/stm32-dac.adb
@@ -122,7 +122,7 @@ package body STM32.DAC is
                           UInt12 (Value and Max_12bit_Resolution);
                   end case;
                when DAC_Resolution_8_Bits =>
-                  This.DHR8R1.DACC1DHR := Byte (Value and Max_8bit_Resolution);
+                  This.DHR8R1.DACC1DHR := UInt8 (Value and Max_8bit_Resolution);
             end case;
 
          when Channel_2 =>
@@ -137,7 +137,7 @@ package body STM32.DAC is
                           UInt12 (Value and Max_12bit_Resolution);
                   end case;
                when DAC_Resolution_8_Bits =>
-                  This.DHR8R2.DACC2DHR := Byte (Value and Max_8bit_Resolution);
+                  This.DHR8R2.DACC2DHR := UInt8 (Value and Max_8bit_Resolution);
             end case;
 
       end case;
@@ -206,9 +206,9 @@ package body STM32.DAC is
             end case;
          when DAC_Resolution_8_Bits =>
             This.DHR8RD.DACC1DHR :=
-              Byte (Channel_1_Value and Max_8bit_Resolution);
+              UInt8 (Channel_1_Value and Max_8bit_Resolution);
             This.DHR8RD.DACC2DHR :=
-              Byte (Channel_2_Value and Max_8bit_Resolution);
+              UInt8 (Channel_2_Value and Max_8bit_Resolution);
       end case;
    end Set_Dual_Output_Voltages;
 

--- a/arch/ARM/STM32/drivers/stm32-dcmi.adb
+++ b/arch/ARM/STM32/drivers/stm32-dcmi.adb
@@ -136,10 +136,10 @@ package body STM32.DCMI is
    ----------------------------------------
 
    procedure Set_Software_Synchronization_Codes
-     (Frame_Start : Byte;
-      Frame_End   : Byte;
-      Line_Start  : Byte;
-      Line_End    : Byte)
+     (Frame_Start : UInt8;
+      Frame_End   : UInt8;
+      Line_Start  : UInt8;
+      Line_End    : UInt8)
    is
    begin
       DCMI_Periph.ESCR.FSC := Frame_Start;
@@ -153,10 +153,10 @@ package body STM32.DCMI is
    ----------------------------------------
 
    procedure Set_Software_Synchronization_Masks
-     (Frame_Start : Byte;
-      Frame_End   : Byte;
-      Line_Start  : Byte;
-      Line_End    : Byte)
+     (Frame_Start : UInt8;
+      Frame_End   : UInt8;
+      Line_Start  : UInt8;
+      Line_End    : UInt8)
    is
    begin
       DCMI_Periph.ESUR.FSU := Frame_Start;

--- a/arch/ARM/STM32/drivers/stm32-dcmi.ads
+++ b/arch/ARM/STM32/drivers/stm32-dcmi.ads
@@ -78,16 +78,16 @@ package STM32.DCMI is
      with Pre => (if JPEG then not Hardware_Sync);
 
    procedure Set_Software_Synchronization_Codes
-     (Frame_Start : Byte;
-      Frame_End   : Byte;
-      Line_Start  : Byte;
-      Line_End    : Byte);
+     (Frame_Start : UInt8;
+      Frame_End   : UInt8;
+      Line_Start  : UInt8;
+      Line_End    : UInt8);
 
    procedure Set_Software_Synchronization_Masks
-     (Frame_Start : Byte;
-      Frame_End   : Byte;
-      Line_Start  : Byte;
-      Line_End    : Byte);
+     (Frame_Start : UInt8;
+      Frame_End   : UInt8;
+      Line_Start  : UInt8;
+      Line_End    : UInt8);
 
    procedure Set_Crop_Window
      (X      : UInt13;

--- a/arch/ARM/STM32/drivers/stm32-i2s.adb
+++ b/arch/ARM/STM32/drivers/stm32-i2s.adb
@@ -44,9 +44,9 @@ with STM32.Device; use STM32.Device;
 
 package body STM32.I2S is
 
-   function To_Unsigned_16 is new Ada.Unchecked_Conversion (Integer_16,
-                                                            Unsigned_16);
-   function To_Integer_16 is new Ada.Unchecked_Conversion (Unsigned_16,
+   function To_UInt16 is new Ada.Unchecked_Conversion (Integer_16,
+                                                            UInt16);
+   function To_Integer_16 is new Ada.Unchecked_Conversion (UInt16,
                                                            Integer_16);
    ---------------
    -- Configure --
@@ -170,7 +170,7 @@ package body STM32.I2S is
       end if;
 
       This.Periph.I2SPR.ODD    := Is_Odd;
-      This.Periph.I2SPR.I2SDIV := Byte (Divider);
+      This.Periph.I2SPR.I2SDIV := UInt8 (Divider);
    end Set_Frequency;
 
    -------------
@@ -203,7 +203,7 @@ package body STM32.I2S is
          while not This.Periph.SR.TXE loop
             null;
          end loop;
-         This.Periph.DR.DR := To_Unsigned_16 (Elt);
+         This.Periph.DR.DR := To_UInt16 (Elt);
       end loop;
    end Transmit;
 

--- a/arch/ARM/STM32/drivers/stm32-rng-interrupts.adb
+++ b/arch/ARM/STM32/drivers/stm32-rng-interrupts.adb
@@ -43,7 +43,7 @@ with Ada.Interrupts.Names;
 
 package body STM32.RNG.Interrupts is
 
-   type Buffer_Content is array (Integer range <>) of Unsigned_32;
+   type Buffer_Content is array (Integer range <>) of UInt32;
 
    type Ring_Buffer is record
       Content : Buffer_Content (0 .. 9);
@@ -57,10 +57,10 @@ package body STM32.RNG.Interrupts is
 
    protected Receiver is
       pragma Interrupt_Priority;
-      entry Get_Random_32 (Value : out Unsigned_32);
+      entry Get_Random_32 (Value : out UInt32);
    private
 
-      Last           : Unsigned_32 := 0;
+      Last           : UInt32 := 0;
       Buffer         : Ring_Buffer;
       Data_Available : Boolean := False;
 
@@ -82,7 +82,7 @@ package body STM32.RNG.Interrupts is
       -- Get_Random_32 --
       -------------------
 
-      entry Get_Random_32 (Value : out Unsigned_32) when Data_Available is
+      entry Get_Random_32 (Value : out UInt32) when Data_Available is
          Next : constant Integer :=
            (Buffer.Tail + 1) mod Buffer.Content'Length;
       begin
@@ -104,7 +104,7 @@ package body STM32.RNG.Interrupts is
       -----------------------
 
       procedure Interrupt_Handler is
-         Current : Unsigned_32;
+         Current : UInt32;
       begin
          if RNG_Seed_Error_Status then
             Clear_RNG_Seed_Error_Status;
@@ -149,7 +149,7 @@ package body STM32.RNG.Interrupts is
    --------------------
 
    procedure Initialize_RNG is
-      Discard : Unsigned_32;
+      Discard : UInt32;
    begin
       Enable_RNG_Clock;
       Enable_RNG_Interrupt;
@@ -164,8 +164,8 @@ package body STM32.RNG.Interrupts is
    -- Random --
    ------------
 
-   function Random return Unsigned_32 is
-      Result : Unsigned_32;
+   function Random return UInt32 is
+      Result : UInt32;
    begin
       Receiver.Get_Random_32 (Result);
       return Result;

--- a/arch/ARM/STM32/drivers/stm32-rng-interrupts.ads
+++ b/arch/ARM/STM32/drivers/stm32-rng-interrupts.ads
@@ -53,7 +53,7 @@ package STM32.RNG.Interrupts is
    --  interrupts. Both necessary and sufficient.
    --  Enables the clock as well.
 
-   function Random return Interfaces.Unsigned_32;
+   function Random return UInt32;
    --  Uses the interrupt interface to get the next available number.
    --  NB: call Initialize_RNG before any calls to this function.
 

--- a/arch/ARM/STM32/drivers/stm32-rng-polling.adb
+++ b/arch/ARM/STM32/drivers/stm32-rng-polling.adb
@@ -46,7 +46,7 @@ package body STM32.RNG.Polling is
    --------------------
 
    procedure Initialize_RNG is
-      Discard : Unsigned_32;
+      Discard : UInt32;
    begin
       Enable_RNG_Clock;
       Enable_RNG;
@@ -60,7 +60,7 @@ package body STM32.RNG.Polling is
    -- Random --
    ------------
 
-   function Random return Interfaces.Unsigned_32 is
+   function Random return UInt32 is
    begin
       while not RNG_Data_Ready loop
          null;

--- a/arch/ARM/STM32/drivers/stm32-rng-polling.ads
+++ b/arch/ARM/STM32/drivers/stm32-rng-polling.ads
@@ -52,7 +52,7 @@ package STM32.RNG.Polling is
    --  polling. Both necessary and sufficient.
    --  Enables the clock as well.
 
-   function Random return Interfaces.Unsigned_32;
+   function Random return UInt32;
    --  Polls the RNG directly to get the next available number.
    --  NB: call Initialize_RNG before any calls to this function.
 

--- a/arch/ARM/STM32/drivers/stm32-spi.adb
+++ b/arch/ARM/STM32/drivers/stm32-spi.adb
@@ -63,7 +63,7 @@ package body STM32.SPI is
 
    function As_Half_Word_Pointer is new Ada.Unchecked_Conversion
      (Source => System.Address, Target => Half_Word_Pointer);
-   --  So that we can treat the address of a byte as a pointer to a two-byte
+   --  So that we can treat the address of a UInt8 as a pointer to a two-UInt8
    --  sequence representing a Half_Word quantity
 
    ---------------
@@ -162,7 +162,7 @@ package body STM32.SPI is
    -- Send --
    ----------
 
-   procedure Send (This : in out SPI_Port; Data : Byte) is
+   procedure Send (This : in out SPI_Port; Data : UInt8) is
    begin
       Send (This, UInt16 (Data));
    end Send;
@@ -171,9 +171,9 @@ package body STM32.SPI is
    -- Data --
    ----------
 
-   function Data (This : SPI_Port) return Byte is
+   function Data (This : SPI_Port) return UInt8 is
    begin
-      return Byte (UInt16'(Data (This)));
+      return UInt8 (UInt16'(Data (This)));
    end Data;
 
    -------------
@@ -383,7 +383,7 @@ package body STM32.SPI is
          null;
       end loop;
 
-      --  Clear OVERUN flag in 2-Line communication mode because received byte
+      --  Clear OVERUN flag in 2-Line communication mode because received UInt8
       --  is not read.
       if Current_Data_Direction (This) in D2Lines_RxOnly | D2Lines_FullDuplex
       then  -- right comparison ???
@@ -432,7 +432,7 @@ package body STM32.SPI is
          null;
       end loop;
 
-      --  Clear OVERUN flag in 2-Line communication mode because received byte
+      --  Clear OVERUN flag in 2-Line communication mode because received UInt8
       --  is not read.
       if Current_Data_Direction (This) in D2Lines_RxOnly | D2Lines_FullDuplex
       then  -- right comparison ???
@@ -448,7 +448,7 @@ package body STM32.SPI is
 
    procedure Transmit
      (This     : in out SPI_Port;
-      Outgoing : Byte)
+      Outgoing : UInt8)
    is
    begin
       if CRC_Enabled (This) then
@@ -474,7 +474,7 @@ package body STM32.SPI is
          null;
       end loop;
 
-      --  Clear OVERUN flag in 2-Line communication mode because received byte
+      --  Clear OVERUN flag in 2-Line communication mode because received UInt8
       --  is not read.
       if Current_Data_Direction (This) in D2Lines_RxOnly | D2Lines_FullDuplex
       then  -- right comparison ???
@@ -556,7 +556,7 @@ package body STM32.SPI is
 
    procedure Receive
      (This     : in out SPI_Port;
-      Incoming : out Byte)
+      Incoming : out UInt8)
    is
    begin
       if CRC_Enabled (This) then
@@ -573,7 +573,7 @@ package body STM32.SPI is
          null;
       end loop;
 
-      Incoming := Byte (This.Periph.DR.DR);
+      Incoming := UInt8 (This.Periph.DR.DR);
 
       if CRC_Enabled (This) then
          while Rx_Is_Empty (This) loop
@@ -601,8 +601,8 @@ package body STM32.SPI is
 
    procedure Transmit_Receive
      (This     : in out SPI_Port;
-      Outgoing : Byte_Buffer;
-      Incoming : out Byte_Buffer;
+      Outgoing : UInt8_Buffer;
+      Incoming : out UInt8_Buffer;
       Size     : Positive)
    is
    begin
@@ -648,8 +648,8 @@ package body STM32.SPI is
 
    procedure Transmit_Receive
      (This     : in out SPI_Port;
-      Outgoing : Byte;
-      Incoming : out Byte)
+      Outgoing : UInt8;
+      Incoming : out UInt8)
    is
    begin
       if CRC_Enabled (This) then
@@ -676,9 +676,9 @@ package body STM32.SPI is
          null;
       end loop;
 
-      Incoming := Byte (This.Periph.DR.DR);
+      Incoming := UInt8 (This.Periph.DR.DR);
 
-      --  Read CRC byte to close CRC calculation
+      --  Read CRC UInt8 to close CRC calculation
       if CRC_Enabled (This) then
          --  wait until data is received
          while Rx_Is_Empty (This) loop
@@ -706,8 +706,8 @@ package body STM32.SPI is
 
    procedure Send_Receive_16bit_Mode
      (This     : in out SPI_Port;
-      Outgoing : Byte_Buffer;
-      Incoming : out Byte_Buffer;
+      Outgoing : UInt8_Buffer;
+      Incoming : out UInt8_Buffer;
       Size     : Positive)
    is
       Tx_Count : Natural := Size;
@@ -766,7 +766,7 @@ package body STM32.SPI is
          Incoming_Index := Incoming_Index + 2;
       end loop;
 
-      --  receive the last byte
+      --  receive the last UInt8
       if Current_Mode (This) = Slave then
          --  wait until data is received
          while Rx_Is_Empty (This) loop
@@ -785,8 +785,8 @@ package body STM32.SPI is
 
    procedure Send_Receive_8bit_Mode
      (This     : in out SPI_Port;
-      Outgoing : Byte_Buffer;
-      Incoming : out Byte_Buffer;
+      Outgoing : UInt8_Buffer;
+      Incoming : out UInt8_Buffer;
       Size     : Positive)
    is
       Tx_Count : Natural := Size;
@@ -811,7 +811,7 @@ package body STM32.SPI is
             null;
          end loop;
 
-         Incoming (Incoming_Index) := Byte (This.Periph.DR.DR);
+         Incoming (Incoming_Index) := UInt8 (This.Periph.DR.DR);
 
          return;
 
@@ -837,7 +837,7 @@ package body STM32.SPI is
             null;
          end loop;
 
-         Incoming (Incoming_Index) := Byte (This.Periph.DR.DR);
+         Incoming (Incoming_Index) := UInt8 (This.Periph.DR.DR);
          Incoming_Index := Incoming_Index + 1;
       end loop;
 
@@ -958,7 +958,7 @@ package body STM32.SPI is
          while Rx_Is_Empty (This) loop
             null;
          end loop;
-         K := Byte (This.Periph.DR.DR);
+         K := UInt8 (This.Periph.DR.DR);
       end loop;
    end Receive_8bit_Mode;
 

--- a/arch/ARM/STM32/drivers/stm32-spi.ads
+++ b/arch/ARM/STM32/drivers/stm32-spi.ads
@@ -96,9 +96,9 @@ package STM32.SPI is
    function Data (This : SPI_Port) return UInt16
      with Inline;
 
-   procedure Send (This : in out SPI_Port; Data : Byte);
+   procedure Send (This : in out SPI_Port; Data : UInt8);
 
-   function Data (This : SPI_Port) return Byte
+   function Data (This : SPI_Port) return UInt8
      with Inline;
 
    function Is_Busy (This : SPI_Port) return Boolean
@@ -146,7 +146,7 @@ package STM32.SPI is
    --  The following I/O routines implement the higher level functionality for
    --  CRC and data direction, among others.
 
-   type Byte_Buffer is array (Natural range <>) of Byte
+   type UInt8_Buffer is array (Natural range <>) of UInt8
      with Alignment => 2;
    --  The alignment is set to 2 because we treat component pairs as half_word
    --  values when sending/receiving in 16-bit mode.
@@ -172,7 +172,7 @@ package STM32.SPI is
 
    procedure Transmit
      (This     : in out SPI_Port;
-      Outgoing : Byte);
+      Outgoing : UInt8);
 
    overriding
    procedure Receive
@@ -190,18 +190,18 @@ package STM32.SPI is
 
    procedure Receive
      (This     : in out SPI_Port;
-      Incoming : out Byte);
+      Incoming : out UInt8);
 
    procedure Transmit_Receive
      (This      : in out SPI_Port;
-      Outgoing  : Byte_Buffer;
-      Incoming  : out Byte_Buffer;
+      Outgoing  : UInt8_Buffer;
+      Incoming  : out UInt8_Buffer;
       Size      : Positive);
 
    procedure Transmit_Receive
      (This      : in out SPI_Port;
-      Outgoing  : Byte;
-      Incoming  : out Byte);
+      Outgoing  : UInt8;
+      Incoming  : out UInt8);
 
    --  TODO: add the other higher-level HAL routines for interrupts and DMA
 
@@ -214,14 +214,14 @@ private
 
    procedure Send_Receive_16bit_Mode
      (This     : in out SPI_Port;
-      Outgoing : Byte_Buffer;
-      Incoming : out Byte_Buffer;
+      Outgoing : UInt8_Buffer;
+      Incoming : out UInt8_Buffer;
       Size     : Positive);
 
    procedure Send_Receive_8bit_Mode
      (This     : in out SPI_Port;
-      Outgoing : Byte_Buffer;
-      Incoming : out Byte_Buffer;
+      Outgoing : UInt8_Buffer;
+      Incoming : out UInt8_Buffer;
       Size     : Positive);
 
    procedure Send_16bit_Mode

--- a/arch/ARM/STM32/drivers/stm32-timers.adb
+++ b/arch/ARM/STM32/drivers/stm32-timers.adb
@@ -1410,8 +1410,8 @@ package body STM32.Timers is
       Automatic_Output_Enabled      : Boolean;
       Break_Polarity                : Timer_Break_Polarity;
       Break_Enabled                 : Boolean;
-      Off_State_Selection_Run_Mode  : UInt1;
-      Off_State_Selection_Idle_Mode : UInt1;
+      Off_State_Selection_Run_Mode  : Bit;
+      Off_State_Selection_Idle_Mode : Bit;
       Lock_Configuration            : Timer_Lock_Level;
       Deadtime_Generator            : UInt8)
    is

--- a/arch/ARM/STM32/drivers/stm32-timers.adb
+++ b/arch/ARM/STM32/drivers/stm32-timers.adb
@@ -116,7 +116,7 @@ package body STM32.Timers is
       Period        : UInt32;
       Clock_Divisor : Timer_Clock_Divisor;
       Counter_Mode  : Timer_Counter_Alignment_Mode;
-      Repetitions   : Byte)
+      Repetitions   : UInt8)
    is
    begin
       This.ARR := Period;
@@ -1410,10 +1410,10 @@ package body STM32.Timers is
       Automatic_Output_Enabled      : Boolean;
       Break_Polarity                : Timer_Break_Polarity;
       Break_Enabled                 : Boolean;
-      Off_State_Selection_Run_Mode  : Bit;
-      Off_State_Selection_Idle_Mode : Bit;
+      Off_State_Selection_Run_Mode  : UInt1;
+      Off_State_Selection_Idle_Mode : UInt1;
       Lock_Configuration            : Timer_Lock_Level;
-      Deadtime_Generator            : Byte)
+      Deadtime_Generator            : UInt8)
    is
    begin
       This.BDTR.Automatic_Output_Enabled      := Automatic_Output_Enabled;

--- a/arch/ARM/STM32/drivers/stm32-timers.ads
+++ b/arch/ARM/STM32/drivers/stm32-timers.ads
@@ -716,7 +716,7 @@ package STM32.Timers is
       Period        : UInt32;
       Clock_Divisor : Timer_Clock_Divisor;
       Counter_Mode  : Timer_Counter_Alignment_Mode;
-      Repetitions   : Byte)
+      Repetitions   : UInt8)
      with
        Pre  => Advanced_Timer (This) and
                (if Period > UInt32 (UInt16'Last) then Has_32bit_Counter (This)),
@@ -761,10 +761,10 @@ package STM32.Timers is
       Automatic_Output_Enabled      : Boolean;
       Break_Polarity                : Timer_Break_Polarity;
       Break_Enabled                 : Boolean;
-      Off_State_Selection_Run_Mode  : Bit;
-      Off_State_Selection_Idle_Mode : Bit;
+      Off_State_Selection_Run_Mode  : UInt1;
+      Off_State_Selection_Idle_Mode : UInt1;
       Lock_Configuration            : Timer_Lock_Level;
-      Deadtime_Generator            : Byte)
+      Deadtime_Generator            : UInt8)
      with Pre => Advanced_Timer (This);
 
    ----------------------------------------------------------------------------
@@ -1154,7 +1154,7 @@ private
 
    type TIMx_CR2 is record
       Reserved0                                 : UInt16;
-      Reserved1                                 : Bit;
+      Reserved1                                 : UInt1;
       Channel_4_Output_Idle_State               : Timer_Capture_Compare_State;
       Channel_3_Complementary_Output_Idle_State : Timer_Capture_Compare_State;
       Channel_3_Output_Idle_State               : Timer_Capture_Compare_State;
@@ -1166,7 +1166,7 @@ private
       Master_Mode_Selection                     : Timer_Trigger_Output_Source;
       Capture_Compare_DMA_Selection             : Boolean;
       Capture_Compare_Control_Update_Selection  : Boolean;
-      Reserved2                                 : Bit;
+      Reserved2                                 : UInt1;
       Capture_Compare_Preloaded_Control         : Boolean;
    end record with Volatile_Full_Access, Size => 32;
 
@@ -1198,7 +1198,7 @@ private
       External_Trigger_Filter    : Timer_External_Trigger_Filter;
       Master_Slave_Mode          : Boolean;
       Trigger_Selection          : Timer_Trigger_Input_Source;
-      Reserved1                  : Bit;
+      Reserved1                  : UInt1;
       Slave_Mode_Selection       : Timer_Slave_Mode;
    end record with Volatile_Full_Access, Size => 32;
 
@@ -1375,9 +1375,9 @@ private
 
    type Single_CCE is record
       CCxE  : Timer_Capture_Compare_State;
-      CCxP  : Bit;
+      CCxP  : UInt1;
       CCxNE : Timer_Capture_Compare_State;
-      CCxNP : Bit;
+      CCxNP : UInt1;
    end record with Size => 4;
 
    for Single_CCE use record
@@ -1408,10 +1408,10 @@ private
       Automatic_Output_Enabled      : Boolean;
       Break_Polarity                : Timer_Break_Polarity;
       Break_Enable                  : Boolean;
-      Off_State_Selection_Run_Mode  : Bit;
-      Off_State_Selection_Idle_Mode : Bit;
+      Off_State_Selection_Run_Mode  : UInt1;
+      Off_State_Selection_Idle_Mode : UInt1;
       Lock                          : Timer_Lock_Level;
-      Deadtime_Generator            : Byte;
+      Deadtime_Generator            : UInt8;
    end record with Volatile_Full_Access, Size => 32;
 
    for TIMx_BDTR use record

--- a/arch/ARM/STM32/drivers/stm32-timers.ads
+++ b/arch/ARM/STM32/drivers/stm32-timers.ads
@@ -761,8 +761,8 @@ package STM32.Timers is
       Automatic_Output_Enabled      : Boolean;
       Break_Polarity                : Timer_Break_Polarity;
       Break_Enabled                 : Boolean;
-      Off_State_Selection_Run_Mode  : UInt1;
-      Off_State_Selection_Idle_Mode : UInt1;
+      Off_State_Selection_Run_Mode  : Bit;
+      Off_State_Selection_Idle_Mode : Bit;
       Lock_Configuration            : Timer_Lock_Level;
       Deadtime_Generator            : UInt8)
      with Pre => Advanced_Timer (This);
@@ -1154,7 +1154,7 @@ private
 
    type TIMx_CR2 is record
       Reserved0                                 : UInt16;
-      Reserved1                                 : UInt1;
+      Reserved1                                 : Bit;
       Channel_4_Output_Idle_State               : Timer_Capture_Compare_State;
       Channel_3_Complementary_Output_Idle_State : Timer_Capture_Compare_State;
       Channel_3_Output_Idle_State               : Timer_Capture_Compare_State;
@@ -1166,7 +1166,7 @@ private
       Master_Mode_Selection                     : Timer_Trigger_Output_Source;
       Capture_Compare_DMA_Selection             : Boolean;
       Capture_Compare_Control_Update_Selection  : Boolean;
-      Reserved2                                 : UInt1;
+      Reserved2                                 : Bit;
       Capture_Compare_Preloaded_Control         : Boolean;
    end record with Volatile_Full_Access, Size => 32;
 
@@ -1198,7 +1198,7 @@ private
       External_Trigger_Filter    : Timer_External_Trigger_Filter;
       Master_Slave_Mode          : Boolean;
       Trigger_Selection          : Timer_Trigger_Input_Source;
-      Reserved1                  : UInt1;
+      Reserved1                  : Bit;
       Slave_Mode_Selection       : Timer_Slave_Mode;
    end record with Volatile_Full_Access, Size => 32;
 
@@ -1375,9 +1375,9 @@ private
 
    type Single_CCE is record
       CCxE  : Timer_Capture_Compare_State;
-      CCxP  : UInt1;
+      CCxP  : Bit;
       CCxNE : Timer_Capture_Compare_State;
-      CCxNP : UInt1;
+      CCxNP : Bit;
    end record with Size => 4;
 
    for Single_CCE use record
@@ -1408,8 +1408,8 @@ private
       Automatic_Output_Enabled      : Boolean;
       Break_Polarity                : Timer_Break_Polarity;
       Break_Enable                  : Boolean;
-      Off_State_Selection_Run_Mode  : UInt1;
-      Off_State_Selection_Idle_Mode : UInt1;
+      Off_State_Selection_Run_Mode  : Bit;
+      Off_State_Selection_Idle_Mode : Bit;
       Lock                          : Timer_Lock_Level;
       Deadtime_Generator            : UInt8;
    end record with Volatile_Full_Access, Size => 32;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-adc.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-adc.ads
@@ -135,7 +135,7 @@ package STM32_SVD.ADC is
       --  Start conversion of injected channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  External event select for regular group
       EXTSEL         : CR2_EXTSEL_Field := 16#0#;
       --  External trigger enable for regular channels
@@ -143,7 +143,7 @@ package STM32_SVD.ADC is
       --  Start conversion of regular channels
       SWSTART        : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -651,7 +651,7 @@ package STM32_SVD.ADC is
       --  Delay between 2 sampling phases
       DELAY_k        : CCR_DELAY_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.UInt1 := 16#0#;
+      Reserved_12_12 : HAL.Bit := 16#0#;
       --  DMA disable selection for multi-ADC mode
       DDS            : Boolean := False;
       --  Direct memory access mode for multi ADC mode

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-adc.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-adc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -134,7 +135,7 @@ package STM32_SVD.ADC is
       --  Start conversion of injected channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  External event select for regular group
       EXTSEL         : CR2_EXTSEL_Field := 16#0#;
       --  External trigger enable for regular channels
@@ -142,7 +143,7 @@ package STM32_SVD.ADC is
       --  Start conversion of regular channels
       SWSTART        : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -388,7 +389,7 @@ package STM32_SVD.ADC is
       --  Regular channel sequence length
       L              : SQR1_L_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -650,7 +651,7 @@ package STM32_SVD.ADC is
       --  Delay between 2 sampling phases
       DELAY_k        : CCR_DELAY_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.Bit := 16#0#;
+      Reserved_12_12 : HAL.UInt1 := 16#0#;
       --  DMA disable selection for multi-ADC mode
       DDS            : Boolean := False;
       --  Direct memory access mode for multi ADC mode
@@ -664,7 +665,7 @@ package STM32_SVD.ADC is
       --  Temperature sensor and VREFINT enable
       TSVREFE        : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -785,15 +786,15 @@ package STM32_SVD.ADC is
 
    --  Analog-to-digital converter
    ADC1_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC1_Base;
+     with Import, Address => System'To_Address (16#40012000#);
 
    --  Analog-to-digital converter
    ADC2_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC2_Base;
+     with Import, Address => System'To_Address (16#40012100#);
 
    --  Analog-to-digital converter
    ADC3_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC3_Base;
+     with Import, Address => System'To_Address (16#40012200#);
 
    --  Common ADC registers
    type C_ADC_Peripheral is record
@@ -814,6 +815,6 @@ package STM32_SVD.ADC is
 
    --  Common ADC registers
    C_ADC_Periph : aliased C_ADC_Peripheral
-     with Import, Address => C_ADC_Base;
+     with Import, Address => System'To_Address (16#40012300#);
 
 end STM32_SVD.ADC;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-can.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-can.ads
@@ -230,7 +230,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP0
       FMP0          : RF0R_FMP0_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  FULL0
       FULL0         : Boolean := False;
       --  FOVR0
@@ -259,7 +259,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP1
       FMP1          : RF1R_FMP1_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  FULL1
       FULL1         : Boolean := False;
       --  FOVR1
@@ -298,7 +298,7 @@ package STM32_SVD.CAN is
       --  FOVIE1
       FOVIE1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  EWGIE
       EWGIE          : Boolean := False;
       --  EPVIE
@@ -354,7 +354,7 @@ package STM32_SVD.CAN is
       --  Read-only. BOFF
       BOFF          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  LEC
       LEC           : ESR_LEC_Field := 16#0#;
       --  unspecified
@@ -394,7 +394,7 @@ package STM32_SVD.CAN is
       --  TS2
       TS2            : BTR_TS2_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  SJW
       SJW            : BTR_SJW_Field := 16#0#;
       --  unspecified
@@ -755,7 +755,7 @@ package STM32_SVD.CAN is
    --  receive FIFO mailbox identifier register
    type RI0R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.UInt1;
+      Reserved_0_0 : HAL.Bit;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -863,7 +863,7 @@ package STM32_SVD.CAN is
    --  mailbox data high register
    type RI1R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.UInt1;
+      Reserved_0_0 : HAL.Bit;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-can.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-can.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -229,7 +230,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP0
       FMP0          : RF0R_FMP0_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  FULL0
       FULL0         : Boolean := False;
       --  FOVR0
@@ -258,7 +259,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP1
       FMP1          : RF1R_FMP1_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  FULL1
       FULL1         : Boolean := False;
       --  FOVR1
@@ -297,7 +298,7 @@ package STM32_SVD.CAN is
       --  FOVIE1
       FOVIE1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  EWGIE
       EWGIE          : Boolean := False;
       --  EPVIE
@@ -341,8 +342,8 @@ package STM32_SVD.CAN is
    end record;
 
    subtype ESR_LEC_Field is HAL.UInt3;
-   subtype ESR_TEC_Field is HAL.Byte;
-   subtype ESR_REC_Field is HAL.Byte;
+   subtype ESR_TEC_Field is HAL.UInt8;
+   subtype ESR_REC_Field is HAL.UInt8;
 
    --  interrupt enable register
    type ESR_Register is record
@@ -353,7 +354,7 @@ package STM32_SVD.CAN is
       --  Read-only. BOFF
       BOFF          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  LEC
       LEC           : ESR_LEC_Field := 16#0#;
       --  unspecified
@@ -393,7 +394,7 @@ package STM32_SVD.CAN is
       --  TS2
       TS2            : BTR_TS2_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  SJW
       SJW            : BTR_SJW_Field := 16#0#;
       --  unspecified
@@ -473,7 +474,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL0R_DATA array element
-   subtype TDL0R_DATA_Element is HAL.Byte;
+   subtype TDL0R_DATA_Element is HAL.UInt8;
 
    --  TDL0R_DATA array
    type TDL0R_DATA_Field_Array is array (0 .. 3) of TDL0R_DATA_Element
@@ -501,7 +502,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH0R_DATA array element
-   subtype TDH0R_DATA_Element is HAL.Byte;
+   subtype TDH0R_DATA_Element is HAL.UInt8;
 
    --  TDH0R_DATA array
    type TDH0R_DATA_Field_Array is array (4 .. 7) of TDH0R_DATA_Element
@@ -583,7 +584,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL1R_DATA array element
-   subtype TDL1R_DATA_Element is HAL.Byte;
+   subtype TDL1R_DATA_Element is HAL.UInt8;
 
    --  TDL1R_DATA array
    type TDL1R_DATA_Field_Array is array (0 .. 3) of TDL1R_DATA_Element
@@ -611,7 +612,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH1R_DATA array element
-   subtype TDH1R_DATA_Element is HAL.Byte;
+   subtype TDH1R_DATA_Element is HAL.UInt8;
 
    --  TDH1R_DATA array
    type TDH1R_DATA_Field_Array is array (4 .. 7) of TDH1R_DATA_Element
@@ -693,7 +694,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL2R_DATA array element
-   subtype TDL2R_DATA_Element is HAL.Byte;
+   subtype TDL2R_DATA_Element is HAL.UInt8;
 
    --  TDL2R_DATA array
    type TDL2R_DATA_Field_Array is array (0 .. 3) of TDL2R_DATA_Element
@@ -721,7 +722,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH2R_DATA array element
-   subtype TDH2R_DATA_Element is HAL.Byte;
+   subtype TDH2R_DATA_Element is HAL.UInt8;
 
    --  TDH2R_DATA array
    type TDH2R_DATA_Field_Array is array (4 .. 7) of TDH2R_DATA_Element
@@ -754,7 +755,7 @@ package STM32_SVD.CAN is
    --  receive FIFO mailbox identifier register
    type RI0R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.Bit;
+      Reserved_0_0 : HAL.UInt1;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -776,7 +777,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype RDT0R_DLC_Field is HAL.UInt4;
-   subtype RDT0R_FMI_Field is HAL.Byte;
+   subtype RDT0R_FMI_Field is HAL.UInt8;
    subtype RDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
@@ -801,7 +802,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDL0R_DATA array element
-   subtype RDL0R_DATA_Element is HAL.Byte;
+   subtype RDL0R_DATA_Element is HAL.UInt8;
 
    --  RDL0R_DATA array
    type RDL0R_DATA_Field_Array is array (0 .. 3) of RDL0R_DATA_Element
@@ -829,7 +830,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDH0R_DATA array element
-   subtype RDH0R_DATA_Element is HAL.Byte;
+   subtype RDH0R_DATA_Element is HAL.UInt8;
 
    --  RDH0R_DATA array
    type RDH0R_DATA_Field_Array is array (4 .. 7) of RDH0R_DATA_Element
@@ -862,7 +863,7 @@ package STM32_SVD.CAN is
    --  mailbox data high register
    type RI1R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.Bit;
+      Reserved_0_0 : HAL.UInt1;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -884,7 +885,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype RDT1R_DLC_Field is HAL.UInt4;
-   subtype RDT1R_FMI_Field is HAL.Byte;
+   subtype RDT1R_FMI_Field is HAL.UInt8;
    subtype RDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
@@ -909,7 +910,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDL1R_DATA array element
-   subtype RDL1R_DATA_Element is HAL.Byte;
+   subtype RDL1R_DATA_Element is HAL.UInt8;
 
    --  RDL1R_DATA array
    type RDL1R_DATA_Field_Array is array (0 .. 3) of RDL1R_DATA_Element
@@ -937,7 +938,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDH1R_DATA array element
-   subtype RDH1R_DATA_Element is HAL.Byte;
+   subtype RDH1R_DATA_Element is HAL.UInt8;
 
    --  RDH1R_DATA array
    type RDH1R_DATA_Field_Array is array (4 .. 7) of RDH1R_DATA_Element
@@ -2124,10 +2125,10 @@ package STM32_SVD.CAN is
 
    --  Controller area network
    CAN1_Periph : aliased CAN_Peripheral
-     with Import, Address => CAN1_Base;
+     with Import, Address => System'To_Address (16#40006400#);
 
    --  Controller area network
    CAN2_Periph : aliased CAN_Peripheral
-     with Import, Address => CAN2_Base;
+     with Import, Address => System'To_Address (16#40006800#);
 
 end STM32_SVD.CAN;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-crc.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-crc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -13,7 +14,7 @@ package STM32_SVD.CRC is
    -- Registers --
    ---------------
 
-   subtype IDR_IDR_Field is HAL.Byte;
+   subtype IDR_IDR_Field is HAL.UInt8;
 
    --  Independent Data register
    type IDR_Register is record
@@ -52,7 +53,7 @@ package STM32_SVD.CRC is
    --  Cyclic Redundancy Check (CRC) unit
    type CRC_Peripheral is record
       --  Data register
-      DR  : HAL.UInt32 with Volatile; --  work-around for Q207-001
+      DR  : HAL.UInt32;
       --  Independent Data register
       IDR : IDR_Register;
       --  Control register
@@ -68,6 +69,6 @@ package STM32_SVD.CRC is
 
    --  Cyclic Redundancy Check (CRC) unit
    CRC_Periph : aliased CRC_Peripheral
-     with Import, Address => CRC_Base;
+     with Import, Address => System'To_Address (16#40023000#);
 
 end STM32_SVD.CRC;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-dac.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-dac.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -160,7 +161,7 @@ package STM32_SVD.DAC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DHR8R1_DACC1DHR_Field is HAL.Byte;
+   subtype DHR8R1_DACC1DHR_Field is HAL.UInt8;
 
    --  channel1 8-bit right aligned data holding register
    type DHR8R1_Register is record
@@ -214,7 +215,7 @@ package STM32_SVD.DAC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DHR8R2_DACC2DHR_Field is HAL.Byte;
+   subtype DHR8R2_DACC2DHR_Field is HAL.UInt8;
 
    --  channel2 8-bit right-aligned data holding register
    type DHR8R2_Register is record
@@ -279,8 +280,8 @@ package STM32_SVD.DAC is
       DACC2DHR       at 0 range 20 .. 31;
    end record;
 
-   subtype DHR8RD_DACC1DHR_Field is HAL.Byte;
-   subtype DHR8RD_DACC2DHR_Field is HAL.Byte;
+   subtype DHR8RD_DACC1DHR_Field is HAL.UInt8;
+   subtype DHR8RD_DACC2DHR_Field is HAL.UInt8;
 
    --  DUAL DAC 8-bit right aligned data holding register
    type DHR8RD_Register is record
@@ -414,6 +415,6 @@ package STM32_SVD.DAC is
 
    --  Digital-to-analog converter
    DAC_Periph : aliased DAC_Peripheral
-     with Import, Address => DAC_Base;
+     with Import, Address => System'To_Address (16#40007400#);
 
 end STM32_SVD.DAC;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-dbg.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-dbg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -51,7 +52,7 @@ package STM32_SVD.DBG is
       --  TRACE_MODE
       TRACE_MODE             : DBGMCU_CR_TRACE_MODE_Field := 16#0#;
       --  unspecified
-      Reserved_8_15          : HAL.Byte := 16#0#;
+      Reserved_8_15          : HAL.UInt8 := 16#0#;
       --  DBG_I2C2_SMBUS_TIMEOUT
       DBG_I2C2_SMBUS_TIMEOUT : Boolean := False;
       --  DBG_TIM8_STOP
@@ -111,7 +112,7 @@ package STM32_SVD.DBG is
       --  DBG_IWDEG_STOP
       DBG_IWDEG_STOP         : Boolean := False;
       --  unspecified
-      Reserved_13_20         : HAL.Byte := 16#0#;
+      Reserved_13_20         : HAL.UInt8 := 16#0#;
       --  DBG_J2C1_SMBUS_TIMEOUT
       DBG_J2C1_SMBUS_TIMEOUT : Boolean := False;
       --  DBG_J2C2_SMBUS_TIMEOUT
@@ -119,7 +120,7 @@ package STM32_SVD.DBG is
       --  DBG_J2C3SMBUS_TIMEOUT
       DBG_J2C3SMBUS_TIMEOUT  : Boolean := False;
       --  unspecified
-      Reserved_24_24         : HAL.Bit := 16#0#;
+      Reserved_24_24         : HAL.UInt1 := 16#0#;
       --  DBG_CAN1_STOP
       DBG_CAN1_STOP          : Boolean := False;
       --  DBG_CAN2_STOP
@@ -209,6 +210,6 @@ package STM32_SVD.DBG is
 
    --  Debug support
    DBG_Periph : aliased DBG_Peripheral
-     with Import, Address => DBG_Base;
+     with Import, Address => System'To_Address (16#E0042000#);
 
 end STM32_SVD.DBG;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-dbg.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-dbg.ads
@@ -120,7 +120,7 @@ package STM32_SVD.DBG is
       --  DBG_J2C3SMBUS_TIMEOUT
       DBG_J2C3SMBUS_TIMEOUT  : Boolean := False;
       --  unspecified
-      Reserved_24_24         : HAL.UInt1 := 16#0#;
+      Reserved_24_24         : HAL.Bit := 16#0#;
       --  DBG_CAN1_STOP
       DBG_CAN1_STOP          : Boolean := False;
       --  DBG_CAN2_STOP

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-dcmi.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-dcmi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -193,10 +194,10 @@ package STM32_SVD.DCMI is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype ESCR_FSC_Field is HAL.Byte;
-   subtype ESCR_LSC_Field is HAL.Byte;
-   subtype ESCR_LEC_Field is HAL.Byte;
-   subtype ESCR_FEC_Field is HAL.Byte;
+   subtype ESCR_FSC_Field is HAL.UInt8;
+   subtype ESCR_LSC_Field is HAL.UInt8;
+   subtype ESCR_LEC_Field is HAL.UInt8;
+   subtype ESCR_FEC_Field is HAL.UInt8;
 
    --  embedded synchronization code register
    type ESCR_Register is record
@@ -219,10 +220,10 @@ package STM32_SVD.DCMI is
       FEC at 0 range 24 .. 31;
    end record;
 
-   subtype ESUR_FSU_Field is HAL.Byte;
-   subtype ESUR_LSU_Field is HAL.Byte;
-   subtype ESUR_LEU_Field is HAL.Byte;
-   subtype ESUR_FEU_Field is HAL.Byte;
+   subtype ESUR_FSU_Field is HAL.UInt8;
+   subtype ESUR_LSU_Field is HAL.UInt8;
+   subtype ESUR_LEU_Field is HAL.UInt8;
+   subtype ESUR_FEU_Field is HAL.UInt8;
 
    --  embedded synchronization unmask register
    type ESUR_Register is record
@@ -294,7 +295,7 @@ package STM32_SVD.DCMI is
    end record;
 
    --  DR_Byte array element
-   subtype DR_Byte_Element is HAL.Byte;
+   subtype DR_Byte_Element is HAL.UInt8;
 
    --  DR_Byte array
    type DR_Byte_Field_Array is array (0 .. 3) of DR_Byte_Element
@@ -368,6 +369,6 @@ package STM32_SVD.DCMI is
 
    --  Digital camera interface
    DCMI_Periph : aliased DCMI_Peripheral
-     with Import, Address => DCMI_Base;
+     with Import, Address => System'To_Address (16#50050000#);
 
 end STM32_SVD.DCMI;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-dma.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-dma.ads
@@ -19,7 +19,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF0          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1;
+      Reserved_1_1   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF0         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -31,7 +31,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF1          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1;
+      Reserved_7_7   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF1         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -45,7 +45,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF2          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1;
+      Reserved_17_17 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF2         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -57,7 +57,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF3          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1;
+      Reserved_23_23 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF3         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -106,7 +106,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF4          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1;
+      Reserved_1_1   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF4         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -118,7 +118,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF5          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1;
+      Reserved_7_7   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF5         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -132,7 +132,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF6          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1;
+      Reserved_17_17 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF6         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -144,7 +144,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF7          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1;
+      Reserved_23_23 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF7         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -193,7 +193,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF0         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF0        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -205,7 +205,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF1        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -219,7 +219,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF2         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF2        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -231,7 +231,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF3         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF3        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -280,7 +280,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF4         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF4        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -292,7 +292,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF5         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF5        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -306,7 +306,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF6         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF6        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -318,7 +318,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF7         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF7        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -405,7 +405,7 @@ package STM32_SVD.DMA is
       --  Current target (only in double buffer mode)
       CT             : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Peripheral burst transfer configuration
       PBURST         : S0CR_PBURST_Field := 16#0#;
       --  Memory burst transfer configuration
@@ -471,7 +471,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S0FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -598,7 +598,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S1FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -725,7 +725,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S2FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -852,7 +852,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S3FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -979,7 +979,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S4FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1106,7 +1106,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S5FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1233,7 +1233,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S6FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1360,7 +1360,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S7FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-dma.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-dma.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -18,7 +19,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF0          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.Bit;
+      Reserved_1_1   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF0         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -30,7 +31,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF1          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.Bit;
+      Reserved_7_7   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF1         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -44,7 +45,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF2          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.Bit;
+      Reserved_17_17 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF2         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -56,7 +57,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF3          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.Bit;
+      Reserved_23_23 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF3         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -105,7 +106,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF4          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.Bit;
+      Reserved_1_1   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF4         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -117,7 +118,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF5          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.Bit;
+      Reserved_7_7   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF5         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -131,7 +132,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF6          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.Bit;
+      Reserved_17_17 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF6         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -143,7 +144,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF7          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.Bit;
+      Reserved_23_23 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF7         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -192,7 +193,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF0         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF0        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -204,7 +205,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF1        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -218,7 +219,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF2         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF2        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -230,7 +231,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF3         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF3        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -279,7 +280,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF4         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF4        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -291,7 +292,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF5         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF5        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -305,7 +306,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF6         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF6        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -317,7 +318,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF7         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF7        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -404,7 +405,7 @@ package STM32_SVD.DMA is
       --  Current target (only in double buffer mode)
       CT             : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Peripheral burst transfer configuration
       PBURST         : S0CR_PBURST_Field := 16#0#;
       --  Memory burst transfer configuration
@@ -470,7 +471,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S0FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -597,7 +598,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S1FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -724,7 +725,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S2FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -851,7 +852,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S3FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -978,7 +979,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S4FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1105,7 +1106,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S5FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1232,7 +1233,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S6FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1359,7 +1360,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S7FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1547,10 +1548,10 @@ package STM32_SVD.DMA is
 
    --  DMA controller
    DMA1_Periph : aliased DMA_Peripheral
-     with Import, Address => DMA1_Base;
+     with Import, Address => System'To_Address (16#40026000#);
 
    --  DMA controller
    DMA2_Periph : aliased DMA_Peripheral
-     with Import, Address => DMA2_Base;
+     with Import, Address => System'To_Address (16#40026400#);
 
 end STM32_SVD.DMA;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-ethernet.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-ethernet.ads
@@ -112,7 +112,7 @@ package STM32_SVD.Ethernet is
       --  Read-only. no description available
       EBS            : DMASR_EBS_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.UInt1 := 16#0#;
+      Reserved_26_26 : HAL.Bit := 16#0#;
       --  Read-only. no description available
       MMCS           : Boolean := False;
       --  Read-only. no description available
@@ -158,7 +158,7 @@ package STM32_SVD.Ethernet is
    --  Ethernet DMA operation mode register
    type DMAOMR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  SR
       SR             : Boolean := False;
       --  OSF
@@ -166,7 +166,7 @@ package STM32_SVD.Ethernet is
       --  RTC
       RTC            : DMAOMR_RTC_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  FUGF
       FUGF           : Boolean := False;
       --  FEF
@@ -340,7 +340,7 @@ package STM32_SVD.Ethernet is
       --  APCS
       APCS           : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  RD
       RD             : Boolean := False;
       --  IPCO
@@ -354,7 +354,7 @@ package STM32_SVD.Ethernet is
       --  FES
       FES            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#1#;
+      Reserved_15_15 : HAL.Bit := 16#1#;
       --  CSD
       CSD            : Boolean := False;
       --  IFG
@@ -366,7 +366,7 @@ package STM32_SVD.Ethernet is
       --  WD
       WD             : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CSTF
       CSTF           : Boolean := False;
       --  unspecified
@@ -458,7 +458,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       CR             : MACMIIAR_CR_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  no description available
       MR             : MACMIIAR_MR_Field := 16#0#;
       --  no description available
@@ -512,7 +512,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       PLT           : MACFCR_PLT_Field := 16#0#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  no description available
       ZQPD          : Boolean := False;
       --  unspecified
@@ -762,7 +762,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA2L         : MACA2LR_MACA2L_Field := 16#7FFFFFFF#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#1#;
+      Reserved_31_31 : HAL.Bit := 16#1#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-ethernet.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-ethernet.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -111,7 +112,7 @@ package STM32_SVD.Ethernet is
       --  Read-only. no description available
       EBS            : DMASR_EBS_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.Bit := 16#0#;
+      Reserved_26_26 : HAL.UInt1 := 16#0#;
       --  Read-only. no description available
       MMCS           : Boolean := False;
       --  Read-only. no description available
@@ -157,7 +158,7 @@ package STM32_SVD.Ethernet is
    --  Ethernet DMA operation mode register
    type DMAOMR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  SR
       SR             : Boolean := False;
       --  OSF
@@ -165,7 +166,7 @@ package STM32_SVD.Ethernet is
       --  RTC
       RTC            : DMAOMR_RTC_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  FUGF
       FUGF           : Boolean := False;
       --  FEF
@@ -304,7 +305,7 @@ package STM32_SVD.Ethernet is
       Reserved_29_31 at 0 range 29 .. 31;
    end record;
 
-   subtype DMARSWTR_RSWTC_Field is HAL.Byte;
+   subtype DMARSWTR_RSWTC_Field is HAL.UInt8;
 
    --  Ethernet DMA receive status watchdog timer register
    type DMARSWTR_Register is record
@@ -339,7 +340,7 @@ package STM32_SVD.Ethernet is
       --  APCS
       APCS           : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  RD
       RD             : Boolean := False;
       --  IPCO
@@ -353,7 +354,7 @@ package STM32_SVD.Ethernet is
       --  FES
       FES            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#1#;
+      Reserved_15_15 : HAL.UInt1 := 16#1#;
       --  CSD
       CSD            : Boolean := False;
       --  IFG
@@ -365,7 +366,7 @@ package STM32_SVD.Ethernet is
       --  WD
       WD             : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CSTF
       CSTF           : Boolean := False;
       --  unspecified
@@ -457,7 +458,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       CR             : MACMIIAR_CR_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  no description available
       MR             : MACMIIAR_MR_Field := 16#0#;
       --  no description available
@@ -511,11 +512,11 @@ package STM32_SVD.Ethernet is
       --  no description available
       PLT           : MACFCR_PLT_Field := 16#0#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  no description available
       ZQPD          : Boolean := False;
       --  unspecified
-      Reserved_8_15 : HAL.Byte := 16#0#;
+      Reserved_8_15 : HAL.UInt8 := 16#0#;
       --  no description available
       PT            : MACFCR_PT_Field := 16#0#;
    end record
@@ -708,7 +709,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA1H         : MACA1HR_MACA1H_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA1HR_MBC_Field := 16#0#;
       --  no description available
@@ -735,7 +736,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MAC2AH         : MACA2HR_MAC2AH_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA2HR_MBC_Field := 16#0#;
       --  no description available
@@ -761,7 +762,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA2L         : MACA2LR_MACA2L_Field := 16#7FFFFFFF#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#1#;
+      Reserved_31_31 : HAL.UInt1 := 16#1#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -779,7 +780,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA3H         : MACA3HR_MACA3H_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA3HR_MBC_Field := 16#0#;
       --  no description available
@@ -998,7 +999,7 @@ package STM32_SVD.Ethernet is
       Reserved_19_31 at 0 range 19 .. 31;
    end record;
 
-   subtype PTPSSIR_STSSI_Field is HAL.Byte;
+   subtype PTPSSIR_STSSI_Field is HAL.UInt8;
 
    --  Ethernet PTP subsecond increment register
    type PTPSSIR_Register is record
@@ -1141,7 +1142,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: DMA controller operation
    Ethernet_DMA_Periph : aliased Ethernet_DMA_Peripheral
-     with Import, Address => Ethernet_DMA_Base;
+     with Import, Address => System'To_Address (16#40029000#);
 
    --  Ethernet: media access control (MAC)
    type Ethernet_MAC_Peripheral is record
@@ -1213,7 +1214,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: media access control (MAC)
    Ethernet_MAC_Periph : aliased Ethernet_MAC_Peripheral
-     with Import, Address => Ethernet_MAC_Base;
+     with Import, Address => System'To_Address (16#40028000#);
 
    --  Ethernet: MAC management counters
    type Ethernet_MMC_Peripheral is record
@@ -1259,7 +1260,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: MAC management counters
    Ethernet_MMC_Periph : aliased Ethernet_MMC_Peripheral
-     with Import, Address => Ethernet_MMC_Base;
+     with Import, Address => System'To_Address (16#40028100#);
 
    --  Ethernet: Precision time protocol
    type Ethernet_PTP_Peripheral is record
@@ -1304,6 +1305,6 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: Precision time protocol
    Ethernet_PTP_Periph : aliased Ethernet_PTP_Peripheral
-     with Import, Address => Ethernet_PTP_Base;
+     with Import, Address => System'To_Address (16#40028700#);
 
 end STM32_SVD.Ethernet;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-exti.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-exti.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -279,6 +280,6 @@ package STM32_SVD.EXTI is
 
    --  External interrupt/event controller
    EXTI_Periph : aliased EXTI_Peripheral
-     with Import, Address => EXTI_Base;
+     with Import, Address => System'To_Address (16#40013C00#);
 
 end STM32_SVD.EXTI;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-flash.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-flash.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -65,7 +66,7 @@ package STM32_SVD.FLASH is
       --  Programming sequence error
       PGSERR         : Boolean := False;
       --  unspecified
-      Reserved_8_15  : HAL.Byte := 16#0#;
+      Reserved_8_15  : HAL.UInt8 := 16#0#;
       --  Read-only. Busy
       BSY            : Boolean := False;
       --  unspecified
@@ -101,7 +102,7 @@ package STM32_SVD.FLASH is
       --  Sector number
       SNB            : CR_SNB_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Program size
       PSIZE          : CR_PSIZE_Field := 16#0#;
       --  unspecified
@@ -139,7 +140,7 @@ package STM32_SVD.FLASH is
    end record;
 
    subtype OPTCR_BOR_LEV_Field is HAL.UInt2;
-   subtype OPTCR_RDP_Field is HAL.Byte;
+   subtype OPTCR_RDP_Field is HAL.UInt8;
    subtype OPTCR_nWRP_Field is HAL.UInt12;
 
    --  Flash option control register
@@ -151,7 +152,7 @@ package STM32_SVD.FLASH is
       --  BOR reset Level
       BOR_LEV        : OPTCR_BOR_LEV_Field := 16#1#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#1#;
+      Reserved_4_4   : HAL.UInt1 := 16#1#;
       --  WDG_SW User option bytes
       WDG_SW         : Boolean := False;
       --  nRST_STOP User option bytes
@@ -213,6 +214,6 @@ package STM32_SVD.FLASH is
 
    --  FLASH
    FLASH_Periph : aliased FLASH_Peripheral
-     with Import, Address => FLASH_Base;
+     with Import, Address => System'To_Address (16#40023C00#);
 
 end STM32_SVD.FLASH;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-flash.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-flash.ads
@@ -102,7 +102,7 @@ package STM32_SVD.FLASH is
       --  Sector number
       SNB            : CR_SNB_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Program size
       PSIZE          : CR_PSIZE_Field := 16#0#;
       --  unspecified
@@ -152,7 +152,7 @@ package STM32_SVD.FLASH is
       --  BOR reset Level
       BOR_LEV        : OPTCR_BOR_LEV_Field := 16#1#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#1#;
+      Reserved_4_4   : HAL.Bit := 16#1#;
       --  WDG_SW User option bytes
       WDG_SW         : Boolean := False;
       --  nRST_STOP User option bytes

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-fsmc.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-fsmc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -29,13 +30,13 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#1#;
+      Reserved_7_7   : HAL.UInt1 := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
       WAITPOL        : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  WAITCFG
       WAITCFG        : Boolean := False;
       --  WREN
@@ -78,7 +79,7 @@ package STM32_SVD.FSMC is
 
    subtype BTR_ADDSET_Field is HAL.UInt4;
    subtype BTR_ADDHLD_Field is HAL.UInt4;
-   subtype BTR_DATAST_Field is HAL.Byte;
+   subtype BTR_DATAST_Field is HAL.UInt8;
    subtype BTR_BUSTURN_Field is HAL.UInt4;
    subtype BTR_CLKDIV_Field is HAL.UInt4;
    subtype BTR_DATLAT_Field is HAL.UInt4;
@@ -133,7 +134,7 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#1#;
+      Reserved_7_7   : HAL.UInt1 := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
@@ -188,7 +189,7 @@ package STM32_SVD.FSMC is
    --  PC Card/NAND Flash control register 2
    type PCR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  PWAITEN
       PWAITEN        : Boolean := False;
       --  PBKEN
@@ -260,10 +261,10 @@ package STM32_SVD.FSMC is
       Reserved_7_31 at 0 range 7 .. 31;
    end record;
 
-   subtype PMEM_MEMSETx_Field is HAL.Byte;
-   subtype PMEM_MEMWAITx_Field is HAL.Byte;
-   subtype PMEM_MEMHOLDx_Field is HAL.Byte;
-   subtype PMEM_MEMHIZx_Field is HAL.Byte;
+   subtype PMEM_MEMSETx_Field is HAL.UInt8;
+   subtype PMEM_MEMWAITx_Field is HAL.UInt8;
+   subtype PMEM_MEMHOLDx_Field is HAL.UInt8;
+   subtype PMEM_MEMHIZx_Field is HAL.UInt8;
 
    --  Common memory space timing register 2
    type PMEM_Register is record
@@ -286,10 +287,10 @@ package STM32_SVD.FSMC is
       MEMHIZx  at 0 range 24 .. 31;
    end record;
 
-   subtype PATT_ATTSETx_Field is HAL.Byte;
-   subtype PATT_ATTWAITx_Field is HAL.Byte;
-   subtype PATT_ATTHOLDx_Field is HAL.Byte;
-   subtype PATT_ATTHIZx_Field is HAL.Byte;
+   subtype PATT_ATTSETx_Field is HAL.UInt8;
+   subtype PATT_ATTWAITx_Field is HAL.UInt8;
+   subtype PATT_ATTHOLDx_Field is HAL.UInt8;
+   subtype PATT_ATTHIZx_Field is HAL.UInt8;
 
    --  Attribute memory space timing register 2
    type PATT_Register is record
@@ -312,10 +313,10 @@ package STM32_SVD.FSMC is
       ATTHIZx  at 0 range 24 .. 31;
    end record;
 
-   subtype PIO4_IOSETx_Field is HAL.Byte;
-   subtype PIO4_IOWAITx_Field is HAL.Byte;
-   subtype PIO4_IOHOLDx_Field is HAL.Byte;
-   subtype PIO4_IOHIZx_Field is HAL.Byte;
+   subtype PIO4_IOSETx_Field is HAL.UInt8;
+   subtype PIO4_IOWAITx_Field is HAL.UInt8;
+   subtype PIO4_IOHOLDx_Field is HAL.UInt8;
+   subtype PIO4_IOHIZx_Field is HAL.UInt8;
 
    --  I/O space timing register 4
    type PIO4_Register is record
@@ -340,7 +341,7 @@ package STM32_SVD.FSMC is
 
    subtype BWTR_ADDSET_Field is HAL.UInt4;
    subtype BWTR_ADDHLD_Field is HAL.UInt4;
-   subtype BWTR_DATAST_Field is HAL.Byte;
+   subtype BWTR_DATAST_Field is HAL.UInt8;
    subtype BWTR_CLKDIV_Field is HAL.UInt4;
    subtype BWTR_DATLAT_Field is HAL.UInt4;
    subtype BWTR_ACCMOD_Field is HAL.UInt2;
@@ -473,6 +474,6 @@ package STM32_SVD.FSMC is
 
    --  Flexible static memory controller
    FSMC_Periph : aliased FSMC_Peripheral
-     with Import, Address => FSMC_Base;
+     with Import, Address => System'To_Address (16#A0000000#);
 
 end STM32_SVD.FSMC;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-fsmc.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-fsmc.ads
@@ -30,13 +30,13 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#1#;
+      Reserved_7_7   : HAL.Bit := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
       WAITPOL        : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  WAITCFG
       WAITCFG        : Boolean := False;
       --  WREN
@@ -134,7 +134,7 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#1#;
+      Reserved_7_7   : HAL.Bit := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
@@ -189,7 +189,7 @@ package STM32_SVD.FSMC is
    --  PC Card/NAND Flash control register 2
    type PCR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  PWAITEN
       PWAITEN        : Boolean := False;
       --  PBKEN

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-gpio.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-gpio.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -419,38 +420,38 @@ package STM32_SVD.GPIO is
 
    --  General-purpose I/Os
    GPIOA_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOA_Base;
+     with Import, Address => System'To_Address (16#40020000#);
 
    --  General-purpose I/Os
    GPIOB_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOB_Base;
+     with Import, Address => System'To_Address (16#40020400#);
 
    --  General-purpose I/Os
    GPIOC_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOC_Base;
+     with Import, Address => System'To_Address (16#40020800#);
 
    --  General-purpose I/Os
    GPIOD_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOD_Base;
+     with Import, Address => System'To_Address (16#40020C00#);
 
    --  General-purpose I/Os
    GPIOE_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOE_Base;
+     with Import, Address => System'To_Address (16#40021000#);
 
    --  General-purpose I/Os
    GPIOF_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOF_Base;
+     with Import, Address => System'To_Address (16#40021400#);
 
    --  General-purpose I/Os
    GPIOG_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOG_Base;
+     with Import, Address => System'To_Address (16#40021800#);
 
    --  General-purpose I/Os
    GPIOH_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOH_Base;
+     with Import, Address => System'To_Address (16#40021C00#);
 
    --  General-purpose I/Os
    GPIOI_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOI_Base;
+     with Import, Address => System'To_Address (16#40022000#);
 
 end STM32_SVD.GPIO;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-i2c.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-i2c.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -20,7 +21,7 @@ package STM32_SVD.I2C is
       --  SMBus mode
       SMBUS          : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SMBus type
       SMBTYPE        : Boolean := False;
       --  ARP enable
@@ -44,7 +45,7 @@ package STM32_SVD.I2C is
       --  SMBus alert
       ALERT          : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Software reset
       SWRST          : Boolean := False;
       --  unspecified
@@ -158,7 +159,7 @@ package STM32_SVD.I2C is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype DR_DR_Field is HAL.Byte;
+   subtype DR_DR_Field is HAL.UInt8;
 
    --  Data register
    type DR_Register is record
@@ -188,7 +189,7 @@ package STM32_SVD.I2C is
       --  Read-only. Stop detection (slave mode)
       STOPF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Read-only. Data register not empty (receivers)
       RxNE           : Boolean := False;
       --  Read-only. Data register empty (transmitters)
@@ -204,7 +205,7 @@ package STM32_SVD.I2C is
       --  PEC Error in reception
       PECERR         : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  Timeout or Tlow error
       TIMEOUT        : Boolean := False;
       --  SMBus alert
@@ -235,7 +236,7 @@ package STM32_SVD.I2C is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype SR2_PEC_Field is HAL.Byte;
+   subtype SR2_PEC_Field is HAL.UInt8;
 
    --  Status register 2
    type SR2_Register is record
@@ -246,7 +247,7 @@ package STM32_SVD.I2C is
       --  Read-only. Transmitter/receiver
       TRA            : Boolean;
       --  unspecified
-      Reserved_3_3   : HAL.Bit;
+      Reserved_3_3   : HAL.UInt1;
       --  Read-only. General call address (Slave mode)
       GENCALL        : Boolean;
       --  Read-only. SMBus device default address (Slave mode)
@@ -360,14 +361,14 @@ package STM32_SVD.I2C is
 
    --  Inter-integrated circuit
    I2C1_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C1_Base;
+     with Import, Address => System'To_Address (16#40005400#);
 
    --  Inter-integrated circuit
    I2C2_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C2_Base;
+     with Import, Address => System'To_Address (16#40005800#);
 
    --  Inter-integrated circuit
    I2C3_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C3_Base;
+     with Import, Address => System'To_Address (16#40005C00#);
 
 end STM32_SVD.I2C;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-i2c.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-i2c.ads
@@ -21,7 +21,7 @@ package STM32_SVD.I2C is
       --  SMBus mode
       SMBUS          : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SMBus type
       SMBTYPE        : Boolean := False;
       --  ARP enable
@@ -45,7 +45,7 @@ package STM32_SVD.I2C is
       --  SMBus alert
       ALERT          : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Software reset
       SWRST          : Boolean := False;
       --  unspecified
@@ -189,7 +189,7 @@ package STM32_SVD.I2C is
       --  Read-only. Stop detection (slave mode)
       STOPF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Read-only. Data register not empty (receivers)
       RxNE           : Boolean := False;
       --  Read-only. Data register empty (transmitters)
@@ -205,7 +205,7 @@ package STM32_SVD.I2C is
       --  PEC Error in reception
       PECERR         : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  Timeout or Tlow error
       TIMEOUT        : Boolean := False;
       --  SMBus alert
@@ -247,7 +247,7 @@ package STM32_SVD.I2C is
       --  Read-only. Transmitter/receiver
       TRA            : Boolean;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1;
+      Reserved_3_3   : HAL.Bit;
       --  Read-only. General call address (Slave mode)
       GENCALL        : Boolean;
       --  Read-only. SMBus device default address (Slave mode)

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-iwdg.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-iwdg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -108,6 +109,6 @@ package STM32_SVD.IWDG is
 
    --  Independent watchdog
    IWDG_Periph : aliased IWDG_Peripheral
-     with Import, Address => IWDG_Base;
+     with Import, Address => System'To_Address (16#40003000#);
 
 end STM32_SVD.IWDG;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-nvic.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-nvic.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -31,7 +32,7 @@ package STM32_SVD.NVIC is
    end record;
 
    --  IPR_IPR_N array element
-   subtype IPR_IPR_N_Element is HAL.Byte;
+   subtype IPR_IPR_N_Element is HAL.UInt8;
 
    --  IPR_IPR_N array
    type IPR_IPR_N_Field_Array is array (0 .. 3) of IPR_IPR_N_Element
@@ -200,6 +201,6 @@ package STM32_SVD.NVIC is
 
    --  Nested Vectored Interrupt Controller
    NVIC_Periph : aliased NVIC_Peripheral
-     with Import, Address => NVIC_Base;
+     with Import, Address => System'To_Address (16#E000E000#);
 
 end STM32_SVD.NVIC;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-pwr.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-pwr.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -116,6 +117,6 @@ package STM32_SVD.PWR is
 
    --  Power control
    PWR_Periph : aliased PWR_Peripheral
-     with Import, Address => PWR_Base;
+     with Import, Address => System'To_Address (16#40007000#);
 
 end STM32_SVD.PWR;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-rcc.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-rcc.ads
@@ -24,7 +24,7 @@ package STM32_SVD.RCC is
       --  Read-only. Internal high-speed clock ready flag
       HSIRDY         : Boolean := True;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Internal high-speed clock trimming
       HSITRIM        : CR_HSITRIM_Field := 16#10#;
       --  Read-only. Internal high-speed clock calibration
@@ -84,7 +84,7 @@ package STM32_SVD.RCC is
       --  Main PLL (PLL) multiplication factor for VCO
       PLLN           : PLLCFGR_PLLN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Main PLL (PLL) division factor for main system clock
       PLLP           : PLLCFGR_PLLP_Field := 16#0#;
       --  unspecified
@@ -92,7 +92,7 @@ package STM32_SVD.RCC is
       --  Main PLL(PLL) and audio PLL (PLLI2S) entry clock source
       PLLSRC         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Main PLL (PLL) division factor for USB OTG FS, SDIO and random number
       --  generator clocks
       PLLQ           : PLLCFGR_PLLQ_Field := 16#4#;
@@ -207,7 +207,7 @@ package STM32_SVD.RCC is
       --  Read-only. PLLI2S ready interrupt flag
       PLLI2SRDYF     : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  Read-only. Clock security system interrupt flag
       CSSF           : Boolean := False;
       --  LSI ready interrupt enable
@@ -237,7 +237,7 @@ package STM32_SVD.RCC is
       --  Write-only. PLLI2S ready interrupt clear
       PLLI2SRDYC     : Boolean := False;
       --  unspecified
-      Reserved_22_22 : HAL.UInt1 := 16#0#;
+      Reserved_22_22 : HAL.Bit := 16#0#;
       --  Write-only. Clock security system interrupt clear
       CSSC           : Boolean := False;
       --  unspecified
@@ -409,7 +409,7 @@ package STM32_SVD.RCC is
       --  SPI 3 reset
       SPI3RST        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  USART 2 reset
       UART2RST       : Boolean := False;
       --  USART 3 reset
@@ -425,13 +425,13 @@ package STM32_SVD.RCC is
       --  I2C3 reset
       I2C3RST        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CAN1 reset
       CAN1RST        : Boolean := False;
       --  CAN2 reset
       CAN2RST        : Boolean := False;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Power interface reset
       PWRRST         : Boolean := False;
       --  DAC reset
@@ -497,11 +497,11 @@ package STM32_SVD.RCC is
       --  SPI 1 reset
       SPI1RST        : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  System configuration controller reset
       SYSCFGRST      : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 reset
       TIM9RST        : Boolean := False;
       --  TIM10 reset
@@ -583,7 +583,7 @@ package STM32_SVD.RCC is
       --  USB OTG HSULPI clock enable
       OTGHSULPIEN    : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -685,7 +685,7 @@ package STM32_SVD.RCC is
       --  SPI3 clock enable
       SPI3EN         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  USART 2 clock enable
       USART2EN       : Boolean := False;
       --  USART3 clock enable
@@ -701,13 +701,13 @@ package STM32_SVD.RCC is
       --  I2C3 clock enable
       I2C3EN         : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CAN 1 clock enable
       CAN1EN         : Boolean := False;
       --  CAN 2 clock enable
       CAN2EN         : Boolean := False;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Power interface clock enable
       PWREN          : Boolean := False;
       --  DAC interface clock enable
@@ -775,11 +775,11 @@ package STM32_SVD.RCC is
       --  SPI1 clock enable
       SPI1EN         : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  System configuration controller clock enable
       SYSCFGEN       : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 clock enable
       TIM9EN         : Boolean := False;
       --  TIM10 clock enable
@@ -868,7 +868,7 @@ package STM32_SVD.RCC is
       --  USB OTG HS ULPI clock enable during Sleep mode
       OTGHSULPILPEN  : Boolean := True;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -974,7 +974,7 @@ package STM32_SVD.RCC is
       --  SPI3 clock enable during Sleep mode
       SPI3LPEN       : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  USART2 clock enable during Sleep mode
       USART2LPEN     : Boolean := True;
       --  USART3 clock enable during Sleep mode
@@ -990,13 +990,13 @@ package STM32_SVD.RCC is
       --  I2C3 clock enable during Sleep mode
       I2C3LPEN       : Boolean := True;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CAN 1 clock enable during Sleep mode
       CAN1LPEN       : Boolean := True;
       --  CAN 2 clock enable during Sleep mode
       CAN2LPEN       : Boolean := True;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Power interface clock enable during Sleep mode
       PWRLPEN        : Boolean := True;
       --  DAC interface clock enable during Sleep mode
@@ -1064,11 +1064,11 @@ package STM32_SVD.RCC is
       --  SPI 1 clock enable during Sleep mode
       SPI1LPEN       : Boolean := True;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  System configuration controller clock enable during Sleep mode
       SYSCFGLPEN     : Boolean := True;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 clock enable during sleep mode
       TIM9LPEN       : Boolean := True;
       --  TIM10 clock enable during Sleep mode
@@ -1245,7 +1245,7 @@ package STM32_SVD.RCC is
       --  PLLI2S division factor for I2S clocks
       PLLI2SRx       : PLLI2SCFGR_PLLI2SRx_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-rcc.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-rcc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -14,7 +15,7 @@ package STM32_SVD.RCC is
    ---------------
 
    subtype CR_HSITRIM_Field is HAL.UInt5;
-   subtype CR_HSICAL_Field is HAL.Byte;
+   subtype CR_HSICAL_Field is HAL.UInt8;
 
    --  clock control register
    type CR_Register is record
@@ -23,7 +24,7 @@ package STM32_SVD.RCC is
       --  Read-only. Internal high-speed clock ready flag
       HSIRDY         : Boolean := True;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Internal high-speed clock trimming
       HSITRIM        : CR_HSITRIM_Field := 16#10#;
       --  Read-only. Internal high-speed clock calibration
@@ -83,7 +84,7 @@ package STM32_SVD.RCC is
       --  Main PLL (PLL) multiplication factor for VCO
       PLLN           : PLLCFGR_PLLN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Main PLL (PLL) division factor for main system clock
       PLLP           : PLLCFGR_PLLP_Field := 16#0#;
       --  unspecified
@@ -91,7 +92,7 @@ package STM32_SVD.RCC is
       --  Main PLL(PLL) and audio PLL (PLLI2S) entry clock source
       PLLSRC         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Main PLL (PLL) division factor for USB OTG FS, SDIO and random number
       --  generator clocks
       PLLQ           : PLLCFGR_PLLQ_Field := 16#4#;
@@ -206,7 +207,7 @@ package STM32_SVD.RCC is
       --  Read-only. PLLI2S ready interrupt flag
       PLLI2SRDYF     : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  Read-only. Clock security system interrupt flag
       CSSF           : Boolean := False;
       --  LSI ready interrupt enable
@@ -236,11 +237,11 @@ package STM32_SVD.RCC is
       --  Write-only. PLLI2S ready interrupt clear
       PLLI2SRDYC     : Boolean := False;
       --  unspecified
-      Reserved_22_22 : HAL.Bit := 16#0#;
+      Reserved_22_22 : HAL.UInt1 := 16#0#;
       --  Write-only. Clock security system interrupt clear
       CSSC           : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -297,7 +298,7 @@ package STM32_SVD.RCC is
       --  CRC reset
       CRCRST         : Boolean := False;
       --  unspecified
-      Reserved_13_20 : HAL.Byte := 16#0#;
+      Reserved_13_20 : HAL.UInt8 := 16#0#;
       --  DMA2 reset
       DMA1RST        : Boolean := False;
       --  DMA2 reset
@@ -408,7 +409,7 @@ package STM32_SVD.RCC is
       --  SPI 3 reset
       SPI3RST        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  USART 2 reset
       UART2RST       : Boolean := False;
       --  USART 3 reset
@@ -424,13 +425,13 @@ package STM32_SVD.RCC is
       --  I2C3 reset
       I2C3RST        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CAN1 reset
       CAN1RST        : Boolean := False;
       --  CAN2 reset
       CAN2RST        : Boolean := False;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Power interface reset
       PWRRST         : Boolean := False;
       --  DAC reset
@@ -496,11 +497,11 @@ package STM32_SVD.RCC is
       --  SPI 1 reset
       SPI1RST        : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  System configuration controller reset
       SYSCFGRST      : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 reset
       TIM9RST        : Boolean := False;
       --  TIM10 reset
@@ -582,7 +583,7 @@ package STM32_SVD.RCC is
       --  USB OTG HSULPI clock enable
       OTGHSULPIEN    : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -684,7 +685,7 @@ package STM32_SVD.RCC is
       --  SPI3 clock enable
       SPI3EN         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  USART 2 clock enable
       USART2EN       : Boolean := False;
       --  USART3 clock enable
@@ -700,13 +701,13 @@ package STM32_SVD.RCC is
       --  I2C3 clock enable
       I2C3EN         : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CAN 1 clock enable
       CAN1EN         : Boolean := False;
       --  CAN 2 clock enable
       CAN2EN         : Boolean := False;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Power interface clock enable
       PWREN          : Boolean := False;
       --  DAC interface clock enable
@@ -774,11 +775,11 @@ package STM32_SVD.RCC is
       --  SPI1 clock enable
       SPI1EN         : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  System configuration controller clock enable
       SYSCFGEN       : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 clock enable
       TIM9EN         : Boolean := False;
       --  TIM10 clock enable
@@ -867,7 +868,7 @@ package STM32_SVD.RCC is
       --  USB OTG HS ULPI clock enable during Sleep mode
       OTGHSULPILPEN  : Boolean := True;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -973,7 +974,7 @@ package STM32_SVD.RCC is
       --  SPI3 clock enable during Sleep mode
       SPI3LPEN       : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  USART2 clock enable during Sleep mode
       USART2LPEN     : Boolean := True;
       --  USART3 clock enable during Sleep mode
@@ -989,13 +990,13 @@ package STM32_SVD.RCC is
       --  I2C3 clock enable during Sleep mode
       I2C3LPEN       : Boolean := True;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CAN 1 clock enable during Sleep mode
       CAN1LPEN       : Boolean := True;
       --  CAN 2 clock enable during Sleep mode
       CAN2LPEN       : Boolean := True;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Power interface clock enable during Sleep mode
       PWRLPEN        : Boolean := True;
       --  DAC interface clock enable during Sleep mode
@@ -1063,11 +1064,11 @@ package STM32_SVD.RCC is
       --  SPI 1 clock enable during Sleep mode
       SPI1LPEN       : Boolean := True;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  System configuration controller clock enable during Sleep mode
       SYSCFGLPEN     : Boolean := True;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 clock enable during sleep mode
       TIM9LPEN       : Boolean := True;
       --  TIM10 clock enable during Sleep mode
@@ -1244,7 +1245,7 @@ package STM32_SVD.RCC is
       --  PLLI2S division factor for I2S clocks
       PLLI2SRx       : PLLI2SCFGR_PLLI2SRx_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1340,6 +1341,6 @@ package STM32_SVD.RCC is
 
    --  Reset and clock control
    RCC_Periph : aliased RCC_Peripheral
-     with Import, Address => RCC_Base;
+     with Import, Address => System'To_Address (16#40023800#);
 
 end STM32_SVD.RCC;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-rng.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-rng.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -87,6 +88,6 @@ package STM32_SVD.RNG is
 
    --  Random number generator
    RNG_Periph : aliased RNG_Peripheral
-     with Import, Address => RNG_Base;
+     with Import, Address => System'To_Address (16#50060800#);
 
 end STM32_SVD.RNG;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-rtc.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-rtc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -27,13 +28,13 @@ package STM32_SVD.RTC is
       --  Second tens in BCD format
       ST             : TR_ST_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Minute units in BCD format
       MNU            : TR_MNU_Field := 16#0#;
       --  Minute tens in BCD format
       MNT            : TR_MNT_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Hour units in BCD format
       HU             : TR_HU_Field := 16#0#;
       --  Hour tens in BCD format
@@ -85,7 +86,7 @@ package STM32_SVD.RTC is
       --  Year tens in BCD format
       YT             : DR_YT_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -114,7 +115,7 @@ package STM32_SVD.RTC is
       --  Reference clock detection enable (50 or 60 Hz)
       REFCKON        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Hour format
       FMT            : Boolean := False;
       --  Coarse digital calibration enable
@@ -142,7 +143,7 @@ package STM32_SVD.RTC is
       --  Backup
       BKP            : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  Output polarity
       POL            : Boolean := False;
       --  Output selection
@@ -150,7 +151,7 @@ package STM32_SVD.RTC is
       --  Calibration output enable
       COE            : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -213,7 +214,7 @@ package STM32_SVD.RTC is
       --  TAMPER2 detection flag
       TAMP2F         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Read-only. Recalibration pending Flag
       RECALPF        : Boolean := False;
       --  unspecified
@@ -251,7 +252,7 @@ package STM32_SVD.RTC is
       --  Synchronous prescaler factor
       PREDIV_S       : PRER_PREDIV_S_Field := 16#FF#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Asynchronous prescaler factor
       PREDIV_A       : PRER_PREDIV_A_Field := 16#7F#;
       --  unspecified
@@ -427,7 +428,7 @@ package STM32_SVD.RTC is
       MSK4  at 0 range 31 .. 31;
    end record;
 
-   subtype WPR_KEY_Field is HAL.Byte;
+   subtype WPR_KEY_Field is HAL.UInt8;
 
    --  write protection register
    type WPR_Register is record
@@ -853,6 +854,6 @@ package STM32_SVD.RTC is
 
    --  Real-time clock
    RTC_Periph : aliased RTC_Peripheral
-     with Import, Address => RTC_Base;
+     with Import, Address => System'To_Address (16#40002800#);
 
 end STM32_SVD.RTC;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-rtc.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-rtc.ads
@@ -28,13 +28,13 @@ package STM32_SVD.RTC is
       --  Second tens in BCD format
       ST             : TR_ST_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Minute units in BCD format
       MNU            : TR_MNU_Field := 16#0#;
       --  Minute tens in BCD format
       MNT            : TR_MNT_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Hour units in BCD format
       HU             : TR_HU_Field := 16#0#;
       --  Hour tens in BCD format
@@ -115,7 +115,7 @@ package STM32_SVD.RTC is
       --  Reference clock detection enable (50 or 60 Hz)
       REFCKON        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Hour format
       FMT            : Boolean := False;
       --  Coarse digital calibration enable
@@ -143,7 +143,7 @@ package STM32_SVD.RTC is
       --  Backup
       BKP            : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  Output polarity
       POL            : Boolean := False;
       --  Output selection
@@ -214,7 +214,7 @@ package STM32_SVD.RTC is
       --  TAMPER2 detection flag
       TAMP2F         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Read-only. Recalibration pending Flag
       RECALPF        : Boolean := False;
       --  unspecified
@@ -252,7 +252,7 @@ package STM32_SVD.RTC is
       --  Synchronous prescaler factor
       PREDIV_S       : PRER_PREDIV_S_Field := 16#FF#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Asynchronous prescaler factor
       PREDIV_A       : PRER_PREDIV_A_Field := 16#7F#;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-sdio.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-sdio.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -30,7 +31,7 @@ package STM32_SVD.SDIO is
       Reserved_2_31 at 0 range 2 .. 31;
    end record;
 
-   subtype CLKCR_CLKDIV_Field is HAL.Byte;
+   subtype CLKCR_CLKDIV_Field is HAL.UInt8;
    subtype CLKCR_WIDBUS_Field is HAL.UInt2;
 
    --  SDI clock control register
@@ -255,7 +256,7 @@ package STM32_SVD.SDIO is
       --  Read-only. CE-ATA command completion signal received for CMD61
       CEATAEND       : Boolean;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -319,7 +320,7 @@ package STM32_SVD.SDIO is
       --  CEATAEND flag clear bit
       CEATAENDC      : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -393,7 +394,7 @@ package STM32_SVD.SDIO is
       --  CE-ATA command completion signal received interrupt enable
       CEATAENDIE     : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -434,7 +435,7 @@ package STM32_SVD.SDIO is
       --  the FIFO.
       FIFOCOUNT      : FIFOCNT_FIFOCOUNT_Field;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -512,6 +513,6 @@ package STM32_SVD.SDIO is
 
    --  Secure digital input/output interface
    SDIO_Periph : aliased SDIO_Peripheral
-     with Import, Address => SDIO_Base;
+     with Import, Address => System'To_Address (16#40012C00#);
 
 end STM32_SVD.SDIO;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-spi.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-spi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -78,7 +79,7 @@ package STM32_SVD.SPI is
       --  SS output enable
       SSOE          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Frame format
       FRF           : Boolean := False;
       --  Error interrupt enable
@@ -227,7 +228,7 @@ package STM32_SVD.SPI is
       --  I2S standard selection
       I2SSTD         : I2SCFGR_I2SSTD_Field := 16#0#;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  PCM frame synchronization
       PCMSYNC        : Boolean := False;
       --  I2S configuration mode
@@ -255,7 +256,7 @@ package STM32_SVD.SPI is
       Reserved_12_31 at 0 range 12 .. 31;
    end record;
 
-   subtype I2SPR_I2SDIV_Field is HAL.Byte;
+   subtype I2SPR_I2SDIV_Field is HAL.UInt8;
 
    --  I2S prescaler register
    type I2SPR_Register is record
@@ -319,22 +320,22 @@ package STM32_SVD.SPI is
 
    --  Serial peripheral interface
    I2S2ext_Periph : aliased SPI_Peripheral
-     with Import, Address => I2S2ext_Base;
+     with Import, Address => System'To_Address (16#40003400#);
 
    --  Serial peripheral interface
    I2S3ext_Periph : aliased SPI_Peripheral
-     with Import, Address => I2S3ext_Base;
+     with Import, Address => System'To_Address (16#40004000#);
 
    --  Serial peripheral interface
    SPI1_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI1_Base;
+     with Import, Address => System'To_Address (16#40013000#);
 
    --  Serial peripheral interface
    SPI2_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI2_Base;
+     with Import, Address => System'To_Address (16#40003800#);
 
    --  Serial peripheral interface
    SPI3_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI3_Base;
+     with Import, Address => System'To_Address (16#40003C00#);
 
 end STM32_SVD.SPI;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-spi.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-spi.ads
@@ -79,7 +79,7 @@ package STM32_SVD.SPI is
       --  SS output enable
       SSOE          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Frame format
       FRF           : Boolean := False;
       --  Error interrupt enable
@@ -228,7 +228,7 @@ package STM32_SVD.SPI is
       --  I2S standard selection
       I2SSTD         : I2SCFGR_I2SSTD_Field := 16#0#;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  PCM frame synchronization
       PCMSYNC        : Boolean := False;
       --  I2S configuration mode

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-syscfg.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-syscfg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -37,7 +38,7 @@ package STM32_SVD.SYSCFG is
       --  Ethernet PHY interface selection
       MII_RMII_SEL   : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -276,6 +277,6 @@ package STM32_SVD.SYSCFG is
 
    --  System configuration controller
    SYSCFG_Periph : aliased SYSCFG_Peripheral
-     with Import, Address => SYSCFG_Base;
+     with Import, Address => System'To_Address (16#40013800#);
 
 end STM32_SVD.SYSCFG;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-tim.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-tim.ads
@@ -60,7 +60,7 @@ package STM32_SVD.TIM is
       --  Capture/compare preloaded control
       CCPC           : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Capture/compare control update selection
       CCUS           : Boolean := False;
       --  Capture/compare DMA selection
@@ -116,7 +116,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -223,7 +223,7 @@ package STM32_SVD.TIM is
       --  Break interrupt flag
       BIF            : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  Capture/Compare 1 overcapture flag
       CC1OF          : Boolean := False;
       --  Capture/compare 2 overcapture flag
@@ -766,11 +766,11 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt enable
       CC4IE          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Trigger interrupt enable
       TIE            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Update DMA request enable
       UDE            : Boolean := False;
       --  Capture/Compare 1 DMA request enable
@@ -782,7 +782,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 DMA request enable
       CC4DE          : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  Trigger DMA request enable
       TDE            : Boolean := False;
       --  unspecified
@@ -823,7 +823,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt flag
       CC4IF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Trigger interrupt flag
       TIF            : Boolean := False;
       --  unspecified
@@ -871,7 +871,7 @@ package STM32_SVD.TIM is
       --  Write-only. Capture/compare 4 generation
       CC4G          : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  Write-only. Trigger generation
       TG            : Boolean := False;
       --  unspecified
@@ -940,7 +940,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP          : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -948,7 +948,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P           : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP          : Boolean := False;
       --  Capture/Compare 3 output enable
@@ -956,7 +956,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC3P           : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Capture/Compare 3 output Polarity
       CC3NP          : Boolean := False;
       --  Capture/Compare 4 output enable
@@ -964,7 +964,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC4P           : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
@@ -1278,7 +1278,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS           : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Trigger selection
       TS            : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -1398,7 +1398,7 @@ package STM32_SVD.TIM is
       --  Output Compare 1 mode
       OC1M           : CCMR1_Output_OC1M_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Output_CC2S_Field := 16#0#;
       --  Output Compare 2 fast enable
@@ -1438,7 +1438,7 @@ package STM32_SVD.TIM is
       --  Input capture 1 filter
       IC1F           : CCMR1_Input_IC1F_Field_1 := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Input_CC2S_Field := 16#0#;
       --  Input capture 2 prescaler
@@ -1469,7 +1469,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1477,7 +1477,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P          : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP         : Boolean := False;
       --  unspecified
@@ -1640,7 +1640,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-tim.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-tim.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -59,7 +60,7 @@ package STM32_SVD.TIM is
       --  Capture/compare preloaded control
       CCPC           : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Capture/compare control update selection
       CCUS           : Boolean := False;
       --  Capture/compare DMA selection
@@ -115,7 +116,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -222,7 +223,7 @@ package STM32_SVD.TIM is
       --  Break interrupt flag
       BIF            : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 overcapture flag
       CC1OF          : Boolean := False;
       --  Capture/compare 2 overcapture flag
@@ -563,7 +564,7 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype RCR_REP_Field is HAL.Byte;
+   subtype RCR_REP_Field is HAL.UInt8;
 
    --  repetition counter register
    type RCR_Register is record
@@ -648,7 +649,7 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype BDTR_DTG_Field is HAL.Byte;
+   subtype BDTR_DTG_Field is HAL.UInt8;
    subtype BDTR_LOCK_Field is HAL.UInt2;
 
    --  break and dead-time register
@@ -765,11 +766,11 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt enable
       CC4IE          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Trigger interrupt enable
       TIE            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Update DMA request enable
       UDE            : Boolean := False;
       --  Capture/Compare 1 DMA request enable
@@ -781,7 +782,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 DMA request enable
       CC4DE          : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  Trigger DMA request enable
       TDE            : Boolean := False;
       --  unspecified
@@ -822,7 +823,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt flag
       CC4IF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Trigger interrupt flag
       TIF            : Boolean := False;
       --  unspecified
@@ -870,7 +871,7 @@ package STM32_SVD.TIM is
       --  Write-only. Capture/compare 4 generation
       CC4G          : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  Write-only. Trigger generation
       TG            : Boolean := False;
       --  unspecified
@@ -939,7 +940,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP          : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -947,7 +948,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P           : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP          : Boolean := False;
       --  Capture/Compare 3 output enable
@@ -955,7 +956,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC3P           : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Capture/Compare 3 output Polarity
       CC3NP          : Boolean := False;
       --  Capture/Compare 4 output enable
@@ -963,7 +964,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC4P           : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
@@ -1277,7 +1278,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS           : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Trigger selection
       TS            : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -1397,7 +1398,7 @@ package STM32_SVD.TIM is
       --  Output Compare 1 mode
       OC1M           : CCMR1_Output_OC1M_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Output_CC2S_Field := 16#0#;
       --  Output Compare 2 fast enable
@@ -1437,7 +1438,7 @@ package STM32_SVD.TIM is
       --  Input capture 1 filter
       IC1F           : CCMR1_Input_IC1F_Field_1 := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Input_CC2S_Field := 16#0#;
       --  Input capture 2 prescaler
@@ -1468,7 +1469,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1476,7 +1477,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P          : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP         : Boolean := False;
       --  unspecified
@@ -1639,7 +1640,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  unspecified
@@ -1764,11 +1765,11 @@ package STM32_SVD.TIM is
 
    --  Advanced-timers
    TIM1_Periph : aliased TIM1_Peripheral
-     with Import, Address => TIM1_Base;
+     with Import, Address => System'To_Address (16#40010000#);
 
    --  Advanced-timers
    TIM8_Periph : aliased TIM1_Peripheral
-     with Import, Address => TIM8_Base;
+     with Import, Address => System'To_Address (16#40010400#);
 
    type TIM2_Disc is
      (
@@ -1854,7 +1855,7 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM2_Periph : aliased TIM2_Peripheral
-     with Import, Address => TIM2_Base;
+     with Import, Address => System'To_Address (16#40000000#);
 
    type TIM3_Disc is
      (
@@ -1937,11 +1938,11 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM3_Periph : aliased TIM3_Peripheral
-     with Import, Address => TIM3_Base;
+     with Import, Address => System'To_Address (16#40000400#);
 
    --  General purpose timers
    TIM4_Periph : aliased TIM3_Peripheral
-     with Import, Address => TIM4_Base;
+     with Import, Address => System'To_Address (16#40000800#);
 
    type TIM5_Disc is
      (
@@ -2027,7 +2028,7 @@ package STM32_SVD.TIM is
 
    --  General-purpose-timers
    TIM5_Periph : aliased TIM5_Peripheral
-     with Import, Address => TIM5_Base;
+     with Import, Address => System'To_Address (16#40000C00#);
 
    --  Basic timers
    type TIM6_Peripheral is record
@@ -2063,11 +2064,11 @@ package STM32_SVD.TIM is
 
    --  Basic timers
    TIM6_Periph : aliased TIM6_Peripheral
-     with Import, Address => TIM6_Base;
+     with Import, Address => System'To_Address (16#40001000#);
 
    --  Basic timers
    TIM7_Periph : aliased TIM6_Peripheral
-     with Import, Address => TIM7_Base;
+     with Import, Address => System'To_Address (16#40001400#);
 
    type TIM9_Disc is
      (
@@ -2132,11 +2133,11 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM9_Periph : aliased TIM9_Peripheral
-     with Import, Address => TIM9_Base;
+     with Import, Address => System'To_Address (16#40014000#);
 
    --  General purpose timers
    TIM12_Periph : aliased TIM9_Peripheral
-     with Import, Address => TIM12_Base;
+     with Import, Address => System'To_Address (16#40001800#);
 
    type TIM10_Disc is
      (
@@ -2192,15 +2193,15 @@ package STM32_SVD.TIM is
 
    --  General-purpose-timers
    TIM10_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM10_Base;
+     with Import, Address => System'To_Address (16#40014400#);
 
    --  General-purpose-timers
    TIM13_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM13_Base;
+     with Import, Address => System'To_Address (16#40001C00#);
 
    --  General-purpose-timers
    TIM14_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM14_Base;
+     with Import, Address => System'To_Address (16#40002000#);
 
    type TIM11_Disc is
      (
@@ -2259,6 +2260,6 @@ package STM32_SVD.TIM is
 
    --  General-purpose-timers
    TIM11_Periph : aliased TIM11_Peripheral
-     with Import, Address => TIM11_Base;
+     with Import, Address => System'To_Address (16#40014800#);
 
 end STM32_SVD.TIM;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-usart.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-usart.ads
@@ -122,7 +122,7 @@ package STM32_SVD.USART is
       --  USART enable
       UE             : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Oversampling mode
       OVER8          : Boolean := False;
       --  unspecified
@@ -159,7 +159,7 @@ package STM32_SVD.USART is
       --  Address of the USART node
       ADD            : CR2_ADD_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  lin break detection length
       LBDL           : Boolean := False;
       --  LIN break detection interrupt enable
@@ -273,13 +273,13 @@ package STM32_SVD.USART is
       --  Address of the USART node
       ADD            : CR2_ADD_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  lin break detection length
       LBDL           : Boolean := False;
       --  LIN break detection interrupt enable
       LBDIE          : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Last bit clock pulse
       LBCL           : Boolean := False;
       --  Clock phase

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-usart.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-usart.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -121,7 +122,7 @@ package STM32_SVD.USART is
       --  USART enable
       UE             : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Oversampling mode
       OVER8          : Boolean := False;
       --  unspecified
@@ -158,7 +159,7 @@ package STM32_SVD.USART is
       --  Address of the USART node
       ADD            : CR2_ADD_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  lin break detection length
       LBDL           : Boolean := False;
       --  LIN break detection interrupt enable
@@ -272,13 +273,13 @@ package STM32_SVD.USART is
       --  Address of the USART node
       ADD            : CR2_ADD_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  lin break detection length
       LBDL           : Boolean := False;
       --  LIN break detection interrupt enable
       LBDIE          : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Last bit clock pulse
       LBCL           : Boolean := False;
       --  Clock phase
@@ -360,8 +361,8 @@ package STM32_SVD.USART is
       Reserved_12_31 at 0 range 12 .. 31;
    end record;
 
-   subtype GTPR_PSC_Field is HAL.Byte;
-   subtype GTPR_GT_Field is HAL.Byte;
+   subtype GTPR_PSC_Field is HAL.UInt8;
+   subtype GTPR_GT_Field is HAL.UInt8;
 
    --  Guard time and prescaler register
    type GTPR_Register is record
@@ -413,11 +414,11 @@ package STM32_SVD.USART is
 
    --  Universal synchronous asynchronous receiver transmitter
    UART4_Periph : aliased UART4_Peripheral
-     with Import, Address => UART4_Base;
+     with Import, Address => System'To_Address (16#40004C00#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART5_Periph : aliased UART4_Peripheral
-     with Import, Address => UART5_Base;
+     with Import, Address => System'To_Address (16#40005000#);
 
    --  Universal synchronous asynchronous receiver transmitter
    type USART1_Peripheral is record
@@ -450,18 +451,18 @@ package STM32_SVD.USART is
 
    --  Universal synchronous asynchronous receiver transmitter
    USART1_Periph : aliased USART1_Peripheral
-     with Import, Address => USART1_Base;
+     with Import, Address => System'To_Address (16#40011000#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART2_Periph : aliased USART1_Peripheral
-     with Import, Address => USART2_Base;
+     with Import, Address => System'To_Address (16#40004400#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART3_Periph : aliased USART1_Peripheral
-     with Import, Address => USART3_Base;
+     with Import, Address => System'To_Address (16#40004800#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART6_Periph : aliased USART1_Peripheral
-     with Import, Address => USART6_Base;
+     with Import, Address => System'To_Address (16#40011400#);
 
 end STM32_SVD.USART;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-usb_otg_fs.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-usb_otg_fs.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -24,7 +25,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Non-zero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Device address
       DAD            : FS_DCFG_DAD_Field := 16#0#;
       --  Periodic frame interval
@@ -126,7 +127,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (Non-isochronous endpoints)
       TOM           : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -160,7 +161,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  SETUP phase done mask
       STUPM         : Boolean := False;
       --  OUT token received when endpoint disabled mask
@@ -280,13 +281,13 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
       EPTYP          : FS_DIEPCTL0_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  STALL handshake
       STALL          : Boolean := False;
       --  TxFIFO number
@@ -329,13 +330,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  TOC
       TOC           : Boolean := False;
       --  ITTXFE
       ITTXFE        : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  INEPNE
       INEPNE        : Boolean := False;
       --  Read-only. TXFE
@@ -418,7 +419,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : DIEPCTL1_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -470,7 +471,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Multi count
       MCNT           : DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -501,7 +502,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -552,7 +553,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USBAEP
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAKSTS
       NAKSTS         : Boolean := False;
       --  Read-only. EPTYP
@@ -601,13 +602,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  STUP
       STUP          : Boolean := False;
       --  OTEPDIS
       OTEPDIS       : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  B2BSTUP
       B2BSTUP       : Boolean := False;
       --  unspecified
@@ -643,7 +644,7 @@ package STM32_SVD.USB_OTG_FS is
       --  SETUP packet count
       STUPCNT        : DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -727,7 +728,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -862,7 +863,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Write-only. Full Speed serial transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -906,7 +907,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -985,7 +986,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE              : Boolean := True;
       --  unspecified
-      Reserved_27_27     : HAL.Bit := 16#0#;
+      Reserved_27_27     : HAL.UInt1 := 16#0#;
       --  Connector ID status change
       CIDSCHG            : Boolean := False;
       --  Disconnect detected interrupt
@@ -1033,7 +1034,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS interrupt mask register (OTG_FS_GINTMSK)
    type FS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0     : HAL.Bit := 16#0#;
+      Reserved_0_0     : HAL.UInt1 := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM            : Boolean := False;
       --  OTG interrupt mask
@@ -1063,7 +1064,7 @@ package STM32_SVD.USB_OTG_FS is
       --  End of periodic frame interrupt mask
       EOPFM            : Boolean := False;
       --  unspecified
-      Reserved_16_16   : HAL.Bit := 16#0#;
+      Reserved_16_16   : HAL.UInt1 := 16#0#;
       --  Endpoint mismatch interrupt mask
       EPMISM           : Boolean := False;
       --  IN endpoints interrupt mask
@@ -1084,7 +1085,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Periodic TxFIFO empty mask
       PTXFEM           : Boolean := False;
       --  unspecified
-      Reserved_27_27   : HAL.Bit := 16#0#;
+      Reserved_27_27   : HAL.UInt1 := 16#0#;
       --  Connector ID status change mask
       CIDSCHGM         : Boolean := False;
       --  Disconnect detected interrupt mask
@@ -1250,7 +1251,7 @@ package STM32_SVD.USB_OTG_FS is
    end record;
 
    subtype FS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
-   subtype FS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
+   subtype FS_GNPTXSTS_NPTQXSAV_Field is HAL.UInt8;
    subtype FS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
    --  OTG_FS non-periodic transmit FIFO/queue status register
@@ -1263,7 +1264,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Top of the non-periodic transmit request queue
       NPTXQTOP       : FS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.Bit;
+      Reserved_31_31 : HAL.UInt1;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1282,7 +1283,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Power down
       PWRDWN         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Enable the VBUS sensing device
       VBUSASEN       : Boolean := False;
       --  Enable the VBUS sensing device
@@ -1397,8 +1398,8 @@ package STM32_SVD.USB_OTG_FS is
    end record;
 
    subtype FS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
-   subtype FS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
-   subtype FS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
+   subtype FS_HPTXSTS_PTXQSAV_Field is HAL.UInt8;
+   subtype FS_HPTXSTS_PTXQTOP_Field is HAL.UInt8;
 
    --  OTG_FS_Host periodic transmit FIFO/queue status register
    --  (OTG_FS_HPTXSTS)
@@ -1478,7 +1479,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. Port line status
       PLSTS          : FS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1526,7 +1527,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1566,7 +1567,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted
       CHH            : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  STALL response received interrupt
       STALL          : Boolean := False;
       --  NAK response received interrupt
@@ -1574,7 +1575,7 @@ package STM32_SVD.USB_OTG_FS is
       --  ACK response received/transmitted interrupt
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  Transaction error
       TXERR          : Boolean := False;
       --  Babble error
@@ -1611,7 +1612,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted mask
       CHHM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  STALL response received interrupt mask
       STALLM         : Boolean := False;
       --  NAK response received interrupt mask
@@ -1662,7 +1663,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Data PID
       DPID           : FS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1829,7 +1830,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_DEVICE_Periph : aliased OTG_FS_DEVICE_Peripheral
-     with Import, Address => OTG_FS_DEVICE_Base;
+     with Import, Address => System'To_Address (16#50000800#);
 
    type OTG_FS_GLOBAL_Disc is
      (
@@ -1913,7 +1914,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_GLOBAL_Periph : aliased OTG_FS_GLOBAL_Peripheral
-     with Import, Address => OTG_FS_GLOBAL_Base;
+     with Import, Address => System'To_Address (16#50000000#);
 
    --  USB on the go full speed
    type OTG_FS_HOST_Peripheral is record
@@ -2043,7 +2044,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_HOST_Periph : aliased OTG_FS_HOST_Peripheral
-     with Import, Address => OTG_FS_HOST_Base;
+     with Import, Address => System'To_Address (16#50000400#);
 
    --  USB on the go full speed
    type OTG_FS_PWRCLK_Peripheral is record
@@ -2058,6 +2059,6 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_PWRCLK_Periph : aliased OTG_FS_PWRCLK_Peripheral
-     with Import, Address => OTG_FS_PWRCLK_Base;
+     with Import, Address => System'To_Address (16#50000E00#);
 
 end STM32_SVD.USB_OTG_FS;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-usb_otg_fs.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-usb_otg_fs.ads
@@ -25,7 +25,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Non-zero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Device address
       DAD            : FS_DCFG_DAD_Field := 16#0#;
       --  Periodic frame interval
@@ -127,7 +127,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Timeout condition mask (Non-isochronous endpoints)
       TOM           : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -161,7 +161,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  SETUP phase done mask
       STUPM         : Boolean := False;
       --  OUT token received when endpoint disabled mask
@@ -281,13 +281,13 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
       EPTYP          : FS_DIEPCTL0_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  STALL handshake
       STALL          : Boolean := False;
       --  TxFIFO number
@@ -330,13 +330,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  TOC
       TOC           : Boolean := False;
       --  ITTXFE
       ITTXFE        : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  INEPNE
       INEPNE        : Boolean := False;
       --  Read-only. TXFE
@@ -419,7 +419,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : DIEPCTL1_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -471,7 +471,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Multi count
       MCNT           : DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -502,7 +502,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -553,7 +553,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USBAEP
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAKSTS
       NAKSTS         : Boolean := False;
       --  Read-only. EPTYP
@@ -602,13 +602,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  STUP
       STUP          : Boolean := False;
       --  OTEPDIS
       OTEPDIS       : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  B2BSTUP
       B2BSTUP       : Boolean := False;
       --  unspecified
@@ -644,7 +644,7 @@ package STM32_SVD.USB_OTG_FS is
       --  SETUP packet count
       STUPCNT        : DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -728,7 +728,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -863,7 +863,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Write-only. Full Speed serial transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -907,7 +907,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -986,7 +986,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE              : Boolean := True;
       --  unspecified
-      Reserved_27_27     : HAL.UInt1 := 16#0#;
+      Reserved_27_27     : HAL.Bit := 16#0#;
       --  Connector ID status change
       CIDSCHG            : Boolean := False;
       --  Disconnect detected interrupt
@@ -1034,7 +1034,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS interrupt mask register (OTG_FS_GINTMSK)
    type FS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0     : HAL.UInt1 := 16#0#;
+      Reserved_0_0     : HAL.Bit := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM            : Boolean := False;
       --  OTG interrupt mask
@@ -1064,7 +1064,7 @@ package STM32_SVD.USB_OTG_FS is
       --  End of periodic frame interrupt mask
       EOPFM            : Boolean := False;
       --  unspecified
-      Reserved_16_16   : HAL.UInt1 := 16#0#;
+      Reserved_16_16   : HAL.Bit := 16#0#;
       --  Endpoint mismatch interrupt mask
       EPMISM           : Boolean := False;
       --  IN endpoints interrupt mask
@@ -1085,7 +1085,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Periodic TxFIFO empty mask
       PTXFEM           : Boolean := False;
       --  unspecified
-      Reserved_27_27   : HAL.UInt1 := 16#0#;
+      Reserved_27_27   : HAL.Bit := 16#0#;
       --  Connector ID status change mask
       CIDSCHGM         : Boolean := False;
       --  Disconnect detected interrupt mask
@@ -1264,7 +1264,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Top of the non-periodic transmit request queue
       NPTXQTOP       : FS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1;
+      Reserved_31_31 : HAL.Bit;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1283,7 +1283,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Power down
       PWRDWN         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Enable the VBUS sensing device
       VBUSASEN       : Boolean := False;
       --  Enable the VBUS sensing device
@@ -1479,7 +1479,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. Port line status
       PLSTS          : FS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1527,7 +1527,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1567,7 +1567,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted
       CHH            : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  STALL response received interrupt
       STALL          : Boolean := False;
       --  NAK response received interrupt
@@ -1575,7 +1575,7 @@ package STM32_SVD.USB_OTG_FS is
       --  ACK response received/transmitted interrupt
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  Transaction error
       TXERR          : Boolean := False;
       --  Babble error
@@ -1612,7 +1612,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted mask
       CHHM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  STALL response received interrupt mask
       STALLM         : Boolean := False;
       --  NAK response received interrupt mask
@@ -1663,7 +1663,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Data PID
       DPID           : FS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-usb_otg_hs.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-usb_otg_hs.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -25,7 +26,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Nonzero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Device address
       DAD            : OTG_HS_DCFG_DAD_Field := 16#0#;
       --  Periodic (micro)frame interval
@@ -132,7 +133,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -142,7 +143,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -174,17 +175,17 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SETUP phase done mask
       STUPM          : Boolean := False;
       --  OUT token received when endpoint disabled mask
       OTEPDM         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Back-to-back SETUP packets received mask
       B2BSTUP        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  OUT packet error mask
       OPEM           : Boolean := False;
       --  BNA interrupt mask
@@ -297,7 +298,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Receive threshold length
       RXTHRLEN       : OTG_HS_DTHRCTL_RXTHRLEN_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.Bit := 16#0#;
+      Reserved_26_26 : HAL.UInt1 := 16#0#;
       --  Arbiter parking enable
       ARPEN          : Boolean := False;
       --  unspecified
@@ -338,7 +339,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register
    type OTG_HS_DEACHINT_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  IN endpoint 1interrupt bit
       IEP1INT        : Boolean := False;
       --  unspecified
@@ -362,7 +363,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register mask
    type OTG_HS_DEACHINTMSK_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  IN Endpoint 1 interrupt mask bit
       IEP1INTM       : Boolean := False;
       --  unspecified
@@ -390,7 +391,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -400,7 +401,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -438,7 +439,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition mask
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -448,7 +449,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  OUT packet error mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -504,7 +505,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint type
       EPTYP          : OTG_HS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  STALL handshake
       Stall          : Boolean := False;
       --  TxFIFO number
@@ -550,13 +551,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition
       TOC            : Boolean := False;
       --  IN token received when TxFIFO is empty
       ITTXFE         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  IN endpoint NAK effective
       INEPNE         : Boolean := False;
       --  Read-only. Transmit FIFO empty
@@ -566,7 +567,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Buffer not available interrupt
       BNA            : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Packet dropped status
       PKTDRPSTS      : Boolean := False;
       --  Babble error interrupt
@@ -651,7 +652,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Multi count
       MCNT           : OTG_HS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -675,7 +676,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
@@ -724,13 +725,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SETUP phase done
       STUP           : Boolean := False;
       --  OUT token received when endpoint disabled
       OTEPDIS        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Back-to-back SETUP packets received
       B2BSTUP        : Boolean := False;
       --  unspecified
@@ -772,7 +773,7 @@ package STM32_SVD.USB_OTG_HS is
       --  SETUP packet count
       STUPCNT        : OTG_HS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -856,7 +857,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_HS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -966,7 +967,7 @@ package STM32_SVD.USB_OTG_HS is
       --  DMA enable
       DMAEN         : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  TxFIFO empty level
       TXFELVL       : Boolean := False;
       --  Periodic TxFIFO empty level
@@ -1000,7 +1001,7 @@ package STM32_SVD.USB_OTG_HS is
       --  transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -1008,11 +1009,11 @@ package STM32_SVD.USB_OTG_HS is
       --  USB turnaround time
       TRDT           : OTG_HS_GUSBCFG_TRDT_Field := 16#2#;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  PHY Low-power clock select
       PHYLPCS        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  ULPI FS/LS select
       ULPIFSLS       : Boolean := False;
       --  ULPI Auto-resume
@@ -1080,7 +1081,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1155,7 +1156,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended
       DATAFSUSP         : Boolean := False;
       --  unspecified
-      Reserved_23_23    : HAL.Bit := 16#0#;
+      Reserved_23_23    : HAL.UInt1 := 16#0#;
       --  Read-only. Host port interrupt
       HPRTINT           : Boolean := False;
       --  Read-only. Host channels interrupt
@@ -1163,7 +1164,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE             : Boolean := True;
       --  unspecified
-      Reserved_27_27    : HAL.Bit := 16#0#;
+      Reserved_27_27    : HAL.UInt1 := 16#0#;
       --  Connector ID status change
       CIDSCHG           : Boolean := False;
       --  Disconnect detected interrupt
@@ -1212,7 +1213,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS interrupt mask register
    type OTG_HS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0    : HAL.Bit := 16#0#;
+      Reserved_0_0    : HAL.UInt1 := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM           : Boolean := False;
       --  OTG interrupt mask
@@ -1242,7 +1243,7 @@ package STM32_SVD.USB_OTG_HS is
       --  End of periodic frame interrupt mask
       EOPFM           : Boolean := False;
       --  unspecified
-      Reserved_16_16  : HAL.Bit := 16#0#;
+      Reserved_16_16  : HAL.UInt1 := 16#0#;
       --  Endpoint mismatch interrupt mask
       EPMISM          : Boolean := False;
       --  IN endpoints interrupt mask
@@ -1256,7 +1257,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended mask
       FSUSPM          : Boolean := False;
       --  unspecified
-      Reserved_23_23  : HAL.Bit := 16#0#;
+      Reserved_23_23  : HAL.UInt1 := 16#0#;
       --  Read-only. Host port interrupt mask
       PRTIM           : Boolean := False;
       --  Host channels interrupt mask
@@ -1264,7 +1265,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Periodic TxFIFO empty mask
       PTXFEM          : Boolean := False;
       --  unspecified
-      Reserved_27_27  : HAL.Bit := 16#0#;
+      Reserved_27_27  : HAL.UInt1 := 16#0#;
       --  Connector ID status change mask
       CIDSCHGM        : Boolean := False;
       --  Disconnect detected interrupt mask
@@ -1489,7 +1490,7 @@ package STM32_SVD.USB_OTG_HS is
    end record;
 
    subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
-   subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
+   subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.UInt8;
    subtype OTG_HS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
    --  OTG_HS nonperiodic transmit FIFO/queue status register
@@ -1501,7 +1502,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Top of the nonperiodic transmit request queue
       NPTXQTOP       : OTG_HS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.Bit;
+      Reserved_31_31 : HAL.UInt1;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1638,8 +1639,8 @@ package STM32_SVD.USB_OTG_HS is
    end record;
 
    subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
-   subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
-   subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
+   subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.UInt8;
+   subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.UInt8;
 
    --  OTG_HS_Host periodic transmit FIFO/queue status register
    type OTG_HS_HPTXSTS_Register is record
@@ -1718,7 +1719,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_HS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1766,7 +1767,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1933,7 +1934,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data PID
       DPID           : OTG_HS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2178,7 +2179,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_DEVICE_Periph : aliased OTG_HS_DEVICE_Peripheral
-     with Import, Address => OTG_HS_DEVICE_Base;
+     with Import, Address => System'To_Address (16#40040800#);
 
    type OTG_HS_GLOBAL_Disc is
      (
@@ -2281,7 +2282,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_GLOBAL_Periph : aliased OTG_HS_GLOBAL_Peripheral
-     with Import, Address => OTG_HS_GLOBAL_Base;
+     with Import, Address => System'To_Address (16#40040000#);
 
    --  USB on the go high speed
    type OTG_HS_HOST_Peripheral is record
@@ -2530,7 +2531,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_HOST_Periph : aliased OTG_HS_HOST_Peripheral
-     with Import, Address => OTG_HS_HOST_Base;
+     with Import, Address => System'To_Address (16#40040400#);
 
    --  USB on the go high speed
    type OTG_HS_PWRCLK_Peripheral is record
@@ -2545,6 +2546,6 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_PWRCLK_Periph : aliased OTG_HS_PWRCLK_Peripheral
-     with Import, Address => OTG_HS_PWRCLK_Base;
+     with Import, Address => System'To_Address (16#40040E00#);
 
 end STM32_SVD.USB_OTG_HS;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-usb_otg_hs.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-usb_otg_hs.ads
@@ -26,7 +26,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Nonzero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Device address
       DAD            : OTG_HS_DCFG_DAD_Field := 16#0#;
       --  Periodic (micro)frame interval
@@ -133,7 +133,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -143,7 +143,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -175,17 +175,17 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SETUP phase done mask
       STUPM          : Boolean := False;
       --  OUT token received when endpoint disabled mask
       OTEPDM         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Back-to-back SETUP packets received mask
       B2BSTUP        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  OUT packet error mask
       OPEM           : Boolean := False;
       --  BNA interrupt mask
@@ -298,7 +298,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Receive threshold length
       RXTHRLEN       : OTG_HS_DTHRCTL_RXTHRLEN_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.UInt1 := 16#0#;
+      Reserved_26_26 : HAL.Bit := 16#0#;
       --  Arbiter parking enable
       ARPEN          : Boolean := False;
       --  unspecified
@@ -339,7 +339,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register
    type OTG_HS_DEACHINT_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  IN endpoint 1interrupt bit
       IEP1INT        : Boolean := False;
       --  unspecified
@@ -363,7 +363,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register mask
    type OTG_HS_DEACHINTMSK_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  IN Endpoint 1 interrupt mask bit
       IEP1INTM       : Boolean := False;
       --  unspecified
@@ -391,7 +391,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -401,7 +401,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -439,7 +439,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition mask
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -449,7 +449,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  OUT packet error mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -505,7 +505,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint type
       EPTYP          : OTG_HS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  STALL handshake
       Stall          : Boolean := False;
       --  TxFIFO number
@@ -551,13 +551,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition
       TOC            : Boolean := False;
       --  IN token received when TxFIFO is empty
       ITTXFE         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  IN endpoint NAK effective
       INEPNE         : Boolean := False;
       --  Read-only. Transmit FIFO empty
@@ -567,7 +567,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Buffer not available interrupt
       BNA            : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Packet dropped status
       PKTDRPSTS      : Boolean := False;
       --  Babble error interrupt
@@ -652,7 +652,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Multi count
       MCNT           : OTG_HS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -676,7 +676,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
@@ -725,13 +725,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SETUP phase done
       STUP           : Boolean := False;
       --  OUT token received when endpoint disabled
       OTEPDIS        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Back-to-back SETUP packets received
       B2BSTUP        : Boolean := False;
       --  unspecified
@@ -773,7 +773,7 @@ package STM32_SVD.USB_OTG_HS is
       --  SETUP packet count
       STUPCNT        : OTG_HS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -857,7 +857,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_HS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -967,7 +967,7 @@ package STM32_SVD.USB_OTG_HS is
       --  DMA enable
       DMAEN         : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  TxFIFO empty level
       TXFELVL       : Boolean := False;
       --  Periodic TxFIFO empty level
@@ -1001,7 +1001,7 @@ package STM32_SVD.USB_OTG_HS is
       --  transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -1009,11 +1009,11 @@ package STM32_SVD.USB_OTG_HS is
       --  USB turnaround time
       TRDT           : OTG_HS_GUSBCFG_TRDT_Field := 16#2#;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  PHY Low-power clock select
       PHYLPCS        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  ULPI FS/LS select
       ULPIFSLS       : Boolean := False;
       --  ULPI Auto-resume
@@ -1081,7 +1081,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1156,7 +1156,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended
       DATAFSUSP         : Boolean := False;
       --  unspecified
-      Reserved_23_23    : HAL.UInt1 := 16#0#;
+      Reserved_23_23    : HAL.Bit := 16#0#;
       --  Read-only. Host port interrupt
       HPRTINT           : Boolean := False;
       --  Read-only. Host channels interrupt
@@ -1164,7 +1164,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE             : Boolean := True;
       --  unspecified
-      Reserved_27_27    : HAL.UInt1 := 16#0#;
+      Reserved_27_27    : HAL.Bit := 16#0#;
       --  Connector ID status change
       CIDSCHG           : Boolean := False;
       --  Disconnect detected interrupt
@@ -1213,7 +1213,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS interrupt mask register
    type OTG_HS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0    : HAL.UInt1 := 16#0#;
+      Reserved_0_0    : HAL.Bit := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM           : Boolean := False;
       --  OTG interrupt mask
@@ -1243,7 +1243,7 @@ package STM32_SVD.USB_OTG_HS is
       --  End of periodic frame interrupt mask
       EOPFM           : Boolean := False;
       --  unspecified
-      Reserved_16_16  : HAL.UInt1 := 16#0#;
+      Reserved_16_16  : HAL.Bit := 16#0#;
       --  Endpoint mismatch interrupt mask
       EPMISM          : Boolean := False;
       --  IN endpoints interrupt mask
@@ -1257,7 +1257,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended mask
       FSUSPM          : Boolean := False;
       --  unspecified
-      Reserved_23_23  : HAL.UInt1 := 16#0#;
+      Reserved_23_23  : HAL.Bit := 16#0#;
       --  Read-only. Host port interrupt mask
       PRTIM           : Boolean := False;
       --  Host channels interrupt mask
@@ -1265,7 +1265,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Periodic TxFIFO empty mask
       PTXFEM          : Boolean := False;
       --  unspecified
-      Reserved_27_27  : HAL.UInt1 := 16#0#;
+      Reserved_27_27  : HAL.Bit := 16#0#;
       --  Connector ID status change mask
       CIDSCHGM        : Boolean := False;
       --  Disconnect detected interrupt mask
@@ -1502,7 +1502,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Top of the nonperiodic transmit request queue
       NPTXQTOP       : OTG_HS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1;
+      Reserved_31_31 : HAL.Bit;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1719,7 +1719,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_HS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1767,7 +1767,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1934,7 +1934,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data PID
       DPID           : OTG_HS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd-wwdg.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd-wwdg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -118,6 +119,6 @@ package STM32_SVD.WWDG is
 
    --  Window watchdog
    WWDG_Periph : aliased WWDG_Peripheral
-     with Import, Address => WWDG_Base;
+     with Import, Address => System'To_Address (16#40002C00#);
 
 end STM32_SVD.WWDG;

--- a/arch/ARM/STM32/svd/stm32f40x/stm32_svd.ads
+++ b/arch/ARM/STM32/svd/stm32f40x/stm32_svd.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with System;
 

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-adc.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-adc.ads
@@ -135,7 +135,7 @@ package STM32_SVD.ADC is
       --  Start conversion of injected channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  External event select for regular group
       EXTSEL         : CR2_EXTSEL_Field := 16#0#;
       --  External trigger enable for regular channels
@@ -143,7 +143,7 @@ package STM32_SVD.ADC is
       --  Start conversion of regular channels
       SWSTART        : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -651,7 +651,7 @@ package STM32_SVD.ADC is
       --  Delay between 2 sampling phases
       DELAY_k        : CCR_DELAY_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.UInt1 := 16#0#;
+      Reserved_12_12 : HAL.Bit := 16#0#;
       --  DMA disable selection for multi-ADC mode
       DDS            : Boolean := False;
       --  Direct memory access mode for multi ADC mode

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-adc.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-adc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -134,7 +135,7 @@ package STM32_SVD.ADC is
       --  Start conversion of injected channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  External event select for regular group
       EXTSEL         : CR2_EXTSEL_Field := 16#0#;
       --  External trigger enable for regular channels
@@ -142,7 +143,7 @@ package STM32_SVD.ADC is
       --  Start conversion of regular channels
       SWSTART        : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -388,7 +389,7 @@ package STM32_SVD.ADC is
       --  Regular channel sequence length
       L              : SQR1_L_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -650,7 +651,7 @@ package STM32_SVD.ADC is
       --  Delay between 2 sampling phases
       DELAY_k        : CCR_DELAY_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.Bit := 16#0#;
+      Reserved_12_12 : HAL.UInt1 := 16#0#;
       --  DMA disable selection for multi-ADC mode
       DDS            : Boolean := False;
       --  Direct memory access mode for multi ADC mode
@@ -664,7 +665,7 @@ package STM32_SVD.ADC is
       --  Temperature sensor and VREFINT enable
       TSVREFE        : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -785,15 +786,15 @@ package STM32_SVD.ADC is
 
    --  Analog-to-digital converter
    ADC1_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC1_Base;
+     with Import, Address => System'To_Address (16#40012000#);
 
    --  Analog-to-digital converter
    ADC2_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC2_Base;
+     with Import, Address => System'To_Address (16#40012100#);
 
    --  Analog-to-digital converter
    ADC3_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC3_Base;
+     with Import, Address => System'To_Address (16#40012200#);
 
    --  Common ADC registers
    type C_ADC_Peripheral is record
@@ -814,6 +815,6 @@ package STM32_SVD.ADC is
 
    --  Common ADC registers
    C_ADC_Periph : aliased C_ADC_Peripheral
-     with Import, Address => C_ADC_Base;
+     with Import, Address => System'To_Address (16#40012300#);
 
 end STM32_SVD.ADC;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-can.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-can.ads
@@ -230,7 +230,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP0
       FMP0          : RF0R_FMP0_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  FULL0
       FULL0         : Boolean := False;
       --  FOVR0
@@ -259,7 +259,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP1
       FMP1          : RF1R_FMP1_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  FULL1
       FULL1         : Boolean := False;
       --  FOVR1
@@ -298,7 +298,7 @@ package STM32_SVD.CAN is
       --  FOVIE1
       FOVIE1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  EWGIE
       EWGIE          : Boolean := False;
       --  EPVIE
@@ -354,7 +354,7 @@ package STM32_SVD.CAN is
       --  Read-only. BOFF
       BOFF          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  LEC
       LEC           : ESR_LEC_Field := 16#0#;
       --  unspecified
@@ -394,7 +394,7 @@ package STM32_SVD.CAN is
       --  TS2
       TS2            : BTR_TS2_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  SJW
       SJW            : BTR_SJW_Field := 16#0#;
       --  unspecified
@@ -755,7 +755,7 @@ package STM32_SVD.CAN is
    --  receive FIFO mailbox identifier register
    type RI0R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.UInt1;
+      Reserved_0_0 : HAL.Bit;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -863,7 +863,7 @@ package STM32_SVD.CAN is
    --  mailbox data high register
    type RI1R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.UInt1;
+      Reserved_0_0 : HAL.Bit;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-can.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-can.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -229,7 +230,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP0
       FMP0          : RF0R_FMP0_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  FULL0
       FULL0         : Boolean := False;
       --  FOVR0
@@ -258,7 +259,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP1
       FMP1          : RF1R_FMP1_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  FULL1
       FULL1         : Boolean := False;
       --  FOVR1
@@ -297,7 +298,7 @@ package STM32_SVD.CAN is
       --  FOVIE1
       FOVIE1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  EWGIE
       EWGIE          : Boolean := False;
       --  EPVIE
@@ -341,8 +342,8 @@ package STM32_SVD.CAN is
    end record;
 
    subtype ESR_LEC_Field is HAL.UInt3;
-   subtype ESR_TEC_Field is HAL.Byte;
-   subtype ESR_REC_Field is HAL.Byte;
+   subtype ESR_TEC_Field is HAL.UInt8;
+   subtype ESR_REC_Field is HAL.UInt8;
 
    --  interrupt enable register
    type ESR_Register is record
@@ -353,7 +354,7 @@ package STM32_SVD.CAN is
       --  Read-only. BOFF
       BOFF          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  LEC
       LEC           : ESR_LEC_Field := 16#0#;
       --  unspecified
@@ -393,7 +394,7 @@ package STM32_SVD.CAN is
       --  TS2
       TS2            : BTR_TS2_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  SJW
       SJW            : BTR_SJW_Field := 16#0#;
       --  unspecified
@@ -473,7 +474,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL0R_DATA array element
-   subtype TDL0R_DATA_Element is HAL.Byte;
+   subtype TDL0R_DATA_Element is HAL.UInt8;
 
    --  TDL0R_DATA array
    type TDL0R_DATA_Field_Array is array (0 .. 3) of TDL0R_DATA_Element
@@ -501,7 +502,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH0R_DATA array element
-   subtype TDH0R_DATA_Element is HAL.Byte;
+   subtype TDH0R_DATA_Element is HAL.UInt8;
 
    --  TDH0R_DATA array
    type TDH0R_DATA_Field_Array is array (4 .. 7) of TDH0R_DATA_Element
@@ -583,7 +584,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL1R_DATA array element
-   subtype TDL1R_DATA_Element is HAL.Byte;
+   subtype TDL1R_DATA_Element is HAL.UInt8;
 
    --  TDL1R_DATA array
    type TDL1R_DATA_Field_Array is array (0 .. 3) of TDL1R_DATA_Element
@@ -611,7 +612,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH1R_DATA array element
-   subtype TDH1R_DATA_Element is HAL.Byte;
+   subtype TDH1R_DATA_Element is HAL.UInt8;
 
    --  TDH1R_DATA array
    type TDH1R_DATA_Field_Array is array (4 .. 7) of TDH1R_DATA_Element
@@ -693,7 +694,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL2R_DATA array element
-   subtype TDL2R_DATA_Element is HAL.Byte;
+   subtype TDL2R_DATA_Element is HAL.UInt8;
 
    --  TDL2R_DATA array
    type TDL2R_DATA_Field_Array is array (0 .. 3) of TDL2R_DATA_Element
@@ -721,7 +722,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH2R_DATA array element
-   subtype TDH2R_DATA_Element is HAL.Byte;
+   subtype TDH2R_DATA_Element is HAL.UInt8;
 
    --  TDH2R_DATA array
    type TDH2R_DATA_Field_Array is array (4 .. 7) of TDH2R_DATA_Element
@@ -754,7 +755,7 @@ package STM32_SVD.CAN is
    --  receive FIFO mailbox identifier register
    type RI0R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.Bit;
+      Reserved_0_0 : HAL.UInt1;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -776,7 +777,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype RDT0R_DLC_Field is HAL.UInt4;
-   subtype RDT0R_FMI_Field is HAL.Byte;
+   subtype RDT0R_FMI_Field is HAL.UInt8;
    subtype RDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
@@ -801,7 +802,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDL0R_DATA array element
-   subtype RDL0R_DATA_Element is HAL.Byte;
+   subtype RDL0R_DATA_Element is HAL.UInt8;
 
    --  RDL0R_DATA array
    type RDL0R_DATA_Field_Array is array (0 .. 3) of RDL0R_DATA_Element
@@ -829,7 +830,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDH0R_DATA array element
-   subtype RDH0R_DATA_Element is HAL.Byte;
+   subtype RDH0R_DATA_Element is HAL.UInt8;
 
    --  RDH0R_DATA array
    type RDH0R_DATA_Field_Array is array (4 .. 7) of RDH0R_DATA_Element
@@ -862,7 +863,7 @@ package STM32_SVD.CAN is
    --  mailbox data high register
    type RI1R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.Bit;
+      Reserved_0_0 : HAL.UInt1;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -884,7 +885,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype RDT1R_DLC_Field is HAL.UInt4;
-   subtype RDT1R_FMI_Field is HAL.Byte;
+   subtype RDT1R_FMI_Field is HAL.UInt8;
    subtype RDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
@@ -909,7 +910,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDL1R_DATA array element
-   subtype RDL1R_DATA_Element is HAL.Byte;
+   subtype RDL1R_DATA_Element is HAL.UInt8;
 
    --  RDL1R_DATA array
    type RDL1R_DATA_Field_Array is array (0 .. 3) of RDL1R_DATA_Element
@@ -937,7 +938,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDH1R_DATA array element
-   subtype RDH1R_DATA_Element is HAL.Byte;
+   subtype RDH1R_DATA_Element is HAL.UInt8;
 
    --  RDH1R_DATA array
    type RDH1R_DATA_Field_Array is array (4 .. 7) of RDH1R_DATA_Element
@@ -2124,10 +2125,10 @@ package STM32_SVD.CAN is
 
    --  Controller area network
    CAN1_Periph : aliased CAN_Peripheral
-     with Import, Address => CAN1_Base;
+     with Import, Address => System'To_Address (16#40006400#);
 
    --  Controller area network
    CAN2_Periph : aliased CAN_Peripheral
-     with Import, Address => CAN2_Base;
+     with Import, Address => System'To_Address (16#40006800#);
 
 end STM32_SVD.CAN;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-crc.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-crc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -13,7 +14,7 @@ package STM32_SVD.CRC is
    -- Registers --
    ---------------
 
-   subtype IDR_IDR_Field is HAL.Byte;
+   subtype IDR_IDR_Field is HAL.UInt8;
 
    --  Independent Data register
    type IDR_Register is record
@@ -52,7 +53,7 @@ package STM32_SVD.CRC is
    --  Cyclic Redundancy Check (CRC) unit
    type CRC_Peripheral is record
       --  Data register
-      DR  : HAL.UInt32 with Volatile; --  work-around for Q207-001
+      DR  : HAL.UInt32;
       --  Independent Data register
       IDR : IDR_Register;
       --  Control register
@@ -68,6 +69,6 @@ package STM32_SVD.CRC is
 
    --  Cyclic Redundancy Check (CRC) unit
    CRC_Periph : aliased CRC_Peripheral
-     with Import, Address => CRC_Base;
+     with Import, Address => System'To_Address (16#40023000#);
 
 end STM32_SVD.CRC;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dac.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dac.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -160,7 +161,7 @@ package STM32_SVD.DAC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DHR8R1_DACC1DHR_Field is HAL.Byte;
+   subtype DHR8R1_DACC1DHR_Field is HAL.UInt8;
 
    --  channel1 8-bit right aligned data holding register
    type DHR8R1_Register is record
@@ -214,7 +215,7 @@ package STM32_SVD.DAC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DHR8R2_DACC2DHR_Field is HAL.Byte;
+   subtype DHR8R2_DACC2DHR_Field is HAL.UInt8;
 
    --  channel2 8-bit right-aligned data holding register
    type DHR8R2_Register is record
@@ -279,8 +280,8 @@ package STM32_SVD.DAC is
       DACC2DHR       at 0 range 20 .. 31;
    end record;
 
-   subtype DHR8RD_DACC1DHR_Field is HAL.Byte;
-   subtype DHR8RD_DACC2DHR_Field is HAL.Byte;
+   subtype DHR8RD_DACC1DHR_Field is HAL.UInt8;
+   subtype DHR8RD_DACC2DHR_Field is HAL.UInt8;
 
    --  DUAL DAC 8-bit right aligned data holding register
    type DHR8RD_Register is record
@@ -414,6 +415,6 @@ package STM32_SVD.DAC is
 
    --  Digital-to-analog converter
    DAC_Periph : aliased DAC_Peripheral
-     with Import, Address => DAC_Base;
+     with Import, Address => System'To_Address (16#40007400#);
 
 end STM32_SVD.DAC;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dbg.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dbg.ads
@@ -102,7 +102,7 @@ package STM32_SVD.DBG is
       --  DBG_J2C3SMBUS_TIMEOUT
       DBG_J2C3SMBUS_TIMEOUT  : Boolean := False;
       --  unspecified
-      Reserved_24_24         : HAL.UInt1 := 16#0#;
+      Reserved_24_24         : HAL.Bit := 16#0#;
       --  DBG_CAN1_STOP
       DBG_CAN1_STOP          : Boolean := False;
       --  DBG_CAN2_STOP

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dbg.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dbg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -93,7 +94,7 @@ package STM32_SVD.DBG is
       --  DBG_IWDEG_STOP
       DBG_IWDEG_STOP         : Boolean := False;
       --  unspecified
-      Reserved_13_20         : HAL.Byte := 16#0#;
+      Reserved_13_20         : HAL.UInt8 := 16#0#;
       --  DBG_J2C1_SMBUS_TIMEOUT
       DBG_J2C1_SMBUS_TIMEOUT : Boolean := False;
       --  DBG_J2C2_SMBUS_TIMEOUT
@@ -101,7 +102,7 @@ package STM32_SVD.DBG is
       --  DBG_J2C3SMBUS_TIMEOUT
       DBG_J2C3SMBUS_TIMEOUT  : Boolean := False;
       --  unspecified
-      Reserved_24_24         : HAL.Bit := 16#0#;
+      Reserved_24_24         : HAL.UInt1 := 16#0#;
       --  DBG_CAN1_STOP
       DBG_CAN1_STOP          : Boolean := False;
       --  DBG_CAN2_STOP
@@ -191,6 +192,6 @@ package STM32_SVD.DBG is
 
    --  Debug support
    DBG_Periph : aliased DBG_Peripheral
-     with Import, Address => DBG_Base;
+     with Import, Address => System'To_Address (16#E0042000#);
 
 end STM32_SVD.DBG;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dcmi.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dcmi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -193,10 +194,10 @@ package STM32_SVD.DCMI is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype ESCR_FSC_Field is HAL.Byte;
-   subtype ESCR_LSC_Field is HAL.Byte;
-   subtype ESCR_LEC_Field is HAL.Byte;
-   subtype ESCR_FEC_Field is HAL.Byte;
+   subtype ESCR_FSC_Field is HAL.UInt8;
+   subtype ESCR_LSC_Field is HAL.UInt8;
+   subtype ESCR_LEC_Field is HAL.UInt8;
+   subtype ESCR_FEC_Field is HAL.UInt8;
 
    --  embedded synchronization code register
    type ESCR_Register is record
@@ -219,10 +220,10 @@ package STM32_SVD.DCMI is
       FEC at 0 range 24 .. 31;
    end record;
 
-   subtype ESUR_FSU_Field is HAL.Byte;
-   subtype ESUR_LSU_Field is HAL.Byte;
-   subtype ESUR_LEU_Field is HAL.Byte;
-   subtype ESUR_FEU_Field is HAL.Byte;
+   subtype ESUR_FSU_Field is HAL.UInt8;
+   subtype ESUR_LSU_Field is HAL.UInt8;
+   subtype ESUR_LEU_Field is HAL.UInt8;
+   subtype ESUR_FEU_Field is HAL.UInt8;
 
    --  embedded synchronization unmask register
    type ESUR_Register is record
@@ -294,7 +295,7 @@ package STM32_SVD.DCMI is
    end record;
 
    --  DR_Byte array element
-   subtype DR_Byte_Element is HAL.Byte;
+   subtype DR_Byte_Element is HAL.UInt8;
 
    --  DR_Byte array
    type DR_Byte_Field_Array is array (0 .. 3) of DR_Byte_Element
@@ -368,6 +369,6 @@ package STM32_SVD.DCMI is
 
    --  Digital camera interface
    DCMI_Periph : aliased DCMI_Peripheral
-     with Import, Address => DCMI_Base;
+     with Import, Address => System'To_Address (16#50050000#);
 
 end STM32_SVD.DCMI;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dma.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dma.ads
@@ -19,7 +19,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF0          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1;
+      Reserved_1_1   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF0         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -31,7 +31,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF1          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1;
+      Reserved_7_7   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF1         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -45,7 +45,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF2          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1;
+      Reserved_17_17 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF2         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -57,7 +57,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF3          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1;
+      Reserved_23_23 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF3         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -106,7 +106,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF4          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1;
+      Reserved_1_1   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF4         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -118,7 +118,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF5          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1;
+      Reserved_7_7   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF5         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -132,7 +132,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF6          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1;
+      Reserved_17_17 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF6         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -144,7 +144,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF7          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1;
+      Reserved_23_23 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF7         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -193,7 +193,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF0         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF0        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -205,7 +205,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF1        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -219,7 +219,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF2         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF2        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -231,7 +231,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF3         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF3        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -280,7 +280,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF4         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF4        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -292,7 +292,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF5         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF5        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -306,7 +306,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF6         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF6        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -318,7 +318,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF7         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF7        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -405,7 +405,7 @@ package STM32_SVD.DMA is
       --  Current target (only in double buffer mode)
       CT             : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Peripheral burst transfer configuration
       PBURST         : S0CR_PBURST_Field := 16#0#;
       --  Memory burst transfer configuration
@@ -471,7 +471,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S0FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -598,7 +598,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S1FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -725,7 +725,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S2FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -852,7 +852,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S3FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -979,7 +979,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S4FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1106,7 +1106,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S5FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1233,7 +1233,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S6FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1360,7 +1360,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S7FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dma.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dma.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -18,7 +19,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF0          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.Bit;
+      Reserved_1_1   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF0         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -30,7 +31,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF1          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.Bit;
+      Reserved_7_7   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF1         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -44,7 +45,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF2          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.Bit;
+      Reserved_17_17 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF2         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -56,7 +57,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF3          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.Bit;
+      Reserved_23_23 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF3         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -105,7 +106,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF4          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.Bit;
+      Reserved_1_1   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF4         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -117,7 +118,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF5          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.Bit;
+      Reserved_7_7   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF5         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -131,7 +132,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF6          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.Bit;
+      Reserved_17_17 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF6         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -143,7 +144,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF7          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.Bit;
+      Reserved_23_23 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF7         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -192,7 +193,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF0         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF0        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -204,7 +205,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF1        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -218,7 +219,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF2         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF2        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -230,7 +231,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF3         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF3        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -279,7 +280,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF4         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF4        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -291,7 +292,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF5         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF5        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -305,7 +306,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF6         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF6        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -317,7 +318,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF7         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF7        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -404,7 +405,7 @@ package STM32_SVD.DMA is
       --  Current target (only in double buffer mode)
       CT             : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Peripheral burst transfer configuration
       PBURST         : S0CR_PBURST_Field := 16#0#;
       --  Memory burst transfer configuration
@@ -470,7 +471,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S0FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -597,7 +598,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S1FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -724,7 +725,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S2FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -851,7 +852,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S3FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -978,7 +979,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S4FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1105,7 +1106,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S5FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1232,7 +1233,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S6FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1359,7 +1360,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S7FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1547,10 +1548,10 @@ package STM32_SVD.DMA is
 
    --  DMA controller
    DMA1_Periph : aliased DMA_Peripheral
-     with Import, Address => DMA1_Base;
+     with Import, Address => System'To_Address (16#40026000#);
 
    --  DMA controller
    DMA2_Periph : aliased DMA_Peripheral
-     with Import, Address => DMA2_Base;
+     with Import, Address => System'To_Address (16#40026400#);
 
 end STM32_SVD.DMA;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dma2d.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-dma2d.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -158,9 +159,9 @@ package STM32_SVD.DMA2D is
    end record;
 
    subtype FGPFCCR_CM_Field is HAL.UInt4;
-   subtype FGPFCCR_CS_Field is HAL.Byte;
+   subtype FGPFCCR_CS_Field is HAL.UInt8;
    subtype FGPFCCR_AM_Field is HAL.UInt2;
-   subtype FGPFCCR_ALPHA_Field is HAL.Byte;
+   subtype FGPFCCR_ALPHA_Field is HAL.UInt8;
 
    --  foreground PFC control register
    type FGPFCCR_Register is record
@@ -195,9 +196,9 @@ package STM32_SVD.DMA2D is
       ALPHA          at 0 range 24 .. 31;
    end record;
 
-   subtype FGCOLR_BLUE_Field is HAL.Byte;
-   subtype FGCOLR_GREEN_Field is HAL.Byte;
-   subtype FGCOLR_RED_Field is HAL.Byte;
+   subtype FGCOLR_BLUE_Field is HAL.UInt8;
+   subtype FGCOLR_GREEN_Field is HAL.UInt8;
+   subtype FGCOLR_RED_Field is HAL.UInt8;
 
    --  foreground color register
    type FGCOLR_Register is record
@@ -208,7 +209,7 @@ package STM32_SVD.DMA2D is
       --  Red Value
       RED            : FGCOLR_RED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -221,9 +222,9 @@ package STM32_SVD.DMA2D is
    end record;
 
    subtype BGPFCCR_CM_Field is HAL.UInt4;
-   subtype BGPFCCR_CS_Field is HAL.Byte;
+   subtype BGPFCCR_CS_Field is HAL.UInt8;
    subtype BGPFCCR_AM_Field is HAL.UInt2;
-   subtype BGPFCCR_ALPHA_Field is HAL.Byte;
+   subtype BGPFCCR_ALPHA_Field is HAL.UInt8;
 
    --  background PFC control register
    type BGPFCCR_Register is record
@@ -258,9 +259,9 @@ package STM32_SVD.DMA2D is
       ALPHA          at 0 range 24 .. 31;
    end record;
 
-   subtype BGCOLR_BLUE_Field is HAL.Byte;
-   subtype BGCOLR_GREEN_Field is HAL.Byte;
-   subtype BGCOLR_RED_Field is HAL.Byte;
+   subtype BGCOLR_BLUE_Field is HAL.UInt8;
+   subtype BGCOLR_GREEN_Field is HAL.UInt8;
+   subtype BGCOLR_RED_Field is HAL.UInt8;
 
    --  background color register
    type BGCOLR_Register is record
@@ -271,7 +272,7 @@ package STM32_SVD.DMA2D is
       --  Red Value
       RED            : BGCOLR_RED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -300,10 +301,10 @@ package STM32_SVD.DMA2D is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype OCOLR_BLUE_Field is HAL.Byte;
-   subtype OCOLR_GREEN_Field is HAL.Byte;
-   subtype OCOLR_RED_Field is HAL.Byte;
-   subtype OCOLR_APLHA_Field is HAL.Byte;
+   subtype OCOLR_BLUE_Field is HAL.UInt8;
+   subtype OCOLR_GREEN_Field is HAL.UInt8;
+   subtype OCOLR_RED_Field is HAL.UInt8;
+   subtype OCOLR_APLHA_Field is HAL.UInt8;
 
    --  output color register
    type OCOLR_Register is record
@@ -381,7 +382,7 @@ package STM32_SVD.DMA2D is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype AMTCR_DT_Field is HAL.Byte;
+   subtype AMTCR_DT_Field is HAL.UInt8;
 
    --  AHB master timer configuration register
    type AMTCR_Register is record
@@ -404,10 +405,10 @@ package STM32_SVD.DMA2D is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype FGCLUT_BLUE_Field is HAL.Byte;
-   subtype FGCLUT_GREEN_Field is HAL.Byte;
-   subtype FGCLUT_RED_Field is HAL.Byte;
-   subtype FGCLUT_APLHA_Field is HAL.Byte;
+   subtype FGCLUT_BLUE_Field is HAL.UInt8;
+   subtype FGCLUT_GREEN_Field is HAL.UInt8;
+   subtype FGCLUT_RED_Field is HAL.UInt8;
+   subtype FGCLUT_APLHA_Field is HAL.UInt8;
 
    --  FGCLUT
    type FGCLUT_Register is record
@@ -430,10 +431,10 @@ package STM32_SVD.DMA2D is
       APLHA at 0 range 24 .. 31;
    end record;
 
-   subtype BGCLUT_BLUE_Field is HAL.Byte;
-   subtype BGCLUT_GREEN_Field is HAL.Byte;
-   subtype BGCLUT_RED_Field is HAL.Byte;
-   subtype BGCLUT_APLHA_Field is HAL.Byte;
+   subtype BGCLUT_BLUE_Field is HAL.UInt8;
+   subtype BGCLUT_GREEN_Field is HAL.UInt8;
+   subtype BGCLUT_RED_Field is HAL.UInt8;
+   subtype BGCLUT_APLHA_Field is HAL.UInt8;
 
    --  BGCLUT
    type BGCLUT_Register is record
@@ -536,6 +537,6 @@ package STM32_SVD.DMA2D is
 
    --  DMA2D controller
    DMA2D_Periph : aliased DMA2D_Peripheral
-     with Import, Address => DMA2D_Base;
+     with Import, Address => System'To_Address (16#4002B000#);
 
 end STM32_SVD.DMA2D;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-ethernet.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-ethernet.ads
@@ -112,7 +112,7 @@ package STM32_SVD.Ethernet is
       --  Read-only. no description available
       EBS            : DMASR_EBS_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.UInt1 := 16#0#;
+      Reserved_26_26 : HAL.Bit := 16#0#;
       --  Read-only. no description available
       MMCS           : Boolean := False;
       --  Read-only. no description available
@@ -158,7 +158,7 @@ package STM32_SVD.Ethernet is
    --  Ethernet DMA operation mode register
    type DMAOMR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  SR
       SR             : Boolean := False;
       --  OSF
@@ -166,7 +166,7 @@ package STM32_SVD.Ethernet is
       --  RTC
       RTC            : DMAOMR_RTC_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  FUGF
       FUGF           : Boolean := False;
       --  FEF
@@ -340,7 +340,7 @@ package STM32_SVD.Ethernet is
       --  APCS
       APCS           : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  RD
       RD             : Boolean := False;
       --  IPCO
@@ -354,7 +354,7 @@ package STM32_SVD.Ethernet is
       --  FES
       FES            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#1#;
+      Reserved_15_15 : HAL.Bit := 16#1#;
       --  CSD
       CSD            : Boolean := False;
       --  IFG
@@ -366,7 +366,7 @@ package STM32_SVD.Ethernet is
       --  WD
       WD             : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CSTF
       CSTF           : Boolean := False;
       --  unspecified
@@ -458,7 +458,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       CR             : MACMIIAR_CR_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  no description available
       MR             : MACMIIAR_MR_Field := 16#0#;
       --  no description available
@@ -512,7 +512,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       PLT           : MACFCR_PLT_Field := 16#0#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  no description available
       ZQPD          : Boolean := False;
       --  unspecified
@@ -762,7 +762,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA2L         : MACA2LR_MACA2L_Field := 16#7FFFFFFF#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#1#;
+      Reserved_31_31 : HAL.Bit := 16#1#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-ethernet.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-ethernet.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -111,7 +112,7 @@ package STM32_SVD.Ethernet is
       --  Read-only. no description available
       EBS            : DMASR_EBS_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.Bit := 16#0#;
+      Reserved_26_26 : HAL.UInt1 := 16#0#;
       --  Read-only. no description available
       MMCS           : Boolean := False;
       --  Read-only. no description available
@@ -157,7 +158,7 @@ package STM32_SVD.Ethernet is
    --  Ethernet DMA operation mode register
    type DMAOMR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  SR
       SR             : Boolean := False;
       --  OSF
@@ -165,7 +166,7 @@ package STM32_SVD.Ethernet is
       --  RTC
       RTC            : DMAOMR_RTC_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  FUGF
       FUGF           : Boolean := False;
       --  FEF
@@ -304,7 +305,7 @@ package STM32_SVD.Ethernet is
       Reserved_29_31 at 0 range 29 .. 31;
    end record;
 
-   subtype DMARSWTR_RSWTC_Field is HAL.Byte;
+   subtype DMARSWTR_RSWTC_Field is HAL.UInt8;
 
    --  Ethernet DMA receive status watchdog timer register
    type DMARSWTR_Register is record
@@ -339,7 +340,7 @@ package STM32_SVD.Ethernet is
       --  APCS
       APCS           : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  RD
       RD             : Boolean := False;
       --  IPCO
@@ -353,7 +354,7 @@ package STM32_SVD.Ethernet is
       --  FES
       FES            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#1#;
+      Reserved_15_15 : HAL.UInt1 := 16#1#;
       --  CSD
       CSD            : Boolean := False;
       --  IFG
@@ -365,7 +366,7 @@ package STM32_SVD.Ethernet is
       --  WD
       WD             : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CSTF
       CSTF           : Boolean := False;
       --  unspecified
@@ -457,7 +458,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       CR             : MACMIIAR_CR_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  no description available
       MR             : MACMIIAR_MR_Field := 16#0#;
       --  no description available
@@ -511,11 +512,11 @@ package STM32_SVD.Ethernet is
       --  no description available
       PLT           : MACFCR_PLT_Field := 16#0#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  no description available
       ZQPD          : Boolean := False;
       --  unspecified
-      Reserved_8_15 : HAL.Byte := 16#0#;
+      Reserved_8_15 : HAL.UInt8 := 16#0#;
       --  no description available
       PT            : MACFCR_PT_Field := 16#0#;
    end record
@@ -708,7 +709,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA1H         : MACA1HR_MACA1H_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA1HR_MBC_Field := 16#0#;
       --  no description available
@@ -735,7 +736,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MAC2AH         : MACA2HR_MAC2AH_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA2HR_MBC_Field := 16#0#;
       --  no description available
@@ -761,7 +762,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA2L         : MACA2LR_MACA2L_Field := 16#7FFFFFFF#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#1#;
+      Reserved_31_31 : HAL.UInt1 := 16#1#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -779,7 +780,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA3H         : MACA3HR_MACA3H_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA3HR_MBC_Field := 16#0#;
       --  no description available
@@ -998,7 +999,7 @@ package STM32_SVD.Ethernet is
       Reserved_19_31 at 0 range 19 .. 31;
    end record;
 
-   subtype PTPSSIR_STSSI_Field is HAL.Byte;
+   subtype PTPSSIR_STSSI_Field is HAL.UInt8;
 
    --  Ethernet PTP subsecond increment register
    type PTPSSIR_Register is record
@@ -1141,7 +1142,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: DMA controller operation
    Ethernet_DMA_Periph : aliased Ethernet_DMA_Peripheral
-     with Import, Address => Ethernet_DMA_Base;
+     with Import, Address => System'To_Address (16#40029000#);
 
    --  Ethernet: media access control (MAC)
    type Ethernet_MAC_Peripheral is record
@@ -1213,7 +1214,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: media access control (MAC)
    Ethernet_MAC_Periph : aliased Ethernet_MAC_Peripheral
-     with Import, Address => Ethernet_MAC_Base;
+     with Import, Address => System'To_Address (16#40028000#);
 
    --  Ethernet: MAC management counters
    type Ethernet_MMC_Peripheral is record
@@ -1259,7 +1260,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: MAC management counters
    Ethernet_MMC_Periph : aliased Ethernet_MMC_Peripheral
-     with Import, Address => Ethernet_MMC_Base;
+     with Import, Address => System'To_Address (16#40028100#);
 
    --  Ethernet: Precision time protocol
    type Ethernet_PTP_Peripheral is record
@@ -1304,6 +1305,6 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: Precision time protocol
    Ethernet_PTP_Periph : aliased Ethernet_PTP_Peripheral
-     with Import, Address => Ethernet_PTP_Base;
+     with Import, Address => System'To_Address (16#40028700#);
 
 end STM32_SVD.Ethernet;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-exti.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-exti.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -279,6 +280,6 @@ package STM32_SVD.EXTI is
 
    --  External interrupt/event controller
    EXTI_Periph : aliased EXTI_Peripheral
-     with Import, Address => EXTI_Base;
+     with Import, Address => System'To_Address (16#40013C00#);
 
 end STM32_SVD.EXTI;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-flash.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-flash.ads
@@ -152,7 +152,7 @@ package STM32_SVD.FLASH is
       --  BOR reset Level
       BOR_LEV        : OPTCR_BOR_LEV_Field := 16#3#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  WDG_SW User option bytes
       WDG_SW         : Boolean := True;
       --  nRST_STOP User option bytes

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-flash.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-flash.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -65,7 +66,7 @@ package STM32_SVD.FLASH is
       --  Programming sequence error
       PGSERR         : Boolean := False;
       --  unspecified
-      Reserved_8_15  : HAL.Byte := 16#0#;
+      Reserved_8_15  : HAL.UInt8 := 16#0#;
       --  Read-only. Busy
       BSY            : Boolean := False;
       --  unspecified
@@ -139,7 +140,7 @@ package STM32_SVD.FLASH is
    end record;
 
    subtype OPTCR_BOR_LEV_Field is HAL.UInt2;
-   subtype OPTCR_RDP_Field is HAL.Byte;
+   subtype OPTCR_RDP_Field is HAL.UInt8;
    subtype OPTCR_nWRP_Field is HAL.UInt12;
 
    --  Flash option control register
@@ -151,7 +152,7 @@ package STM32_SVD.FLASH is
       --  BOR reset Level
       BOR_LEV        : OPTCR_BOR_LEV_Field := 16#3#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  WDG_SW User option bytes
       WDG_SW         : Boolean := True;
       --  nRST_STOP User option bytes
@@ -236,6 +237,6 @@ package STM32_SVD.FLASH is
 
    --  FLASH
    FLASH_Periph : aliased FLASH_Peripheral
-     with Import, Address => FLASH_Base;
+     with Import, Address => System'To_Address (16#40023C00#);
 
 end STM32_SVD.FLASH;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-fsmc.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-fsmc.ads
@@ -30,13 +30,13 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#1#;
+      Reserved_7_7   : HAL.Bit := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
       WAITPOL        : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  WAITCFG
       WAITCFG        : Boolean := False;
       --  WREN
@@ -137,7 +137,7 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#1#;
+      Reserved_7_7   : HAL.Bit := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
@@ -192,7 +192,7 @@ package STM32_SVD.FSMC is
    --  PC Card/NAND Flash control register 2
    type PCR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  PWAITEN
       PWAITEN        : Boolean := False;
       --  PBKEN

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-fsmc.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-fsmc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -29,13 +30,13 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#1#;
+      Reserved_7_7   : HAL.UInt1 := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
       WAITPOL        : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  WAITCFG
       WAITCFG        : Boolean := False;
       --  WREN
@@ -81,7 +82,7 @@ package STM32_SVD.FSMC is
 
    subtype BTR_ADDSET_Field is HAL.UInt4;
    subtype BTR_ADDHLD_Field is HAL.UInt4;
-   subtype BTR_DATAST_Field is HAL.Byte;
+   subtype BTR_DATAST_Field is HAL.UInt8;
    subtype BTR_BUSTURN_Field is HAL.UInt4;
    subtype BTR_CLKDIV_Field is HAL.UInt4;
    subtype BTR_DATLAT_Field is HAL.UInt4;
@@ -136,7 +137,7 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#1#;
+      Reserved_7_7   : HAL.UInt1 := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
@@ -191,7 +192,7 @@ package STM32_SVD.FSMC is
    --  PC Card/NAND Flash control register 2
    type PCR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  PWAITEN
       PWAITEN        : Boolean := False;
       --  PBKEN
@@ -263,10 +264,10 @@ package STM32_SVD.FSMC is
       Reserved_7_31 at 0 range 7 .. 31;
    end record;
 
-   subtype PMEM_MEMSETx_Field is HAL.Byte;
-   subtype PMEM_MEMWAITx_Field is HAL.Byte;
-   subtype PMEM_MEMHOLDx_Field is HAL.Byte;
-   subtype PMEM_MEMHIZx_Field is HAL.Byte;
+   subtype PMEM_MEMSETx_Field is HAL.UInt8;
+   subtype PMEM_MEMWAITx_Field is HAL.UInt8;
+   subtype PMEM_MEMHOLDx_Field is HAL.UInt8;
+   subtype PMEM_MEMHIZx_Field is HAL.UInt8;
 
    --  Common memory space timing register 2
    type PMEM_Register is record
@@ -289,10 +290,10 @@ package STM32_SVD.FSMC is
       MEMHIZx  at 0 range 24 .. 31;
    end record;
 
-   subtype PATT_ATTSETx_Field is HAL.Byte;
-   subtype PATT_ATTWAITx_Field is HAL.Byte;
-   subtype PATT_ATTHOLDx_Field is HAL.Byte;
-   subtype PATT_ATTHIZx_Field is HAL.Byte;
+   subtype PATT_ATTSETx_Field is HAL.UInt8;
+   subtype PATT_ATTWAITx_Field is HAL.UInt8;
+   subtype PATT_ATTHOLDx_Field is HAL.UInt8;
+   subtype PATT_ATTHIZx_Field is HAL.UInt8;
 
    --  Attribute memory space timing register 2
    type PATT_Register is record
@@ -315,10 +316,10 @@ package STM32_SVD.FSMC is
       ATTHIZx  at 0 range 24 .. 31;
    end record;
 
-   subtype PIO4_IOSETx_Field is HAL.Byte;
-   subtype PIO4_IOWAITx_Field is HAL.Byte;
-   subtype PIO4_IOHOLDx_Field is HAL.Byte;
-   subtype PIO4_IOHIZx_Field is HAL.Byte;
+   subtype PIO4_IOSETx_Field is HAL.UInt8;
+   subtype PIO4_IOWAITx_Field is HAL.UInt8;
+   subtype PIO4_IOHOLDx_Field is HAL.UInt8;
+   subtype PIO4_IOHIZx_Field is HAL.UInt8;
 
    --  I/O space timing register 4
    type PIO4_Register is record
@@ -343,7 +344,7 @@ package STM32_SVD.FSMC is
 
    subtype BWTR_ADDSET_Field is HAL.UInt4;
    subtype BWTR_ADDHLD_Field is HAL.UInt4;
-   subtype BWTR_DATAST_Field is HAL.Byte;
+   subtype BWTR_DATAST_Field is HAL.UInt8;
    subtype BWTR_CLKDIV_Field is HAL.UInt4;
    subtype BWTR_DATLAT_Field is HAL.UInt4;
    subtype BWTR_ACCMOD_Field is HAL.UInt2;
@@ -708,6 +709,6 @@ package STM32_SVD.FSMC is
 
    --  Flexible memory controller
    FMC_Periph : aliased FMC_Peripheral
-     with Import, Address => FMC_Base;
+     with Import, Address => System'To_Address (16#A0000000#);
 
 end STM32_SVD.FSMC;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-gpio.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-gpio.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -419,46 +420,46 @@ package STM32_SVD.GPIO is
 
    --  General-purpose I/Os
    GPIOA_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOA_Base;
+     with Import, Address => System'To_Address (16#40020000#);
 
    --  General-purpose I/Os
    GPIOB_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOB_Base;
+     with Import, Address => System'To_Address (16#40020400#);
 
    --  General-purpose I/Os
    GPIOC_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOC_Base;
+     with Import, Address => System'To_Address (16#40020800#);
 
    --  General-purpose I/Os
    GPIOD_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOD_Base;
+     with Import, Address => System'To_Address (16#40020C00#);
 
    --  General-purpose I/Os
    GPIOE_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOE_Base;
+     with Import, Address => System'To_Address (16#40021000#);
 
    --  General-purpose I/Os
    GPIOF_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOF_Base;
+     with Import, Address => System'To_Address (16#40021400#);
 
    --  General-purpose I/Os
    GPIOG_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOG_Base;
+     with Import, Address => System'To_Address (16#40021800#);
 
    --  General-purpose I/Os
    GPIOH_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOH_Base;
+     with Import, Address => System'To_Address (16#40021C00#);
 
    --  General-purpose I/Os
    GPIOI_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOI_Base;
+     with Import, Address => System'To_Address (16#40022000#);
 
    --  General-purpose I/Os
    GPIOJ_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOJ_Base;
+     with Import, Address => System'To_Address (16#40022400#);
 
    --  General-purpose I/Os
    GPIOK_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOK_Base;
+     with Import, Address => System'To_Address (16#40022800#);
 
 end STM32_SVD.GPIO;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-i2c.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-i2c.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -20,7 +21,7 @@ package STM32_SVD.I2C is
       --  SMBus mode
       SMBUS          : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SMBus type
       SMBTYPE        : Boolean := False;
       --  ARP enable
@@ -44,7 +45,7 @@ package STM32_SVD.I2C is
       --  SMBus alert
       ALERT          : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Software reset
       SWRST          : Boolean := False;
       --  unspecified
@@ -158,7 +159,7 @@ package STM32_SVD.I2C is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype DR_DR_Field is HAL.Byte;
+   subtype DR_DR_Field is HAL.UInt8;
 
    --  Data register
    type DR_Register is record
@@ -188,7 +189,7 @@ package STM32_SVD.I2C is
       --  Read-only. Stop detection (slave mode)
       STOPF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Read-only. Data register not empty (receivers)
       RxNE           : Boolean := False;
       --  Read-only. Data register empty (transmitters)
@@ -204,7 +205,7 @@ package STM32_SVD.I2C is
       --  PEC Error in reception
       PECERR         : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  Timeout or Tlow error
       TIMEOUT        : Boolean := False;
       --  SMBus alert
@@ -235,7 +236,7 @@ package STM32_SVD.I2C is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype SR2_PEC_Field is HAL.Byte;
+   subtype SR2_PEC_Field is HAL.UInt8;
 
    --  Status register 2
    type SR2_Register is record
@@ -246,7 +247,7 @@ package STM32_SVD.I2C is
       --  Read-only. Transmitter/receiver
       TRA            : Boolean;
       --  unspecified
-      Reserved_3_3   : HAL.Bit;
+      Reserved_3_3   : HAL.UInt1;
       --  Read-only. General call address (Slave mode)
       GENCALL        : Boolean;
       --  Read-only. SMBus device default address (Slave mode)
@@ -384,14 +385,14 @@ package STM32_SVD.I2C is
 
    --  Inter-integrated circuit
    I2C1_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C1_Base;
+     with Import, Address => System'To_Address (16#40005400#);
 
    --  Inter-integrated circuit
    I2C2_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C2_Base;
+     with Import, Address => System'To_Address (16#40005800#);
 
    --  Inter-integrated circuit
    I2C3_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C3_Base;
+     with Import, Address => System'To_Address (16#40005C00#);
 
 end STM32_SVD.I2C;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-i2c.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-i2c.ads
@@ -21,7 +21,7 @@ package STM32_SVD.I2C is
       --  SMBus mode
       SMBUS          : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SMBus type
       SMBTYPE        : Boolean := False;
       --  ARP enable
@@ -45,7 +45,7 @@ package STM32_SVD.I2C is
       --  SMBus alert
       ALERT          : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Software reset
       SWRST          : Boolean := False;
       --  unspecified
@@ -189,7 +189,7 @@ package STM32_SVD.I2C is
       --  Read-only. Stop detection (slave mode)
       STOPF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Read-only. Data register not empty (receivers)
       RxNE           : Boolean := False;
       --  Read-only. Data register empty (transmitters)
@@ -205,7 +205,7 @@ package STM32_SVD.I2C is
       --  PEC Error in reception
       PECERR         : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  Timeout or Tlow error
       TIMEOUT        : Boolean := False;
       --  SMBus alert
@@ -247,7 +247,7 @@ package STM32_SVD.I2C is
       --  Read-only. Transmitter/receiver
       TRA            : Boolean;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1;
+      Reserved_3_3   : HAL.Bit;
       --  Read-only. General call address (Slave mode)
       GENCALL        : Boolean;
       --  Read-only. SMBus device default address (Slave mode)

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-iwdg.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-iwdg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -108,6 +109,6 @@ package STM32_SVD.IWDG is
 
    --  Independent watchdog
    IWDG_Periph : aliased IWDG_Peripheral
-     with Import, Address => IWDG_Base;
+     with Import, Address => System'To_Address (16#40003000#);
 
 end STM32_SVD.IWDG;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-ltdc.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-ltdc.ads
@@ -123,15 +123,15 @@ package STM32_SVD.LTDC is
       --  Read-only. Dither Blue Width
       DBW            : GCR_DBW_Field := 16#2#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Read-only. Dither Green Width
       DGW            : GCR_DGW_Field := 16#2#;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  Read-only. Dither Red Width
       DRW            : GCR_DRW_Field := 16#2#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Dither Enable
       DEN            : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-ltdc.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-ltdc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -122,15 +123,15 @@ package STM32_SVD.LTDC is
       --  Read-only. Dither Blue Width
       DBW            : GCR_DBW_Field := 16#2#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Read-only. Dither Green Width
       DGW            : GCR_DGW_Field := 16#2#;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  Read-only. Dither Red Width
       DRW            : GCR_DRW_Field := 16#2#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Dither Enable
       DEN            : Boolean := False;
       --  unspecified
@@ -189,7 +190,7 @@ package STM32_SVD.LTDC is
       --  Background Color Red value
       BC             : BCCR_BC_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -402,9 +403,9 @@ package STM32_SVD.LTDC is
       Reserved_27_31 at 0 range 27 .. 31;
    end record;
 
-   subtype L1CKCR_CKBLUE_Field is HAL.Byte;
-   subtype L1CKCR_CKGREEN_Field is HAL.Byte;
-   subtype L1CKCR_CKRED_Field is HAL.Byte;
+   subtype L1CKCR_CKBLUE_Field is HAL.UInt8;
+   subtype L1CKCR_CKGREEN_Field is HAL.UInt8;
+   subtype L1CKCR_CKRED_Field is HAL.UInt8;
 
    --  Layerx Color Keying Configuration Register
    type L1CKCR_Register is record
@@ -415,7 +416,7 @@ package STM32_SVD.LTDC is
       --  Color Key Red value
       CKRED          : L1CKCR_CKRED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -444,7 +445,7 @@ package STM32_SVD.LTDC is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype L1CACR_CONSTA_Field is HAL.Byte;
+   subtype L1CACR_CONSTA_Field is HAL.UInt8;
 
    --  Layerx Constant Alpha Configuration Register
    type L1CACR_Register is record
@@ -461,10 +462,10 @@ package STM32_SVD.LTDC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype L1DCCR_DCBLUE_Field is HAL.Byte;
-   subtype L1DCCR_DCGREEN_Field is HAL.Byte;
-   subtype L1DCCR_DCRED_Field is HAL.Byte;
-   subtype L1DCCR_DCALPHA_Field is HAL.Byte;
+   subtype L1DCCR_DCBLUE_Field is HAL.UInt8;
+   subtype L1DCCR_DCGREEN_Field is HAL.UInt8;
+   subtype L1DCCR_DCRED_Field is HAL.UInt8;
+   subtype L1DCCR_DCALPHA_Field is HAL.UInt8;
 
    --  Layerx Default Color Configuration Register
    type L1DCCR_Register is record
@@ -552,10 +553,10 @@ package STM32_SVD.LTDC is
       Reserved_11_31 at 0 range 11 .. 31;
    end record;
 
-   subtype L1CLUTWR_BLUE_Field is HAL.Byte;
-   subtype L1CLUTWR_GREEN_Field is HAL.Byte;
-   subtype L1CLUTWR_RED_Field is HAL.Byte;
-   subtype L1CLUTWR_CLUTADD_Field is HAL.Byte;
+   subtype L1CLUTWR_BLUE_Field is HAL.UInt8;
+   subtype L1CLUTWR_GREEN_Field is HAL.UInt8;
+   subtype L1CLUTWR_RED_Field is HAL.UInt8;
+   subtype L1CLUTWR_CLUTADD_Field is HAL.UInt8;
 
    --  Layerx CLUT Write Register
    type L1CLUTWR_Register is record
@@ -650,7 +651,7 @@ package STM32_SVD.LTDC is
       Reserved_27_31 at 0 range 27 .. 31;
    end record;
 
-   subtype L2CKCR_CKBLUE_Field is HAL.Byte;
+   subtype L2CKCR_CKBLUE_Field is HAL.UInt8;
    subtype L2CKCR_CKGREEN_Field is HAL.UInt7;
    subtype L2CKCR_CKRED_Field is HAL.UInt9;
 
@@ -663,7 +664,7 @@ package STM32_SVD.LTDC is
       --  Color Key Red value
       CKRED          : L2CKCR_CKRED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -692,7 +693,7 @@ package STM32_SVD.LTDC is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype L2CACR_CONSTA_Field is HAL.Byte;
+   subtype L2CACR_CONSTA_Field is HAL.UInt8;
 
    --  Layerx Constant Alpha Configuration Register
    type L2CACR_Register is record
@@ -709,10 +710,10 @@ package STM32_SVD.LTDC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype L2DCCR_DCBLUE_Field is HAL.Byte;
-   subtype L2DCCR_DCGREEN_Field is HAL.Byte;
-   subtype L2DCCR_DCRED_Field is HAL.Byte;
-   subtype L2DCCR_DCALPHA_Field is HAL.Byte;
+   subtype L2DCCR_DCBLUE_Field is HAL.UInt8;
+   subtype L2DCCR_DCGREEN_Field is HAL.UInt8;
+   subtype L2DCCR_DCRED_Field is HAL.UInt8;
+   subtype L2DCCR_DCALPHA_Field is HAL.UInt8;
 
    --  Layerx Default Color Configuration Register
    type L2DCCR_Register is record
@@ -800,10 +801,10 @@ package STM32_SVD.LTDC is
       Reserved_11_31 at 0 range 11 .. 31;
    end record;
 
-   subtype L2CLUTWR_BLUE_Field is HAL.Byte;
-   subtype L2CLUTWR_GREEN_Field is HAL.Byte;
-   subtype L2CLUTWR_RED_Field is HAL.Byte;
-   subtype L2CLUTWR_CLUTADD_Field is HAL.Byte;
+   subtype L2CLUTWR_BLUE_Field is HAL.UInt8;
+   subtype L2CLUTWR_GREEN_Field is HAL.UInt8;
+   subtype L2CLUTWR_RED_Field is HAL.UInt8;
+   subtype L2CLUTWR_CLUTADD_Field is HAL.UInt8;
 
    --  Layerx CLUT Write Register
    type L2CLUTWR_Register is record
@@ -951,6 +952,6 @@ package STM32_SVD.LTDC is
 
    --  LCD-TFT Controller
    LTDC_Periph : aliased LTDC_Peripheral
-     with Import, Address => LTDC_Base;
+     with Import, Address => System'To_Address (16#40016800#);
 
 end STM32_SVD.LTDC;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-nvic.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-nvic.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -31,7 +32,7 @@ package STM32_SVD.NVIC is
    end record;
 
    --  IPR_IPR_N array element
-   subtype IPR_IPR_N_Element is HAL.Byte;
+   subtype IPR_IPR_N_Element is HAL.UInt8;
 
    --  IPR_IPR_N array
    type IPR_IPR_N_Field_Array is array (0 .. 3) of IPR_IPR_N_Element
@@ -203,6 +204,6 @@ package STM32_SVD.NVIC is
 
    --  Nested Vectored Interrupt Controller
    NVIC_Periph : aliased NVIC_Peripheral
-     with Import, Address => NVIC_Base;
+     with Import, Address => System'To_Address (16#E000E000#);
 
 end STM32_SVD.NVIC;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-pwr.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-pwr.ads
@@ -41,7 +41,7 @@ package STM32_SVD.PWR is
       --  Main regulator low voltage in deepsleep mode
       MRLVDS         : Boolean := False;
       --  unspecified
-      Reserved_12_12 : HAL.UInt1 := 16#0#;
+      Reserved_12_12 : HAL.Bit := 16#0#;
       --  ADCDC1
       ADCDC1         : Boolean := False;
       --  Regulator voltage scaling output selection
@@ -101,7 +101,7 @@ package STM32_SVD.PWR is
       --  Regulator voltage scaling output selection ready bit
       VOSRDY         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Read-only. Over-drive mode ready
       ODRDY          : Boolean := False;
       --  Read-only. Over-drive mode switching ready

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-pwr.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-pwr.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -40,7 +41,7 @@ package STM32_SVD.PWR is
       --  Main regulator low voltage in deepsleep mode
       MRLVDS         : Boolean := False;
       --  unspecified
-      Reserved_12_12 : HAL.Bit := 16#0#;
+      Reserved_12_12 : HAL.UInt1 := 16#0#;
       --  ADCDC1
       ADCDC1         : Boolean := False;
       --  Regulator voltage scaling output selection
@@ -100,7 +101,7 @@ package STM32_SVD.PWR is
       --  Regulator voltage scaling output selection ready bit
       VOSRDY         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Read-only. Over-drive mode ready
       ODRDY          : Boolean := False;
       --  Read-only. Over-drive mode switching ready
@@ -150,6 +151,6 @@ package STM32_SVD.PWR is
 
    --  Power control
    PWR_Periph : aliased PWR_Peripheral
-     with Import, Address => PWR_Base;
+     with Import, Address => System'To_Address (16#40007000#);
 
 end STM32_SVD.PWR;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-rcc.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-rcc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -14,7 +15,7 @@ package STM32_SVD.RCC is
    ---------------
 
    subtype CR_HSITRIM_Field is HAL.UInt5;
-   subtype CR_HSICAL_Field is HAL.Byte;
+   subtype CR_HSICAL_Field is HAL.UInt8;
 
    --  clock control register
    type CR_Register is record
@@ -23,7 +24,7 @@ package STM32_SVD.RCC is
       --  Read-only. Internal high-speed clock ready flag
       HSIRDY         : Boolean := True;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Internal high-speed clock trimming
       HSITRIM        : CR_HSITRIM_Field := 16#10#;
       --  Read-only. Internal high-speed clock calibration
@@ -83,7 +84,7 @@ package STM32_SVD.RCC is
       --  Main PLL (PLL) multiplication factor for VCO
       PLLN           : PLLCFGR_PLLN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Main PLL (PLL) division factor for main system clock
       PLLP           : PLLCFGR_PLLP_Field := 16#0#;
       --  unspecified
@@ -91,7 +92,7 @@ package STM32_SVD.RCC is
       --  Main PLL(PLL) and audio PLL (PLLI2S) entry clock source
       PLLSRC         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Main PLL (PLL) division factor for USB OTG FS, SDIO and random number
       --  generator clocks
       PLLQ           : PLLCFGR_PLLQ_Field := 16#4#;
@@ -224,7 +225,7 @@ package STM32_SVD.RCC is
       --  PLLSAI Ready Interrupt Enable
       PLLSAIRDYIE    : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Write-only. LSI ready interrupt clear
       LSIRDYC        : Boolean := False;
       --  Write-only. LSE ready interrupt clear
@@ -242,7 +243,7 @@ package STM32_SVD.RCC is
       --  Write-only. Clock security system interrupt clear
       CSSC           : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -300,11 +301,11 @@ package STM32_SVD.RCC is
       --  IO port K reset
       GPIOKRST       : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  CRC reset
       CRCRST         : Boolean := False;
       --  unspecified
-      Reserved_13_20 : HAL.Byte := 16#0#;
+      Reserved_13_20 : HAL.UInt8 := 16#0#;
       --  DMA2 reset
       DMA1RST        : Boolean := False;
       --  DMA2 reset
@@ -312,7 +313,7 @@ package STM32_SVD.RCC is
       --  DMA2D reset
       DMA2DRST       : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  Ethernet MAC reset
       ETHMACRST      : Boolean := False;
       --  unspecified
@@ -420,7 +421,7 @@ package STM32_SVD.RCC is
       --  SPI 3 reset
       SPI3RST        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  USART 2 reset
       UART2RST       : Boolean := False;
       --  USART 3 reset
@@ -436,13 +437,13 @@ package STM32_SVD.RCC is
       --  I2C3 reset
       I2C3RST        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CAN1 reset
       CAN1RST        : Boolean := False;
       --  CAN2 reset
       CAN2RST        : Boolean := False;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Power interface reset
       PWRRST         : Boolean := False;
       --  DAC reset
@@ -515,7 +516,7 @@ package STM32_SVD.RCC is
       --  System configuration controller reset
       SYSCFGRST      : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 reset
       TIM9RST        : Boolean := False;
       --  TIM10 reset
@@ -523,7 +524,7 @@ package STM32_SVD.RCC is
       --  TIM11 reset
       TIM11RST       : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  SPI5 reset
       SPI5RST        : Boolean := False;
       --  SPI6 reset
@@ -591,7 +592,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable
       GPIOKEN        : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  CRC clock enable
       CRCEN          : Boolean := False;
       --  unspecified
@@ -599,7 +600,7 @@ package STM32_SVD.RCC is
       --  Backup SRAM interface clock enable
       BKPSRAMEN      : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  CCM data RAM clock enable
       CCMDATARAMEN   : Boolean := True;
       --  DMA1 clock enable
@@ -609,7 +610,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable
       DMA2DEN        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  Ethernet MAC clock enable
       ETHMACEN       : Boolean := False;
       --  Ethernet Transmission clock enable
@@ -623,7 +624,7 @@ package STM32_SVD.RCC is
       --  USB OTG HSULPI clock enable
       OTGHSULPIEN    : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -729,7 +730,7 @@ package STM32_SVD.RCC is
       --  SPI3 clock enable
       SPI3EN         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  USART 2 clock enable
       USART2EN       : Boolean := False;
       --  USART3 clock enable
@@ -745,13 +746,13 @@ package STM32_SVD.RCC is
       --  I2C3 clock enable
       I2C3EN         : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CAN 1 clock enable
       CAN1EN         : Boolean := False;
       --  CAN 2 clock enable
       CAN2EN         : Boolean := False;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Power interface clock enable
       PWREN          : Boolean := False;
       --  DAC interface clock enable
@@ -826,7 +827,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable
       SYSCFGEN       : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 clock enable
       TIM9EN         : Boolean := False;
       --  TIM10 clock enable
@@ -834,7 +835,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable
       TIM11EN        : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  SPI5 clock enable
       SPI5ENR        : Boolean := False;
       --  SPI6 clock enable
@@ -903,7 +904,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable during Sleep mode
       GPIOKLPEN      : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  CRC clock enable during Sleep mode
       CRCLPEN        : Boolean := True;
       --  unspecified
@@ -919,7 +920,7 @@ package STM32_SVD.RCC is
       --  SRAM 3 interface clock enable during Sleep mode
       SRAM3LPEN      : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  DMA1 clock enable during Sleep mode
       DMA1LPEN       : Boolean := True;
       --  DMA2 clock enable during Sleep mode
@@ -927,7 +928,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable during Sleep mode
       DMA2DLPEN      : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  Ethernet MAC clock enable during Sleep mode
       ETHMACLPEN     : Boolean := True;
       --  Ethernet transmission clock enable during Sleep mode
@@ -941,7 +942,7 @@ package STM32_SVD.RCC is
       --  USB OTG HS ULPI clock enable during Sleep mode
       OTGHSULPILPEN  : Boolean := True;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1050,7 +1051,7 @@ package STM32_SVD.RCC is
       --  SPI3 clock enable during Sleep mode
       SPI3LPEN       : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  USART2 clock enable during Sleep mode
       USART2LPEN     : Boolean := True;
       --  USART3 clock enable during Sleep mode
@@ -1066,13 +1067,13 @@ package STM32_SVD.RCC is
       --  I2C3 clock enable during Sleep mode
       I2C3LPEN       : Boolean := True;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CAN 1 clock enable during Sleep mode
       CAN1LPEN       : Boolean := True;
       --  CAN 2 clock enable during Sleep mode
       CAN2LPEN       : Boolean := True;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Power interface clock enable during Sleep mode
       PWRLPEN        : Boolean := True;
       --  DAC interface clock enable during Sleep mode
@@ -1147,7 +1148,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable during Sleep mode
       SYSCFGLPEN     : Boolean := True;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 clock enable during sleep mode
       TIM9LPEN       : Boolean := True;
       --  TIM10 clock enable during Sleep mode
@@ -1155,7 +1156,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable during Sleep mode
       TIM11LPEN      : Boolean := True;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  SPI 5 clock enable during Sleep mode
       SPI5LPEN       : Boolean := False;
       --  SPI 6 clock enable during Sleep mode
@@ -1345,7 +1346,7 @@ package STM32_SVD.RCC is
       --  PLLI2S division factor for I2S clocks
       PLLI2SR        : PLLI2SCFGR_PLLI2SR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1376,7 +1377,7 @@ package STM32_SVD.RCC is
       --  PLLSAIN
       PLLSAIR        : PLLSAICFGR_PLLSAIR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1524,6 +1525,6 @@ package STM32_SVD.RCC is
 
    --  Reset and clock control
    RCC_Periph : aliased RCC_Peripheral
-     with Import, Address => RCC_Base;
+     with Import, Address => System'To_Address (16#40023800#);
 
 end STM32_SVD.RCC;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-rcc.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-rcc.ads
@@ -24,7 +24,7 @@ package STM32_SVD.RCC is
       --  Read-only. Internal high-speed clock ready flag
       HSIRDY         : Boolean := True;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Internal high-speed clock trimming
       HSITRIM        : CR_HSITRIM_Field := 16#10#;
       --  Read-only. Internal high-speed clock calibration
@@ -84,7 +84,7 @@ package STM32_SVD.RCC is
       --  Main PLL (PLL) multiplication factor for VCO
       PLLN           : PLLCFGR_PLLN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Main PLL (PLL) division factor for main system clock
       PLLP           : PLLCFGR_PLLP_Field := 16#0#;
       --  unspecified
@@ -92,7 +92,7 @@ package STM32_SVD.RCC is
       --  Main PLL(PLL) and audio PLL (PLLI2S) entry clock source
       PLLSRC         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Main PLL (PLL) division factor for USB OTG FS, SDIO and random number
       --  generator clocks
       PLLQ           : PLLCFGR_PLLQ_Field := 16#4#;
@@ -225,7 +225,7 @@ package STM32_SVD.RCC is
       --  PLLSAI Ready Interrupt Enable
       PLLSAIRDYIE    : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Write-only. LSI ready interrupt clear
       LSIRDYC        : Boolean := False;
       --  Write-only. LSE ready interrupt clear
@@ -301,7 +301,7 @@ package STM32_SVD.RCC is
       --  IO port K reset
       GPIOKRST       : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  CRC reset
       CRCRST         : Boolean := False;
       --  unspecified
@@ -313,7 +313,7 @@ package STM32_SVD.RCC is
       --  DMA2D reset
       DMA2DRST       : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  Ethernet MAC reset
       ETHMACRST      : Boolean := False;
       --  unspecified
@@ -421,7 +421,7 @@ package STM32_SVD.RCC is
       --  SPI 3 reset
       SPI3RST        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  USART 2 reset
       UART2RST       : Boolean := False;
       --  USART 3 reset
@@ -437,13 +437,13 @@ package STM32_SVD.RCC is
       --  I2C3 reset
       I2C3RST        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CAN1 reset
       CAN1RST        : Boolean := False;
       --  CAN2 reset
       CAN2RST        : Boolean := False;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Power interface reset
       PWRRST         : Boolean := False;
       --  DAC reset
@@ -516,7 +516,7 @@ package STM32_SVD.RCC is
       --  System configuration controller reset
       SYSCFGRST      : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 reset
       TIM9RST        : Boolean := False;
       --  TIM10 reset
@@ -524,7 +524,7 @@ package STM32_SVD.RCC is
       --  TIM11 reset
       TIM11RST       : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  SPI5 reset
       SPI5RST        : Boolean := False;
       --  SPI6 reset
@@ -592,7 +592,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable
       GPIOKEN        : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  CRC clock enable
       CRCEN          : Boolean := False;
       --  unspecified
@@ -600,7 +600,7 @@ package STM32_SVD.RCC is
       --  Backup SRAM interface clock enable
       BKPSRAMEN      : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  CCM data RAM clock enable
       CCMDATARAMEN   : Boolean := True;
       --  DMA1 clock enable
@@ -610,7 +610,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable
       DMA2DEN        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  Ethernet MAC clock enable
       ETHMACEN       : Boolean := False;
       --  Ethernet Transmission clock enable
@@ -624,7 +624,7 @@ package STM32_SVD.RCC is
       --  USB OTG HSULPI clock enable
       OTGHSULPIEN    : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -730,7 +730,7 @@ package STM32_SVD.RCC is
       --  SPI3 clock enable
       SPI3EN         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  USART 2 clock enable
       USART2EN       : Boolean := False;
       --  USART3 clock enable
@@ -746,13 +746,13 @@ package STM32_SVD.RCC is
       --  I2C3 clock enable
       I2C3EN         : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CAN 1 clock enable
       CAN1EN         : Boolean := False;
       --  CAN 2 clock enable
       CAN2EN         : Boolean := False;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Power interface clock enable
       PWREN          : Boolean := False;
       --  DAC interface clock enable
@@ -827,7 +827,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable
       SYSCFGEN       : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 clock enable
       TIM9EN         : Boolean := False;
       --  TIM10 clock enable
@@ -835,7 +835,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable
       TIM11EN        : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  SPI5 clock enable
       SPI5ENR        : Boolean := False;
       --  SPI6 clock enable
@@ -904,7 +904,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable during Sleep mode
       GPIOKLPEN      : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  CRC clock enable during Sleep mode
       CRCLPEN        : Boolean := True;
       --  unspecified
@@ -920,7 +920,7 @@ package STM32_SVD.RCC is
       --  SRAM 3 interface clock enable during Sleep mode
       SRAM3LPEN      : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  DMA1 clock enable during Sleep mode
       DMA1LPEN       : Boolean := True;
       --  DMA2 clock enable during Sleep mode
@@ -928,7 +928,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable during Sleep mode
       DMA2DLPEN      : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  Ethernet MAC clock enable during Sleep mode
       ETHMACLPEN     : Boolean := True;
       --  Ethernet transmission clock enable during Sleep mode
@@ -942,7 +942,7 @@ package STM32_SVD.RCC is
       --  USB OTG HS ULPI clock enable during Sleep mode
       OTGHSULPILPEN  : Boolean := True;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1051,7 +1051,7 @@ package STM32_SVD.RCC is
       --  SPI3 clock enable during Sleep mode
       SPI3LPEN       : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  USART2 clock enable during Sleep mode
       USART2LPEN     : Boolean := True;
       --  USART3 clock enable during Sleep mode
@@ -1067,13 +1067,13 @@ package STM32_SVD.RCC is
       --  I2C3 clock enable during Sleep mode
       I2C3LPEN       : Boolean := True;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CAN 1 clock enable during Sleep mode
       CAN1LPEN       : Boolean := True;
       --  CAN 2 clock enable during Sleep mode
       CAN2LPEN       : Boolean := True;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Power interface clock enable during Sleep mode
       PWRLPEN        : Boolean := True;
       --  DAC interface clock enable during Sleep mode
@@ -1148,7 +1148,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable during Sleep mode
       SYSCFGLPEN     : Boolean := True;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 clock enable during sleep mode
       TIM9LPEN       : Boolean := True;
       --  TIM10 clock enable during Sleep mode
@@ -1156,7 +1156,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable during Sleep mode
       TIM11LPEN      : Boolean := True;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  SPI 5 clock enable during Sleep mode
       SPI5LPEN       : Boolean := False;
       --  SPI 6 clock enable during Sleep mode
@@ -1346,7 +1346,7 @@ package STM32_SVD.RCC is
       --  PLLI2S division factor for I2S clocks
       PLLI2SR        : PLLI2SCFGR_PLLI2SR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1377,7 +1377,7 @@ package STM32_SVD.RCC is
       --  PLLSAIN
       PLLSAIR        : PLLSAICFGR_PLLSAIR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-rng.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-rng.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -87,6 +88,6 @@ package STM32_SVD.RNG is
 
    --  Random number generator
    RNG_Periph : aliased RNG_Peripheral
-     with Import, Address => RNG_Base;
+     with Import, Address => System'To_Address (16#50060800#);
 
 end STM32_SVD.RNG;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-rtc.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-rtc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -27,13 +28,13 @@ package STM32_SVD.RTC is
       --  Second tens in BCD format
       ST             : TR_ST_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Minute units in BCD format
       MNU            : TR_MNU_Field := 16#0#;
       --  Minute tens in BCD format
       MNT            : TR_MNT_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Hour units in BCD format
       HU             : TR_HU_Field := 16#0#;
       --  Hour tens in BCD format
@@ -85,7 +86,7 @@ package STM32_SVD.RTC is
       --  Year tens in BCD format
       YT             : DR_YT_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -114,7 +115,7 @@ package STM32_SVD.RTC is
       --  Reference clock detection enable (50 or 60 Hz)
       REFCKON        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Hour format
       FMT            : Boolean := False;
       --  Coarse digital calibration enable
@@ -142,7 +143,7 @@ package STM32_SVD.RTC is
       --  Backup
       BKP            : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  Output polarity
       POL            : Boolean := False;
       --  Output selection
@@ -150,7 +151,7 @@ package STM32_SVD.RTC is
       --  Calibration output enable
       COE            : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -213,7 +214,7 @@ package STM32_SVD.RTC is
       --  TAMPER2 detection flag
       TAMP2F         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Read-only. Recalibration pending Flag
       RECALPF        : Boolean := False;
       --  unspecified
@@ -251,7 +252,7 @@ package STM32_SVD.RTC is
       --  Synchronous prescaler factor
       PREDIV_S       : PRER_PREDIV_S_Field := 16#FF#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Asynchronous prescaler factor
       PREDIV_A       : PRER_PREDIV_A_Field := 16#7F#;
       --  unspecified
@@ -427,7 +428,7 @@ package STM32_SVD.RTC is
       MSK4  at 0 range 31 .. 31;
    end record;
 
-   subtype WPR_KEY_Field is HAL.Byte;
+   subtype WPR_KEY_Field is HAL.UInt8;
 
    --  write protection register
    type WPR_Register is record
@@ -853,6 +854,6 @@ package STM32_SVD.RTC is
 
    --  Real-time clock
    RTC_Periph : aliased RTC_Peripheral
-     with Import, Address => RTC_Base;
+     with Import, Address => System'To_Address (16#40002800#);
 
 end STM32_SVD.RTC;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-rtc.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-rtc.ads
@@ -28,13 +28,13 @@ package STM32_SVD.RTC is
       --  Second tens in BCD format
       ST             : TR_ST_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Minute units in BCD format
       MNU            : TR_MNU_Field := 16#0#;
       --  Minute tens in BCD format
       MNT            : TR_MNT_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Hour units in BCD format
       HU             : TR_HU_Field := 16#0#;
       --  Hour tens in BCD format
@@ -115,7 +115,7 @@ package STM32_SVD.RTC is
       --  Reference clock detection enable (50 or 60 Hz)
       REFCKON        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Hour format
       FMT            : Boolean := False;
       --  Coarse digital calibration enable
@@ -143,7 +143,7 @@ package STM32_SVD.RTC is
       --  Backup
       BKP            : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  Output polarity
       POL            : Boolean := False;
       --  Output selection
@@ -214,7 +214,7 @@ package STM32_SVD.RTC is
       --  TAMPER2 detection flag
       TAMP2F         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Read-only. Recalibration pending Flag
       RECALPF        : Boolean := False;
       --  unspecified
@@ -252,7 +252,7 @@ package STM32_SVD.RTC is
       --  Synchronous prescaler factor
       PREDIV_S       : PRER_PREDIV_S_Field := 16#FF#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Asynchronous prescaler factor
       PREDIV_A       : PRER_PREDIV_A_Field := 16#7F#;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-sai.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-sai.ads
@@ -27,7 +27,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : ACR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Data size
       DS             : ACR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -47,7 +47,7 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.UInt1 := 16#0#;
+      Reserved_18_18 : HAL.Bit := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
@@ -127,7 +127,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : AFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -160,7 +160,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : ASLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Slot size
       SLOTSZ         : ASLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -265,7 +265,7 @@ package STM32_SVD.SAI is
       --  Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Clear anticipated frame synchronization detection flag.
@@ -302,7 +302,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : BCR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Data size
       DS             : BCR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -322,7 +322,7 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.UInt1 := 16#0#;
+      Reserved_18_18 : HAL.Bit := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
@@ -402,7 +402,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : BFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -435,7 +435,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : BSLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Slot size
       SLOTSZ         : BSLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -540,7 +540,7 @@ package STM32_SVD.SAI is
       --  Write-only. Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Write-only. Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Write-only. Clear anticipated frame synchronization detection flag

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-sai.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-sai.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -26,7 +27,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : ACR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Data size
       DS             : ACR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -46,13 +47,13 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.Bit := 16#0#;
+      Reserved_18_18 : HAL.UInt1 := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
       MCJDIV         : ACR1_MCJDIV_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -116,7 +117,7 @@ package STM32_SVD.SAI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype AFRCR_FRL_Field is HAL.Byte;
+   subtype AFRCR_FRL_Field is HAL.UInt8;
    subtype AFRCR_FSALL_Field is HAL.UInt7;
 
    --  AFRCR
@@ -126,7 +127,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : AFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -159,7 +160,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : ASLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Slot size
       SLOTSZ         : ASLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -264,7 +265,7 @@ package STM32_SVD.SAI is
       --  Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Clear anticipated frame synchronization detection flag.
@@ -301,7 +302,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : BCR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Data size
       DS             : BCR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -321,13 +322,13 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.Bit := 16#0#;
+      Reserved_18_18 : HAL.UInt1 := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
       MCJDIV         : BCR1_MCJDIV_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -391,7 +392,7 @@ package STM32_SVD.SAI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype BFRCR_FRL_Field is HAL.Byte;
+   subtype BFRCR_FRL_Field is HAL.UInt8;
    subtype BFRCR_FSALL_Field is HAL.UInt7;
 
    --  BFRCR
@@ -401,7 +402,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : BFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -434,7 +435,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : BSLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Slot size
       SLOTSZ         : BSLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -539,7 +540,7 @@ package STM32_SVD.SAI is
       --  Write-only. Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Write-only. Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Write-only. Clear anticipated frame synchronization detection flag
@@ -625,6 +626,6 @@ package STM32_SVD.SAI is
 
    --  Serial audio interface
    SAI_Periph : aliased SAI_Peripheral
-     with Import, Address => SAI_Base;
+     with Import, Address => System'To_Address (16#40015800#);
 
 end STM32_SVD.SAI;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-sdio.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-sdio.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -30,7 +31,7 @@ package STM32_SVD.SDIO is
       Reserved_2_31 at 0 range 2 .. 31;
    end record;
 
-   subtype CLKCR_CLKDIV_Field is HAL.Byte;
+   subtype CLKCR_CLKDIV_Field is HAL.UInt8;
    subtype CLKCR_WIDBUS_Field is HAL.UInt2;
 
    --  SDI clock control register
@@ -255,7 +256,7 @@ package STM32_SVD.SDIO is
       --  Read-only. CE-ATA command completion signal received for CMD61
       CEATAEND       : Boolean;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -319,7 +320,7 @@ package STM32_SVD.SDIO is
       --  CEATAEND flag clear bit
       CEATAENDC      : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -393,7 +394,7 @@ package STM32_SVD.SDIO is
       --  CE-ATA command completion signal received interrupt enable
       CEATAENDIE     : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -434,7 +435,7 @@ package STM32_SVD.SDIO is
       --  the FIFO.
       FIFOCOUNT      : FIFOCNT_FIFOCOUNT_Field;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -512,6 +513,6 @@ package STM32_SVD.SDIO is
 
    --  Secure digital input/output interface
    SDIO_Periph : aliased SDIO_Peripheral
-     with Import, Address => SDIO_Base;
+     with Import, Address => System'To_Address (16#40012C00#);
 
 end STM32_SVD.SDIO;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-spi.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-spi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -78,7 +79,7 @@ package STM32_SVD.SPI is
       --  SS output enable
       SSOE          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Frame format
       FRF           : Boolean := False;
       --  Error interrupt enable
@@ -227,7 +228,7 @@ package STM32_SVD.SPI is
       --  I2S standard selection
       I2SSTD         : I2SCFGR_I2SSTD_Field := 16#0#;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  PCM frame synchronization
       PCMSYNC        : Boolean := False;
       --  I2S configuration mode
@@ -255,7 +256,7 @@ package STM32_SVD.SPI is
       Reserved_12_31 at 0 range 12 .. 31;
    end record;
 
-   subtype I2SPR_I2SDIV_Field is HAL.Byte;
+   subtype I2SPR_I2SDIV_Field is HAL.UInt8;
 
    --  I2S prescaler register
    type I2SPR_Register is record
@@ -319,34 +320,34 @@ package STM32_SVD.SPI is
 
    --  Serial peripheral interface
    I2S2ext_Periph : aliased SPI_Peripheral
-     with Import, Address => I2S2ext_Base;
+     with Import, Address => System'To_Address (16#40003400#);
 
    --  Serial peripheral interface
    I2S3ext_Periph : aliased SPI_Peripheral
-     with Import, Address => I2S3ext_Base;
+     with Import, Address => System'To_Address (16#40004000#);
 
    --  Serial peripheral interface
    SPI1_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI1_Base;
+     with Import, Address => System'To_Address (16#40013000#);
 
    --  Serial peripheral interface
    SPI2_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI2_Base;
+     with Import, Address => System'To_Address (16#40003800#);
 
    --  Serial peripheral interface
    SPI3_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI3_Base;
+     with Import, Address => System'To_Address (16#40003C00#);
 
    --  Serial peripheral interface
    SPI4_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI4_Base;
+     with Import, Address => System'To_Address (16#40013400#);
 
    --  Serial peripheral interface
    SPI5_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI5_Base;
+     with Import, Address => System'To_Address (16#40015000#);
 
    --  Serial peripheral interface
    SPI6_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI6_Base;
+     with Import, Address => System'To_Address (16#40015400#);
 
 end STM32_SVD.SPI;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-spi.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-spi.ads
@@ -79,7 +79,7 @@ package STM32_SVD.SPI is
       --  SS output enable
       SSOE          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Frame format
       FRF           : Boolean := False;
       --  Error interrupt enable
@@ -228,7 +228,7 @@ package STM32_SVD.SPI is
       --  I2S standard selection
       I2SSTD         : I2SCFGR_I2SSTD_Field := 16#0#;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  PCM frame synchronization
       PCMSYNC        : Boolean := False;
       --  I2S configuration mode

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-syscfg.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-syscfg.ads
@@ -26,7 +26,7 @@ package STM32_SVD.SYSCFG is
       --  Flash bank mode selection
       FB_MODE        : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  FMC memory mapping swap
       SWP_FMC        : MEMRM_SWP_FMC_Field := 16#0#;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-syscfg.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-syscfg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -25,7 +26,7 @@ package STM32_SVD.SYSCFG is
       --  Flash bank mode selection
       FB_MODE        : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  FMC memory mapping swap
       SWP_FMC        : MEMRM_SWP_FMC_Field := 16#0#;
       --  unspecified
@@ -58,7 +59,7 @@ package STM32_SVD.SYSCFG is
       --  Ethernet PHY interface selection
       MII_RMII_SEL   : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -301,6 +302,6 @@ package STM32_SVD.SYSCFG is
 
    --  System configuration controller
    SYSCFG_Periph : aliased SYSCFG_Peripheral
-     with Import, Address => SYSCFG_Base;
+     with Import, Address => System'To_Address (16#40013800#);
 
 end STM32_SVD.SYSCFG;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-tim.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-tim.ads
@@ -60,7 +60,7 @@ package STM32_SVD.TIM is
       --  Capture/compare preloaded control
       CCPC           : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Capture/compare control update selection
       CCUS           : Boolean := False;
       --  Capture/compare DMA selection
@@ -116,7 +116,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -223,7 +223,7 @@ package STM32_SVD.TIM is
       --  Break interrupt flag
       BIF            : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  Capture/Compare 1 overcapture flag
       CC1OF          : Boolean := False;
       --  Capture/compare 2 overcapture flag
@@ -766,11 +766,11 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt enable
       CC4IE          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Trigger interrupt enable
       TIE            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Update DMA request enable
       UDE            : Boolean := False;
       --  Capture/Compare 1 DMA request enable
@@ -782,7 +782,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 DMA request enable
       CC4DE          : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  Trigger DMA request enable
       TDE            : Boolean := False;
       --  unspecified
@@ -823,7 +823,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt flag
       CC4IF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Trigger interrupt flag
       TIF            : Boolean := False;
       --  unspecified
@@ -871,7 +871,7 @@ package STM32_SVD.TIM is
       --  Write-only. Capture/compare 4 generation
       CC4G          : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  Write-only. Trigger generation
       TG            : Boolean := False;
       --  unspecified
@@ -940,7 +940,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP          : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -948,7 +948,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P           : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP          : Boolean := False;
       --  Capture/Compare 3 output enable
@@ -956,7 +956,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC3P           : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Capture/Compare 3 output Polarity
       CC3NP          : Boolean := False;
       --  Capture/Compare 4 output enable
@@ -964,7 +964,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC4P           : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
@@ -1278,7 +1278,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS           : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Trigger selection
       TS            : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -1398,7 +1398,7 @@ package STM32_SVD.TIM is
       --  Output Compare 1 mode
       OC1M           : CCMR1_Output_OC1M_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Output_CC2S_Field := 16#0#;
       --  Output Compare 2 fast enable
@@ -1438,7 +1438,7 @@ package STM32_SVD.TIM is
       --  Input capture 1 filter
       IC1F           : CCMR1_Input_IC1F_Field_1 := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Input_CC2S_Field := 16#0#;
       --  Input capture 2 prescaler
@@ -1469,7 +1469,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1477,7 +1477,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P          : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP         : Boolean := False;
       --  unspecified
@@ -1640,7 +1640,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-tim.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-tim.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -59,7 +60,7 @@ package STM32_SVD.TIM is
       --  Capture/compare preloaded control
       CCPC           : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Capture/compare control update selection
       CCUS           : Boolean := False;
       --  Capture/compare DMA selection
@@ -115,7 +116,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -222,7 +223,7 @@ package STM32_SVD.TIM is
       --  Break interrupt flag
       BIF            : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 overcapture flag
       CC1OF          : Boolean := False;
       --  Capture/compare 2 overcapture flag
@@ -563,7 +564,7 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype RCR_REP_Field is HAL.Byte;
+   subtype RCR_REP_Field is HAL.UInt8;
 
    --  repetition counter register
    type RCR_Register is record
@@ -648,7 +649,7 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype BDTR_DTG_Field is HAL.Byte;
+   subtype BDTR_DTG_Field is HAL.UInt8;
    subtype BDTR_LOCK_Field is HAL.UInt2;
 
    --  break and dead-time register
@@ -765,11 +766,11 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt enable
       CC4IE          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Trigger interrupt enable
       TIE            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Update DMA request enable
       UDE            : Boolean := False;
       --  Capture/Compare 1 DMA request enable
@@ -781,7 +782,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 DMA request enable
       CC4DE          : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  Trigger DMA request enable
       TDE            : Boolean := False;
       --  unspecified
@@ -822,7 +823,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt flag
       CC4IF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Trigger interrupt flag
       TIF            : Boolean := False;
       --  unspecified
@@ -870,7 +871,7 @@ package STM32_SVD.TIM is
       --  Write-only. Capture/compare 4 generation
       CC4G          : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  Write-only. Trigger generation
       TG            : Boolean := False;
       --  unspecified
@@ -939,7 +940,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP          : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -947,7 +948,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P           : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP          : Boolean := False;
       --  Capture/Compare 3 output enable
@@ -955,7 +956,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC3P           : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Capture/Compare 3 output Polarity
       CC3NP          : Boolean := False;
       --  Capture/Compare 4 output enable
@@ -963,7 +964,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC4P           : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
@@ -1277,7 +1278,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS           : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Trigger selection
       TS            : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -1397,7 +1398,7 @@ package STM32_SVD.TIM is
       --  Output Compare 1 mode
       OC1M           : CCMR1_Output_OC1M_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Output_CC2S_Field := 16#0#;
       --  Output Compare 2 fast enable
@@ -1437,7 +1438,7 @@ package STM32_SVD.TIM is
       --  Input capture 1 filter
       IC1F           : CCMR1_Input_IC1F_Field_1 := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Input_CC2S_Field := 16#0#;
       --  Input capture 2 prescaler
@@ -1468,7 +1469,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1476,7 +1477,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P          : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP         : Boolean := False;
       --  unspecified
@@ -1639,7 +1640,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  unspecified
@@ -1764,11 +1765,11 @@ package STM32_SVD.TIM is
 
    --  Advanced-timers
    TIM1_Periph : aliased TIM1_Peripheral
-     with Import, Address => TIM1_Base;
+     with Import, Address => System'To_Address (16#40010000#);
 
    --  Advanced-timers
    TIM8_Periph : aliased TIM1_Peripheral
-     with Import, Address => TIM8_Base;
+     with Import, Address => System'To_Address (16#40010400#);
 
    type TIM2_Disc is
      (
@@ -1854,7 +1855,7 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM2_Periph : aliased TIM2_Peripheral
-     with Import, Address => TIM2_Base;
+     with Import, Address => System'To_Address (16#40000000#);
 
    type TIM3_Disc is
      (
@@ -1937,11 +1938,11 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM3_Periph : aliased TIM3_Peripheral
-     with Import, Address => TIM3_Base;
+     with Import, Address => System'To_Address (16#40000400#);
 
    --  General purpose timers
    TIM4_Periph : aliased TIM3_Peripheral
-     with Import, Address => TIM4_Base;
+     with Import, Address => System'To_Address (16#40000800#);
 
    type TIM5_Disc is
      (
@@ -2027,7 +2028,7 @@ package STM32_SVD.TIM is
 
    --  General-purpose-timers
    TIM5_Periph : aliased TIM5_Peripheral
-     with Import, Address => TIM5_Base;
+     with Import, Address => System'To_Address (16#40000C00#);
 
    --  Basic timers
    type TIM6_Peripheral is record
@@ -2063,11 +2064,11 @@ package STM32_SVD.TIM is
 
    --  Basic timers
    TIM6_Periph : aliased TIM6_Peripheral
-     with Import, Address => TIM6_Base;
+     with Import, Address => System'To_Address (16#40001000#);
 
    --  Basic timers
    TIM7_Periph : aliased TIM6_Peripheral
-     with Import, Address => TIM7_Base;
+     with Import, Address => System'To_Address (16#40001400#);
 
    type TIM9_Disc is
      (
@@ -2132,11 +2133,11 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM9_Periph : aliased TIM9_Peripheral
-     with Import, Address => TIM9_Base;
+     with Import, Address => System'To_Address (16#40014000#);
 
    --  General purpose timers
    TIM12_Periph : aliased TIM9_Peripheral
-     with Import, Address => TIM12_Base;
+     with Import, Address => System'To_Address (16#40001800#);
 
    type TIM10_Disc is
      (
@@ -2192,15 +2193,15 @@ package STM32_SVD.TIM is
 
    --  General-purpose-timers
    TIM10_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM10_Base;
+     with Import, Address => System'To_Address (16#40014400#);
 
    --  General-purpose-timers
    TIM13_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM13_Base;
+     with Import, Address => System'To_Address (16#40001C00#);
 
    --  General-purpose-timers
    TIM14_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM14_Base;
+     with Import, Address => System'To_Address (16#40002000#);
 
    type TIM11_Disc is
      (
@@ -2259,6 +2260,6 @@ package STM32_SVD.TIM is
 
    --  General-purpose-timers
    TIM11_Periph : aliased TIM11_Peripheral
-     with Import, Address => TIM11_Base;
+     with Import, Address => System'To_Address (16#40014800#);
 
 end STM32_SVD.TIM;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-usart.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-usart.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -121,7 +122,7 @@ package STM32_SVD.USART is
       --  USART enable
       UE             : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Oversampling mode
       OVER8          : Boolean := False;
       --  unspecified
@@ -158,7 +159,7 @@ package STM32_SVD.USART is
       --  Address of the USART node
       ADD            : CR2_ADD_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  lin break detection length
       LBDL           : Boolean := False;
       --  LIN break detection interrupt enable
@@ -272,13 +273,13 @@ package STM32_SVD.USART is
       --  Address of the USART node
       ADD            : CR2_ADD_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  lin break detection length
       LBDL           : Boolean := False;
       --  LIN break detection interrupt enable
       LBDIE          : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Last bit clock pulse
       LBCL           : Boolean := False;
       --  Clock phase
@@ -360,8 +361,8 @@ package STM32_SVD.USART is
       Reserved_12_31 at 0 range 12 .. 31;
    end record;
 
-   subtype GTPR_PSC_Field is HAL.Byte;
-   subtype GTPR_GT_Field is HAL.Byte;
+   subtype GTPR_PSC_Field is HAL.UInt8;
+   subtype GTPR_GT_Field is HAL.UInt8;
 
    --  Guard time and prescaler register
    type GTPR_Register is record
@@ -413,19 +414,19 @@ package STM32_SVD.USART is
 
    --  Universal synchronous asynchronous receiver transmitter
    UART4_Periph : aliased UART4_Peripheral
-     with Import, Address => UART4_Base;
+     with Import, Address => System'To_Address (16#40004C00#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART5_Periph : aliased UART4_Peripheral
-     with Import, Address => UART5_Base;
+     with Import, Address => System'To_Address (16#40005000#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART7_Periph : aliased UART4_Peripheral
-     with Import, Address => UART7_Base;
+     with Import, Address => System'To_Address (16#40007800#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART8_Periph : aliased UART4_Peripheral
-     with Import, Address => UART8_Base;
+     with Import, Address => System'To_Address (16#40007C00#);
 
    --  Universal synchronous asynchronous receiver transmitter
    type USART1_Peripheral is record
@@ -458,18 +459,18 @@ package STM32_SVD.USART is
 
    --  Universal synchronous asynchronous receiver transmitter
    USART1_Periph : aliased USART1_Peripheral
-     with Import, Address => USART1_Base;
+     with Import, Address => System'To_Address (16#40011000#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART2_Periph : aliased USART1_Peripheral
-     with Import, Address => USART2_Base;
+     with Import, Address => System'To_Address (16#40004400#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART3_Periph : aliased USART1_Peripheral
-     with Import, Address => USART3_Base;
+     with Import, Address => System'To_Address (16#40004800#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART6_Periph : aliased USART1_Peripheral
-     with Import, Address => USART6_Base;
+     with Import, Address => System'To_Address (16#40011400#);
 
 end STM32_SVD.USART;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-usart.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-usart.ads
@@ -122,7 +122,7 @@ package STM32_SVD.USART is
       --  USART enable
       UE             : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Oversampling mode
       OVER8          : Boolean := False;
       --  unspecified
@@ -159,7 +159,7 @@ package STM32_SVD.USART is
       --  Address of the USART node
       ADD            : CR2_ADD_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  lin break detection length
       LBDL           : Boolean := False;
       --  LIN break detection interrupt enable
@@ -273,13 +273,13 @@ package STM32_SVD.USART is
       --  Address of the USART node
       ADD            : CR2_ADD_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  lin break detection length
       LBDL           : Boolean := False;
       --  LIN break detection interrupt enable
       LBDIE          : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Last bit clock pulse
       LBCL           : Boolean := False;
       --  Clock phase

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-usb_otg_fs.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-usb_otg_fs.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -24,7 +25,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Non-zero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Device address
       DAD            : FS_DCFG_DAD_Field := 16#0#;
       --  Periodic frame interval
@@ -126,7 +127,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (Non-isochronous endpoints)
       TOM           : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -160,7 +161,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  SETUP phase done mask
       STUPM         : Boolean := False;
       --  OUT token received when endpoint disabled mask
@@ -280,13 +281,13 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
       EPTYP          : FS_DIEPCTL0_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  STALL handshake
       STALL          : Boolean := False;
       --  TxFIFO number
@@ -329,13 +330,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  TOC
       TOC           : Boolean := False;
       --  ITTXFE
       ITTXFE        : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  INEPNE
       INEPNE        : Boolean := False;
       --  Read-only. TXFE
@@ -418,7 +419,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : DIEPCTL1_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -470,7 +471,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Multi count
       MCNT           : DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -501,7 +502,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -552,7 +553,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USBAEP
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAKSTS
       NAKSTS         : Boolean := False;
       --  Read-only. EPTYP
@@ -601,13 +602,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  STUP
       STUP          : Boolean := False;
       --  OTEPDIS
       OTEPDIS       : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  B2BSTUP
       B2BSTUP       : Boolean := False;
       --  unspecified
@@ -643,7 +644,7 @@ package STM32_SVD.USB_OTG_FS is
       --  SETUP packet count
       STUPCNT        : DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -727,7 +728,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -862,7 +863,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Write-only. Full Speed serial transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -906,7 +907,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -985,7 +986,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE              : Boolean := True;
       --  unspecified
-      Reserved_27_27     : HAL.Bit := 16#0#;
+      Reserved_27_27     : HAL.UInt1 := 16#0#;
       --  Connector ID status change
       CIDSCHG            : Boolean := False;
       --  Disconnect detected interrupt
@@ -1033,7 +1034,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS interrupt mask register (OTG_FS_GINTMSK)
    type FS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0     : HAL.Bit := 16#0#;
+      Reserved_0_0     : HAL.UInt1 := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM            : Boolean := False;
       --  OTG interrupt mask
@@ -1063,7 +1064,7 @@ package STM32_SVD.USB_OTG_FS is
       --  End of periodic frame interrupt mask
       EOPFM            : Boolean := False;
       --  unspecified
-      Reserved_16_16   : HAL.Bit := 16#0#;
+      Reserved_16_16   : HAL.UInt1 := 16#0#;
       --  Endpoint mismatch interrupt mask
       EPMISM           : Boolean := False;
       --  IN endpoints interrupt mask
@@ -1084,7 +1085,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Periodic TxFIFO empty mask
       PTXFEM           : Boolean := False;
       --  unspecified
-      Reserved_27_27   : HAL.Bit := 16#0#;
+      Reserved_27_27   : HAL.UInt1 := 16#0#;
       --  Connector ID status change mask
       CIDSCHGM         : Boolean := False;
       --  Disconnect detected interrupt mask
@@ -1250,7 +1251,7 @@ package STM32_SVD.USB_OTG_FS is
    end record;
 
    subtype FS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
-   subtype FS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
+   subtype FS_GNPTXSTS_NPTQXSAV_Field is HAL.UInt8;
    subtype FS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
    --  OTG_FS non-periodic transmit FIFO/queue status register
@@ -1263,7 +1264,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Top of the non-periodic transmit request queue
       NPTXQTOP       : FS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.Bit;
+      Reserved_31_31 : HAL.UInt1;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1282,7 +1283,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Power down
       PWRDWN         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Enable the VBUS sensing device
       VBUSASEN       : Boolean := False;
       --  Enable the VBUS sensing device
@@ -1397,8 +1398,8 @@ package STM32_SVD.USB_OTG_FS is
    end record;
 
    subtype FS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
-   subtype FS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
-   subtype FS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
+   subtype FS_HPTXSTS_PTXQSAV_Field is HAL.UInt8;
+   subtype FS_HPTXSTS_PTXQTOP_Field is HAL.UInt8;
 
    --  OTG_FS_Host periodic transmit FIFO/queue status register
    --  (OTG_FS_HPTXSTS)
@@ -1478,7 +1479,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. Port line status
       PLSTS          : FS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1526,7 +1527,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1566,7 +1567,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted
       CHH            : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  STALL response received interrupt
       STALL          : Boolean := False;
       --  NAK response received interrupt
@@ -1574,7 +1575,7 @@ package STM32_SVD.USB_OTG_FS is
       --  ACK response received/transmitted interrupt
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  Transaction error
       TXERR          : Boolean := False;
       --  Babble error
@@ -1611,7 +1612,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted mask
       CHHM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  STALL response received interrupt mask
       STALLM         : Boolean := False;
       --  NAK response received interrupt mask
@@ -1662,7 +1663,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Data PID
       DPID           : FS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1829,7 +1830,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_DEVICE_Periph : aliased OTG_FS_DEVICE_Peripheral
-     with Import, Address => OTG_FS_DEVICE_Base;
+     with Import, Address => System'To_Address (16#50000800#);
 
    type OTG_FS_GLOBAL_Disc is
      (
@@ -1913,7 +1914,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_GLOBAL_Periph : aliased OTG_FS_GLOBAL_Peripheral
-     with Import, Address => OTG_FS_GLOBAL_Base;
+     with Import, Address => System'To_Address (16#50000000#);
 
    --  USB on the go full speed
    type OTG_FS_HOST_Peripheral is record
@@ -2043,7 +2044,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_HOST_Periph : aliased OTG_FS_HOST_Peripheral
-     with Import, Address => OTG_FS_HOST_Base;
+     with Import, Address => System'To_Address (16#50000400#);
 
    --  USB on the go full speed
    type OTG_FS_PWRCLK_Peripheral is record
@@ -2058,6 +2059,6 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_PWRCLK_Periph : aliased OTG_FS_PWRCLK_Peripheral
-     with Import, Address => OTG_FS_PWRCLK_Base;
+     with Import, Address => System'To_Address (16#50000E00#);
 
 end STM32_SVD.USB_OTG_FS;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-usb_otg_fs.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-usb_otg_fs.ads
@@ -25,7 +25,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Non-zero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Device address
       DAD            : FS_DCFG_DAD_Field := 16#0#;
       --  Periodic frame interval
@@ -127,7 +127,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Timeout condition mask (Non-isochronous endpoints)
       TOM           : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -161,7 +161,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  SETUP phase done mask
       STUPM         : Boolean := False;
       --  OUT token received when endpoint disabled mask
@@ -281,13 +281,13 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
       EPTYP          : FS_DIEPCTL0_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  STALL handshake
       STALL          : Boolean := False;
       --  TxFIFO number
@@ -330,13 +330,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  TOC
       TOC           : Boolean := False;
       --  ITTXFE
       ITTXFE        : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  INEPNE
       INEPNE        : Boolean := False;
       --  Read-only. TXFE
@@ -419,7 +419,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : DIEPCTL1_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -471,7 +471,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Multi count
       MCNT           : DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -502,7 +502,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -553,7 +553,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USBAEP
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAKSTS
       NAKSTS         : Boolean := False;
       --  Read-only. EPTYP
@@ -602,13 +602,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  STUP
       STUP          : Boolean := False;
       --  OTEPDIS
       OTEPDIS       : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  B2BSTUP
       B2BSTUP       : Boolean := False;
       --  unspecified
@@ -644,7 +644,7 @@ package STM32_SVD.USB_OTG_FS is
       --  SETUP packet count
       STUPCNT        : DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -728,7 +728,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -863,7 +863,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Write-only. Full Speed serial transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -907,7 +907,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -986,7 +986,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE              : Boolean := True;
       --  unspecified
-      Reserved_27_27     : HAL.UInt1 := 16#0#;
+      Reserved_27_27     : HAL.Bit := 16#0#;
       --  Connector ID status change
       CIDSCHG            : Boolean := False;
       --  Disconnect detected interrupt
@@ -1034,7 +1034,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS interrupt mask register (OTG_FS_GINTMSK)
    type FS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0     : HAL.UInt1 := 16#0#;
+      Reserved_0_0     : HAL.Bit := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM            : Boolean := False;
       --  OTG interrupt mask
@@ -1064,7 +1064,7 @@ package STM32_SVD.USB_OTG_FS is
       --  End of periodic frame interrupt mask
       EOPFM            : Boolean := False;
       --  unspecified
-      Reserved_16_16   : HAL.UInt1 := 16#0#;
+      Reserved_16_16   : HAL.Bit := 16#0#;
       --  Endpoint mismatch interrupt mask
       EPMISM           : Boolean := False;
       --  IN endpoints interrupt mask
@@ -1085,7 +1085,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Periodic TxFIFO empty mask
       PTXFEM           : Boolean := False;
       --  unspecified
-      Reserved_27_27   : HAL.UInt1 := 16#0#;
+      Reserved_27_27   : HAL.Bit := 16#0#;
       --  Connector ID status change mask
       CIDSCHGM         : Boolean := False;
       --  Disconnect detected interrupt mask
@@ -1264,7 +1264,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Top of the non-periodic transmit request queue
       NPTXQTOP       : FS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1;
+      Reserved_31_31 : HAL.Bit;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1283,7 +1283,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Power down
       PWRDWN         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Enable the VBUS sensing device
       VBUSASEN       : Boolean := False;
       --  Enable the VBUS sensing device
@@ -1479,7 +1479,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. Port line status
       PLSTS          : FS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1527,7 +1527,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1567,7 +1567,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted
       CHH            : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  STALL response received interrupt
       STALL          : Boolean := False;
       --  NAK response received interrupt
@@ -1575,7 +1575,7 @@ package STM32_SVD.USB_OTG_FS is
       --  ACK response received/transmitted interrupt
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  Transaction error
       TXERR          : Boolean := False;
       --  Babble error
@@ -1612,7 +1612,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted mask
       CHHM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  STALL response received interrupt mask
       STALLM         : Boolean := False;
       --  NAK response received interrupt mask
@@ -1663,7 +1663,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Data PID
       DPID           : FS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-usb_otg_hs.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-usb_otg_hs.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -25,7 +26,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Nonzero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Device address
       DAD            : OTG_HS_DCFG_DAD_Field := 16#0#;
       --  Periodic (micro)frame interval
@@ -132,7 +133,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -142,7 +143,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -174,17 +175,17 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SETUP phase done mask
       STUPM          : Boolean := False;
       --  OUT token received when endpoint disabled mask
       OTEPDM         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Back-to-back SETUP packets received mask
       B2BSTUP        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  OUT packet error mask
       OPEM           : Boolean := False;
       --  BNA interrupt mask
@@ -297,7 +298,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Receive threshold length
       RXTHRLEN       : OTG_HS_DTHRCTL_RXTHRLEN_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.Bit := 16#0#;
+      Reserved_26_26 : HAL.UInt1 := 16#0#;
       --  Arbiter parking enable
       ARPEN          : Boolean := False;
       --  unspecified
@@ -338,7 +339,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register
    type OTG_HS_DEACHINT_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  IN endpoint 1interrupt bit
       IEP1INT        : Boolean := False;
       --  unspecified
@@ -362,7 +363,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register mask
    type OTG_HS_DEACHINTMSK_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  IN Endpoint 1 interrupt mask bit
       IEP1INTM       : Boolean := False;
       --  unspecified
@@ -390,7 +391,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -400,7 +401,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -438,7 +439,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition mask
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -448,7 +449,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  OUT packet error mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -504,7 +505,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint type
       EPTYP          : OTG_HS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  STALL handshake
       Stall          : Boolean := False;
       --  TxFIFO number
@@ -550,13 +551,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition
       TOC            : Boolean := False;
       --  IN token received when TxFIFO is empty
       ITTXFE         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  IN endpoint NAK effective
       INEPNE         : Boolean := False;
       --  Read-only. Transmit FIFO empty
@@ -566,7 +567,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Buffer not available interrupt
       BNA            : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Packet dropped status
       PKTDRPSTS      : Boolean := False;
       --  Babble error interrupt
@@ -651,7 +652,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Multi count
       MCNT           : OTG_HS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -675,7 +676,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
@@ -724,13 +725,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SETUP phase done
       STUP           : Boolean := False;
       --  OUT token received when endpoint disabled
       OTEPDIS        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Back-to-back SETUP packets received
       B2BSTUP        : Boolean := False;
       --  unspecified
@@ -772,7 +773,7 @@ package STM32_SVD.USB_OTG_HS is
       --  SETUP packet count
       STUPCNT        : OTG_HS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -856,7 +857,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_HS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -966,7 +967,7 @@ package STM32_SVD.USB_OTG_HS is
       --  DMA enable
       DMAEN         : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  TxFIFO empty level
       TXFELVL       : Boolean := False;
       --  Periodic TxFIFO empty level
@@ -1000,7 +1001,7 @@ package STM32_SVD.USB_OTG_HS is
       --  transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -1008,11 +1009,11 @@ package STM32_SVD.USB_OTG_HS is
       --  USB turnaround time
       TRDT           : OTG_HS_GUSBCFG_TRDT_Field := 16#2#;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  PHY Low-power clock select
       PHYLPCS        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  ULPI FS/LS select
       ULPIFSLS       : Boolean := False;
       --  ULPI Auto-resume
@@ -1080,7 +1081,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1155,7 +1156,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended
       DATAFSUSP         : Boolean := False;
       --  unspecified
-      Reserved_23_23    : HAL.Bit := 16#0#;
+      Reserved_23_23    : HAL.UInt1 := 16#0#;
       --  Read-only. Host port interrupt
       HPRTINT           : Boolean := False;
       --  Read-only. Host channels interrupt
@@ -1163,7 +1164,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE             : Boolean := True;
       --  unspecified
-      Reserved_27_27    : HAL.Bit := 16#0#;
+      Reserved_27_27    : HAL.UInt1 := 16#0#;
       --  Connector ID status change
       CIDSCHG           : Boolean := False;
       --  Disconnect detected interrupt
@@ -1212,7 +1213,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS interrupt mask register
    type OTG_HS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0    : HAL.Bit := 16#0#;
+      Reserved_0_0    : HAL.UInt1 := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM           : Boolean := False;
       --  OTG interrupt mask
@@ -1242,7 +1243,7 @@ package STM32_SVD.USB_OTG_HS is
       --  End of periodic frame interrupt mask
       EOPFM           : Boolean := False;
       --  unspecified
-      Reserved_16_16  : HAL.Bit := 16#0#;
+      Reserved_16_16  : HAL.UInt1 := 16#0#;
       --  Endpoint mismatch interrupt mask
       EPMISM          : Boolean := False;
       --  IN endpoints interrupt mask
@@ -1256,7 +1257,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended mask
       FSUSPM          : Boolean := False;
       --  unspecified
-      Reserved_23_23  : HAL.Bit := 16#0#;
+      Reserved_23_23  : HAL.UInt1 := 16#0#;
       --  Read-only. Host port interrupt mask
       PRTIM           : Boolean := False;
       --  Host channels interrupt mask
@@ -1264,7 +1265,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Periodic TxFIFO empty mask
       PTXFEM          : Boolean := False;
       --  unspecified
-      Reserved_27_27  : HAL.Bit := 16#0#;
+      Reserved_27_27  : HAL.UInt1 := 16#0#;
       --  Connector ID status change mask
       CIDSCHGM        : Boolean := False;
       --  Disconnect detected interrupt mask
@@ -1489,7 +1490,7 @@ package STM32_SVD.USB_OTG_HS is
    end record;
 
    subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
-   subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
+   subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.UInt8;
    subtype OTG_HS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
    --  OTG_HS nonperiodic transmit FIFO/queue status register
@@ -1501,7 +1502,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Top of the nonperiodic transmit request queue
       NPTXQTOP       : OTG_HS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.Bit;
+      Reserved_31_31 : HAL.UInt1;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1638,8 +1639,8 @@ package STM32_SVD.USB_OTG_HS is
    end record;
 
    subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
-   subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
-   subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
+   subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.UInt8;
+   subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.UInt8;
 
    --  OTG_HS_Host periodic transmit FIFO/queue status register
    type OTG_HS_HPTXSTS_Register is record
@@ -1718,7 +1719,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_HS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1766,7 +1767,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1933,7 +1934,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data PID
       DPID           : OTG_HS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2178,7 +2179,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_DEVICE_Periph : aliased OTG_HS_DEVICE_Peripheral
-     with Import, Address => OTG_HS_DEVICE_Base;
+     with Import, Address => System'To_Address (16#40040800#);
 
    type OTG_HS_GLOBAL_Disc is
      (
@@ -2281,7 +2282,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_GLOBAL_Periph : aliased OTG_HS_GLOBAL_Peripheral
-     with Import, Address => OTG_HS_GLOBAL_Base;
+     with Import, Address => System'To_Address (16#40040000#);
 
    --  USB on the go high speed
    type OTG_HS_HOST_Peripheral is record
@@ -2530,7 +2531,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_HOST_Periph : aliased OTG_HS_HOST_Peripheral
-     with Import, Address => OTG_HS_HOST_Base;
+     with Import, Address => System'To_Address (16#40040400#);
 
    --  USB on the go high speed
    type OTG_HS_PWRCLK_Peripheral is record
@@ -2545,6 +2546,6 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_PWRCLK_Periph : aliased OTG_HS_PWRCLK_Peripheral
-     with Import, Address => OTG_HS_PWRCLK_Base;
+     with Import, Address => System'To_Address (16#40040E00#);
 
 end STM32_SVD.USB_OTG_HS;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-usb_otg_hs.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-usb_otg_hs.ads
@@ -26,7 +26,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Nonzero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Device address
       DAD            : OTG_HS_DCFG_DAD_Field := 16#0#;
       --  Periodic (micro)frame interval
@@ -133,7 +133,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -143,7 +143,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -175,17 +175,17 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SETUP phase done mask
       STUPM          : Boolean := False;
       --  OUT token received when endpoint disabled mask
       OTEPDM         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Back-to-back SETUP packets received mask
       B2BSTUP        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  OUT packet error mask
       OPEM           : Boolean := False;
       --  BNA interrupt mask
@@ -298,7 +298,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Receive threshold length
       RXTHRLEN       : OTG_HS_DTHRCTL_RXTHRLEN_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.UInt1 := 16#0#;
+      Reserved_26_26 : HAL.Bit := 16#0#;
       --  Arbiter parking enable
       ARPEN          : Boolean := False;
       --  unspecified
@@ -339,7 +339,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register
    type OTG_HS_DEACHINT_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  IN endpoint 1interrupt bit
       IEP1INT        : Boolean := False;
       --  unspecified
@@ -363,7 +363,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register mask
    type OTG_HS_DEACHINTMSK_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  IN Endpoint 1 interrupt mask bit
       IEP1INTM       : Boolean := False;
       --  unspecified
@@ -391,7 +391,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -401,7 +401,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -439,7 +439,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition mask
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -449,7 +449,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  OUT packet error mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -505,7 +505,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint type
       EPTYP          : OTG_HS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  STALL handshake
       Stall          : Boolean := False;
       --  TxFIFO number
@@ -551,13 +551,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition
       TOC            : Boolean := False;
       --  IN token received when TxFIFO is empty
       ITTXFE         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  IN endpoint NAK effective
       INEPNE         : Boolean := False;
       --  Read-only. Transmit FIFO empty
@@ -567,7 +567,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Buffer not available interrupt
       BNA            : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Packet dropped status
       PKTDRPSTS      : Boolean := False;
       --  Babble error interrupt
@@ -652,7 +652,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Multi count
       MCNT           : OTG_HS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -676,7 +676,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
@@ -725,13 +725,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SETUP phase done
       STUP           : Boolean := False;
       --  OUT token received when endpoint disabled
       OTEPDIS        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Back-to-back SETUP packets received
       B2BSTUP        : Boolean := False;
       --  unspecified
@@ -773,7 +773,7 @@ package STM32_SVD.USB_OTG_HS is
       --  SETUP packet count
       STUPCNT        : OTG_HS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -857,7 +857,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_HS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -967,7 +967,7 @@ package STM32_SVD.USB_OTG_HS is
       --  DMA enable
       DMAEN         : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  TxFIFO empty level
       TXFELVL       : Boolean := False;
       --  Periodic TxFIFO empty level
@@ -1001,7 +1001,7 @@ package STM32_SVD.USB_OTG_HS is
       --  transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -1009,11 +1009,11 @@ package STM32_SVD.USB_OTG_HS is
       --  USB turnaround time
       TRDT           : OTG_HS_GUSBCFG_TRDT_Field := 16#2#;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  PHY Low-power clock select
       PHYLPCS        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  ULPI FS/LS select
       ULPIFSLS       : Boolean := False;
       --  ULPI Auto-resume
@@ -1081,7 +1081,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1156,7 +1156,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended
       DATAFSUSP         : Boolean := False;
       --  unspecified
-      Reserved_23_23    : HAL.UInt1 := 16#0#;
+      Reserved_23_23    : HAL.Bit := 16#0#;
       --  Read-only. Host port interrupt
       HPRTINT           : Boolean := False;
       --  Read-only. Host channels interrupt
@@ -1164,7 +1164,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE             : Boolean := True;
       --  unspecified
-      Reserved_27_27    : HAL.UInt1 := 16#0#;
+      Reserved_27_27    : HAL.Bit := 16#0#;
       --  Connector ID status change
       CIDSCHG           : Boolean := False;
       --  Disconnect detected interrupt
@@ -1213,7 +1213,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS interrupt mask register
    type OTG_HS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0    : HAL.UInt1 := 16#0#;
+      Reserved_0_0    : HAL.Bit := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM           : Boolean := False;
       --  OTG interrupt mask
@@ -1243,7 +1243,7 @@ package STM32_SVD.USB_OTG_HS is
       --  End of periodic frame interrupt mask
       EOPFM           : Boolean := False;
       --  unspecified
-      Reserved_16_16  : HAL.UInt1 := 16#0#;
+      Reserved_16_16  : HAL.Bit := 16#0#;
       --  Endpoint mismatch interrupt mask
       EPMISM          : Boolean := False;
       --  IN endpoints interrupt mask
@@ -1257,7 +1257,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended mask
       FSUSPM          : Boolean := False;
       --  unspecified
-      Reserved_23_23  : HAL.UInt1 := 16#0#;
+      Reserved_23_23  : HAL.Bit := 16#0#;
       --  Read-only. Host port interrupt mask
       PRTIM           : Boolean := False;
       --  Host channels interrupt mask
@@ -1265,7 +1265,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Periodic TxFIFO empty mask
       PTXFEM          : Boolean := False;
       --  unspecified
-      Reserved_27_27  : HAL.UInt1 := 16#0#;
+      Reserved_27_27  : HAL.Bit := 16#0#;
       --  Connector ID status change mask
       CIDSCHGM        : Boolean := False;
       --  Disconnect detected interrupt mask
@@ -1502,7 +1502,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Top of the nonperiodic transmit request queue
       NPTXQTOP       : OTG_HS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1;
+      Reserved_31_31 : HAL.Bit;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1719,7 +1719,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_HS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1767,7 +1767,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1934,7 +1934,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data PID
       DPID           : OTG_HS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd-wwdg.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd-wwdg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -118,6 +119,6 @@ package STM32_SVD.WWDG is
 
    --  Window watchdog
    WWDG_Periph : aliased WWDG_Peripheral
-     with Import, Address => WWDG_Base;
+     with Import, Address => System'To_Address (16#40002C00#);
 
 end STM32_SVD.WWDG;

--- a/arch/ARM/STM32/svd/stm32f429x/stm32_svd.ads
+++ b/arch/ARM/STM32/svd/stm32f429x/stm32_svd.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with System;
 

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-adc.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-adc.ads
@@ -135,7 +135,7 @@ package STM32_SVD.ADC is
       --  Start conversion of injected channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  External event select for regular group
       EXTSEL         : CR2_EXTSEL_Field := 16#0#;
       --  External trigger enable for regular channels
@@ -143,7 +143,7 @@ package STM32_SVD.ADC is
       --  Start conversion of regular channels
       SWSTART        : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -651,7 +651,7 @@ package STM32_SVD.ADC is
       --  Delay between 2 sampling phases
       DELAY_k        : CCR_DELAY_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.UInt1 := 16#0#;
+      Reserved_12_12 : HAL.Bit := 16#0#;
       --  DMA disable selection for multi-ADC mode
       DDS            : Boolean := False;
       --  Direct memory access mode for multi ADC mode

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-adc.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-adc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -134,7 +135,7 @@ package STM32_SVD.ADC is
       --  Start conversion of injected channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  External event select for regular group
       EXTSEL         : CR2_EXTSEL_Field := 16#0#;
       --  External trigger enable for regular channels
@@ -142,7 +143,7 @@ package STM32_SVD.ADC is
       --  Start conversion of regular channels
       SWSTART        : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -388,7 +389,7 @@ package STM32_SVD.ADC is
       --  Regular channel sequence length
       L              : SQR1_L_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -650,7 +651,7 @@ package STM32_SVD.ADC is
       --  Delay between 2 sampling phases
       DELAY_k        : CCR_DELAY_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.Bit := 16#0#;
+      Reserved_12_12 : HAL.UInt1 := 16#0#;
       --  DMA disable selection for multi-ADC mode
       DDS            : Boolean := False;
       --  Direct memory access mode for multi ADC mode
@@ -664,7 +665,7 @@ package STM32_SVD.ADC is
       --  Temperature sensor and VREFINT enable
       TSVREFE        : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -785,15 +786,15 @@ package STM32_SVD.ADC is
 
    --  Analog-to-digital converter
    ADC1_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC1_Base;
+     with Import, Address => System'To_Address (16#40012000#);
 
    --  Analog-to-digital converter
    ADC2_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC2_Base;
+     with Import, Address => System'To_Address (16#40012100#);
 
    --  Analog-to-digital converter
    ADC3_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC3_Base;
+     with Import, Address => System'To_Address (16#40012200#);
 
    --  Common ADC registers
    type C_ADC_Peripheral is record
@@ -814,6 +815,6 @@ package STM32_SVD.ADC is
 
    --  Common ADC registers
    C_ADC_Periph : aliased C_ADC_Peripheral
-     with Import, Address => C_ADC_Base;
+     with Import, Address => System'To_Address (16#40012300#);
 
 end STM32_SVD.ADC;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-can.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-can.ads
@@ -230,7 +230,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP0
       FMP0          : RF0R_FMP0_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  FULL0
       FULL0         : Boolean := False;
       --  FOVR0
@@ -259,7 +259,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP1
       FMP1          : RF1R_FMP1_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  FULL1
       FULL1         : Boolean := False;
       --  FOVR1
@@ -298,7 +298,7 @@ package STM32_SVD.CAN is
       --  FOVIE1
       FOVIE1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  EWGIE
       EWGIE          : Boolean := False;
       --  EPVIE
@@ -354,7 +354,7 @@ package STM32_SVD.CAN is
       --  Read-only. BOFF
       BOFF          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  LEC
       LEC           : ESR_LEC_Field := 16#0#;
       --  unspecified
@@ -394,7 +394,7 @@ package STM32_SVD.CAN is
       --  TS2
       TS2            : BTR_TS2_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  SJW
       SJW            : BTR_SJW_Field := 16#0#;
       --  unspecified
@@ -755,7 +755,7 @@ package STM32_SVD.CAN is
    --  receive FIFO mailbox identifier register
    type RI0R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.UInt1;
+      Reserved_0_0 : HAL.Bit;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -863,7 +863,7 @@ package STM32_SVD.CAN is
    --  mailbox data high register
    type RI1R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.UInt1;
+      Reserved_0_0 : HAL.Bit;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-can.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-can.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -229,7 +230,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP0
       FMP0          : RF0R_FMP0_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  FULL0
       FULL0         : Boolean := False;
       --  FOVR0
@@ -258,7 +259,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP1
       FMP1          : RF1R_FMP1_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  FULL1
       FULL1         : Boolean := False;
       --  FOVR1
@@ -297,7 +298,7 @@ package STM32_SVD.CAN is
       --  FOVIE1
       FOVIE1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  EWGIE
       EWGIE          : Boolean := False;
       --  EPVIE
@@ -341,8 +342,8 @@ package STM32_SVD.CAN is
    end record;
 
    subtype ESR_LEC_Field is HAL.UInt3;
-   subtype ESR_TEC_Field is HAL.Byte;
-   subtype ESR_REC_Field is HAL.Byte;
+   subtype ESR_TEC_Field is HAL.UInt8;
+   subtype ESR_REC_Field is HAL.UInt8;
 
    --  interrupt enable register
    type ESR_Register is record
@@ -353,7 +354,7 @@ package STM32_SVD.CAN is
       --  Read-only. BOFF
       BOFF          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  LEC
       LEC           : ESR_LEC_Field := 16#0#;
       --  unspecified
@@ -393,7 +394,7 @@ package STM32_SVD.CAN is
       --  TS2
       TS2            : BTR_TS2_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  SJW
       SJW            : BTR_SJW_Field := 16#0#;
       --  unspecified
@@ -473,7 +474,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL0R_DATA array element
-   subtype TDL0R_DATA_Element is HAL.Byte;
+   subtype TDL0R_DATA_Element is HAL.UInt8;
 
    --  TDL0R_DATA array
    type TDL0R_DATA_Field_Array is array (0 .. 3) of TDL0R_DATA_Element
@@ -501,7 +502,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH0R_DATA array element
-   subtype TDH0R_DATA_Element is HAL.Byte;
+   subtype TDH0R_DATA_Element is HAL.UInt8;
 
    --  TDH0R_DATA array
    type TDH0R_DATA_Field_Array is array (4 .. 7) of TDH0R_DATA_Element
@@ -583,7 +584,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL1R_DATA array element
-   subtype TDL1R_DATA_Element is HAL.Byte;
+   subtype TDL1R_DATA_Element is HAL.UInt8;
 
    --  TDL1R_DATA array
    type TDL1R_DATA_Field_Array is array (0 .. 3) of TDL1R_DATA_Element
@@ -611,7 +612,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH1R_DATA array element
-   subtype TDH1R_DATA_Element is HAL.Byte;
+   subtype TDH1R_DATA_Element is HAL.UInt8;
 
    --  TDH1R_DATA array
    type TDH1R_DATA_Field_Array is array (4 .. 7) of TDH1R_DATA_Element
@@ -693,7 +694,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL2R_DATA array element
-   subtype TDL2R_DATA_Element is HAL.Byte;
+   subtype TDL2R_DATA_Element is HAL.UInt8;
 
    --  TDL2R_DATA array
    type TDL2R_DATA_Field_Array is array (0 .. 3) of TDL2R_DATA_Element
@@ -721,7 +722,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH2R_DATA array element
-   subtype TDH2R_DATA_Element is HAL.Byte;
+   subtype TDH2R_DATA_Element is HAL.UInt8;
 
    --  TDH2R_DATA array
    type TDH2R_DATA_Field_Array is array (4 .. 7) of TDH2R_DATA_Element
@@ -754,7 +755,7 @@ package STM32_SVD.CAN is
    --  receive FIFO mailbox identifier register
    type RI0R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.Bit;
+      Reserved_0_0 : HAL.UInt1;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -776,7 +777,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype RDT0R_DLC_Field is HAL.UInt4;
-   subtype RDT0R_FMI_Field is HAL.Byte;
+   subtype RDT0R_FMI_Field is HAL.UInt8;
    subtype RDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
@@ -801,7 +802,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDL0R_DATA array element
-   subtype RDL0R_DATA_Element is HAL.Byte;
+   subtype RDL0R_DATA_Element is HAL.UInt8;
 
    --  RDL0R_DATA array
    type RDL0R_DATA_Field_Array is array (0 .. 3) of RDL0R_DATA_Element
@@ -829,7 +830,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDH0R_DATA array element
-   subtype RDH0R_DATA_Element is HAL.Byte;
+   subtype RDH0R_DATA_Element is HAL.UInt8;
 
    --  RDH0R_DATA array
    type RDH0R_DATA_Field_Array is array (4 .. 7) of RDH0R_DATA_Element
@@ -862,7 +863,7 @@ package STM32_SVD.CAN is
    --  mailbox data high register
    type RI1R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.Bit;
+      Reserved_0_0 : HAL.UInt1;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -884,7 +885,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype RDT1R_DLC_Field is HAL.UInt4;
-   subtype RDT1R_FMI_Field is HAL.Byte;
+   subtype RDT1R_FMI_Field is HAL.UInt8;
    subtype RDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
@@ -909,7 +910,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDL1R_DATA array element
-   subtype RDL1R_DATA_Element is HAL.Byte;
+   subtype RDL1R_DATA_Element is HAL.UInt8;
 
    --  RDL1R_DATA array
    type RDL1R_DATA_Field_Array is array (0 .. 3) of RDL1R_DATA_Element
@@ -937,7 +938,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDH1R_DATA array element
-   subtype RDH1R_DATA_Element is HAL.Byte;
+   subtype RDH1R_DATA_Element is HAL.UInt8;
 
    --  RDH1R_DATA array
    type RDH1R_DATA_Field_Array is array (4 .. 7) of RDH1R_DATA_Element
@@ -2124,10 +2125,10 @@ package STM32_SVD.CAN is
 
    --  Controller area network
    CAN1_Periph : aliased CAN_Peripheral
-     with Import, Address => CAN1_Base;
+     with Import, Address => System'To_Address (16#40006400#);
 
    --  Controller area network
    CAN2_Periph : aliased CAN_Peripheral
-     with Import, Address => CAN2_Base;
+     with Import, Address => System'To_Address (16#40006800#);
 
 end STM32_SVD.CAN;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-crc.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-crc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -13,7 +14,7 @@ package STM32_SVD.CRC is
    -- Registers --
    ---------------
 
-   subtype IDR_IDR_Field is HAL.Byte;
+   subtype IDR_IDR_Field is HAL.UInt8;
 
    --  Independent Data register
    type IDR_Register is record
@@ -52,7 +53,7 @@ package STM32_SVD.CRC is
    --  Cyclic Redundancy Check (CRC) unit
    type CRC_Peripheral is record
       --  Data register
-      DR  : HAL.UInt32 with Volatile; --  work-around for Q207-001
+      DR  : HAL.UInt32;
       --  Independent Data register
       IDR : IDR_Register;
       --  Control register
@@ -68,6 +69,6 @@ package STM32_SVD.CRC is
 
    --  Cyclic Redundancy Check (CRC) unit
    CRC_Periph : aliased CRC_Peripheral
-     with Import, Address => CRC_Base;
+     with Import, Address => System'To_Address (16#40023000#);
 
 end STM32_SVD.CRC;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-cryp.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-cryp.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -39,7 +40,7 @@ package STM32_SVD.CRYP is
       --  GCM_CCMPH
       GCM_CCMPH      : CR_GCM_CCMPH_Field := 16#0#;
       --  unspecified
-      Reserved_18_18 : HAL.Bit := 16#0#;
+      Reserved_18_18 : HAL.UInt1 := 16#0#;
       --  ALGOMODE
       ALGOMODE3      : Boolean := False;
       --  unspecified
@@ -584,6 +585,6 @@ package STM32_SVD.CRYP is
 
    --  Cryptographic processor
    CRYP_Periph : aliased CRYP_Peripheral
-     with Import, Address => CRYP_Base;
+     with Import, Address => System'To_Address (16#50060000#);
 
 end STM32_SVD.CRYP;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-cryp.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-cryp.ads
@@ -40,7 +40,7 @@ package STM32_SVD.CRYP is
       --  GCM_CCMPH
       GCM_CCMPH      : CR_GCM_CCMPH_Field := 16#0#;
       --  unspecified
-      Reserved_18_18 : HAL.UInt1 := 16#0#;
+      Reserved_18_18 : HAL.Bit := 16#0#;
       --  ALGOMODE
       ALGOMODE3      : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dac.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dac.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -160,7 +161,7 @@ package STM32_SVD.DAC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DHR8R1_DACC1DHR_Field is HAL.Byte;
+   subtype DHR8R1_DACC1DHR_Field is HAL.UInt8;
 
    --  channel1 8-bit right aligned data holding register
    type DHR8R1_Register is record
@@ -214,7 +215,7 @@ package STM32_SVD.DAC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DHR8R2_DACC2DHR_Field is HAL.Byte;
+   subtype DHR8R2_DACC2DHR_Field is HAL.UInt8;
 
    --  channel2 8-bit right-aligned data holding register
    type DHR8R2_Register is record
@@ -279,8 +280,8 @@ package STM32_SVD.DAC is
       DACC2DHR       at 0 range 20 .. 31;
    end record;
 
-   subtype DHR8RD_DACC1DHR_Field is HAL.Byte;
-   subtype DHR8RD_DACC2DHR_Field is HAL.Byte;
+   subtype DHR8RD_DACC1DHR_Field is HAL.UInt8;
+   subtype DHR8RD_DACC2DHR_Field is HAL.UInt8;
 
    --  DUAL DAC 8-bit right aligned data holding register
    type DHR8RD_Register is record
@@ -414,6 +415,6 @@ package STM32_SVD.DAC is
 
    --  Digital-to-analog converter
    DAC_Periph : aliased DAC_Peripheral
-     with Import, Address => DAC_Base;
+     with Import, Address => System'To_Address (16#40007400#);
 
 end STM32_SVD.DAC;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dbg.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dbg.ads
@@ -102,7 +102,7 @@ package STM32_SVD.DBG is
       --  DBG_J2C3SMBUS_TIMEOUT
       DBG_J2C3SMBUS_TIMEOUT  : Boolean := False;
       --  unspecified
-      Reserved_24_24         : HAL.UInt1 := 16#0#;
+      Reserved_24_24         : HAL.Bit := 16#0#;
       --  DBG_CAN1_STOP
       DBG_CAN1_STOP          : Boolean := False;
       --  DBG_CAN2_STOP

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dbg.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dbg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -93,7 +94,7 @@ package STM32_SVD.DBG is
       --  DBG_IWDEG_STOP
       DBG_IWDEG_STOP         : Boolean := False;
       --  unspecified
-      Reserved_13_20         : HAL.Byte := 16#0#;
+      Reserved_13_20         : HAL.UInt8 := 16#0#;
       --  DBG_J2C1_SMBUS_TIMEOUT
       DBG_J2C1_SMBUS_TIMEOUT : Boolean := False;
       --  DBG_J2C2_SMBUS_TIMEOUT
@@ -101,7 +102,7 @@ package STM32_SVD.DBG is
       --  DBG_J2C3SMBUS_TIMEOUT
       DBG_J2C3SMBUS_TIMEOUT  : Boolean := False;
       --  unspecified
-      Reserved_24_24         : HAL.Bit := 16#0#;
+      Reserved_24_24         : HAL.UInt1 := 16#0#;
       --  DBG_CAN1_STOP
       DBG_CAN1_STOP          : Boolean := False;
       --  DBG_CAN2_STOP
@@ -191,6 +192,6 @@ package STM32_SVD.DBG is
 
    --  Debug support
    DBG_Periph : aliased DBG_Peripheral
-     with Import, Address => DBG_Base;
+     with Import, Address => System'To_Address (16#E0042000#);
 
 end STM32_SVD.DBG;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dcmi.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dcmi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -193,10 +194,10 @@ package STM32_SVD.DCMI is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype ESCR_FSC_Field is HAL.Byte;
-   subtype ESCR_LSC_Field is HAL.Byte;
-   subtype ESCR_LEC_Field is HAL.Byte;
-   subtype ESCR_FEC_Field is HAL.Byte;
+   subtype ESCR_FSC_Field is HAL.UInt8;
+   subtype ESCR_LSC_Field is HAL.UInt8;
+   subtype ESCR_LEC_Field is HAL.UInt8;
+   subtype ESCR_FEC_Field is HAL.UInt8;
 
    --  embedded synchronization code register
    type ESCR_Register is record
@@ -219,10 +220,10 @@ package STM32_SVD.DCMI is
       FEC at 0 range 24 .. 31;
    end record;
 
-   subtype ESUR_FSU_Field is HAL.Byte;
-   subtype ESUR_LSU_Field is HAL.Byte;
-   subtype ESUR_LEU_Field is HAL.Byte;
-   subtype ESUR_FEU_Field is HAL.Byte;
+   subtype ESUR_FSU_Field is HAL.UInt8;
+   subtype ESUR_LSU_Field is HAL.UInt8;
+   subtype ESUR_LEU_Field is HAL.UInt8;
+   subtype ESUR_FEU_Field is HAL.UInt8;
 
    --  embedded synchronization unmask register
    type ESUR_Register is record
@@ -294,7 +295,7 @@ package STM32_SVD.DCMI is
    end record;
 
    --  DR_Byte array element
-   subtype DR_Byte_Element is HAL.Byte;
+   subtype DR_Byte_Element is HAL.UInt8;
 
    --  DR_Byte array
    type DR_Byte_Field_Array is array (0 .. 3) of DR_Byte_Element
@@ -368,6 +369,6 @@ package STM32_SVD.DCMI is
 
    --  Digital camera interface
    DCMI_Periph : aliased DCMI_Peripheral
-     with Import, Address => DCMI_Base;
+     with Import, Address => System'To_Address (16#50050000#);
 
 end STM32_SVD.DCMI;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dma.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dma.ads
@@ -19,7 +19,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF0          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1;
+      Reserved_1_1   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF0         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -31,7 +31,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF1          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1;
+      Reserved_7_7   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF1         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -45,7 +45,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF2          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1;
+      Reserved_17_17 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF2         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -57,7 +57,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF3          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1;
+      Reserved_23_23 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF3         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -106,7 +106,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF4          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1;
+      Reserved_1_1   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF4         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -118,7 +118,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF5          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1;
+      Reserved_7_7   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF5         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -132,7 +132,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF6          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1;
+      Reserved_17_17 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF6         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -144,7 +144,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF7          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1;
+      Reserved_23_23 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF7         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -193,7 +193,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF0         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF0        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -205,7 +205,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF1        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -219,7 +219,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF2         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF2        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -231,7 +231,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF3         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF3        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -280,7 +280,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF4         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF4        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -292,7 +292,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF5         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF5        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -306,7 +306,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF6         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF6        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -318,7 +318,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF7         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF7        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -405,7 +405,7 @@ package STM32_SVD.DMA is
       --  Current target (only in double buffer mode)
       CT             : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Peripheral burst transfer configuration
       PBURST         : S0CR_PBURST_Field := 16#0#;
       --  Memory burst transfer configuration
@@ -471,7 +471,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S0FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -598,7 +598,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S1FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -725,7 +725,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S2FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -852,7 +852,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S3FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -979,7 +979,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S4FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1106,7 +1106,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S5FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1233,7 +1233,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S6FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1360,7 +1360,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S7FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dma.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dma.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -18,7 +19,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF0          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.Bit;
+      Reserved_1_1   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF0         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -30,7 +31,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF1          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.Bit;
+      Reserved_7_7   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF1         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -44,7 +45,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF2          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.Bit;
+      Reserved_17_17 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF2         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -56,7 +57,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF3          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.Bit;
+      Reserved_23_23 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF3         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -105,7 +106,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF4          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.Bit;
+      Reserved_1_1   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF4         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -117,7 +118,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF5          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.Bit;
+      Reserved_7_7   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF5         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -131,7 +132,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF6          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.Bit;
+      Reserved_17_17 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF6         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -143,7 +144,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF7          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.Bit;
+      Reserved_23_23 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF7         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -192,7 +193,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF0         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF0        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -204,7 +205,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF1        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -218,7 +219,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF2         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF2        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -230,7 +231,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF3         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF3        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -279,7 +280,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF4         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF4        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -291,7 +292,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF5         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF5        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -305,7 +306,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF6         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF6        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -317,7 +318,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF7         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF7        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -404,7 +405,7 @@ package STM32_SVD.DMA is
       --  Current target (only in double buffer mode)
       CT             : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Peripheral burst transfer configuration
       PBURST         : S0CR_PBURST_Field := 16#0#;
       --  Memory burst transfer configuration
@@ -470,7 +471,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S0FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -597,7 +598,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S1FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -724,7 +725,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S2FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -851,7 +852,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S3FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -978,7 +979,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S4FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1105,7 +1106,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S5FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1232,7 +1233,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S6FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1359,7 +1360,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S7FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1547,10 +1548,10 @@ package STM32_SVD.DMA is
 
    --  DMA controller
    DMA1_Periph : aliased DMA_Peripheral
-     with Import, Address => DMA1_Base;
+     with Import, Address => System'To_Address (16#40026000#);
 
    --  DMA controller
    DMA2_Periph : aliased DMA_Peripheral
-     with Import, Address => DMA2_Base;
+     with Import, Address => System'To_Address (16#40026400#);
 
 end STM32_SVD.DMA;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dma2d.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dma2d.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -158,9 +159,9 @@ package STM32_SVD.DMA2D is
    end record;
 
    subtype FGPFCCR_CM_Field is HAL.UInt4;
-   subtype FGPFCCR_CS_Field is HAL.Byte;
+   subtype FGPFCCR_CS_Field is HAL.UInt8;
    subtype FGPFCCR_AM_Field is HAL.UInt2;
-   subtype FGPFCCR_ALPHA_Field is HAL.Byte;
+   subtype FGPFCCR_ALPHA_Field is HAL.UInt8;
 
    --  foreground PFC control register
    type FGPFCCR_Register is record
@@ -195,9 +196,9 @@ package STM32_SVD.DMA2D is
       ALPHA          at 0 range 24 .. 31;
    end record;
 
-   subtype FGCOLR_BLUE_Field is HAL.Byte;
-   subtype FGCOLR_GREEN_Field is HAL.Byte;
-   subtype FGCOLR_RED_Field is HAL.Byte;
+   subtype FGCOLR_BLUE_Field is HAL.UInt8;
+   subtype FGCOLR_GREEN_Field is HAL.UInt8;
+   subtype FGCOLR_RED_Field is HAL.UInt8;
 
    --  foreground color register
    type FGCOLR_Register is record
@@ -208,7 +209,7 @@ package STM32_SVD.DMA2D is
       --  Red Value
       RED            : FGCOLR_RED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -221,9 +222,9 @@ package STM32_SVD.DMA2D is
    end record;
 
    subtype BGPFCCR_CM_Field is HAL.UInt4;
-   subtype BGPFCCR_CS_Field is HAL.Byte;
+   subtype BGPFCCR_CS_Field is HAL.UInt8;
    subtype BGPFCCR_AM_Field is HAL.UInt2;
-   subtype BGPFCCR_ALPHA_Field is HAL.Byte;
+   subtype BGPFCCR_ALPHA_Field is HAL.UInt8;
 
    --  background PFC control register
    type BGPFCCR_Register is record
@@ -258,9 +259,9 @@ package STM32_SVD.DMA2D is
       ALPHA          at 0 range 24 .. 31;
    end record;
 
-   subtype BGCOLR_BLUE_Field is HAL.Byte;
-   subtype BGCOLR_GREEN_Field is HAL.Byte;
-   subtype BGCOLR_RED_Field is HAL.Byte;
+   subtype BGCOLR_BLUE_Field is HAL.UInt8;
+   subtype BGCOLR_GREEN_Field is HAL.UInt8;
+   subtype BGCOLR_RED_Field is HAL.UInt8;
 
    --  background color register
    type BGCOLR_Register is record
@@ -271,7 +272,7 @@ package STM32_SVD.DMA2D is
       --  Red Value
       RED            : BGCOLR_RED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -300,10 +301,10 @@ package STM32_SVD.DMA2D is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype OCOLR_BLUE_Field is HAL.Byte;
-   subtype OCOLR_GREEN_Field is HAL.Byte;
-   subtype OCOLR_RED_Field is HAL.Byte;
-   subtype OCOLR_APLHA_Field is HAL.Byte;
+   subtype OCOLR_BLUE_Field is HAL.UInt8;
+   subtype OCOLR_GREEN_Field is HAL.UInt8;
+   subtype OCOLR_RED_Field is HAL.UInt8;
+   subtype OCOLR_APLHA_Field is HAL.UInt8;
 
    --  output color register
    type OCOLR_Register is record
@@ -381,7 +382,7 @@ package STM32_SVD.DMA2D is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype AMTCR_DT_Field is HAL.Byte;
+   subtype AMTCR_DT_Field is HAL.UInt8;
 
    --  AHB master timer configuration register
    type AMTCR_Register is record
@@ -404,10 +405,10 @@ package STM32_SVD.DMA2D is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype FGCLUT_BLUE_Field is HAL.Byte;
-   subtype FGCLUT_GREEN_Field is HAL.Byte;
-   subtype FGCLUT_RED_Field is HAL.Byte;
-   subtype FGCLUT_APLHA_Field is HAL.Byte;
+   subtype FGCLUT_BLUE_Field is HAL.UInt8;
+   subtype FGCLUT_GREEN_Field is HAL.UInt8;
+   subtype FGCLUT_RED_Field is HAL.UInt8;
+   subtype FGCLUT_APLHA_Field is HAL.UInt8;
 
    --  FGCLUT
    type FGCLUT_Register is record
@@ -430,10 +431,10 @@ package STM32_SVD.DMA2D is
       APLHA at 0 range 24 .. 31;
    end record;
 
-   subtype BGCLUT_BLUE_Field is HAL.Byte;
-   subtype BGCLUT_GREEN_Field is HAL.Byte;
-   subtype BGCLUT_RED_Field is HAL.Byte;
-   subtype BGCLUT_APLHA_Field is HAL.Byte;
+   subtype BGCLUT_BLUE_Field is HAL.UInt8;
+   subtype BGCLUT_GREEN_Field is HAL.UInt8;
+   subtype BGCLUT_RED_Field is HAL.UInt8;
+   subtype BGCLUT_APLHA_Field is HAL.UInt8;
 
    --  BGCLUT
    type BGCLUT_Register is record
@@ -536,6 +537,6 @@ package STM32_SVD.DMA2D is
 
    --  DMA2D controller
    DMA2D_Periph : aliased DMA2D_Peripheral
-     with Import, Address => DMA2D_Base;
+     with Import, Address => System'To_Address (16#4002B000#);
 
 end STM32_SVD.DMA2D;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dsi.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dsi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -28,8 +29,8 @@ package STM32_SVD.DSI is
       Reserved_1_31 at 0 range 1 .. 31;
    end record;
 
-   subtype DSI_CCR_TXECKDIV_Field is HAL.Byte;
-   subtype DSI_CCR_TOCKDIV_Field is HAL.Byte;
+   subtype DSI_CCR_TXECKDIV_Field is HAL.UInt8;
+   subtype DSI_CCR_TOCKDIV_Field is HAL.UInt8;
 
    --  DSI HOST Clock Control Register
    type DSI_CCR_Register is record
@@ -110,19 +111,19 @@ package STM32_SVD.DSI is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype DSI_LPMCR_VLPSIZE_Field is HAL.Byte;
-   subtype DSI_LPMCR_LPSIZE_Field is HAL.Byte;
+   subtype DSI_LPMCR_VLPSIZE_Field is HAL.UInt8;
+   subtype DSI_LPMCR_LPSIZE_Field is HAL.UInt8;
 
    --  DSI Host Low-Power Mode Configuration Register
    type DSI_LPMCR_Register is record
       --  VACT Largest Packet Size
       VLPSIZE        : DSI_LPMCR_VLPSIZE_Field := 16#0#;
       --  unspecified
-      Reserved_8_15  : HAL.Byte := 16#0#;
+      Reserved_8_15  : HAL.UInt8 := 16#0#;
       --  Largest Packet Size
       LPSIZE         : DSI_LPMCR_LPSIZE_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -462,7 +463,7 @@ package STM32_SVD.DSI is
       --  Generic Long Write Transmission
       GLWTX          : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  DCS Short Write Zero parameter Transmission
       DSW0TX         : Boolean := False;
       --  DCS Short Read One parameter Transmission
@@ -504,8 +505,8 @@ package STM32_SVD.DSI is
 
    subtype DSI_GHCR_DT_Field is HAL.UInt6;
    subtype DSI_GHCR_VCID_Field is HAL.UInt2;
-   subtype DSI_GHCR_WCLSB_Field is HAL.Byte;
-   subtype DSI_GHCR_WCMSB_Field is HAL.Byte;
+   subtype DSI_GHCR_WCLSB_Field is HAL.UInt8;
+   subtype DSI_GHCR_WCMSB_Field is HAL.UInt8;
 
    --  DSI Host Generic Header Configuration Register
    type DSI_GHCR_Register is record
@@ -518,7 +519,7 @@ package STM32_SVD.DSI is
       --  WordCount MSB
       WCMSB          : DSI_GHCR_WCMSB_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -532,7 +533,7 @@ package STM32_SVD.DSI is
    end record;
 
    --  DSI_GPDR_DATA array element
-   subtype DSI_GPDR_DATA_Element is HAL.Byte;
+   subtype DSI_GPDR_DATA_Element is HAL.UInt8;
 
    --  DSI_GPDR_DATA array
    type DSI_GPDR_DATA_Field_Array is array (1 .. 4) of DSI_GPDR_DATA_Element
@@ -651,7 +652,7 @@ package STM32_SVD.DSI is
       --  High-Speed Write Timeout Counter
       HSWR_TOCNT     : DSI_TCCR3_HSWR_TOCNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  Presp Mode
       PM             : Boolean := False;
       --  unspecified
@@ -744,15 +745,15 @@ package STM32_SVD.DSI is
    end record;
 
    subtype DSI_DLTCR_MRD_TIME_Field is HAL.UInt15;
-   subtype DSI_DLTCR_LP2HS_TIME_Field is HAL.Byte;
-   subtype DSI_DLTCR_HS2LP_TIME_Field is HAL.Byte;
+   subtype DSI_DLTCR_LP2HS_TIME_Field is HAL.UInt8;
+   subtype DSI_DLTCR_HS2LP_TIME_Field is HAL.UInt8;
 
    --  DSI Host Data Lane Timer Configuration Register
    type DSI_DLTCR_Register is record
       --  Maximum Read Time
       MRD_TIME       : DSI_DLTCR_MRD_TIME_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Low-Power To High-Speed Time
       LP2HS_TIME     : DSI_DLTCR_LP2HS_TIME_Field := 16#0#;
       --  High-Speed To Low-Power Time
@@ -771,7 +772,7 @@ package STM32_SVD.DSI is
    --  DSI Host PHY Control Register
    type DSI_PCTLR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit := 16#0#;
+      Reserved_0_0  : HAL.UInt1 := 16#0#;
       --  Digital Enable
       DEN           : Boolean := False;
       --  Clock Enable
@@ -790,7 +791,7 @@ package STM32_SVD.DSI is
    end record;
 
    subtype DSI_PCONFR_NL_Field is HAL.UInt2;
-   subtype DSI_PCONFR_SW_TIME_Field is HAL.Byte;
+   subtype DSI_PCONFR_SW_TIME_Field is HAL.UInt8;
 
    --  DSI Host PHY Configuration Register
    type DSI_PCONFR_Register is record
@@ -857,7 +858,7 @@ package STM32_SVD.DSI is
    --  DSI Host PHY Status Register
    type DSI_PSR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit;
+      Reserved_0_0  : HAL.UInt1;
       --  Read-only. PHY Direction
       PD            : Boolean;
       --  Read-only. PHY Stop State Clock lane
@@ -1316,19 +1317,19 @@ package STM32_SVD.DSI is
       Reserved_9_31 at 0 range 9 .. 31;
    end record;
 
-   subtype DSI_LPMCCR_VLPSIZE_Field is HAL.Byte;
-   subtype DSI_LPMCCR_LPSIZE_Field is HAL.Byte;
+   subtype DSI_LPMCCR_VLPSIZE_Field is HAL.UInt8;
+   subtype DSI_LPMCCR_LPSIZE_Field is HAL.UInt8;
 
    --  DSI Host Low-power Mode Current Configuration Register
    type DSI_LPMCCR_Register is record
       --  Read-only. VACT Largest Packet Size
       VLPSIZE        : DSI_LPMCCR_VLPSIZE_Field;
       --  unspecified
-      Reserved_8_15  : HAL.Byte;
+      Reserved_8_15  : HAL.UInt8;
       --  Read-only. Largest Packet Size
       LPSIZE         : DSI_LPMCCR_LPSIZE_Field;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1657,7 +1658,7 @@ package STM32_SVD.DSI is
       --  Read-only. PLL Unlock Interrupt Flag
       PLLUIF         : Boolean;
       --  unspecified
-      Reserved_11_11 : HAL.Bit;
+      Reserved_11_11 : HAL.UInt1;
       --  Read-only. Regulator Ready Status
       RRS            : Boolean;
       --  Read-only. Regulator Ready Interrupt Flag
@@ -1786,11 +1787,11 @@ package STM32_SVD.DSI is
       --  Contention Detection OFF on Data Lanes
       CDOFFDL        : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Turn Disable Data Lanes
       TDDL           : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Pull-Down Enable
       PDEN           : Boolean := False;
       --  custom time for tCLK-PREPARE Enable
@@ -1904,10 +1905,10 @@ package STM32_SVD.DSI is
       Reserved_27_31 at 0 range 27 .. 31;
    end record;
 
-   subtype DSI_WPCR3_TCLKPREP_Field is HAL.Byte;
-   subtype DSI_WPCR3_TCLKZEO_Field is HAL.Byte;
-   subtype DSI_WPCR3_THSPREP_Field is HAL.Byte;
-   subtype DSI_WPCR3_THSTRAIL_Field is HAL.Byte;
+   subtype DSI_WPCR3_TCLKPREP_Field is HAL.UInt8;
+   subtype DSI_WPCR3_TCLKZEO_Field is HAL.UInt8;
+   subtype DSI_WPCR3_THSPREP_Field is HAL.UInt8;
+   subtype DSI_WPCR3_THSTRAIL_Field is HAL.UInt8;
 
    --  DSI Wrapper PHY Configuration Register 3
    type DSI_WPCR3_Register is record
@@ -1930,10 +1931,10 @@ package STM32_SVD.DSI is
       THSTRAIL at 0 range 24 .. 31;
    end record;
 
-   subtype DSI_WPCR4_THSZERO_Field is HAL.Byte;
-   subtype DSI_WPCR4_TLPXD_Field is HAL.Byte;
-   subtype DSI_WPCR4_THSEXIT_Field is HAL.Byte;
-   subtype DSI_WPCR4_TLPXC_Field is HAL.Byte;
+   subtype DSI_WPCR4_THSZERO_Field is HAL.UInt8;
+   subtype DSI_WPCR4_TLPXD_Field is HAL.UInt8;
+   subtype DSI_WPCR4_THSEXIT_Field is HAL.UInt8;
+   subtype DSI_WPCR4_TLPXC_Field is HAL.UInt8;
 
    --  DSI_WPCR4
    type DSI_WPCR4_Register is record
@@ -1956,7 +1957,7 @@ package STM32_SVD.DSI is
       TLPXC   at 0 range 24 .. 31;
    end record;
 
-   subtype DSI_WPCR5_THSZERO_Field is HAL.Byte;
+   subtype DSI_WPCR5_THSZERO_Field is HAL.UInt8;
 
    --  DSI Wrapper PHY Configuration Register 5
    type DSI_WPCR5_Register is record
@@ -1982,7 +1983,7 @@ package STM32_SVD.DSI is
       --  PLL Enable
       PLLEN          : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  PLL Loop Division Factor
       NDIV           : DSI_WRPCR_NDIV_Field := 16#0#;
       --  unspecified
@@ -1990,7 +1991,7 @@ package STM32_SVD.DSI is
       --  PLL Input Division Factor
       IDF            : DSI_WRPCR_IDF_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  PLL Output Division Factor
       ODF            : DSI_WRPCR_ODF_Field := 16#0#;
       --  unspecified
@@ -2246,6 +2247,6 @@ package STM32_SVD.DSI is
 
    --  DSI Host
    DSI_Periph : aliased DSI_Peripheral
-     with Import, Address => DSI_Base;
+     with Import, Address => System'To_Address (16#40016C00#);
 
 end STM32_SVD.DSI;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dsi.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-dsi.ads
@@ -463,7 +463,7 @@ package STM32_SVD.DSI is
       --  Generic Long Write Transmission
       GLWTX          : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  DCS Short Write Zero parameter Transmission
       DSW0TX         : Boolean := False;
       --  DCS Short Read One parameter Transmission
@@ -753,7 +753,7 @@ package STM32_SVD.DSI is
       --  Maximum Read Time
       MRD_TIME       : DSI_DLTCR_MRD_TIME_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Low-Power To High-Speed Time
       LP2HS_TIME     : DSI_DLTCR_LP2HS_TIME_Field := 16#0#;
       --  High-Speed To Low-Power Time
@@ -772,7 +772,7 @@ package STM32_SVD.DSI is
    --  DSI Host PHY Control Register
    type DSI_PCTLR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1 := 16#0#;
+      Reserved_0_0  : HAL.Bit := 16#0#;
       --  Digital Enable
       DEN           : Boolean := False;
       --  Clock Enable
@@ -858,7 +858,7 @@ package STM32_SVD.DSI is
    --  DSI Host PHY Status Register
    type DSI_PSR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1;
+      Reserved_0_0  : HAL.Bit;
       --  Read-only. PHY Direction
       PD            : Boolean;
       --  Read-only. PHY Stop State Clock lane
@@ -1658,7 +1658,7 @@ package STM32_SVD.DSI is
       --  Read-only. PLL Unlock Interrupt Flag
       PLLUIF         : Boolean;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1;
+      Reserved_11_11 : HAL.Bit;
       --  Read-only. Regulator Ready Status
       RRS            : Boolean;
       --  Read-only. Regulator Ready Interrupt Flag
@@ -1787,11 +1787,11 @@ package STM32_SVD.DSI is
       --  Contention Detection OFF on Data Lanes
       CDOFFDL        : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Turn Disable Data Lanes
       TDDL           : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Pull-Down Enable
       PDEN           : Boolean := False;
       --  custom time for tCLK-PREPARE Enable
@@ -1983,7 +1983,7 @@ package STM32_SVD.DSI is
       --  PLL Enable
       PLLEN          : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  PLL Loop Division Factor
       NDIV           : DSI_WRPCR_NDIV_Field := 16#0#;
       --  unspecified
@@ -1991,7 +1991,7 @@ package STM32_SVD.DSI is
       --  PLL Input Division Factor
       IDF            : DSI_WRPCR_IDF_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  PLL Output Division Factor
       ODF            : DSI_WRPCR_ODF_Field := 16#0#;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-ethernet.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-ethernet.ads
@@ -112,7 +112,7 @@ package STM32_SVD.Ethernet is
       --  Read-only. no description available
       EBS            : DMASR_EBS_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.UInt1 := 16#0#;
+      Reserved_26_26 : HAL.Bit := 16#0#;
       --  Read-only. no description available
       MMCS           : Boolean := False;
       --  Read-only. no description available
@@ -158,7 +158,7 @@ package STM32_SVD.Ethernet is
    --  Ethernet DMA operation mode register
    type DMAOMR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  SR
       SR             : Boolean := False;
       --  OSF
@@ -166,7 +166,7 @@ package STM32_SVD.Ethernet is
       --  RTC
       RTC            : DMAOMR_RTC_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  FUGF
       FUGF           : Boolean := False;
       --  FEF
@@ -340,7 +340,7 @@ package STM32_SVD.Ethernet is
       --  APCS
       APCS           : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  RD
       RD             : Boolean := False;
       --  IPCO
@@ -354,7 +354,7 @@ package STM32_SVD.Ethernet is
       --  FES
       FES            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#1#;
+      Reserved_15_15 : HAL.Bit := 16#1#;
       --  CSD
       CSD            : Boolean := False;
       --  IFG
@@ -366,7 +366,7 @@ package STM32_SVD.Ethernet is
       --  WD
       WD             : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CSTF
       CSTF           : Boolean := False;
       --  unspecified
@@ -458,7 +458,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       CR             : MACMIIAR_CR_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  no description available
       MR             : MACMIIAR_MR_Field := 16#0#;
       --  no description available
@@ -512,7 +512,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       PLT           : MACFCR_PLT_Field := 16#0#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  no description available
       ZQPD          : Boolean := False;
       --  unspecified
@@ -762,7 +762,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA2L         : MACA2LR_MACA2L_Field := 16#7FFFFFFF#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#1#;
+      Reserved_31_31 : HAL.Bit := 16#1#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-ethernet.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-ethernet.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -111,7 +112,7 @@ package STM32_SVD.Ethernet is
       --  Read-only. no description available
       EBS            : DMASR_EBS_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.Bit := 16#0#;
+      Reserved_26_26 : HAL.UInt1 := 16#0#;
       --  Read-only. no description available
       MMCS           : Boolean := False;
       --  Read-only. no description available
@@ -157,7 +158,7 @@ package STM32_SVD.Ethernet is
    --  Ethernet DMA operation mode register
    type DMAOMR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  SR
       SR             : Boolean := False;
       --  OSF
@@ -165,7 +166,7 @@ package STM32_SVD.Ethernet is
       --  RTC
       RTC            : DMAOMR_RTC_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  FUGF
       FUGF           : Boolean := False;
       --  FEF
@@ -304,7 +305,7 @@ package STM32_SVD.Ethernet is
       Reserved_29_31 at 0 range 29 .. 31;
    end record;
 
-   subtype DMARSWTR_RSWTC_Field is HAL.Byte;
+   subtype DMARSWTR_RSWTC_Field is HAL.UInt8;
 
    --  Ethernet DMA receive status watchdog timer register
    type DMARSWTR_Register is record
@@ -339,7 +340,7 @@ package STM32_SVD.Ethernet is
       --  APCS
       APCS           : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  RD
       RD             : Boolean := False;
       --  IPCO
@@ -353,7 +354,7 @@ package STM32_SVD.Ethernet is
       --  FES
       FES            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#1#;
+      Reserved_15_15 : HAL.UInt1 := 16#1#;
       --  CSD
       CSD            : Boolean := False;
       --  IFG
@@ -365,7 +366,7 @@ package STM32_SVD.Ethernet is
       --  WD
       WD             : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CSTF
       CSTF           : Boolean := False;
       --  unspecified
@@ -457,7 +458,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       CR             : MACMIIAR_CR_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  no description available
       MR             : MACMIIAR_MR_Field := 16#0#;
       --  no description available
@@ -511,11 +512,11 @@ package STM32_SVD.Ethernet is
       --  no description available
       PLT           : MACFCR_PLT_Field := 16#0#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  no description available
       ZQPD          : Boolean := False;
       --  unspecified
-      Reserved_8_15 : HAL.Byte := 16#0#;
+      Reserved_8_15 : HAL.UInt8 := 16#0#;
       --  no description available
       PT            : MACFCR_PT_Field := 16#0#;
    end record
@@ -708,7 +709,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA1H         : MACA1HR_MACA1H_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA1HR_MBC_Field := 16#0#;
       --  no description available
@@ -735,7 +736,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MAC2AH         : MACA2HR_MAC2AH_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA2HR_MBC_Field := 16#0#;
       --  no description available
@@ -761,7 +762,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA2L         : MACA2LR_MACA2L_Field := 16#7FFFFFFF#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#1#;
+      Reserved_31_31 : HAL.UInt1 := 16#1#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -779,7 +780,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA3H         : MACA3HR_MACA3H_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA3HR_MBC_Field := 16#0#;
       --  no description available
@@ -998,7 +999,7 @@ package STM32_SVD.Ethernet is
       Reserved_19_31 at 0 range 19 .. 31;
    end record;
 
-   subtype PTPSSIR_STSSI_Field is HAL.Byte;
+   subtype PTPSSIR_STSSI_Field is HAL.UInt8;
 
    --  Ethernet PTP subsecond increment register
    type PTPSSIR_Register is record
@@ -1141,7 +1142,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: DMA controller operation
    Ethernet_DMA_Periph : aliased Ethernet_DMA_Peripheral
-     with Import, Address => Ethernet_DMA_Base;
+     with Import, Address => System'To_Address (16#40029000#);
 
    --  Ethernet: media access control (MAC)
    type Ethernet_MAC_Peripheral is record
@@ -1213,7 +1214,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: media access control (MAC)
    Ethernet_MAC_Periph : aliased Ethernet_MAC_Peripheral
-     with Import, Address => Ethernet_MAC_Base;
+     with Import, Address => System'To_Address (16#40028000#);
 
    --  Ethernet: MAC management counters
    type Ethernet_MMC_Peripheral is record
@@ -1259,7 +1260,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: MAC management counters
    Ethernet_MMC_Periph : aliased Ethernet_MMC_Peripheral
-     with Import, Address => Ethernet_MMC_Base;
+     with Import, Address => System'To_Address (16#40028100#);
 
    --  Ethernet: Precision time protocol
    type Ethernet_PTP_Peripheral is record
@@ -1304,6 +1305,6 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: Precision time protocol
    Ethernet_PTP_Periph : aliased Ethernet_PTP_Peripheral
-     with Import, Address => Ethernet_PTP_Base;
+     with Import, Address => System'To_Address (16#40028700#);
 
 end STM32_SVD.Ethernet;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-exti.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-exti.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -279,6 +280,6 @@ package STM32_SVD.EXTI is
 
    --  External interrupt/event controller
    EXTI_Periph : aliased EXTI_Peripheral
-     with Import, Address => EXTI_Base;
+     with Import, Address => System'To_Address (16#40013C00#);
 
 end STM32_SVD.EXTI;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-flash.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-flash.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -142,7 +143,7 @@ package STM32_SVD.FLASH is
    end record;
 
    subtype OPTCR_BOR_LEV_Field is HAL.UInt2;
-   subtype OPTCR_RDP_Field is HAL.Byte;
+   subtype OPTCR_RDP_Field is HAL.UInt8;
    subtype OPTCR_nWRP_Field is HAL.UInt12;
 
    --  Flash option control register
@@ -245,6 +246,6 @@ package STM32_SVD.FLASH is
 
    --  FLASH
    FLASH_Periph : aliased FLASH_Peripheral
-     with Import, Address => FLASH_Base;
+     with Import, Address => System'To_Address (16#40023C00#);
 
 end STM32_SVD.FLASH;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-fsmc.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-fsmc.ads
@@ -30,13 +30,13 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#1#;
+      Reserved_7_7   : HAL.Bit := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
       WAITPOL        : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  WAITCFG
       WAITCFG        : Boolean := False;
       --  WREN
@@ -137,7 +137,7 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#1#;
+      Reserved_7_7   : HAL.Bit := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
@@ -192,7 +192,7 @@ package STM32_SVD.FSMC is
    --  PC Card/NAND Flash control register 3
    type PCR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  PWAITEN
       PWAITEN        : Boolean := False;
       --  PBKEN

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-fsmc.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-fsmc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -29,13 +30,13 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#1#;
+      Reserved_7_7   : HAL.UInt1 := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
       WAITPOL        : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  WAITCFG
       WAITCFG        : Boolean := False;
       --  WREN
@@ -81,7 +82,7 @@ package STM32_SVD.FSMC is
 
    subtype BTR_ADDSET_Field is HAL.UInt4;
    subtype BTR_ADDHLD_Field is HAL.UInt4;
-   subtype BTR_DATAST_Field is HAL.Byte;
+   subtype BTR_DATAST_Field is HAL.UInt8;
    subtype BTR_BUSTURN_Field is HAL.UInt4;
    subtype BTR_CLKDIV_Field is HAL.UInt4;
    subtype BTR_DATLAT_Field is HAL.UInt4;
@@ -136,7 +137,7 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#1#;
+      Reserved_7_7   : HAL.UInt1 := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
@@ -191,7 +192,7 @@ package STM32_SVD.FSMC is
    --  PC Card/NAND Flash control register 3
    type PCR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  PWAITEN
       PWAITEN        : Boolean := False;
       --  PBKEN
@@ -263,10 +264,10 @@ package STM32_SVD.FSMC is
       Reserved_7_31 at 0 range 7 .. 31;
    end record;
 
-   subtype PMEM_MEMSETx_Field is HAL.Byte;
-   subtype PMEM_MEMWAITx_Field is HAL.Byte;
-   subtype PMEM_MEMHOLDx_Field is HAL.Byte;
-   subtype PMEM_MEMHIZx_Field is HAL.Byte;
+   subtype PMEM_MEMSETx_Field is HAL.UInt8;
+   subtype PMEM_MEMWAITx_Field is HAL.UInt8;
+   subtype PMEM_MEMHOLDx_Field is HAL.UInt8;
+   subtype PMEM_MEMHIZx_Field is HAL.UInt8;
 
    --  Common memory space timing register 3
    type PMEM_Register is record
@@ -289,10 +290,10 @@ package STM32_SVD.FSMC is
       MEMHIZx  at 0 range 24 .. 31;
    end record;
 
-   subtype PATT_ATTSETx_Field is HAL.Byte;
-   subtype PATT_ATTWAITx_Field is HAL.Byte;
-   subtype PATT_ATTHOLDx_Field is HAL.Byte;
-   subtype PATT_ATTHIZx_Field is HAL.Byte;
+   subtype PATT_ATTSETx_Field is HAL.UInt8;
+   subtype PATT_ATTWAITx_Field is HAL.UInt8;
+   subtype PATT_ATTHOLDx_Field is HAL.UInt8;
+   subtype PATT_ATTHIZx_Field is HAL.UInt8;
 
    --  Attribute memory space timing register 3
    type PATT_Register is record
@@ -317,7 +318,7 @@ package STM32_SVD.FSMC is
 
    subtype BWTR_ADDSET_Field is HAL.UInt4;
    subtype BWTR_ADDHLD_Field is HAL.UInt4;
-   subtype BWTR_DATAST_Field is HAL.Byte;
+   subtype BWTR_DATAST_Field is HAL.UInt8;
    subtype BWTR_CLKDIV_Field is HAL.UInt4;
    subtype BWTR_DATLAT_Field is HAL.UInt4;
    subtype BWTR_ACCMOD_Field is HAL.UInt2;
@@ -652,6 +653,6 @@ package STM32_SVD.FSMC is
 
    --  Flexible memory controller
    FMC_Periph : aliased FMC_Peripheral
-     with Import, Address => FMC_Base;
+     with Import, Address => System'To_Address (16#A0000000#);
 
 end STM32_SVD.FSMC;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-gpio.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-gpio.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -419,46 +420,46 @@ package STM32_SVD.GPIO is
 
    --  General-purpose I/Os
    GPIOA_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOA_Base;
+     with Import, Address => System'To_Address (16#40020000#);
 
    --  General-purpose I/Os
    GPIOB_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOB_Base;
+     with Import, Address => System'To_Address (16#40020400#);
 
    --  General-purpose I/Os
    GPIOC_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOC_Base;
+     with Import, Address => System'To_Address (16#40020800#);
 
    --  General-purpose I/Os
    GPIOD_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOD_Base;
+     with Import, Address => System'To_Address (16#40020C00#);
 
    --  General-purpose I/Os
    GPIOE_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOE_Base;
+     with Import, Address => System'To_Address (16#40021000#);
 
    --  General-purpose I/Os
    GPIOF_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOF_Base;
+     with Import, Address => System'To_Address (16#40021400#);
 
    --  General-purpose I/Os
    GPIOG_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOG_Base;
+     with Import, Address => System'To_Address (16#40021800#);
 
    --  General-purpose I/Os
    GPIOH_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOH_Base;
+     with Import, Address => System'To_Address (16#40021C00#);
 
    --  General-purpose I/Os
    GPIOI_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOI_Base;
+     with Import, Address => System'To_Address (16#40022000#);
 
    --  General-purpose I/Os
    GPIOJ_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOJ_Base;
+     with Import, Address => System'To_Address (16#40022400#);
 
    --  General-purpose I/Os
    GPIOK_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOK_Base;
+     with Import, Address => System'To_Address (16#40022800#);
 
 end STM32_SVD.GPIO;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-hash.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-hash.ads
@@ -42,7 +42,7 @@ package STM32_SVD.HASH is
       --  Long key selection
       LKEY           : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  ALGO
       ALGO1          : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-hash.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-hash.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -41,7 +42,7 @@ package STM32_SVD.HASH is
       --  Long key selection
       LKEY           : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  ALGO
       ALGO1          : Boolean := False;
       --  unspecified
@@ -362,6 +363,6 @@ package STM32_SVD.HASH is
 
    --  Hash processor
    HASH_Periph : aliased HASH_Peripheral
-     with Import, Address => HASH_Base;
+     with Import, Address => System'To_Address (16#50060400#);
 
 end STM32_SVD.HASH;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-i2c.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-i2c.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -20,7 +21,7 @@ package STM32_SVD.I2C is
       --  SMBus mode
       SMBUS          : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SMBus type
       SMBTYPE        : Boolean := False;
       --  ARP enable
@@ -44,7 +45,7 @@ package STM32_SVD.I2C is
       --  SMBus alert
       ALERT          : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Software reset
       SWRST          : Boolean := False;
       --  unspecified
@@ -158,7 +159,7 @@ package STM32_SVD.I2C is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype DR_DR_Field is HAL.Byte;
+   subtype DR_DR_Field is HAL.UInt8;
 
    --  Data register
    type DR_Register is record
@@ -188,7 +189,7 @@ package STM32_SVD.I2C is
       --  Read-only. Stop detection (slave mode)
       STOPF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Read-only. Data register not empty (receivers)
       RxNE           : Boolean := False;
       --  Read-only. Data register empty (transmitters)
@@ -204,7 +205,7 @@ package STM32_SVD.I2C is
       --  PEC Error in reception
       PECERR         : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  Timeout or Tlow error
       TIMEOUT        : Boolean := False;
       --  SMBus alert
@@ -235,7 +236,7 @@ package STM32_SVD.I2C is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype SR2_PEC_Field is HAL.Byte;
+   subtype SR2_PEC_Field is HAL.UInt8;
 
    --  Status register 2
    type SR2_Register is record
@@ -246,7 +247,7 @@ package STM32_SVD.I2C is
       --  Read-only. Transmitter/receiver
       TRA            : Boolean;
       --  unspecified
-      Reserved_3_3   : HAL.Bit;
+      Reserved_3_3   : HAL.UInt1;
       --  Read-only. General call address (Slave mode)
       GENCALL        : Boolean;
       --  Read-only. SMBus device default address (Slave mode)
@@ -383,14 +384,14 @@ package STM32_SVD.I2C is
 
    --  Inter-integrated circuit
    I2C1_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C1_Base;
+     with Import, Address => System'To_Address (16#40005400#);
 
    --  Inter-integrated circuit
    I2C2_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C2_Base;
+     with Import, Address => System'To_Address (16#40005800#);
 
    --  Inter-integrated circuit
    I2C3_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C3_Base;
+     with Import, Address => System'To_Address (16#40005C00#);
 
 end STM32_SVD.I2C;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-i2c.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-i2c.ads
@@ -21,7 +21,7 @@ package STM32_SVD.I2C is
       --  SMBus mode
       SMBUS          : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SMBus type
       SMBTYPE        : Boolean := False;
       --  ARP enable
@@ -45,7 +45,7 @@ package STM32_SVD.I2C is
       --  SMBus alert
       ALERT          : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Software reset
       SWRST          : Boolean := False;
       --  unspecified
@@ -189,7 +189,7 @@ package STM32_SVD.I2C is
       --  Read-only. Stop detection (slave mode)
       STOPF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Read-only. Data register not empty (receivers)
       RxNE           : Boolean := False;
       --  Read-only. Data register empty (transmitters)
@@ -205,7 +205,7 @@ package STM32_SVD.I2C is
       --  PEC Error in reception
       PECERR         : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  Timeout or Tlow error
       TIMEOUT        : Boolean := False;
       --  SMBus alert
@@ -247,7 +247,7 @@ package STM32_SVD.I2C is
       --  Read-only. Transmitter/receiver
       TRA            : Boolean;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1;
+      Reserved_3_3   : HAL.Bit;
       --  Read-only. General call address (Slave mode)
       GENCALL        : Boolean;
       --  Read-only. SMBus device default address (Slave mode)

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-iwdg.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-iwdg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -108,6 +109,6 @@ package STM32_SVD.IWDG is
 
    --  Independent watchdog
    IWDG_Periph : aliased IWDG_Peripheral
-     with Import, Address => IWDG_Base;
+     with Import, Address => System'To_Address (16#40003000#);
 
 end STM32_SVD.IWDG;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-ltdc.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-ltdc.ads
@@ -123,15 +123,15 @@ package STM32_SVD.LTDC is
       --  Read-only. Dither Blue Width
       DBW            : GCR_DBW_Field := 16#2#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Read-only. Dither Green Width
       DGW            : GCR_DGW_Field := 16#2#;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  Read-only. Dither Red Width
       DRW            : GCR_DRW_Field := 16#2#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Dither Enable
       DEN            : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-ltdc.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-ltdc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -122,15 +123,15 @@ package STM32_SVD.LTDC is
       --  Read-only. Dither Blue Width
       DBW            : GCR_DBW_Field := 16#2#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Read-only. Dither Green Width
       DGW            : GCR_DGW_Field := 16#2#;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  Read-only. Dither Red Width
       DRW            : GCR_DRW_Field := 16#2#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Dither Enable
       DEN            : Boolean := False;
       --  unspecified
@@ -189,7 +190,7 @@ package STM32_SVD.LTDC is
       --  Background Color Red value
       BC             : BCCR_BC_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -402,9 +403,9 @@ package STM32_SVD.LTDC is
       Reserved_27_31 at 0 range 27 .. 31;
    end record;
 
-   subtype L1CKCR_CKBLUE_Field is HAL.Byte;
-   subtype L1CKCR_CKGREEN_Field is HAL.Byte;
-   subtype L1CKCR_CKRED_Field is HAL.Byte;
+   subtype L1CKCR_CKBLUE_Field is HAL.UInt8;
+   subtype L1CKCR_CKGREEN_Field is HAL.UInt8;
+   subtype L1CKCR_CKRED_Field is HAL.UInt8;
 
    --  Layerx Color Keying Configuration Register
    type L1CKCR_Register is record
@@ -415,7 +416,7 @@ package STM32_SVD.LTDC is
       --  Color Key Red value
       CKRED          : L1CKCR_CKRED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -444,7 +445,7 @@ package STM32_SVD.LTDC is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype L1CACR_CONSTA_Field is HAL.Byte;
+   subtype L1CACR_CONSTA_Field is HAL.UInt8;
 
    --  Layerx Constant Alpha Configuration Register
    type L1CACR_Register is record
@@ -461,10 +462,10 @@ package STM32_SVD.LTDC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype L1DCCR_DCBLUE_Field is HAL.Byte;
-   subtype L1DCCR_DCGREEN_Field is HAL.Byte;
-   subtype L1DCCR_DCRED_Field is HAL.Byte;
-   subtype L1DCCR_DCALPHA_Field is HAL.Byte;
+   subtype L1DCCR_DCBLUE_Field is HAL.UInt8;
+   subtype L1DCCR_DCGREEN_Field is HAL.UInt8;
+   subtype L1DCCR_DCRED_Field is HAL.UInt8;
+   subtype L1DCCR_DCALPHA_Field is HAL.UInt8;
 
    --  Layerx Default Color Configuration Register
    type L1DCCR_Register is record
@@ -552,10 +553,10 @@ package STM32_SVD.LTDC is
       Reserved_11_31 at 0 range 11 .. 31;
    end record;
 
-   subtype L1CLUTWR_BLUE_Field is HAL.Byte;
-   subtype L1CLUTWR_GREEN_Field is HAL.Byte;
-   subtype L1CLUTWR_RED_Field is HAL.Byte;
-   subtype L1CLUTWR_CLUTADD_Field is HAL.Byte;
+   subtype L1CLUTWR_BLUE_Field is HAL.UInt8;
+   subtype L1CLUTWR_GREEN_Field is HAL.UInt8;
+   subtype L1CLUTWR_RED_Field is HAL.UInt8;
+   subtype L1CLUTWR_CLUTADD_Field is HAL.UInt8;
 
    --  Layerx CLUT Write Register
    type L1CLUTWR_Register is record
@@ -650,7 +651,7 @@ package STM32_SVD.LTDC is
       Reserved_27_31 at 0 range 27 .. 31;
    end record;
 
-   subtype L2CKCR_CKBLUE_Field is HAL.Byte;
+   subtype L2CKCR_CKBLUE_Field is HAL.UInt8;
    subtype L2CKCR_CKGREEN_Field is HAL.UInt7;
    subtype L2CKCR_CKRED_Field is HAL.UInt9;
 
@@ -663,7 +664,7 @@ package STM32_SVD.LTDC is
       --  Color Key Red value
       CKRED          : L2CKCR_CKRED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -692,7 +693,7 @@ package STM32_SVD.LTDC is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype L2CACR_CONSTA_Field is HAL.Byte;
+   subtype L2CACR_CONSTA_Field is HAL.UInt8;
 
    --  Layerx Constant Alpha Configuration Register
    type L2CACR_Register is record
@@ -709,10 +710,10 @@ package STM32_SVD.LTDC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype L2DCCR_DCBLUE_Field is HAL.Byte;
-   subtype L2DCCR_DCGREEN_Field is HAL.Byte;
-   subtype L2DCCR_DCRED_Field is HAL.Byte;
-   subtype L2DCCR_DCALPHA_Field is HAL.Byte;
+   subtype L2DCCR_DCBLUE_Field is HAL.UInt8;
+   subtype L2DCCR_DCGREEN_Field is HAL.UInt8;
+   subtype L2DCCR_DCRED_Field is HAL.UInt8;
+   subtype L2DCCR_DCALPHA_Field is HAL.UInt8;
 
    --  Layerx Default Color Configuration Register
    type L2DCCR_Register is record
@@ -800,10 +801,10 @@ package STM32_SVD.LTDC is
       Reserved_11_31 at 0 range 11 .. 31;
    end record;
 
-   subtype L2CLUTWR_BLUE_Field is HAL.Byte;
-   subtype L2CLUTWR_GREEN_Field is HAL.Byte;
-   subtype L2CLUTWR_RED_Field is HAL.Byte;
-   subtype L2CLUTWR_CLUTADD_Field is HAL.Byte;
+   subtype L2CLUTWR_BLUE_Field is HAL.UInt8;
+   subtype L2CLUTWR_GREEN_Field is HAL.UInt8;
+   subtype L2CLUTWR_RED_Field is HAL.UInt8;
+   subtype L2CLUTWR_CLUTADD_Field is HAL.UInt8;
 
    --  Layerx CLUT Write Register
    type L2CLUTWR_Register is record
@@ -951,6 +952,6 @@ package STM32_SVD.LTDC is
 
    --  LCD-TFT Controller
    LTDC_Periph : aliased LTDC_Peripheral
-     with Import, Address => LTDC_Base;
+     with Import, Address => System'To_Address (16#40016800#);
 
 end STM32_SVD.LTDC;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-nvic.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-nvic.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -31,7 +32,7 @@ package STM32_SVD.NVIC is
    end record;
 
    --  IPR_IPR_N array element
-   subtype IPR_IPR_N_Element is HAL.Byte;
+   subtype IPR_IPR_N_Element is HAL.UInt8;
 
    --  IPR_IPR_N array
    type IPR_IPR_N_Field_Array is array (0 .. 3) of IPR_IPR_N_Element
@@ -203,6 +204,6 @@ package STM32_SVD.NVIC is
 
    --  Nested Vectored Interrupt Controller
    NVIC_Periph : aliased NVIC_Peripheral
-     with Import, Address => NVIC_Base;
+     with Import, Address => System'To_Address (16#E000E000#);
 
 end STM32_SVD.NVIC;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-pwr.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-pwr.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -97,7 +98,7 @@ package STM32_SVD.PWR is
       --  Regulator voltage scaling output selection ready bit
       VOSRDY         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Read-only. Over-drive mode ready
       ODRDY          : Boolean := False;
       --  Read-only. Over-drive mode switching ready
@@ -147,6 +148,6 @@ package STM32_SVD.PWR is
 
    --  Power control
    PWR_Periph : aliased PWR_Peripheral
-     with Import, Address => PWR_Base;
+     with Import, Address => System'To_Address (16#40007000#);
 
 end STM32_SVD.PWR;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-pwr.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-pwr.ads
@@ -98,7 +98,7 @@ package STM32_SVD.PWR is
       --  Regulator voltage scaling output selection ready bit
       VOSRDY         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Read-only. Over-drive mode ready
       ODRDY          : Boolean := False;
       --  Read-only. Over-drive mode switching ready

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-quadspi.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-quadspi.ads
@@ -30,7 +30,7 @@ package STM32_SVD.QUADSPI is
       --  Sample shift
       SSHIFT         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Dual-flash mode
       DFM            : Boolean := False;
       --  FLASH memory selection
@@ -50,7 +50,7 @@ package STM32_SVD.QUADSPI is
       --  TimeOut interrupt enable
       TOIE           : Boolean := False;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Automatic poll mode stop
       APMS           : Boolean := False;
       --  Polling match mode
@@ -158,7 +158,7 @@ package STM32_SVD.QUADSPI is
       --  Clear transfer complete flag
       CTCF          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Clear status match flag
       CSMF          : Boolean := False;
       --  Clear timeout flag
@@ -205,7 +205,7 @@ package STM32_SVD.QUADSPI is
       --  Number of dummy cycles
       DCYC           : CCR_DCYC_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Data mode
       DMODE          : CCR_DMODE_Field := 16#0#;
       --  Functional mode
@@ -213,7 +213,7 @@ package STM32_SVD.QUADSPI is
       --  Send instruction only once mode
       SIOO           : Boolean := False;
       --  unspecified
-      Reserved_29_29 : HAL.UInt1 := 16#0#;
+      Reserved_29_29 : HAL.Bit := 16#0#;
       --  DDR hold half cycle
       DHHC           : Boolean := False;
       --  Double data rate mode

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-quadspi.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-quadspi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -14,7 +15,7 @@ package STM32_SVD.QUADSPI is
    ---------------
 
    subtype CR_FTHRES_Field is HAL.UInt5;
-   subtype CR_PRESCALER_Field is HAL.Byte;
+   subtype CR_PRESCALER_Field is HAL.UInt8;
 
    --  control register
    type CR_Register is record
@@ -29,7 +30,7 @@ package STM32_SVD.QUADSPI is
       --  Sample shift
       SSHIFT         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Dual-flash mode
       DFM            : Boolean := False;
       --  FLASH memory selection
@@ -49,7 +50,7 @@ package STM32_SVD.QUADSPI is
       --  TimeOut interrupt enable
       TOIE           : Boolean := False;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Automatic poll mode stop
       APMS           : Boolean := False;
       --  Polling match mode
@@ -157,7 +158,7 @@ package STM32_SVD.QUADSPI is
       --  Clear transfer complete flag
       CTCF          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Clear status match flag
       CSMF          : Boolean := False;
       --  Clear timeout flag
@@ -177,7 +178,7 @@ package STM32_SVD.QUADSPI is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype CCR_INSTRUCTION_Field is HAL.Byte;
+   subtype CCR_INSTRUCTION_Field is HAL.UInt8;
    subtype CCR_IMODE_Field is HAL.UInt2;
    subtype CCR_ADMODE_Field is HAL.UInt2;
    subtype CCR_ADSIZE_Field is HAL.UInt2;
@@ -204,7 +205,7 @@ package STM32_SVD.QUADSPI is
       --  Number of dummy cycles
       DCYC           : CCR_DCYC_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Data mode
       DMODE          : CCR_DMODE_Field := 16#0#;
       --  Functional mode
@@ -212,7 +213,7 @@ package STM32_SVD.QUADSPI is
       --  Send instruction only once mode
       SIOO           : Boolean := False;
       --  unspecified
-      Reserved_29_29 : HAL.Bit := 16#0#;
+      Reserved_29_29 : HAL.UInt1 := 16#0#;
       --  DDR hold half cycle
       DHHC           : Boolean := False;
       --  Double data rate mode
@@ -325,6 +326,6 @@ package STM32_SVD.QUADSPI is
 
    --  QuadSPI interface
    QUADSPI_Periph : aliased QUADSPI_Peripheral
-     with Import, Address => QUADSPI_Base;
+     with Import, Address => System'To_Address (16#A0001000#);
 
 end STM32_SVD.QUADSPI;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-rcc.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-rcc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -14,7 +15,7 @@ package STM32_SVD.RCC is
    ---------------
 
    subtype CR_HSITRIM_Field is HAL.UInt5;
-   subtype CR_HSICAL_Field is HAL.Byte;
+   subtype CR_HSICAL_Field is HAL.UInt8;
 
    --  clock control register
    type CR_Register is record
@@ -23,7 +24,7 @@ package STM32_SVD.RCC is
       --  Read-only. Internal high-speed clock ready flag
       HSIRDY         : Boolean := True;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Internal high-speed clock trimming
       HSITRIM        : CR_HSITRIM_Field := 16#10#;
       --  Read-only. Internal high-speed clock calibration
@@ -90,7 +91,7 @@ package STM32_SVD.RCC is
       --  Main PLL (PLL) multiplication factor for VCO
       PLLN           : PLLCFGR_PLLN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Main PLL (PLL) division factor for main system clock
       PLLP           : PLLCFGR_PLLP_Field := 16#0#;
       --  unspecified
@@ -98,14 +99,14 @@ package STM32_SVD.RCC is
       --  Main PLL(PLL) and audio PLL (PLLI2S) entry clock source
       PLLSRC         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Main PLL (PLL) division factor for USB OTG FS, SDIO and random number
       --  generator clocks
       PLLQ           : PLLCFGR_PLLQ_Field := 16#4#;
       --  Main PLL division factor for DSI clock
       PLLR           : PLLCFGR_PLLR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -234,7 +235,7 @@ package STM32_SVD.RCC is
       --  PLLSAI Ready Interrupt Enable
       PLLSAIRDYIE    : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Write-only. LSI ready interrupt clear
       LSIRDYC        : Boolean := False;
       --  Write-only. LSE ready interrupt clear
@@ -252,7 +253,7 @@ package STM32_SVD.RCC is
       --  Write-only. Clock security system interrupt clear
       CSSC           : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -310,11 +311,11 @@ package STM32_SVD.RCC is
       --  IO port K reset
       GPIOKRST       : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  CRC reset
       CRCRST         : Boolean := False;
       --  unspecified
-      Reserved_13_20 : HAL.Byte := 16#0#;
+      Reserved_13_20 : HAL.UInt8 := 16#0#;
       --  DMA2 reset
       DMA1RST        : Boolean := False;
       --  DMA2 reset
@@ -322,7 +323,7 @@ package STM32_SVD.RCC is
       --  DMA2D reset
       DMA2DRST       : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  Ethernet MAC reset
       ETHMACRST      : Boolean := False;
       --  unspecified
@@ -439,7 +440,7 @@ package STM32_SVD.RCC is
       --  SPI 3 reset
       SPI3RST        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  USART 2 reset
       UART2RST       : Boolean := False;
       --  USART 3 reset
@@ -455,13 +456,13 @@ package STM32_SVD.RCC is
       --  I2C3 reset
       I2C3RST        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CAN1 reset
       CAN1RST        : Boolean := False;
       --  CAN2 reset
       CAN2RST        : Boolean := False;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Power interface reset
       PWRRST         : Boolean := False;
       --  DAC reset
@@ -534,7 +535,7 @@ package STM32_SVD.RCC is
       --  System configuration controller reset
       SYSCFGRST      : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 reset
       TIM9RST        : Boolean := False;
       --  TIM10 reset
@@ -542,7 +543,7 @@ package STM32_SVD.RCC is
       --  TIM11 reset
       TIM11RST       : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  SPI5 reset
       SPI5RST        : Boolean := False;
       --  SPI6 reset
@@ -613,7 +614,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable
       GPIOKEN        : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  CRC clock enable
       CRCEN          : Boolean := False;
       --  unspecified
@@ -621,7 +622,7 @@ package STM32_SVD.RCC is
       --  Backup SRAM interface clock enable
       BKPSRAMEN      : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  CCM data RAM clock enable
       CCMDATARAMEN   : Boolean := True;
       --  DMA1 clock enable
@@ -631,7 +632,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable
       DMA2DEN        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  Ethernet MAC clock enable
       ETHMACEN       : Boolean := False;
       --  Ethernet Transmission clock enable
@@ -645,7 +646,7 @@ package STM32_SVD.RCC is
       --  USB OTG HSULPI clock enable
       OTGHSULPIEN    : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -760,7 +761,7 @@ package STM32_SVD.RCC is
       --  SPI3 clock enable
       SPI3EN         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  USART 2 clock enable
       USART2EN       : Boolean := False;
       --  USART3 clock enable
@@ -776,13 +777,13 @@ package STM32_SVD.RCC is
       --  I2C3 clock enable
       I2C3EN         : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CAN 1 clock enable
       CAN1EN         : Boolean := False;
       --  CAN 2 clock enable
       CAN2EN         : Boolean := False;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Power interface clock enable
       PWREN          : Boolean := False;
       --  DAC interface clock enable
@@ -857,7 +858,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable
       SYSCFGEN       : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 clock enable
       TIM9EN         : Boolean := False;
       --  TIM10 clock enable
@@ -865,7 +866,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable
       TIM11EN        : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  SPI5 clock enable
       SPI5ENR        : Boolean := False;
       --  SPI6 clock enable
@@ -937,7 +938,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable during Sleep mode
       GPIOKLPEN      : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  CRC clock enable during Sleep mode
       CRCLPEN        : Boolean := True;
       --  unspecified
@@ -953,7 +954,7 @@ package STM32_SVD.RCC is
       --  SRAM 3 interface clock enable during Sleep mode
       SRAM3LPEN      : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  DMA1 clock enable during Sleep mode
       DMA1LPEN       : Boolean := True;
       --  DMA2 clock enable during Sleep mode
@@ -961,7 +962,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable during Sleep mode
       DMA2DLPEN      : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  Ethernet MAC clock enable during Sleep mode
       ETHMACLPEN     : Boolean := True;
       --  Ethernet transmission clock enable during Sleep mode
@@ -975,7 +976,7 @@ package STM32_SVD.RCC is
       --  USB OTG HS ULPI clock enable during Sleep mode
       OTGHSULPILPEN  : Boolean := True;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1093,7 +1094,7 @@ package STM32_SVD.RCC is
       --  SPI3 clock enable during Sleep mode
       SPI3LPEN       : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  USART2 clock enable during Sleep mode
       USART2LPEN     : Boolean := True;
       --  USART3 clock enable during Sleep mode
@@ -1109,13 +1110,13 @@ package STM32_SVD.RCC is
       --  I2C3 clock enable during Sleep mode
       I2C3LPEN       : Boolean := True;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CAN 1 clock enable during Sleep mode
       CAN1LPEN       : Boolean := True;
       --  CAN 2 clock enable during Sleep mode
       CAN2LPEN       : Boolean := True;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Power interface clock enable during Sleep mode
       PWRLPEN        : Boolean := True;
       --  DAC interface clock enable during Sleep mode
@@ -1190,7 +1191,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable during Sleep mode
       SYSCFGLPEN     : Boolean := True;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 clock enable during sleep mode
       TIM9LPEN       : Boolean := True;
       --  TIM10 clock enable during Sleep mode
@@ -1198,7 +1199,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable during Sleep mode
       TIM11LPEN      : Boolean := True;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  SPI 5 clock enable during Sleep mode
       SPI5LPEN       : Boolean := False;
       --  SPI 6 clock enable during Sleep mode
@@ -1394,7 +1395,7 @@ package STM32_SVD.RCC is
       --  PLLI2S division factor for I2S clocks
       PLLI2SR        : PLLI2SCFGR_PLLI2SR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1420,7 +1421,7 @@ package STM32_SVD.RCC is
       --  PLLSAI division factor for VCO
       PLLSAIN        : PLLSAICFGR_PLLSAIN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  PLLSAI division factor for 48 MHz clock
       PLLSAIP        : PLLSAICFGR_PLLSAIP_Field := 16#0#;
       --  unspecified
@@ -1430,7 +1431,7 @@ package STM32_SVD.RCC is
       --  PLLSAI division factor for LCD clock
       PLLSAIR        : PLLSAICFGR_PLLSAIR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1592,6 +1593,6 @@ package STM32_SVD.RCC is
 
    --  Reset and clock control
    RCC_Periph : aliased RCC_Peripheral
-     with Import, Address => RCC_Base;
+     with Import, Address => System'To_Address (16#40023800#);
 
 end STM32_SVD.RCC;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-rcc.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-rcc.ads
@@ -24,7 +24,7 @@ package STM32_SVD.RCC is
       --  Read-only. Internal high-speed clock ready flag
       HSIRDY         : Boolean := True;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Internal high-speed clock trimming
       HSITRIM        : CR_HSITRIM_Field := 16#10#;
       --  Read-only. Internal high-speed clock calibration
@@ -91,7 +91,7 @@ package STM32_SVD.RCC is
       --  Main PLL (PLL) multiplication factor for VCO
       PLLN           : PLLCFGR_PLLN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Main PLL (PLL) division factor for main system clock
       PLLP           : PLLCFGR_PLLP_Field := 16#0#;
       --  unspecified
@@ -99,14 +99,14 @@ package STM32_SVD.RCC is
       --  Main PLL(PLL) and audio PLL (PLLI2S) entry clock source
       PLLSRC         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Main PLL (PLL) division factor for USB OTG FS, SDIO and random number
       --  generator clocks
       PLLQ           : PLLCFGR_PLLQ_Field := 16#4#;
       --  Main PLL division factor for DSI clock
       PLLR           : PLLCFGR_PLLR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -235,7 +235,7 @@ package STM32_SVD.RCC is
       --  PLLSAI Ready Interrupt Enable
       PLLSAIRDYIE    : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Write-only. LSI ready interrupt clear
       LSIRDYC        : Boolean := False;
       --  Write-only. LSE ready interrupt clear
@@ -311,7 +311,7 @@ package STM32_SVD.RCC is
       --  IO port K reset
       GPIOKRST       : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  CRC reset
       CRCRST         : Boolean := False;
       --  unspecified
@@ -323,7 +323,7 @@ package STM32_SVD.RCC is
       --  DMA2D reset
       DMA2DRST       : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  Ethernet MAC reset
       ETHMACRST      : Boolean := False;
       --  unspecified
@@ -440,7 +440,7 @@ package STM32_SVD.RCC is
       --  SPI 3 reset
       SPI3RST        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  USART 2 reset
       UART2RST       : Boolean := False;
       --  USART 3 reset
@@ -456,13 +456,13 @@ package STM32_SVD.RCC is
       --  I2C3 reset
       I2C3RST        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CAN1 reset
       CAN1RST        : Boolean := False;
       --  CAN2 reset
       CAN2RST        : Boolean := False;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Power interface reset
       PWRRST         : Boolean := False;
       --  DAC reset
@@ -535,7 +535,7 @@ package STM32_SVD.RCC is
       --  System configuration controller reset
       SYSCFGRST      : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 reset
       TIM9RST        : Boolean := False;
       --  TIM10 reset
@@ -543,7 +543,7 @@ package STM32_SVD.RCC is
       --  TIM11 reset
       TIM11RST       : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  SPI5 reset
       SPI5RST        : Boolean := False;
       --  SPI6 reset
@@ -614,7 +614,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable
       GPIOKEN        : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  CRC clock enable
       CRCEN          : Boolean := False;
       --  unspecified
@@ -622,7 +622,7 @@ package STM32_SVD.RCC is
       --  Backup SRAM interface clock enable
       BKPSRAMEN      : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  CCM data RAM clock enable
       CCMDATARAMEN   : Boolean := True;
       --  DMA1 clock enable
@@ -632,7 +632,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable
       DMA2DEN        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  Ethernet MAC clock enable
       ETHMACEN       : Boolean := False;
       --  Ethernet Transmission clock enable
@@ -646,7 +646,7 @@ package STM32_SVD.RCC is
       --  USB OTG HSULPI clock enable
       OTGHSULPIEN    : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -761,7 +761,7 @@ package STM32_SVD.RCC is
       --  SPI3 clock enable
       SPI3EN         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  USART 2 clock enable
       USART2EN       : Boolean := False;
       --  USART3 clock enable
@@ -777,13 +777,13 @@ package STM32_SVD.RCC is
       --  I2C3 clock enable
       I2C3EN         : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CAN 1 clock enable
       CAN1EN         : Boolean := False;
       --  CAN 2 clock enable
       CAN2EN         : Boolean := False;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Power interface clock enable
       PWREN          : Boolean := False;
       --  DAC interface clock enable
@@ -858,7 +858,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable
       SYSCFGEN       : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 clock enable
       TIM9EN         : Boolean := False;
       --  TIM10 clock enable
@@ -866,7 +866,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable
       TIM11EN        : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  SPI5 clock enable
       SPI5ENR        : Boolean := False;
       --  SPI6 clock enable
@@ -938,7 +938,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable during Sleep mode
       GPIOKLPEN      : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  CRC clock enable during Sleep mode
       CRCLPEN        : Boolean := True;
       --  unspecified
@@ -954,7 +954,7 @@ package STM32_SVD.RCC is
       --  SRAM 3 interface clock enable during Sleep mode
       SRAM3LPEN      : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  DMA1 clock enable during Sleep mode
       DMA1LPEN       : Boolean := True;
       --  DMA2 clock enable during Sleep mode
@@ -962,7 +962,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable during Sleep mode
       DMA2DLPEN      : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  Ethernet MAC clock enable during Sleep mode
       ETHMACLPEN     : Boolean := True;
       --  Ethernet transmission clock enable during Sleep mode
@@ -976,7 +976,7 @@ package STM32_SVD.RCC is
       --  USB OTG HS ULPI clock enable during Sleep mode
       OTGHSULPILPEN  : Boolean := True;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1094,7 +1094,7 @@ package STM32_SVD.RCC is
       --  SPI3 clock enable during Sleep mode
       SPI3LPEN       : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  USART2 clock enable during Sleep mode
       USART2LPEN     : Boolean := True;
       --  USART3 clock enable during Sleep mode
@@ -1110,13 +1110,13 @@ package STM32_SVD.RCC is
       --  I2C3 clock enable during Sleep mode
       I2C3LPEN       : Boolean := True;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CAN 1 clock enable during Sleep mode
       CAN1LPEN       : Boolean := True;
       --  CAN 2 clock enable during Sleep mode
       CAN2LPEN       : Boolean := True;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Power interface clock enable during Sleep mode
       PWRLPEN        : Boolean := True;
       --  DAC interface clock enable during Sleep mode
@@ -1191,7 +1191,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable during Sleep mode
       SYSCFGLPEN     : Boolean := True;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 clock enable during sleep mode
       TIM9LPEN       : Boolean := True;
       --  TIM10 clock enable during Sleep mode
@@ -1199,7 +1199,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable during Sleep mode
       TIM11LPEN      : Boolean := True;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  SPI 5 clock enable during Sleep mode
       SPI5LPEN       : Boolean := False;
       --  SPI 6 clock enable during Sleep mode
@@ -1395,7 +1395,7 @@ package STM32_SVD.RCC is
       --  PLLI2S division factor for I2S clocks
       PLLI2SR        : PLLI2SCFGR_PLLI2SR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1421,7 +1421,7 @@ package STM32_SVD.RCC is
       --  PLLSAI division factor for VCO
       PLLSAIN        : PLLSAICFGR_PLLSAIN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  PLLSAI division factor for 48 MHz clock
       PLLSAIP        : PLLSAICFGR_PLLSAIP_Field := 16#0#;
       --  unspecified
@@ -1431,7 +1431,7 @@ package STM32_SVD.RCC is
       --  PLLSAI division factor for LCD clock
       PLLSAIR        : PLLSAICFGR_PLLSAIR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-rng.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-rng.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -87,6 +88,6 @@ package STM32_SVD.RNG is
 
    --  Random number generator
    RNG_Periph : aliased RNG_Peripheral
-     with Import, Address => RNG_Base;
+     with Import, Address => System'To_Address (16#50060800#);
 
 end STM32_SVD.RNG;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-rtc.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-rtc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -27,13 +28,13 @@ package STM32_SVD.RTC is
       --  Second tens in BCD format
       ST             : TR_ST_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Minute units in BCD format
       MNU            : TR_MNU_Field := 16#0#;
       --  Minute tens in BCD format
       MNT            : TR_MNT_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Hour units in BCD format
       HU             : TR_HU_Field := 16#0#;
       --  Hour tens in BCD format
@@ -85,7 +86,7 @@ package STM32_SVD.RTC is
       --  Year tens in BCD format
       YT             : DR_YT_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -114,7 +115,7 @@ package STM32_SVD.RTC is
       --  Reference clock detection enable (50 or 60 Hz)
       REFCKON        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Hour format
       FMT            : Boolean := False;
       --  Coarse digital calibration enable
@@ -142,7 +143,7 @@ package STM32_SVD.RTC is
       --  Backup
       BKP            : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  Output polarity
       POL            : Boolean := False;
       --  Output selection
@@ -150,7 +151,7 @@ package STM32_SVD.RTC is
       --  Calibration output enable
       COE            : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -213,7 +214,7 @@ package STM32_SVD.RTC is
       --  TAMPER2 detection flag
       TAMP2F         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Read-only. Recalibration pending Flag
       RECALPF        : Boolean := False;
       --  unspecified
@@ -251,7 +252,7 @@ package STM32_SVD.RTC is
       --  Synchronous prescaler factor
       PREDIV_S       : PRER_PREDIV_S_Field := 16#FF#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Asynchronous prescaler factor
       PREDIV_A       : PRER_PREDIV_A_Field := 16#7F#;
       --  unspecified
@@ -427,7 +428,7 @@ package STM32_SVD.RTC is
       MSK4  at 0 range 31 .. 31;
    end record;
 
-   subtype WPR_KEY_Field is HAL.Byte;
+   subtype WPR_KEY_Field is HAL.UInt8;
 
    --  write protection register
    type WPR_Register is record
@@ -853,6 +854,6 @@ package STM32_SVD.RTC is
 
    --  Real-time clock
    RTC_Periph : aliased RTC_Peripheral
-     with Import, Address => RTC_Base;
+     with Import, Address => System'To_Address (16#40002800#);
 
 end STM32_SVD.RTC;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-rtc.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-rtc.ads
@@ -28,13 +28,13 @@ package STM32_SVD.RTC is
       --  Second tens in BCD format
       ST             : TR_ST_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Minute units in BCD format
       MNU            : TR_MNU_Field := 16#0#;
       --  Minute tens in BCD format
       MNT            : TR_MNT_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Hour units in BCD format
       HU             : TR_HU_Field := 16#0#;
       --  Hour tens in BCD format
@@ -115,7 +115,7 @@ package STM32_SVD.RTC is
       --  Reference clock detection enable (50 or 60 Hz)
       REFCKON        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Hour format
       FMT            : Boolean := False;
       --  Coarse digital calibration enable
@@ -143,7 +143,7 @@ package STM32_SVD.RTC is
       --  Backup
       BKP            : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  Output polarity
       POL            : Boolean := False;
       --  Output selection
@@ -214,7 +214,7 @@ package STM32_SVD.RTC is
       --  TAMPER2 detection flag
       TAMP2F         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Read-only. Recalibration pending Flag
       RECALPF        : Boolean := False;
       --  unspecified
@@ -252,7 +252,7 @@ package STM32_SVD.RTC is
       --  Synchronous prescaler factor
       PREDIV_S       : PRER_PREDIV_S_Field := 16#FF#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Asynchronous prescaler factor
       PREDIV_A       : PRER_PREDIV_A_Field := 16#7F#;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-sai.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-sai.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -43,7 +44,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : ACR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Data size
       DS             : ACR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -63,13 +64,13 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.Bit := 16#0#;
+      Reserved_18_18 : HAL.UInt1 := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
       MCJDIV         : ACR1_MCJDIV_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -133,7 +134,7 @@ package STM32_SVD.SAI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype AFRCR_FRL_Field is HAL.Byte;
+   subtype AFRCR_FRL_Field is HAL.UInt8;
    subtype AFRCR_FSALL_Field is HAL.UInt7;
 
    --  AFRCR
@@ -143,7 +144,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : AFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -176,7 +177,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : ASLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Slot size
       SLOTSZ         : ASLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -281,7 +282,7 @@ package STM32_SVD.SAI is
       --  Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Clear anticipated frame synchronization detection flag.
@@ -318,7 +319,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : BCR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Data size
       DS             : BCR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -338,13 +339,13 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.Bit := 16#0#;
+      Reserved_18_18 : HAL.UInt1 := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
       MCJDIV         : BCR1_MCJDIV_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -408,7 +409,7 @@ package STM32_SVD.SAI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype BFRCR_FRL_Field is HAL.Byte;
+   subtype BFRCR_FRL_Field is HAL.UInt8;
    subtype BFRCR_FSALL_Field is HAL.UInt7;
 
    --  BFRCR
@@ -418,7 +419,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : BFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -451,7 +452,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : BSLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Slot size
       SLOTSZ         : BSLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -556,7 +557,7 @@ package STM32_SVD.SAI is
       --  Write-only. Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Write-only. Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Write-only. Clear anticipated frame synchronization detection flag
@@ -645,6 +646,6 @@ package STM32_SVD.SAI is
 
    --  Serial audio interface
    SAI_Periph : aliased SAI_Peripheral
-     with Import, Address => SAI_Base;
+     with Import, Address => System'To_Address (16#40015800#);
 
 end STM32_SVD.SAI;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-sai.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-sai.ads
@@ -44,7 +44,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : ACR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Data size
       DS             : ACR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -64,7 +64,7 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.UInt1 := 16#0#;
+      Reserved_18_18 : HAL.Bit := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
@@ -144,7 +144,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : AFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -177,7 +177,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : ASLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Slot size
       SLOTSZ         : ASLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -282,7 +282,7 @@ package STM32_SVD.SAI is
       --  Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Clear anticipated frame synchronization detection flag.
@@ -319,7 +319,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : BCR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Data size
       DS             : BCR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -339,7 +339,7 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.UInt1 := 16#0#;
+      Reserved_18_18 : HAL.Bit := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
@@ -419,7 +419,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : BFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -452,7 +452,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : BSLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Slot size
       SLOTSZ         : BSLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -557,7 +557,7 @@ package STM32_SVD.SAI is
       --  Write-only. Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Write-only. Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Write-only. Clear anticipated frame synchronization detection flag

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-sdio.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-sdio.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -40,7 +41,7 @@ package STM32_SVD.SDIO is
       Reserved_2_31 at 0 range 2 .. 31;
    end record;
 
-   subtype CLKCR_CLKDIV_Field is HAL.Byte;
+   subtype CLKCR_CLKDIV_Field is HAL.UInt8;
 
    --  Wide bus mode enable bit
    type CLKCR_WIDBUS_Field is
@@ -379,7 +380,7 @@ package STM32_SVD.SDIO is
       --  Read-only. CE-ATA command completion signal received for CMD61
       CEATAEND       : Boolean;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -443,7 +444,7 @@ package STM32_SVD.SDIO is
       --  CEATAEND flag clear bit
       CEATAENDC      : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -517,7 +518,7 @@ package STM32_SVD.SDIO is
       --  CE-ATA command completion signal received interrupt enable
       CEATAENDIE     : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -558,7 +559,7 @@ package STM32_SVD.SDIO is
       --  the FIFO.
       FIFOCOUNT      : FIFOCNT_FIFOCOUNT_Field;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -636,6 +637,6 @@ package STM32_SVD.SDIO is
 
    --  Secure digital input/output interface
    SDIO_Periph : aliased SDIO_Peripheral
-     with Import, Address => SDIO_Base;
+     with Import, Address => System'To_Address (16#40012C00#);
 
 end STM32_SVD.SDIO;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-spi.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-spi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -78,7 +79,7 @@ package STM32_SVD.SPI is
       --  SS output enable
       SSOE          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Frame format
       FRF           : Boolean := False;
       --  Error interrupt enable
@@ -227,7 +228,7 @@ package STM32_SVD.SPI is
       --  I2S standard selection
       I2SSTD         : I2SCFGR_I2SSTD_Field := 16#0#;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  PCM frame synchronization
       PCMSYNC        : Boolean := False;
       --  I2S configuration mode
@@ -255,7 +256,7 @@ package STM32_SVD.SPI is
       Reserved_12_31 at 0 range 12 .. 31;
    end record;
 
-   subtype I2SPR_I2SDIV_Field is HAL.Byte;
+   subtype I2SPR_I2SDIV_Field is HAL.UInt8;
 
    --  I2S prescaler register
    type I2SPR_Register is record
@@ -319,34 +320,34 @@ package STM32_SVD.SPI is
 
    --  Serial peripheral interface
    I2S2ext_Periph : aliased SPI_Peripheral
-     with Import, Address => I2S2ext_Base;
+     with Import, Address => System'To_Address (16#40003400#);
 
    --  Serial peripheral interface
    I2S3ext_Periph : aliased SPI_Peripheral
-     with Import, Address => I2S3ext_Base;
+     with Import, Address => System'To_Address (16#40004000#);
 
    --  Serial peripheral interface
    SPI1_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI1_Base;
+     with Import, Address => System'To_Address (16#40013000#);
 
    --  Serial peripheral interface
    SPI2_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI2_Base;
+     with Import, Address => System'To_Address (16#40003800#);
 
    --  Serial peripheral interface
    SPI3_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI3_Base;
+     with Import, Address => System'To_Address (16#40003C00#);
 
    --  Serial peripheral interface
    SPI4_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI4_Base;
+     with Import, Address => System'To_Address (16#40013400#);
 
    --  Serial peripheral interface
    SPI5_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI5_Base;
+     with Import, Address => System'To_Address (16#40015000#);
 
    --  Serial peripheral interface
    SPI6_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI6_Base;
+     with Import, Address => System'To_Address (16#40015400#);
 
 end STM32_SVD.SPI;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-spi.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-spi.ads
@@ -79,7 +79,7 @@ package STM32_SVD.SPI is
       --  SS output enable
       SSOE          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Frame format
       FRF           : Boolean := False;
       --  Error interrupt enable
@@ -228,7 +228,7 @@ package STM32_SVD.SPI is
       --  I2S standard selection
       I2SSTD         : I2SCFGR_I2SSTD_Field := 16#0#;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  PCM frame synchronization
       PCMSYNC        : Boolean := False;
       --  I2S configuration mode

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-syscfg.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-syscfg.ads
@@ -26,7 +26,7 @@ package STM32_SVD.SYSCFG is
       --  Flash bank mode selection
       FB_MODE        : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  FMC memory mapping swap
       SWP_FMC        : MEMRM_SWP_FMC_Field := 16#0#;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-syscfg.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-syscfg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -25,7 +26,7 @@ package STM32_SVD.SYSCFG is
       --  Flash bank mode selection
       FB_MODE        : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  FMC memory mapping swap
       SWP_FMC        : MEMRM_SWP_FMC_Field := 16#0#;
       --  unspecified
@@ -58,7 +59,7 @@ package STM32_SVD.SYSCFG is
       --  Ethernet PHY interface selection
       MII_RMII_SEL   : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -301,6 +302,6 @@ package STM32_SVD.SYSCFG is
 
    --  System configuration controller
    SYSCFG_Periph : aliased SYSCFG_Peripheral
-     with Import, Address => SYSCFG_Base;
+     with Import, Address => System'To_Address (16#40013800#);
 
 end STM32_SVD.SYSCFG;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-tim.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-tim.ads
@@ -60,7 +60,7 @@ package STM32_SVD.TIM is
       --  Capture/compare preloaded control
       CCPC           : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Capture/compare control update selection
       CCUS           : Boolean := False;
       --  Capture/compare DMA selection
@@ -116,7 +116,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -223,7 +223,7 @@ package STM32_SVD.TIM is
       --  Break interrupt flag
       BIF            : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  Capture/Compare 1 overcapture flag
       CC1OF          : Boolean := False;
       --  Capture/compare 2 overcapture flag
@@ -766,11 +766,11 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt enable
       CC4IE          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Trigger interrupt enable
       TIE            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Update DMA request enable
       UDE            : Boolean := False;
       --  Capture/Compare 1 DMA request enable
@@ -782,7 +782,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 DMA request enable
       CC4DE          : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  Trigger DMA request enable
       TDE            : Boolean := False;
       --  unspecified
@@ -823,7 +823,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt flag
       CC4IF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Trigger interrupt flag
       TIF            : Boolean := False;
       --  unspecified
@@ -871,7 +871,7 @@ package STM32_SVD.TIM is
       --  Write-only. Capture/compare 4 generation
       CC4G          : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  Write-only. Trigger generation
       TG            : Boolean := False;
       --  unspecified
@@ -940,7 +940,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP          : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -948,7 +948,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P           : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP          : Boolean := False;
       --  Capture/Compare 3 output enable
@@ -956,7 +956,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC3P           : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Capture/Compare 3 output Polarity
       CC3NP          : Boolean := False;
       --  Capture/Compare 4 output enable
@@ -964,7 +964,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC4P           : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
@@ -1278,7 +1278,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS           : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Trigger selection
       TS            : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -1398,7 +1398,7 @@ package STM32_SVD.TIM is
       --  Output Compare 1 mode
       OC1M           : CCMR1_Output_OC1M_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Output_CC2S_Field := 16#0#;
       --  Output Compare 2 fast enable
@@ -1438,7 +1438,7 @@ package STM32_SVD.TIM is
       --  Input capture 1 filter
       IC1F           : CCMR1_Input_IC1F_Field_1 := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Input_CC2S_Field := 16#0#;
       --  Input capture 2 prescaler
@@ -1469,7 +1469,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1477,7 +1477,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P          : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP         : Boolean := False;
       --  unspecified
@@ -1640,7 +1640,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-tim.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-tim.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -59,7 +60,7 @@ package STM32_SVD.TIM is
       --  Capture/compare preloaded control
       CCPC           : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Capture/compare control update selection
       CCUS           : Boolean := False;
       --  Capture/compare DMA selection
@@ -115,7 +116,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -222,7 +223,7 @@ package STM32_SVD.TIM is
       --  Break interrupt flag
       BIF            : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 overcapture flag
       CC1OF          : Boolean := False;
       --  Capture/compare 2 overcapture flag
@@ -563,7 +564,7 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype RCR_REP_Field is HAL.Byte;
+   subtype RCR_REP_Field is HAL.UInt8;
 
    --  repetition counter register
    type RCR_Register is record
@@ -648,7 +649,7 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype BDTR_DTG_Field is HAL.Byte;
+   subtype BDTR_DTG_Field is HAL.UInt8;
    subtype BDTR_LOCK_Field is HAL.UInt2;
 
    --  break and dead-time register
@@ -765,11 +766,11 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt enable
       CC4IE          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Trigger interrupt enable
       TIE            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Update DMA request enable
       UDE            : Boolean := False;
       --  Capture/Compare 1 DMA request enable
@@ -781,7 +782,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 DMA request enable
       CC4DE          : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  Trigger DMA request enable
       TDE            : Boolean := False;
       --  unspecified
@@ -822,7 +823,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt flag
       CC4IF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Trigger interrupt flag
       TIF            : Boolean := False;
       --  unspecified
@@ -870,7 +871,7 @@ package STM32_SVD.TIM is
       --  Write-only. Capture/compare 4 generation
       CC4G          : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  Write-only. Trigger generation
       TG            : Boolean := False;
       --  unspecified
@@ -939,7 +940,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP          : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -947,7 +948,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P           : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP          : Boolean := False;
       --  Capture/Compare 3 output enable
@@ -955,7 +956,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC3P           : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Capture/Compare 3 output Polarity
       CC3NP          : Boolean := False;
       --  Capture/Compare 4 output enable
@@ -963,7 +964,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC4P           : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
@@ -1277,7 +1278,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS           : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Trigger selection
       TS            : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -1397,7 +1398,7 @@ package STM32_SVD.TIM is
       --  Output Compare 1 mode
       OC1M           : CCMR1_Output_OC1M_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Output_CC2S_Field := 16#0#;
       --  Output Compare 2 fast enable
@@ -1437,7 +1438,7 @@ package STM32_SVD.TIM is
       --  Input capture 1 filter
       IC1F           : CCMR1_Input_IC1F_Field_1 := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Input_CC2S_Field := 16#0#;
       --  Input capture 2 prescaler
@@ -1468,7 +1469,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1476,7 +1477,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P          : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP         : Boolean := False;
       --  unspecified
@@ -1639,7 +1640,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  unspecified
@@ -1764,11 +1765,11 @@ package STM32_SVD.TIM is
 
    --  Advanced-timers
    TIM1_Periph : aliased TIM1_Peripheral
-     with Import, Address => TIM1_Base;
+     with Import, Address => System'To_Address (16#40010000#);
 
    --  Advanced-timers
    TIM8_Periph : aliased TIM1_Peripheral
-     with Import, Address => TIM8_Base;
+     with Import, Address => System'To_Address (16#40010400#);
 
    type TIM2_Disc is
      (
@@ -1854,7 +1855,7 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM2_Periph : aliased TIM2_Peripheral
-     with Import, Address => TIM2_Base;
+     with Import, Address => System'To_Address (16#40000000#);
 
    type TIM3_Disc is
      (
@@ -1937,11 +1938,11 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM3_Periph : aliased TIM3_Peripheral
-     with Import, Address => TIM3_Base;
+     with Import, Address => System'To_Address (16#40000400#);
 
    --  General purpose timers
    TIM4_Periph : aliased TIM3_Peripheral
-     with Import, Address => TIM4_Base;
+     with Import, Address => System'To_Address (16#40000800#);
 
    type TIM5_Disc is
      (
@@ -2027,7 +2028,7 @@ package STM32_SVD.TIM is
 
    --  General-purpose-timers
    TIM5_Periph : aliased TIM5_Peripheral
-     with Import, Address => TIM5_Base;
+     with Import, Address => System'To_Address (16#40000C00#);
 
    --  Basic timers
    type TIM6_Peripheral is record
@@ -2063,11 +2064,11 @@ package STM32_SVD.TIM is
 
    --  Basic timers
    TIM6_Periph : aliased TIM6_Peripheral
-     with Import, Address => TIM6_Base;
+     with Import, Address => System'To_Address (16#40001000#);
 
    --  Basic timers
    TIM7_Periph : aliased TIM6_Peripheral
-     with Import, Address => TIM7_Base;
+     with Import, Address => System'To_Address (16#40001400#);
 
    type TIM9_Disc is
      (
@@ -2129,11 +2130,11 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM9_Periph : aliased TIM9_Peripheral
-     with Import, Address => TIM9_Base;
+     with Import, Address => System'To_Address (16#40014000#);
 
    --  General purpose timers
    TIM12_Periph : aliased TIM9_Peripheral
-     with Import, Address => TIM12_Base;
+     with Import, Address => System'To_Address (16#40001800#);
 
    type TIM10_Disc is
      (
@@ -2189,15 +2190,15 @@ package STM32_SVD.TIM is
 
    --  General-purpose-timers
    TIM10_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM10_Base;
+     with Import, Address => System'To_Address (16#40014400#);
 
    --  General-purpose-timers
    TIM13_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM13_Base;
+     with Import, Address => System'To_Address (16#40001C00#);
 
    --  General-purpose-timers
    TIM14_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM14_Base;
+     with Import, Address => System'To_Address (16#40002000#);
 
    type TIM11_Disc is
      (
@@ -2256,6 +2257,6 @@ package STM32_SVD.TIM is
 
    --  General-purpose-timers
    TIM11_Periph : aliased TIM11_Peripheral
-     with Import, Address => TIM11_Base;
+     with Import, Address => System'To_Address (16#40014800#);
 
 end STM32_SVD.TIM;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-usart.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-usart.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -121,7 +122,7 @@ package STM32_SVD.USART is
       --  USART enable
       UE             : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Oversampling mode
       OVER8          : Boolean := False;
       --  unspecified
@@ -158,7 +159,7 @@ package STM32_SVD.USART is
       --  Address of the USART node
       ADD            : CR2_ADD_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  lin break detection length
       LBDL           : Boolean := False;
       --  LIN break detection interrupt enable
@@ -272,13 +273,13 @@ package STM32_SVD.USART is
       --  Address of the USART node
       ADD            : CR2_ADD_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  lin break detection length
       LBDL           : Boolean := False;
       --  LIN break detection interrupt enable
       LBDIE          : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Last bit clock pulse
       LBCL           : Boolean := False;
       --  Clock phase
@@ -360,8 +361,8 @@ package STM32_SVD.USART is
       Reserved_12_31 at 0 range 12 .. 31;
    end record;
 
-   subtype GTPR_PSC_Field is HAL.Byte;
-   subtype GTPR_GT_Field is HAL.Byte;
+   subtype GTPR_PSC_Field is HAL.UInt8;
+   subtype GTPR_GT_Field is HAL.UInt8;
 
    --  Guard time and prescaler register
    type GTPR_Register is record
@@ -413,19 +414,19 @@ package STM32_SVD.USART is
 
    --  Universal synchronous asynchronous receiver transmitter
    UART4_Periph : aliased UART4_Peripheral
-     with Import, Address => UART4_Base;
+     with Import, Address => System'To_Address (16#40004C00#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART5_Periph : aliased UART4_Peripheral
-     with Import, Address => UART5_Base;
+     with Import, Address => System'To_Address (16#40005000#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART7_Periph : aliased UART4_Peripheral
-     with Import, Address => UART7_Base;
+     with Import, Address => System'To_Address (16#40007800#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART8_Periph : aliased UART4_Peripheral
-     with Import, Address => UART8_Base;
+     with Import, Address => System'To_Address (16#40007C00#);
 
    --  Universal synchronous asynchronous receiver transmitter
    type USART1_Peripheral is record
@@ -458,18 +459,18 @@ package STM32_SVD.USART is
 
    --  Universal synchronous asynchronous receiver transmitter
    USART1_Periph : aliased USART1_Peripheral
-     with Import, Address => USART1_Base;
+     with Import, Address => System'To_Address (16#40011000#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART2_Periph : aliased USART1_Peripheral
-     with Import, Address => USART2_Base;
+     with Import, Address => System'To_Address (16#40004400#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART3_Periph : aliased USART1_Peripheral
-     with Import, Address => USART3_Base;
+     with Import, Address => System'To_Address (16#40004800#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART6_Periph : aliased USART1_Peripheral
-     with Import, Address => USART6_Base;
+     with Import, Address => System'To_Address (16#40011400#);
 
 end STM32_SVD.USART;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-usart.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-usart.ads
@@ -122,7 +122,7 @@ package STM32_SVD.USART is
       --  USART enable
       UE             : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Oversampling mode
       OVER8          : Boolean := False;
       --  unspecified
@@ -159,7 +159,7 @@ package STM32_SVD.USART is
       --  Address of the USART node
       ADD            : CR2_ADD_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  lin break detection length
       LBDL           : Boolean := False;
       --  LIN break detection interrupt enable
@@ -273,13 +273,13 @@ package STM32_SVD.USART is
       --  Address of the USART node
       ADD            : CR2_ADD_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  lin break detection length
       LBDL           : Boolean := False;
       --  LIN break detection interrupt enable
       LBDIE          : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Last bit clock pulse
       LBCL           : Boolean := False;
       --  Clock phase

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-usb_otg_fs.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-usb_otg_fs.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -24,7 +25,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Non-zero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Device address
       DAD            : FS_DCFG_DAD_Field := 16#0#;
       --  Periodic frame interval
@@ -126,7 +127,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (Non-isochronous endpoints)
       TOM           : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -160,7 +161,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  SETUP phase done mask
       STUPM         : Boolean := False;
       --  OUT token received when endpoint disabled mask
@@ -280,13 +281,13 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
       EPTYP          : FS_DIEPCTL0_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  STALL handshake
       STALL          : Boolean := False;
       --  TxFIFO number
@@ -329,13 +330,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  TOC
       TOC           : Boolean := False;
       --  ITTXFE
       ITTXFE        : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  INEPNE
       INEPNE        : Boolean := False;
       --  Read-only. TXFE
@@ -418,7 +419,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : DIEPCTL1_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -470,7 +471,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Multi count
       MCNT           : DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -501,7 +502,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -552,7 +553,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USBAEP
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAKSTS
       NAKSTS         : Boolean := False;
       --  Read-only. EPTYP
@@ -601,13 +602,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  STUP
       STUP          : Boolean := False;
       --  OTEPDIS
       OTEPDIS       : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  B2BSTUP
       B2BSTUP       : Boolean := False;
       --  unspecified
@@ -643,7 +644,7 @@ package STM32_SVD.USB_OTG_FS is
       --  SETUP packet count
       STUPCNT        : DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -727,7 +728,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -862,7 +863,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Write-only. Full Speed serial transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -906,7 +907,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -985,7 +986,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE              : Boolean := True;
       --  unspecified
-      Reserved_27_27     : HAL.Bit := 16#0#;
+      Reserved_27_27     : HAL.UInt1 := 16#0#;
       --  Connector ID status change
       CIDSCHG            : Boolean := False;
       --  Disconnect detected interrupt
@@ -1033,7 +1034,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS interrupt mask register (OTG_FS_GINTMSK)
    type FS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0     : HAL.Bit := 16#0#;
+      Reserved_0_0     : HAL.UInt1 := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM            : Boolean := False;
       --  OTG interrupt mask
@@ -1063,7 +1064,7 @@ package STM32_SVD.USB_OTG_FS is
       --  End of periodic frame interrupt mask
       EOPFM            : Boolean := False;
       --  unspecified
-      Reserved_16_16   : HAL.Bit := 16#0#;
+      Reserved_16_16   : HAL.UInt1 := 16#0#;
       --  Endpoint mismatch interrupt mask
       EPMISM           : Boolean := False;
       --  IN endpoints interrupt mask
@@ -1084,7 +1085,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Periodic TxFIFO empty mask
       PTXFEM           : Boolean := False;
       --  unspecified
-      Reserved_27_27   : HAL.Bit := 16#0#;
+      Reserved_27_27   : HAL.UInt1 := 16#0#;
       --  Connector ID status change mask
       CIDSCHGM         : Boolean := False;
       --  Disconnect detected interrupt mask
@@ -1250,7 +1251,7 @@ package STM32_SVD.USB_OTG_FS is
    end record;
 
    subtype FS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
-   subtype FS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
+   subtype FS_GNPTXSTS_NPTQXSAV_Field is HAL.UInt8;
    subtype FS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
    --  OTG_FS non-periodic transmit FIFO/queue status register
@@ -1263,7 +1264,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Top of the non-periodic transmit request queue
       NPTXQTOP       : FS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.Bit;
+      Reserved_31_31 : HAL.UInt1;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1282,7 +1283,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Power down
       PWRDWN         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Enable the VBUS sensing device
       VBUSASEN       : Boolean := False;
       --  Enable the VBUS sensing device
@@ -1397,8 +1398,8 @@ package STM32_SVD.USB_OTG_FS is
    end record;
 
    subtype FS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
-   subtype FS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
-   subtype FS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
+   subtype FS_HPTXSTS_PTXQSAV_Field is HAL.UInt8;
+   subtype FS_HPTXSTS_PTXQTOP_Field is HAL.UInt8;
 
    --  OTG_FS_Host periodic transmit FIFO/queue status register
    --  (OTG_FS_HPTXSTS)
@@ -1478,7 +1479,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. Port line status
       PLSTS          : FS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1526,7 +1527,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1566,7 +1567,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted
       CHH            : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  STALL response received interrupt
       STALL          : Boolean := False;
       --  NAK response received interrupt
@@ -1574,7 +1575,7 @@ package STM32_SVD.USB_OTG_FS is
       --  ACK response received/transmitted interrupt
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  Transaction error
       TXERR          : Boolean := False;
       --  Babble error
@@ -1611,7 +1612,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted mask
       CHHM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  STALL response received interrupt mask
       STALLM         : Boolean := False;
       --  NAK response received interrupt mask
@@ -1662,7 +1663,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Data PID
       DPID           : FS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1829,7 +1830,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_DEVICE_Periph : aliased OTG_FS_DEVICE_Peripheral
-     with Import, Address => OTG_FS_DEVICE_Base;
+     with Import, Address => System'To_Address (16#50000800#);
 
    type OTG_FS_GLOBAL_Disc is
      (
@@ -1921,7 +1922,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_GLOBAL_Periph : aliased OTG_FS_GLOBAL_Peripheral
-     with Import, Address => OTG_FS_GLOBAL_Base;
+     with Import, Address => System'To_Address (16#50000000#);
 
    --  USB on the go full speed
    type OTG_FS_HOST_Peripheral is record
@@ -2051,7 +2052,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_HOST_Periph : aliased OTG_FS_HOST_Peripheral
-     with Import, Address => OTG_FS_HOST_Base;
+     with Import, Address => System'To_Address (16#50000400#);
 
    --  USB on the go full speed
    type OTG_FS_PWRCLK_Peripheral is record
@@ -2066,6 +2067,6 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_PWRCLK_Periph : aliased OTG_FS_PWRCLK_Peripheral
-     with Import, Address => OTG_FS_PWRCLK_Base;
+     with Import, Address => System'To_Address (16#50000E00#);
 
 end STM32_SVD.USB_OTG_FS;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-usb_otg_fs.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-usb_otg_fs.ads
@@ -25,7 +25,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Non-zero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Device address
       DAD            : FS_DCFG_DAD_Field := 16#0#;
       --  Periodic frame interval
@@ -127,7 +127,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Timeout condition mask (Non-isochronous endpoints)
       TOM           : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -161,7 +161,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  SETUP phase done mask
       STUPM         : Boolean := False;
       --  OUT token received when endpoint disabled mask
@@ -281,13 +281,13 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
       EPTYP          : FS_DIEPCTL0_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  STALL handshake
       STALL          : Boolean := False;
       --  TxFIFO number
@@ -330,13 +330,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  TOC
       TOC           : Boolean := False;
       --  ITTXFE
       ITTXFE        : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  INEPNE
       INEPNE        : Boolean := False;
       --  Read-only. TXFE
@@ -419,7 +419,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : DIEPCTL1_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -471,7 +471,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Multi count
       MCNT           : DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -502,7 +502,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -553,7 +553,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USBAEP
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAKSTS
       NAKSTS         : Boolean := False;
       --  Read-only. EPTYP
@@ -602,13 +602,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  STUP
       STUP          : Boolean := False;
       --  OTEPDIS
       OTEPDIS       : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  B2BSTUP
       B2BSTUP       : Boolean := False;
       --  unspecified
@@ -644,7 +644,7 @@ package STM32_SVD.USB_OTG_FS is
       --  SETUP packet count
       STUPCNT        : DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -728,7 +728,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -863,7 +863,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Write-only. Full Speed serial transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -907,7 +907,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -986,7 +986,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE              : Boolean := True;
       --  unspecified
-      Reserved_27_27     : HAL.UInt1 := 16#0#;
+      Reserved_27_27     : HAL.Bit := 16#0#;
       --  Connector ID status change
       CIDSCHG            : Boolean := False;
       --  Disconnect detected interrupt
@@ -1034,7 +1034,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS interrupt mask register (OTG_FS_GINTMSK)
    type FS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0     : HAL.UInt1 := 16#0#;
+      Reserved_0_0     : HAL.Bit := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM            : Boolean := False;
       --  OTG interrupt mask
@@ -1064,7 +1064,7 @@ package STM32_SVD.USB_OTG_FS is
       --  End of periodic frame interrupt mask
       EOPFM            : Boolean := False;
       --  unspecified
-      Reserved_16_16   : HAL.UInt1 := 16#0#;
+      Reserved_16_16   : HAL.Bit := 16#0#;
       --  Endpoint mismatch interrupt mask
       EPMISM           : Boolean := False;
       --  IN endpoints interrupt mask
@@ -1085,7 +1085,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Periodic TxFIFO empty mask
       PTXFEM           : Boolean := False;
       --  unspecified
-      Reserved_27_27   : HAL.UInt1 := 16#0#;
+      Reserved_27_27   : HAL.Bit := 16#0#;
       --  Connector ID status change mask
       CIDSCHGM         : Boolean := False;
       --  Disconnect detected interrupt mask
@@ -1264,7 +1264,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Top of the non-periodic transmit request queue
       NPTXQTOP       : FS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1;
+      Reserved_31_31 : HAL.Bit;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1283,7 +1283,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Power down
       PWRDWN         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Enable the VBUS sensing device
       VBUSASEN       : Boolean := False;
       --  Enable the VBUS sensing device
@@ -1479,7 +1479,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. Port line status
       PLSTS          : FS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1527,7 +1527,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1567,7 +1567,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted
       CHH            : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  STALL response received interrupt
       STALL          : Boolean := False;
       --  NAK response received interrupt
@@ -1575,7 +1575,7 @@ package STM32_SVD.USB_OTG_FS is
       --  ACK response received/transmitted interrupt
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  Transaction error
       TXERR          : Boolean := False;
       --  Babble error
@@ -1612,7 +1612,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted mask
       CHHM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  STALL response received interrupt mask
       STALLM         : Boolean := False;
       --  NAK response received interrupt mask
@@ -1663,7 +1663,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Data PID
       DPID           : FS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-usb_otg_hs.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-usb_otg_hs.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -25,7 +26,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Nonzero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Device address
       DAD            : OTG_HS_DCFG_DAD_Field := 16#0#;
       --  Periodic (micro)frame interval
@@ -132,7 +133,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -142,7 +143,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -174,17 +175,17 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SETUP phase done mask
       STUPM          : Boolean := False;
       --  OUT token received when endpoint disabled mask
       OTEPDM         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Back-to-back SETUP packets received mask
       B2BSTUP        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  OUT packet error mask
       OPEM           : Boolean := False;
       --  BNA interrupt mask
@@ -297,7 +298,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Receive threshold length
       RXTHRLEN       : OTG_HS_DTHRCTL_RXTHRLEN_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.Bit := 16#0#;
+      Reserved_26_26 : HAL.UInt1 := 16#0#;
       --  Arbiter parking enable
       ARPEN          : Boolean := False;
       --  unspecified
@@ -338,7 +339,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register
    type OTG_HS_DEACHINT_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  IN endpoint 1interrupt bit
       IEP1INT        : Boolean := False;
       --  unspecified
@@ -362,7 +363,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register mask
    type OTG_HS_DEACHINTMSK_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  IN Endpoint 1 interrupt mask bit
       IEP1INTM       : Boolean := False;
       --  unspecified
@@ -390,7 +391,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -400,7 +401,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -438,7 +439,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition mask
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -448,7 +449,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  OUT packet error mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -504,7 +505,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint type
       EPTYP          : OTG_HS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  STALL handshake
       Stall          : Boolean := False;
       --  TxFIFO number
@@ -550,13 +551,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition
       TOC            : Boolean := False;
       --  IN token received when TxFIFO is empty
       ITTXFE         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  IN endpoint NAK effective
       INEPNE         : Boolean := False;
       --  Read-only. Transmit FIFO empty
@@ -566,7 +567,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Buffer not available interrupt
       BNA            : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Packet dropped status
       PKTDRPSTS      : Boolean := False;
       --  Babble error interrupt
@@ -651,7 +652,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Multi count
       MCNT           : OTG_HS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -675,7 +676,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
@@ -724,13 +725,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SETUP phase done
       STUP           : Boolean := False;
       --  OUT token received when endpoint disabled
       OTEPDIS        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Back-to-back SETUP packets received
       B2BSTUP        : Boolean := False;
       --  unspecified
@@ -772,7 +773,7 @@ package STM32_SVD.USB_OTG_HS is
       --  SETUP packet count
       STUPCNT        : OTG_HS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -856,7 +857,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_HS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -966,7 +967,7 @@ package STM32_SVD.USB_OTG_HS is
       --  DMA enable
       DMAEN         : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  TxFIFO empty level
       TXFELVL       : Boolean := False;
       --  Periodic TxFIFO empty level
@@ -1000,7 +1001,7 @@ package STM32_SVD.USB_OTG_HS is
       --  transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -1008,11 +1009,11 @@ package STM32_SVD.USB_OTG_HS is
       --  USB turnaround time
       TRDT           : OTG_HS_GUSBCFG_TRDT_Field := 16#2#;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  PHY Low-power clock select
       PHYLPCS        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  ULPI FS/LS select
       ULPIFSLS       : Boolean := False;
       --  ULPI Auto-resume
@@ -1080,7 +1081,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1155,7 +1156,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended
       DATAFSUSP         : Boolean := False;
       --  unspecified
-      Reserved_23_23    : HAL.Bit := 16#0#;
+      Reserved_23_23    : HAL.UInt1 := 16#0#;
       --  Read-only. Host port interrupt
       HPRTINT           : Boolean := False;
       --  Read-only. Host channels interrupt
@@ -1163,7 +1164,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE             : Boolean := True;
       --  unspecified
-      Reserved_27_27    : HAL.Bit := 16#0#;
+      Reserved_27_27    : HAL.UInt1 := 16#0#;
       --  Connector ID status change
       CIDSCHG           : Boolean := False;
       --  Disconnect detected interrupt
@@ -1212,7 +1213,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS interrupt mask register
    type OTG_HS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0    : HAL.Bit := 16#0#;
+      Reserved_0_0    : HAL.UInt1 := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM           : Boolean := False;
       --  OTG interrupt mask
@@ -1242,7 +1243,7 @@ package STM32_SVD.USB_OTG_HS is
       --  End of periodic frame interrupt mask
       EOPFM           : Boolean := False;
       --  unspecified
-      Reserved_16_16  : HAL.Bit := 16#0#;
+      Reserved_16_16  : HAL.UInt1 := 16#0#;
       --  Endpoint mismatch interrupt mask
       EPMISM          : Boolean := False;
       --  IN endpoints interrupt mask
@@ -1256,7 +1257,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended mask
       FSUSPM          : Boolean := False;
       --  unspecified
-      Reserved_23_23  : HAL.Bit := 16#0#;
+      Reserved_23_23  : HAL.UInt1 := 16#0#;
       --  Read-only. Host port interrupt mask
       PRTIM           : Boolean := False;
       --  Host channels interrupt mask
@@ -1264,7 +1265,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Periodic TxFIFO empty mask
       PTXFEM          : Boolean := False;
       --  unspecified
-      Reserved_27_27  : HAL.Bit := 16#0#;
+      Reserved_27_27  : HAL.UInt1 := 16#0#;
       --  Connector ID status change mask
       CIDSCHGM        : Boolean := False;
       --  Disconnect detected interrupt mask
@@ -1489,7 +1490,7 @@ package STM32_SVD.USB_OTG_HS is
    end record;
 
    subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
-   subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
+   subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.UInt8;
    subtype OTG_HS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
    --  OTG_HS nonperiodic transmit FIFO/queue status register
@@ -1501,7 +1502,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Top of the nonperiodic transmit request queue
       NPTXQTOP       : OTG_HS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.Bit;
+      Reserved_31_31 : HAL.UInt1;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1638,8 +1639,8 @@ package STM32_SVD.USB_OTG_HS is
    end record;
 
    subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
-   subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
-   subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
+   subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.UInt8;
+   subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.UInt8;
 
    --  OTG_HS_Host periodic transmit FIFO/queue status register
    type OTG_HS_HPTXSTS_Register is record
@@ -1718,7 +1719,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_HS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1766,7 +1767,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1933,7 +1934,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data PID
       DPID           : OTG_HS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2178,7 +2179,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_DEVICE_Periph : aliased OTG_HS_DEVICE_Peripheral
-     with Import, Address => OTG_HS_DEVICE_Base;
+     with Import, Address => System'To_Address (16#40040800#);
 
    type OTG_HS_GLOBAL_Disc is
      (
@@ -2281,7 +2282,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_GLOBAL_Periph : aliased OTG_HS_GLOBAL_Peripheral
-     with Import, Address => OTG_HS_GLOBAL_Base;
+     with Import, Address => System'To_Address (16#40040000#);
 
    --  USB on the go high speed
    type OTG_HS_HOST_Peripheral is record
@@ -2530,7 +2531,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_HOST_Periph : aliased OTG_HS_HOST_Peripheral
-     with Import, Address => OTG_HS_HOST_Base;
+     with Import, Address => System'To_Address (16#40040400#);
 
    --  USB on the go high speed
    type OTG_HS_PWRCLK_Peripheral is record
@@ -2545,6 +2546,6 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_PWRCLK_Periph : aliased OTG_HS_PWRCLK_Peripheral
-     with Import, Address => OTG_HS_PWRCLK_Base;
+     with Import, Address => System'To_Address (16#40040E00#);
 
 end STM32_SVD.USB_OTG_HS;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-usb_otg_hs.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-usb_otg_hs.ads
@@ -26,7 +26,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Nonzero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Device address
       DAD            : OTG_HS_DCFG_DAD_Field := 16#0#;
       --  Periodic (micro)frame interval
@@ -133,7 +133,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -143,7 +143,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -175,17 +175,17 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SETUP phase done mask
       STUPM          : Boolean := False;
       --  OUT token received when endpoint disabled mask
       OTEPDM         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Back-to-back SETUP packets received mask
       B2BSTUP        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  OUT packet error mask
       OPEM           : Boolean := False;
       --  BNA interrupt mask
@@ -298,7 +298,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Receive threshold length
       RXTHRLEN       : OTG_HS_DTHRCTL_RXTHRLEN_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.UInt1 := 16#0#;
+      Reserved_26_26 : HAL.Bit := 16#0#;
       --  Arbiter parking enable
       ARPEN          : Boolean := False;
       --  unspecified
@@ -339,7 +339,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register
    type OTG_HS_DEACHINT_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  IN endpoint 1interrupt bit
       IEP1INT        : Boolean := False;
       --  unspecified
@@ -363,7 +363,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register mask
    type OTG_HS_DEACHINTMSK_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  IN Endpoint 1 interrupt mask bit
       IEP1INTM       : Boolean := False;
       --  unspecified
@@ -391,7 +391,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -401,7 +401,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -439,7 +439,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition mask
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -449,7 +449,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  OUT packet error mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -505,7 +505,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint type
       EPTYP          : OTG_HS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  STALL handshake
       Stall          : Boolean := False;
       --  TxFIFO number
@@ -551,13 +551,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition
       TOC            : Boolean := False;
       --  IN token received when TxFIFO is empty
       ITTXFE         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  IN endpoint NAK effective
       INEPNE         : Boolean := False;
       --  Read-only. Transmit FIFO empty
@@ -567,7 +567,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Buffer not available interrupt
       BNA            : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Packet dropped status
       PKTDRPSTS      : Boolean := False;
       --  Babble error interrupt
@@ -652,7 +652,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Multi count
       MCNT           : OTG_HS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -676,7 +676,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
@@ -725,13 +725,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SETUP phase done
       STUP           : Boolean := False;
       --  OUT token received when endpoint disabled
       OTEPDIS        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Back-to-back SETUP packets received
       B2BSTUP        : Boolean := False;
       --  unspecified
@@ -773,7 +773,7 @@ package STM32_SVD.USB_OTG_HS is
       --  SETUP packet count
       STUPCNT        : OTG_HS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -857,7 +857,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_HS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -967,7 +967,7 @@ package STM32_SVD.USB_OTG_HS is
       --  DMA enable
       DMAEN         : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  TxFIFO empty level
       TXFELVL       : Boolean := False;
       --  Periodic TxFIFO empty level
@@ -1001,7 +1001,7 @@ package STM32_SVD.USB_OTG_HS is
       --  transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -1009,11 +1009,11 @@ package STM32_SVD.USB_OTG_HS is
       --  USB turnaround time
       TRDT           : OTG_HS_GUSBCFG_TRDT_Field := 16#2#;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  PHY Low-power clock select
       PHYLPCS        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  ULPI FS/LS select
       ULPIFSLS       : Boolean := False;
       --  ULPI Auto-resume
@@ -1081,7 +1081,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1156,7 +1156,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended
       DATAFSUSP         : Boolean := False;
       --  unspecified
-      Reserved_23_23    : HAL.UInt1 := 16#0#;
+      Reserved_23_23    : HAL.Bit := 16#0#;
       --  Read-only. Host port interrupt
       HPRTINT           : Boolean := False;
       --  Read-only. Host channels interrupt
@@ -1164,7 +1164,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE             : Boolean := True;
       --  unspecified
-      Reserved_27_27    : HAL.UInt1 := 16#0#;
+      Reserved_27_27    : HAL.Bit := 16#0#;
       --  Connector ID status change
       CIDSCHG           : Boolean := False;
       --  Disconnect detected interrupt
@@ -1213,7 +1213,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS interrupt mask register
    type OTG_HS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0    : HAL.UInt1 := 16#0#;
+      Reserved_0_0    : HAL.Bit := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM           : Boolean := False;
       --  OTG interrupt mask
@@ -1243,7 +1243,7 @@ package STM32_SVD.USB_OTG_HS is
       --  End of periodic frame interrupt mask
       EOPFM           : Boolean := False;
       --  unspecified
-      Reserved_16_16  : HAL.UInt1 := 16#0#;
+      Reserved_16_16  : HAL.Bit := 16#0#;
       --  Endpoint mismatch interrupt mask
       EPMISM          : Boolean := False;
       --  IN endpoints interrupt mask
@@ -1257,7 +1257,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended mask
       FSUSPM          : Boolean := False;
       --  unspecified
-      Reserved_23_23  : HAL.UInt1 := 16#0#;
+      Reserved_23_23  : HAL.Bit := 16#0#;
       --  Read-only. Host port interrupt mask
       PRTIM           : Boolean := False;
       --  Host channels interrupt mask
@@ -1265,7 +1265,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Periodic TxFIFO empty mask
       PTXFEM          : Boolean := False;
       --  unspecified
-      Reserved_27_27  : HAL.UInt1 := 16#0#;
+      Reserved_27_27  : HAL.Bit := 16#0#;
       --  Connector ID status change mask
       CIDSCHGM        : Boolean := False;
       --  Disconnect detected interrupt mask
@@ -1502,7 +1502,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Top of the nonperiodic transmit request queue
       NPTXQTOP       : OTG_HS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1;
+      Reserved_31_31 : HAL.Bit;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1719,7 +1719,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_HS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1767,7 +1767,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1934,7 +1934,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data PID
       DPID           : OTG_HS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-wwdg.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd-wwdg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -118,6 +119,6 @@ package STM32_SVD.WWDG is
 
    --  Window watchdog
    WWDG_Periph : aliased WWDG_Peripheral
-     with Import, Address => WWDG_Base;
+     with Import, Address => System'To_Address (16#40002C00#);
 
 end STM32_SVD.WWDG;

--- a/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd.ads
+++ b/arch/ARM/STM32/svd/stm32f46_79x/stm32_svd.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with System;
 

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-adc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-adc.ads
@@ -135,7 +135,7 @@ package STM32_SVD.ADC is
       --  Start conversion of injected channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  External event select for regular group
       EXTSEL         : CR2_EXTSEL_Field := 16#0#;
       --  External trigger enable for regular channels
@@ -143,7 +143,7 @@ package STM32_SVD.ADC is
       --  Start conversion of regular channels
       SWSTART        : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -651,7 +651,7 @@ package STM32_SVD.ADC is
       --  Delay between 2 sampling phases
       DELAY_k        : CCR_DELAY_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.UInt1 := 16#0#;
+      Reserved_12_12 : HAL.Bit := 16#0#;
       --  DMA disable selection for multi-ADC mode
       DDS            : Boolean := False;
       --  Direct memory access mode for multi ADC mode

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-adc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-adc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -134,7 +135,7 @@ package STM32_SVD.ADC is
       --  Start conversion of injected channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  External event select for regular group
       EXTSEL         : CR2_EXTSEL_Field := 16#0#;
       --  External trigger enable for regular channels
@@ -142,7 +143,7 @@ package STM32_SVD.ADC is
       --  Start conversion of regular channels
       SWSTART        : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -388,7 +389,7 @@ package STM32_SVD.ADC is
       --  Regular channel sequence length
       L              : SQR1_L_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -650,7 +651,7 @@ package STM32_SVD.ADC is
       --  Delay between 2 sampling phases
       DELAY_k        : CCR_DELAY_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.Bit := 16#0#;
+      Reserved_12_12 : HAL.UInt1 := 16#0#;
       --  DMA disable selection for multi-ADC mode
       DDS            : Boolean := False;
       --  Direct memory access mode for multi ADC mode
@@ -664,7 +665,7 @@ package STM32_SVD.ADC is
       --  Temperature sensor and VREFINT enable
       TSVREFE        : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -785,15 +786,15 @@ package STM32_SVD.ADC is
 
    --  Analog-to-digital converter
    ADC1_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC1_Base;
+     with Import, Address => System'To_Address (16#40012000#);
 
    --  Analog-to-digital converter
    ADC2_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC2_Base;
+     with Import, Address => System'To_Address (16#40012100#);
 
    --  Analog-to-digital converter
    ADC3_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC3_Base;
+     with Import, Address => System'To_Address (16#40012200#);
 
    --  Common ADC registers
    type C_ADC_Peripheral is record
@@ -814,6 +815,6 @@ package STM32_SVD.ADC is
 
    --  Common ADC registers
    C_ADC_Periph : aliased C_ADC_Peripheral
-     with Import, Address => C_ADC_Base;
+     with Import, Address => System'To_Address (16#40012300#);
 
 end STM32_SVD.ADC;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-can.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-can.ads
@@ -230,7 +230,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP0
       FMP0          : RF0R_FMP0_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  FULL0
       FULL0         : Boolean := False;
       --  FOVR0
@@ -259,7 +259,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP1
       FMP1          : RF1R_FMP1_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  FULL1
       FULL1         : Boolean := False;
       --  FOVR1
@@ -298,7 +298,7 @@ package STM32_SVD.CAN is
       --  FOVIE1
       FOVIE1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  EWGIE
       EWGIE          : Boolean := False;
       --  EPVIE
@@ -354,7 +354,7 @@ package STM32_SVD.CAN is
       --  Read-only. BOFF
       BOFF          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  LEC
       LEC           : ESR_LEC_Field := 16#0#;
       --  unspecified
@@ -394,7 +394,7 @@ package STM32_SVD.CAN is
       --  TS2
       TS2            : BTR_TS2_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  SJW
       SJW            : BTR_SJW_Field := 16#0#;
       --  unspecified
@@ -755,7 +755,7 @@ package STM32_SVD.CAN is
    --  receive FIFO mailbox identifier register
    type RI0R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.UInt1;
+      Reserved_0_0 : HAL.Bit;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -863,7 +863,7 @@ package STM32_SVD.CAN is
    --  mailbox data high register
    type RI1R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.UInt1;
+      Reserved_0_0 : HAL.Bit;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-can.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-can.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -229,7 +230,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP0
       FMP0          : RF0R_FMP0_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  FULL0
       FULL0         : Boolean := False;
       --  FOVR0
@@ -258,7 +259,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP1
       FMP1          : RF1R_FMP1_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  FULL1
       FULL1         : Boolean := False;
       --  FOVR1
@@ -297,7 +298,7 @@ package STM32_SVD.CAN is
       --  FOVIE1
       FOVIE1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  EWGIE
       EWGIE          : Boolean := False;
       --  EPVIE
@@ -341,8 +342,8 @@ package STM32_SVD.CAN is
    end record;
 
    subtype ESR_LEC_Field is HAL.UInt3;
-   subtype ESR_TEC_Field is HAL.Byte;
-   subtype ESR_REC_Field is HAL.Byte;
+   subtype ESR_TEC_Field is HAL.UInt8;
+   subtype ESR_REC_Field is HAL.UInt8;
 
    --  interrupt enable register
    type ESR_Register is record
@@ -353,7 +354,7 @@ package STM32_SVD.CAN is
       --  Read-only. BOFF
       BOFF          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  LEC
       LEC           : ESR_LEC_Field := 16#0#;
       --  unspecified
@@ -393,7 +394,7 @@ package STM32_SVD.CAN is
       --  TS2
       TS2            : BTR_TS2_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  SJW
       SJW            : BTR_SJW_Field := 16#0#;
       --  unspecified
@@ -473,7 +474,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL0R_DATA array element
-   subtype TDL0R_DATA_Element is HAL.Byte;
+   subtype TDL0R_DATA_Element is HAL.UInt8;
 
    --  TDL0R_DATA array
    type TDL0R_DATA_Field_Array is array (0 .. 3) of TDL0R_DATA_Element
@@ -501,7 +502,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH0R_DATA array element
-   subtype TDH0R_DATA_Element is HAL.Byte;
+   subtype TDH0R_DATA_Element is HAL.UInt8;
 
    --  TDH0R_DATA array
    type TDH0R_DATA_Field_Array is array (4 .. 7) of TDH0R_DATA_Element
@@ -583,7 +584,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL1R_DATA array element
-   subtype TDL1R_DATA_Element is HAL.Byte;
+   subtype TDL1R_DATA_Element is HAL.UInt8;
 
    --  TDL1R_DATA array
    type TDL1R_DATA_Field_Array is array (0 .. 3) of TDL1R_DATA_Element
@@ -611,7 +612,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH1R_DATA array element
-   subtype TDH1R_DATA_Element is HAL.Byte;
+   subtype TDH1R_DATA_Element is HAL.UInt8;
 
    --  TDH1R_DATA array
    type TDH1R_DATA_Field_Array is array (4 .. 7) of TDH1R_DATA_Element
@@ -693,7 +694,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL2R_DATA array element
-   subtype TDL2R_DATA_Element is HAL.Byte;
+   subtype TDL2R_DATA_Element is HAL.UInt8;
 
    --  TDL2R_DATA array
    type TDL2R_DATA_Field_Array is array (0 .. 3) of TDL2R_DATA_Element
@@ -721,7 +722,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH2R_DATA array element
-   subtype TDH2R_DATA_Element is HAL.Byte;
+   subtype TDH2R_DATA_Element is HAL.UInt8;
 
    --  TDH2R_DATA array
    type TDH2R_DATA_Field_Array is array (4 .. 7) of TDH2R_DATA_Element
@@ -754,7 +755,7 @@ package STM32_SVD.CAN is
    --  receive FIFO mailbox identifier register
    type RI0R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.Bit;
+      Reserved_0_0 : HAL.UInt1;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -776,7 +777,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype RDT0R_DLC_Field is HAL.UInt4;
-   subtype RDT0R_FMI_Field is HAL.Byte;
+   subtype RDT0R_FMI_Field is HAL.UInt8;
    subtype RDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
@@ -801,7 +802,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDL0R_DATA array element
-   subtype RDL0R_DATA_Element is HAL.Byte;
+   subtype RDL0R_DATA_Element is HAL.UInt8;
 
    --  RDL0R_DATA array
    type RDL0R_DATA_Field_Array is array (0 .. 3) of RDL0R_DATA_Element
@@ -829,7 +830,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDH0R_DATA array element
-   subtype RDH0R_DATA_Element is HAL.Byte;
+   subtype RDH0R_DATA_Element is HAL.UInt8;
 
    --  RDH0R_DATA array
    type RDH0R_DATA_Field_Array is array (4 .. 7) of RDH0R_DATA_Element
@@ -862,7 +863,7 @@ package STM32_SVD.CAN is
    --  mailbox data high register
    type RI1R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.Bit;
+      Reserved_0_0 : HAL.UInt1;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -884,7 +885,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype RDT1R_DLC_Field is HAL.UInt4;
-   subtype RDT1R_FMI_Field is HAL.Byte;
+   subtype RDT1R_FMI_Field is HAL.UInt8;
    subtype RDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
@@ -909,7 +910,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDL1R_DATA array element
-   subtype RDL1R_DATA_Element is HAL.Byte;
+   subtype RDL1R_DATA_Element is HAL.UInt8;
 
    --  RDL1R_DATA array
    type RDL1R_DATA_Field_Array is array (0 .. 3) of RDL1R_DATA_Element
@@ -937,7 +938,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDH1R_DATA array element
-   subtype RDH1R_DATA_Element is HAL.Byte;
+   subtype RDH1R_DATA_Element is HAL.UInt8;
 
    --  RDH1R_DATA array
    type RDH1R_DATA_Field_Array is array (4 .. 7) of RDH1R_DATA_Element
@@ -2124,10 +2125,10 @@ package STM32_SVD.CAN is
 
    --  Controller area network
    CAN1_Periph : aliased CAN_Peripheral
-     with Import, Address => CAN1_Base;
+     with Import, Address => System'To_Address (16#40006400#);
 
    --  Controller area network
    CAN2_Periph : aliased CAN_Peripheral
-     with Import, Address => CAN2_Base;
+     with Import, Address => System'To_Address (16#40006800#);
 
 end STM32_SVD.CAN;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-cec.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-cec.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -76,7 +77,7 @@ package STM32_SVD.CEC is
       LSTN          at 0 range 31 .. 31;
    end record;
 
-   subtype TXDR_TXD_Field is HAL.Byte;
+   subtype TXDR_TXD_Field is HAL.UInt8;
 
    --  Tx data register
    type TXDR_Register is record
@@ -93,7 +94,7 @@ package STM32_SVD.CEC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype RXDR_RXDR_Field is HAL.Byte;
+   subtype RXDR_RXDR_Field is HAL.UInt8;
 
    --  Rx Data Register
    type RXDR_Register is record
@@ -244,6 +245,6 @@ package STM32_SVD.CEC is
 
    --  HDMI-CEC controller
    CEC_Periph : aliased CEC_Peripheral
-     with Import, Address => CEC_Base;
+     with Import, Address => System'To_Address (16#40006C00#);
 
 end STM32_SVD.CEC;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-crc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-crc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -13,7 +14,7 @@ package STM32_SVD.CRC is
    -- Registers --
    ---------------
 
-   subtype IDR_IDR_Field is HAL.Byte;
+   subtype IDR_IDR_Field is HAL.UInt8;
 
    --  Independent Data register
    type IDR_Register is record
@@ -52,7 +53,7 @@ package STM32_SVD.CRC is
    --  Cyclic Redundancy Check (CRC) unit
    type CRC_Peripheral is record
       --  Data register
-      DR  : HAL.UInt32;
+      DR   : HAL.UInt32;
       --  Independent Data register
       IDR  : IDR_Register;
       --  Control register
@@ -74,6 +75,6 @@ package STM32_SVD.CRC is
 
    --  Cyclic Redundancy Check (CRC) unit
    CRC_Periph : aliased CRC_Peripheral
-     with Import, Address => CRC_Base;
+     with Import, Address => System'To_Address (16#40023000#);
 
 end STM32_SVD.CRC;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-cryp.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-cryp.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -39,7 +40,7 @@ package STM32_SVD.CRYP is
       --  GCM_CCMPH
       GCM_CCMPH      : CR_GCM_CCMPH_Field := 16#0#;
       --  unspecified
-      Reserved_18_18 : HAL.Bit := 16#0#;
+      Reserved_18_18 : HAL.UInt1 := 16#0#;
       --  ALGOMODE
       ALGOMODE3      : Boolean := False;
       --  unspecified
@@ -584,6 +585,6 @@ package STM32_SVD.CRYP is
 
    --  Cryptographic processor
    CRYP_Periph : aliased CRYP_Peripheral
-     with Import, Address => CRYP_Base;
+     with Import, Address => System'To_Address (16#50060000#);
 
 end STM32_SVD.CRYP;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-cryp.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-cryp.ads
@@ -40,7 +40,7 @@ package STM32_SVD.CRYP is
       --  GCM_CCMPH
       GCM_CCMPH      : CR_GCM_CCMPH_Field := 16#0#;
       --  unspecified
-      Reserved_18_18 : HAL.UInt1 := 16#0#;
+      Reserved_18_18 : HAL.Bit := 16#0#;
       --  ALGOMODE
       ALGOMODE3      : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dac.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dac.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -160,7 +161,7 @@ package STM32_SVD.DAC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DHR8R1_DACC1DHR_Field is HAL.Byte;
+   subtype DHR8R1_DACC1DHR_Field is HAL.UInt8;
 
    --  channel1 8-bit right aligned data holding register
    type DHR8R1_Register is record
@@ -214,7 +215,7 @@ package STM32_SVD.DAC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DHR8R2_DACC2DHR_Field is HAL.Byte;
+   subtype DHR8R2_DACC2DHR_Field is HAL.UInt8;
 
    --  channel2 8-bit right-aligned data holding register
    type DHR8R2_Register is record
@@ -279,8 +280,8 @@ package STM32_SVD.DAC is
       DACC2DHR       at 0 range 20 .. 31;
    end record;
 
-   subtype DHR8RD_DACC1DHR_Field is HAL.Byte;
-   subtype DHR8RD_DACC2DHR_Field is HAL.Byte;
+   subtype DHR8RD_DACC1DHR_Field is HAL.UInt8;
+   subtype DHR8RD_DACC2DHR_Field is HAL.UInt8;
 
    --  DUAL DAC 8-bit right aligned data holding register
    type DHR8RD_Register is record
@@ -414,6 +415,6 @@ package STM32_SVD.DAC is
 
    --  Digital-to-analog converter
    DAC_Periph : aliased DAC_Peripheral
-     with Import, Address => DAC_Base;
+     with Import, Address => System'To_Address (16#40007400#);
 
 end STM32_SVD.DAC;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dbg.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dbg.ads
@@ -102,7 +102,7 @@ package STM32_SVD.DBG is
       --  DBG_J2C3SMBUS_TIMEOUT
       DBG_J2C3SMBUS_TIMEOUT  : Boolean := False;
       --  unspecified
-      Reserved_24_24         : HAL.UInt1 := 16#0#;
+      Reserved_24_24         : HAL.Bit := 16#0#;
       --  DBG_CAN1_STOP
       DBG_CAN1_STOP          : Boolean := False;
       --  DBG_CAN2_STOP

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dbg.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dbg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -93,7 +94,7 @@ package STM32_SVD.DBG is
       --  DBG_IWDEG_STOP
       DBG_IWDEG_STOP         : Boolean := False;
       --  unspecified
-      Reserved_13_20         : HAL.Byte := 16#0#;
+      Reserved_13_20         : HAL.UInt8 := 16#0#;
       --  DBG_J2C1_SMBUS_TIMEOUT
       DBG_J2C1_SMBUS_TIMEOUT : Boolean := False;
       --  DBG_J2C2_SMBUS_TIMEOUT
@@ -101,7 +102,7 @@ package STM32_SVD.DBG is
       --  DBG_J2C3SMBUS_TIMEOUT
       DBG_J2C3SMBUS_TIMEOUT  : Boolean := False;
       --  unspecified
-      Reserved_24_24         : HAL.Bit := 16#0#;
+      Reserved_24_24         : HAL.UInt1 := 16#0#;
       --  DBG_CAN1_STOP
       DBG_CAN1_STOP          : Boolean := False;
       --  DBG_CAN2_STOP
@@ -191,6 +192,6 @@ package STM32_SVD.DBG is
 
    --  Debug support
    DBG_Periph : aliased DBG_Peripheral
-     with Import, Address => DBG_Base;
+     with Import, Address => System'To_Address (16#E0042000#);
 
 end STM32_SVD.DBG;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dcmi.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dcmi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -193,10 +194,10 @@ package STM32_SVD.DCMI is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype ESCR_FSC_Field is HAL.Byte;
-   subtype ESCR_LSC_Field is HAL.Byte;
-   subtype ESCR_LEC_Field is HAL.Byte;
-   subtype ESCR_FEC_Field is HAL.Byte;
+   subtype ESCR_FSC_Field is HAL.UInt8;
+   subtype ESCR_LSC_Field is HAL.UInt8;
+   subtype ESCR_LEC_Field is HAL.UInt8;
+   subtype ESCR_FEC_Field is HAL.UInt8;
 
    --  embedded synchronization code register
    type ESCR_Register is record
@@ -219,10 +220,10 @@ package STM32_SVD.DCMI is
       FEC at 0 range 24 .. 31;
    end record;
 
-   subtype ESUR_FSU_Field is HAL.Byte;
-   subtype ESUR_LSU_Field is HAL.Byte;
-   subtype ESUR_LEU_Field is HAL.Byte;
-   subtype ESUR_FEU_Field is HAL.Byte;
+   subtype ESUR_FSU_Field is HAL.UInt8;
+   subtype ESUR_LSU_Field is HAL.UInt8;
+   subtype ESUR_LEU_Field is HAL.UInt8;
+   subtype ESUR_FEU_Field is HAL.UInt8;
 
    --  embedded synchronization unmask register
    type ESUR_Register is record
@@ -294,7 +295,7 @@ package STM32_SVD.DCMI is
    end record;
 
    --  DR_Byte array element
-   subtype DR_Byte_Element is HAL.Byte;
+   subtype DR_Byte_Element is HAL.UInt8;
 
    --  DR_Byte array
    type DR_Byte_Field_Array is array (0 .. 3) of DR_Byte_Element
@@ -368,6 +369,6 @@ package STM32_SVD.DCMI is
 
    --  Digital camera interface
    DCMI_Periph : aliased DCMI_Peripheral
-     with Import, Address => DCMI_Base;
+     with Import, Address => System'To_Address (16#50050000#);
 
 end STM32_SVD.DCMI;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dma.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dma.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -18,7 +19,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF0          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.Bit;
+      Reserved_1_1   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF0         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -30,7 +31,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF1          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.Bit;
+      Reserved_7_7   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF1         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -44,7 +45,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF2          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.Bit;
+      Reserved_17_17 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF2         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -56,7 +57,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF3          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.Bit;
+      Reserved_23_23 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF3         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -105,7 +106,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF4          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.Bit;
+      Reserved_1_1   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF4         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -117,7 +118,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF5          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.Bit;
+      Reserved_7_7   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF5         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -131,7 +132,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF6          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.Bit;
+      Reserved_17_17 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF6         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -143,7 +144,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF7          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.Bit;
+      Reserved_23_23 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF7         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -192,7 +193,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF0         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF0        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -204,7 +205,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF1        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -218,7 +219,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF2         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF2        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -230,7 +231,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF3         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF3        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -279,7 +280,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF4         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF4        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -291,7 +292,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF5         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF5        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -305,7 +306,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF6         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF6        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -317,7 +318,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF7         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF7        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -404,7 +405,7 @@ package STM32_SVD.DMA is
       --  Current target (only in double buffer mode)
       CT             : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Peripheral burst transfer configuration
       PBURST         : S0CR_PBURST_Field := 16#0#;
       --  Memory burst transfer configuration
@@ -470,7 +471,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S0FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -531,7 +532,7 @@ package STM32_SVD.DMA is
       --  Current target (only in double buffer mode)
       CT             : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Peripheral burst transfer configuration
       PBURST         : S1CR_PBURST_Field := 16#0#;
       --  Memory burst transfer configuration
@@ -597,7 +598,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S1FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -724,7 +725,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S2FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -851,7 +852,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S3FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -978,7 +979,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S4FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1105,7 +1106,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S5FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1232,7 +1233,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S6FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1359,7 +1360,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S7FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1547,10 +1548,10 @@ package STM32_SVD.DMA is
 
    --  DMA controller
    DMA1_Periph : aliased DMA_Peripheral
-     with Import, Address => DMA1_Base;
+     with Import, Address => System'To_Address (16#40026000#);
 
    --  DMA controller
    DMA2_Periph : aliased DMA_Peripheral
-     with Import, Address => DMA2_Base;
+     with Import, Address => System'To_Address (16#40026400#);
 
 end STM32_SVD.DMA;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dma.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dma.ads
@@ -19,7 +19,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF0          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1;
+      Reserved_1_1   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF0         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -31,7 +31,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF1          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1;
+      Reserved_7_7   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF1         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -45,7 +45,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF2          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1;
+      Reserved_17_17 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF2         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -57,7 +57,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF3          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1;
+      Reserved_23_23 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF3         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -106,7 +106,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF4          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1;
+      Reserved_1_1   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF4         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -118,7 +118,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF5          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1;
+      Reserved_7_7   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF5         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -132,7 +132,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF6          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1;
+      Reserved_17_17 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF6         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -144,7 +144,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF7          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1;
+      Reserved_23_23 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF7         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -193,7 +193,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF0         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF0        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -205,7 +205,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF1        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -219,7 +219,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF2         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF2        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -231,7 +231,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF3         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF3        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -280,7 +280,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF4         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF4        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -292,7 +292,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF5         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF5        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -306,7 +306,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF6         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF6        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -318,7 +318,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF7         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF7        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -405,7 +405,7 @@ package STM32_SVD.DMA is
       --  Current target (only in double buffer mode)
       CT             : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Peripheral burst transfer configuration
       PBURST         : S0CR_PBURST_Field := 16#0#;
       --  Memory burst transfer configuration
@@ -471,7 +471,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S0FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -532,7 +532,7 @@ package STM32_SVD.DMA is
       --  Current target (only in double buffer mode)
       CT             : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Peripheral burst transfer configuration
       PBURST         : S1CR_PBURST_Field := 16#0#;
       --  Memory burst transfer configuration
@@ -598,7 +598,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S1FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -725,7 +725,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S2FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -852,7 +852,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S3FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -979,7 +979,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S4FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1106,7 +1106,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S5FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1233,7 +1233,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S6FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -1360,7 +1360,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : S7FCR_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dma2d.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-dma2d.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -158,9 +159,9 @@ package STM32_SVD.DMA2D is
    end record;
 
    subtype FGPFCCR_CM_Field is HAL.UInt4;
-   subtype FGPFCCR_CS_Field is HAL.Byte;
+   subtype FGPFCCR_CS_Field is HAL.UInt8;
    subtype FGPFCCR_AM_Field is HAL.UInt2;
-   subtype FGPFCCR_ALPHA_Field is HAL.Byte;
+   subtype FGPFCCR_ALPHA_Field is HAL.UInt8;
 
    --  foreground PFC control register
    type FGPFCCR_Register is record
@@ -195,9 +196,9 @@ package STM32_SVD.DMA2D is
       ALPHA          at 0 range 24 .. 31;
    end record;
 
-   subtype FGCOLR_BLUE_Field is HAL.Byte;
-   subtype FGCOLR_GREEN_Field is HAL.Byte;
-   subtype FGCOLR_RED_Field is HAL.Byte;
+   subtype FGCOLR_BLUE_Field is HAL.UInt8;
+   subtype FGCOLR_GREEN_Field is HAL.UInt8;
+   subtype FGCOLR_RED_Field is HAL.UInt8;
 
    --  foreground color register
    type FGCOLR_Register is record
@@ -208,7 +209,7 @@ package STM32_SVD.DMA2D is
       --  Red Value
       RED            : FGCOLR_RED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -221,9 +222,9 @@ package STM32_SVD.DMA2D is
    end record;
 
    subtype BGPFCCR_CM_Field is HAL.UInt4;
-   subtype BGPFCCR_CS_Field is HAL.Byte;
+   subtype BGPFCCR_CS_Field is HAL.UInt8;
    subtype BGPFCCR_AM_Field is HAL.UInt2;
-   subtype BGPFCCR_ALPHA_Field is HAL.Byte;
+   subtype BGPFCCR_ALPHA_Field is HAL.UInt8;
 
    --  background PFC control register
    type BGPFCCR_Register is record
@@ -258,9 +259,9 @@ package STM32_SVD.DMA2D is
       ALPHA          at 0 range 24 .. 31;
    end record;
 
-   subtype BGCOLR_BLUE_Field is HAL.Byte;
-   subtype BGCOLR_GREEN_Field is HAL.Byte;
-   subtype BGCOLR_RED_Field is HAL.Byte;
+   subtype BGCOLR_BLUE_Field is HAL.UInt8;
+   subtype BGCOLR_GREEN_Field is HAL.UInt8;
+   subtype BGCOLR_RED_Field is HAL.UInt8;
 
    --  background color register
    type BGCOLR_Register is record
@@ -271,7 +272,7 @@ package STM32_SVD.DMA2D is
       --  Red Value
       RED            : BGCOLR_RED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -300,10 +301,10 @@ package STM32_SVD.DMA2D is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype OCOLR_BLUE_Field is HAL.Byte;
-   subtype OCOLR_GREEN_Field is HAL.Byte;
-   subtype OCOLR_RED_Field is HAL.Byte;
-   subtype OCOLR_APLHA_Field is HAL.Byte;
+   subtype OCOLR_BLUE_Field is HAL.UInt8;
+   subtype OCOLR_GREEN_Field is HAL.UInt8;
+   subtype OCOLR_RED_Field is HAL.UInt8;
+   subtype OCOLR_APLHA_Field is HAL.UInt8;
 
    --  output color register
    type OCOLR_Register is record
@@ -381,7 +382,7 @@ package STM32_SVD.DMA2D is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype AMTCR_DT_Field is HAL.Byte;
+   subtype AMTCR_DT_Field is HAL.UInt8;
 
    --  AHB master timer configuration register
    type AMTCR_Register is record
@@ -404,10 +405,10 @@ package STM32_SVD.DMA2D is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype FGCLUT_BLUE_Field is HAL.Byte;
-   subtype FGCLUT_GREEN_Field is HAL.Byte;
-   subtype FGCLUT_RED_Field is HAL.Byte;
-   subtype FGCLUT_APLHA_Field is HAL.Byte;
+   subtype FGCLUT_BLUE_Field is HAL.UInt8;
+   subtype FGCLUT_GREEN_Field is HAL.UInt8;
+   subtype FGCLUT_RED_Field is HAL.UInt8;
+   subtype FGCLUT_APLHA_Field is HAL.UInt8;
 
    --  FGCLUT
    type FGCLUT_Register is record
@@ -430,10 +431,10 @@ package STM32_SVD.DMA2D is
       APLHA at 0 range 24 .. 31;
    end record;
 
-   subtype BGCLUT_BLUE_Field is HAL.Byte;
-   subtype BGCLUT_GREEN_Field is HAL.Byte;
-   subtype BGCLUT_RED_Field is HAL.Byte;
-   subtype BGCLUT_APLHA_Field is HAL.Byte;
+   subtype BGCLUT_BLUE_Field is HAL.UInt8;
+   subtype BGCLUT_GREEN_Field is HAL.UInt8;
+   subtype BGCLUT_RED_Field is HAL.UInt8;
+   subtype BGCLUT_APLHA_Field is HAL.UInt8;
 
    --  BGCLUT
    type BGCLUT_Register is record
@@ -536,6 +537,6 @@ package STM32_SVD.DMA2D is
 
    --  DMA2D controller
    DMA2D_Periph : aliased DMA2D_Peripheral
-     with Import, Address => DMA2D_Base;
+     with Import, Address => System'To_Address (16#4002B000#);
 
 end STM32_SVD.DMA2D;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-ethernet.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-ethernet.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -111,7 +112,7 @@ package STM32_SVD.Ethernet is
       --  Read-only. no description available
       EBS            : DMASR_EBS_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.Bit := 16#0#;
+      Reserved_26_26 : HAL.UInt1 := 16#0#;
       --  Read-only. no description available
       MMCS           : Boolean := False;
       --  Read-only. no description available
@@ -157,7 +158,7 @@ package STM32_SVD.Ethernet is
    --  Ethernet DMA operation mode register
    type DMAOMR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  SR
       SR             : Boolean := False;
       --  OSF
@@ -165,7 +166,7 @@ package STM32_SVD.Ethernet is
       --  RTC
       RTC            : DMAOMR_RTC_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  FUGF
       FUGF           : Boolean := False;
       --  FEF
@@ -304,7 +305,7 @@ package STM32_SVD.Ethernet is
       Reserved_29_31 at 0 range 29 .. 31;
    end record;
 
-   subtype DMARSWTR_RSWTC_Field is HAL.Byte;
+   subtype DMARSWTR_RSWTC_Field is HAL.UInt8;
 
    --  Ethernet DMA receive status watchdog timer register
    type DMARSWTR_Register is record
@@ -339,7 +340,7 @@ package STM32_SVD.Ethernet is
       --  APCS
       APCS           : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  RD
       RD             : Boolean := False;
       --  IPCO
@@ -353,7 +354,7 @@ package STM32_SVD.Ethernet is
       --  FES
       FES            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#1#;
+      Reserved_15_15 : HAL.UInt1 := 16#1#;
       --  CSD
       CSD            : Boolean := False;
       --  IFG
@@ -365,7 +366,7 @@ package STM32_SVD.Ethernet is
       --  WD
       WD             : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CSTF
       CSTF           : Boolean := False;
       --  unspecified
@@ -457,7 +458,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       CR             : MACMIIAR_CR_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  no description available
       MR             : MACMIIAR_MR_Field := 16#0#;
       --  no description available
@@ -511,11 +512,11 @@ package STM32_SVD.Ethernet is
       --  no description available
       PLT           : MACFCR_PLT_Field := 16#0#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  no description available
       ZQPD          : Boolean := False;
       --  unspecified
-      Reserved_8_15 : HAL.Byte := 16#0#;
+      Reserved_8_15 : HAL.UInt8 := 16#0#;
       --  no description available
       PT            : MACFCR_PT_Field := 16#0#;
    end record
@@ -708,7 +709,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA1H         : MACA1HR_MACA1H_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA1HR_MBC_Field := 16#0#;
       --  no description available
@@ -735,7 +736,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MAC2AH         : MACA2HR_MAC2AH_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA2HR_MBC_Field := 16#0#;
       --  no description available
@@ -761,7 +762,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA2L         : MACA2LR_MACA2L_Field := 16#7FFFFFFF#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#1#;
+      Reserved_31_31 : HAL.UInt1 := 16#1#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -779,7 +780,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA3H         : MACA3HR_MACA3H_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA3HR_MBC_Field := 16#0#;
       --  no description available
@@ -998,7 +999,7 @@ package STM32_SVD.Ethernet is
       Reserved_19_31 at 0 range 19 .. 31;
    end record;
 
-   subtype PTPSSIR_STSSI_Field is HAL.Byte;
+   subtype PTPSSIR_STSSI_Field is HAL.UInt8;
 
    --  Ethernet PTP subsecond increment register
    type PTPSSIR_Register is record
@@ -1141,7 +1142,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: DMA controller operation
    Ethernet_DMA_Periph : aliased Ethernet_DMA_Peripheral
-     with Import, Address => Ethernet_DMA_Base;
+     with Import, Address => System'To_Address (16#40029000#);
 
    --  Ethernet: media access control (MAC)
    type Ethernet_MAC_Peripheral is record
@@ -1216,7 +1217,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: media access control (MAC)
    Ethernet_MAC_Periph : aliased Ethernet_MAC_Peripheral
-     with Import, Address => Ethernet_MAC_Base;
+     with Import, Address => System'To_Address (16#40028000#);
 
    --  Ethernet: MAC management counters
    type Ethernet_MMC_Peripheral is record
@@ -1262,7 +1263,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: MAC management counters
    Ethernet_MMC_Periph : aliased Ethernet_MMC_Peripheral
-     with Import, Address => Ethernet_MMC_Base;
+     with Import, Address => System'To_Address (16#40028100#);
 
    --  Ethernet: Precision time protocol
    type Ethernet_PTP_Peripheral is record
@@ -1307,6 +1308,6 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: Precision time protocol
    Ethernet_PTP_Periph : aliased Ethernet_PTP_Peripheral
-     with Import, Address => Ethernet_PTP_Base;
+     with Import, Address => System'To_Address (16#40028700#);
 
 end STM32_SVD.Ethernet;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-ethernet.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-ethernet.ads
@@ -112,7 +112,7 @@ package STM32_SVD.Ethernet is
       --  Read-only. no description available
       EBS            : DMASR_EBS_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.UInt1 := 16#0#;
+      Reserved_26_26 : HAL.Bit := 16#0#;
       --  Read-only. no description available
       MMCS           : Boolean := False;
       --  Read-only. no description available
@@ -158,7 +158,7 @@ package STM32_SVD.Ethernet is
    --  Ethernet DMA operation mode register
    type DMAOMR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  SR
       SR             : Boolean := False;
       --  OSF
@@ -166,7 +166,7 @@ package STM32_SVD.Ethernet is
       --  RTC
       RTC            : DMAOMR_RTC_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  FUGF
       FUGF           : Boolean := False;
       --  FEF
@@ -340,7 +340,7 @@ package STM32_SVD.Ethernet is
       --  APCS
       APCS           : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  RD
       RD             : Boolean := False;
       --  IPCO
@@ -354,7 +354,7 @@ package STM32_SVD.Ethernet is
       --  FES
       FES            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#1#;
+      Reserved_15_15 : HAL.Bit := 16#1#;
       --  CSD
       CSD            : Boolean := False;
       --  IFG
@@ -366,7 +366,7 @@ package STM32_SVD.Ethernet is
       --  WD
       WD             : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CSTF
       CSTF           : Boolean := False;
       --  unspecified
@@ -458,7 +458,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       CR             : MACMIIAR_CR_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  no description available
       MR             : MACMIIAR_MR_Field := 16#0#;
       --  no description available
@@ -512,7 +512,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       PLT           : MACFCR_PLT_Field := 16#0#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  no description available
       ZQPD          : Boolean := False;
       --  unspecified
@@ -762,7 +762,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA2L         : MACA2LR_MACA2L_Field := 16#7FFFFFFF#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#1#;
+      Reserved_31_31 : HAL.Bit := 16#1#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-exti.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-exti.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -279,6 +280,6 @@ package STM32_SVD.EXTI is
 
    --  External interrupt/event controller
    EXTI_Periph : aliased EXTI_Peripheral
-     with Import, Address => EXTI_Base;
+     with Import, Address => System'To_Address (16#40013C00#);
 
 end STM32_SVD.EXTI;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-flash.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-flash.ads
@@ -152,7 +152,7 @@ package STM32_SVD.FLASH is
       --  BOR reset Level
       BOR_LEV        : OPTCR_BOR_LEV_Field := 16#3#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  WDG_SW User option bytes
       WDG_SW         : Boolean := True;
       --  nRST_STOP User option bytes

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-flash.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-flash.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -65,7 +66,7 @@ package STM32_SVD.FLASH is
       --  Programming sequence error
       PGSERR         : Boolean := False;
       --  unspecified
-      Reserved_8_15  : HAL.Byte := 16#0#;
+      Reserved_8_15  : HAL.UInt8 := 16#0#;
       --  Read-only. Busy
       BSY            : Boolean := False;
       --  unspecified
@@ -139,7 +140,7 @@ package STM32_SVD.FLASH is
    end record;
 
    subtype OPTCR_BOR_LEV_Field is HAL.UInt2;
-   subtype OPTCR_RDP_Field is HAL.Byte;
+   subtype OPTCR_RDP_Field is HAL.UInt8;
    subtype OPTCR_nWRP_Field is HAL.UInt12;
 
    --  Flash option control register
@@ -151,7 +152,7 @@ package STM32_SVD.FLASH is
       --  BOR reset Level
       BOR_LEV        : OPTCR_BOR_LEV_Field := 16#3#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  WDG_SW User option bytes
       WDG_SW         : Boolean := True;
       --  nRST_STOP User option bytes
@@ -236,6 +237,6 @@ package STM32_SVD.FLASH is
 
    --  FLASH
    FLASH_Periph : aliased FLASH_Peripheral
-     with Import, Address => FLASH_Base;
+     with Import, Address => System'To_Address (16#40023C00#);
 
 end STM32_SVD.FLASH;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-fsmc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-fsmc.ads
@@ -30,13 +30,13 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#1#;
+      Reserved_7_7   : HAL.Bit := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
       WAITPOL        : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  WAITCFG
       WAITCFG        : Boolean := False;
       --  WREN
@@ -137,7 +137,7 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#1#;
+      Reserved_7_7   : HAL.Bit := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
@@ -192,7 +192,7 @@ package STM32_SVD.FSMC is
    --  PC Card/NAND Flash control register
    type PCR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  PWAITEN
       PWAITEN        : Boolean := False;
       --  PBKEN

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-fsmc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-fsmc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -29,13 +30,13 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#1#;
+      Reserved_7_7   : HAL.UInt1 := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
       WAITPOL        : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  WAITCFG
       WAITCFG        : Boolean := False;
       --  WREN
@@ -81,7 +82,7 @@ package STM32_SVD.FSMC is
 
    subtype BTR_ADDSET_Field is HAL.UInt4;
    subtype BTR_ADDHLD_Field is HAL.UInt4;
-   subtype BTR_DATAST_Field is HAL.Byte;
+   subtype BTR_DATAST_Field is HAL.UInt8;
    subtype BTR_BUSTURN_Field is HAL.UInt4;
    subtype BTR_CLKDIV_Field is HAL.UInt4;
    subtype BTR_DATLAT_Field is HAL.UInt4;
@@ -136,7 +137,7 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#1#;
+      Reserved_7_7   : HAL.UInt1 := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
@@ -191,7 +192,7 @@ package STM32_SVD.FSMC is
    --  PC Card/NAND Flash control register
    type PCR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  PWAITEN
       PWAITEN        : Boolean := False;
       --  PBKEN
@@ -263,10 +264,10 @@ package STM32_SVD.FSMC is
       Reserved_7_31 at 0 range 7 .. 31;
    end record;
 
-   subtype PMEM_MEMSETx_Field is HAL.Byte;
-   subtype PMEM_MEMWAITx_Field is HAL.Byte;
-   subtype PMEM_MEMHOLDx_Field is HAL.Byte;
-   subtype PMEM_MEMHIZx_Field is HAL.Byte;
+   subtype PMEM_MEMSETx_Field is HAL.UInt8;
+   subtype PMEM_MEMWAITx_Field is HAL.UInt8;
+   subtype PMEM_MEMHOLDx_Field is HAL.UInt8;
+   subtype PMEM_MEMHIZx_Field is HAL.UInt8;
 
    --  Common memory space timing register
    type PMEM_Register is record
@@ -289,10 +290,10 @@ package STM32_SVD.FSMC is
       MEMHIZx  at 0 range 24 .. 31;
    end record;
 
-   subtype PATT_ATTSETx_Field is HAL.Byte;
-   subtype PATT_ATTWAITx_Field is HAL.Byte;
-   subtype PATT_ATTHOLDx_Field is HAL.Byte;
-   subtype PATT_ATTHIZx_Field is HAL.Byte;
+   subtype PATT_ATTSETx_Field is HAL.UInt8;
+   subtype PATT_ATTWAITx_Field is HAL.UInt8;
+   subtype PATT_ATTHOLDx_Field is HAL.UInt8;
+   subtype PATT_ATTHIZx_Field is HAL.UInt8;
 
    --  Attribute memory space timing register
    type PATT_Register is record
@@ -317,7 +318,7 @@ package STM32_SVD.FSMC is
 
    subtype BWTR_ADDSET_Field is HAL.UInt4;
    subtype BWTR_ADDHLD_Field is HAL.UInt4;
-   subtype BWTR_DATAST_Field is HAL.Byte;
+   subtype BWTR_DATAST_Field is HAL.UInt8;
    subtype BWTR_CLKDIV_Field is HAL.UInt4;
    subtype BWTR_DATLAT_Field is HAL.UInt4;
    subtype BWTR_ACCMOD_Field is HAL.UInt2;
@@ -652,6 +653,6 @@ package STM32_SVD.FSMC is
 
    --  Flexible memory controller
    FMC_Periph : aliased FMC_Peripheral
-     with Import, Address => FMC_Base;
+     with Import, Address => System'To_Address (16#A0000000#);
 
 end STM32_SVD.FSMC;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-gpio.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-gpio.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -461,46 +462,46 @@ package STM32_SVD.GPIO is
 
    --  General-purpose I/Os
    GPIOA_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOA_Base;
+     with Import, Address => System'To_Address (16#40020000#);
 
    --  General-purpose I/Os
    GPIOB_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOB_Base;
+     with Import, Address => System'To_Address (16#40020400#);
 
    --  General-purpose I/Os
    GPIOC_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOC_Base;
+     with Import, Address => System'To_Address (16#40020800#);
 
    --  General-purpose I/Os
    GPIOD_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOD_Base;
+     with Import, Address => System'To_Address (16#40020C00#);
 
    --  General-purpose I/Os
    GPIOE_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOE_Base;
+     with Import, Address => System'To_Address (16#40021000#);
 
    --  General-purpose I/Os
    GPIOF_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOF_Base;
+     with Import, Address => System'To_Address (16#40021400#);
 
    --  General-purpose I/Os
    GPIOG_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOG_Base;
+     with Import, Address => System'To_Address (16#40021800#);
 
    --  General-purpose I/Os
    GPIOH_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOH_Base;
+     with Import, Address => System'To_Address (16#40021C00#);
 
    --  General-purpose I/Os
    GPIOI_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOI_Base;
+     with Import, Address => System'To_Address (16#40022000#);
 
    --  General-purpose I/Os
    GPIOJ_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOJ_Base;
+     with Import, Address => System'To_Address (16#40022400#);
 
    --  General-purpose I/Os
    GPIOK_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOK_Base;
+     with Import, Address => System'To_Address (16#40022800#);
 
 end STM32_SVD.GPIO;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-hash.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-hash.ads
@@ -42,7 +42,7 @@ package STM32_SVD.HASH is
       --  Long key selection
       LKEY           : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  ALGO
       ALGO1          : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-hash.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-hash.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -41,7 +42,7 @@ package STM32_SVD.HASH is
       --  Long key selection
       LKEY           : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  ALGO
       ALGO1          : Boolean := False;
       --  unspecified
@@ -362,6 +363,6 @@ package STM32_SVD.HASH is
 
    --  Hash processor
    HASH_Periph : aliased HASH_Peripheral
-     with Import, Address => HASH_Base;
+     with Import, Address => System'To_Address (16#50060400#);
 
 end STM32_SVD.HASH;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-i2c.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-i2c.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -38,7 +39,7 @@ package STM32_SVD.I2C is
       --  Analog noise filter OFF
       ANFOFF         : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  DMA transmission requests enable
       TXDMAEN        : Boolean := False;
       --  DMA reception requests enable
@@ -60,7 +61,7 @@ package STM32_SVD.I2C is
       --  PEC enable
       PECEN          : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -91,7 +92,7 @@ package STM32_SVD.I2C is
    end record;
 
    subtype CR2_SADD_Field is HAL.UInt10;
-   subtype CR2_NBYTES_Field is HAL.Byte;
+   subtype CR2_NBYTES_Field is HAL.UInt8;
 
    --  Control register 2
    type CR2_Register is record
@@ -170,7 +171,7 @@ package STM32_SVD.I2C is
    --  Own address register 2
    type OAR2_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  Interface address
       OA2            : OAR2_OA2_Field := 16#0#;
       --  Own Address 2 masks
@@ -194,8 +195,8 @@ package STM32_SVD.I2C is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype TIMINGR_SCLL_Field is HAL.Byte;
-   subtype TIMINGR_SCLH_Field is HAL.Byte;
+   subtype TIMINGR_SCLL_Field is HAL.UInt8;
+   subtype TIMINGR_SCLH_Field is HAL.UInt8;
    subtype TIMINGR_SDADEL_Field is HAL.UInt4;
    subtype TIMINGR_SCLDEL_Field is HAL.UInt4;
    subtype TIMINGR_PRESC_Field is HAL.UInt4;
@@ -293,7 +294,7 @@ package STM32_SVD.I2C is
       --  Read-only. SMBus alert
       ALERT          : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Read-only. Bus busy
       BUSY           : Boolean := False;
       --  Read-only. Transfer direction (Slave mode)
@@ -301,7 +302,7 @@ package STM32_SVD.I2C is
       --  Read-only. Address match code (Slave mode)
       ADDCODE        : ISR_ADDCODE_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -373,7 +374,7 @@ package STM32_SVD.I2C is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype PECR_PEC_Field is HAL.Byte;
+   subtype PECR_PEC_Field is HAL.UInt8;
 
    --  PEC register
    type PECR_Register is record
@@ -390,7 +391,7 @@ package STM32_SVD.I2C is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype RXDR_RXDATA_Field is HAL.Byte;
+   subtype RXDR_RXDATA_Field is HAL.UInt8;
 
    --  Receive data register
    type RXDR_Register is record
@@ -407,7 +408,7 @@ package STM32_SVD.I2C is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype TXDR_TXDATA_Field is HAL.Byte;
+   subtype TXDR_TXDATA_Field is HAL.UInt8;
 
    --  Transmit data register
    type TXDR_Register is record
@@ -471,18 +472,18 @@ package STM32_SVD.I2C is
 
    --  Inter-integrated circuit
    I2C1_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C1_Base;
+     with Import, Address => System'To_Address (16#40005400#);
 
    --  Inter-integrated circuit
    I2C2_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C2_Base;
+     with Import, Address => System'To_Address (16#40005800#);
 
    --  Inter-integrated circuit
    I2C3_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C3_Base;
+     with Import, Address => System'To_Address (16#40005C00#);
 
    --  Inter-integrated circuit
    I2C4_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C4_Base;
+     with Import, Address => System'To_Address (16#40006000#);
 
 end STM32_SVD.I2C;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-i2c.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-i2c.ads
@@ -39,7 +39,7 @@ package STM32_SVD.I2C is
       --  Analog noise filter OFF
       ANFOFF         : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  DMA transmission requests enable
       TXDMAEN        : Boolean := False;
       --  DMA reception requests enable
@@ -171,7 +171,7 @@ package STM32_SVD.I2C is
    --  Own address register 2
    type OAR2_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  Interface address
       OA2            : OAR2_OA2_Field := 16#0#;
       --  Own Address 2 masks
@@ -294,7 +294,7 @@ package STM32_SVD.I2C is
       --  Read-only. SMBus alert
       ALERT          : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Read-only. Bus busy
       BUSY           : Boolean := False;
       --  Read-only. Transfer direction (Slave mode)

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-iwdg.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-iwdg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -128,6 +129,6 @@ package STM32_SVD.IWDG is
 
    --  Independent watchdog
    IWDG_Periph : aliased IWDG_Peripheral
-     with Import, Address => IWDG_Base;
+     with Import, Address => System'To_Address (16#40003000#);
 
 end STM32_SVD.IWDG;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-lptim.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-lptim.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -128,19 +129,19 @@ package STM32_SVD.LPTIM is
       --  Configurable digital filter for external clock
       CKFLT          : CFGR_CKFLT_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Configurable digital filter for trigger
       TRGFLT         : CFGR_TRGFLT_Field := 16#0#;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  Clock prescaler
       PRESC          : CFGR_PRESC_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.Bit := 16#0#;
+      Reserved_12_12 : HAL.UInt1 := 16#0#;
       --  Trigger selector
       TRIGSEL        : CFGR_TRIGSEL_Field := 16#0#;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Trigger enable and polarity
       TRIGEN         : CFGR_TRIGEN_Field := 16#0#;
       --  Timeout enable
@@ -292,6 +293,6 @@ package STM32_SVD.LPTIM is
 
    --  Low power timer
    LPTIM1_Periph : aliased LPTIM1_Peripheral
-     with Import, Address => LPTIM1_Base;
+     with Import, Address => System'To_Address (16#40002400#);
 
 end STM32_SVD.LPTIM;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-lptim.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-lptim.ads
@@ -129,19 +129,19 @@ package STM32_SVD.LPTIM is
       --  Configurable digital filter for external clock
       CKFLT          : CFGR_CKFLT_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Configurable digital filter for trigger
       TRGFLT         : CFGR_TRGFLT_Field := 16#0#;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  Clock prescaler
       PRESC          : CFGR_PRESC_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.UInt1 := 16#0#;
+      Reserved_12_12 : HAL.Bit := 16#0#;
       --  Trigger selector
       TRIGSEL        : CFGR_TRIGSEL_Field := 16#0#;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Trigger enable and polarity
       TRIGEN         : CFGR_TRIGEN_Field := 16#0#;
       --  Timeout enable

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-ltdc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-ltdc.ads
@@ -123,15 +123,15 @@ package STM32_SVD.LTDC is
       --  Read-only. Dither Blue Width
       DBW            : GCR_DBW_Field := 16#2#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Read-only. Dither Green Width
       DGW            : GCR_DGW_Field := 16#2#;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  Read-only. Dither Red Width
       DRW            : GCR_DRW_Field := 16#2#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Dither Enable
       DEN            : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-ltdc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-ltdc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -122,15 +123,15 @@ package STM32_SVD.LTDC is
       --  Read-only. Dither Blue Width
       DBW            : GCR_DBW_Field := 16#2#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Read-only. Dither Green Width
       DGW            : GCR_DGW_Field := 16#2#;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  Read-only. Dither Red Width
       DRW            : GCR_DRW_Field := 16#2#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Dither Enable
       DEN            : Boolean := False;
       --  unspecified
@@ -189,7 +190,7 @@ package STM32_SVD.LTDC is
       --  Background Color Red value
       BC             : BCCR_BC_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -402,9 +403,9 @@ package STM32_SVD.LTDC is
       Reserved_27_31 at 0 range 27 .. 31;
    end record;
 
-   subtype L1CKCR_CKBLUE_Field is HAL.Byte;
-   subtype L1CKCR_CKGREEN_Field is HAL.Byte;
-   subtype L1CKCR_CKRED_Field is HAL.Byte;
+   subtype L1CKCR_CKBLUE_Field is HAL.UInt8;
+   subtype L1CKCR_CKGREEN_Field is HAL.UInt8;
+   subtype L1CKCR_CKRED_Field is HAL.UInt8;
 
    --  Layerx Color Keying Configuration Register
    type L1CKCR_Register is record
@@ -415,7 +416,7 @@ package STM32_SVD.LTDC is
       --  Color Key Red value
       CKRED          : L1CKCR_CKRED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -444,7 +445,7 @@ package STM32_SVD.LTDC is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype L1CACR_CONSTA_Field is HAL.Byte;
+   subtype L1CACR_CONSTA_Field is HAL.UInt8;
 
    --  Layerx Constant Alpha Configuration Register
    type L1CACR_Register is record
@@ -461,10 +462,10 @@ package STM32_SVD.LTDC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype L1DCCR_DCBLUE_Field is HAL.Byte;
-   subtype L1DCCR_DCGREEN_Field is HAL.Byte;
-   subtype L1DCCR_DCRED_Field is HAL.Byte;
-   subtype L1DCCR_DCALPHA_Field is HAL.Byte;
+   subtype L1DCCR_DCBLUE_Field is HAL.UInt8;
+   subtype L1DCCR_DCGREEN_Field is HAL.UInt8;
+   subtype L1DCCR_DCRED_Field is HAL.UInt8;
+   subtype L1DCCR_DCALPHA_Field is HAL.UInt8;
 
    --  Layerx Default Color Configuration Register
    type L1DCCR_Register is record
@@ -552,10 +553,10 @@ package STM32_SVD.LTDC is
       Reserved_11_31 at 0 range 11 .. 31;
    end record;
 
-   subtype L1CLUTWR_BLUE_Field is HAL.Byte;
-   subtype L1CLUTWR_GREEN_Field is HAL.Byte;
-   subtype L1CLUTWR_RED_Field is HAL.Byte;
-   subtype L1CLUTWR_CLUTADD_Field is HAL.Byte;
+   subtype L1CLUTWR_BLUE_Field is HAL.UInt8;
+   subtype L1CLUTWR_GREEN_Field is HAL.UInt8;
+   subtype L1CLUTWR_RED_Field is HAL.UInt8;
+   subtype L1CLUTWR_CLUTADD_Field is HAL.UInt8;
 
    --  Layerx CLUT Write Register
    type L1CLUTWR_Register is record
@@ -650,7 +651,7 @@ package STM32_SVD.LTDC is
       Reserved_27_31 at 0 range 27 .. 31;
    end record;
 
-   subtype L2CKCR_CKBLUE_Field is HAL.Byte;
+   subtype L2CKCR_CKBLUE_Field is HAL.UInt8;
    subtype L2CKCR_CKGREEN_Field is HAL.UInt7;
    subtype L2CKCR_CKRED_Field is HAL.UInt9;
 
@@ -663,7 +664,7 @@ package STM32_SVD.LTDC is
       --  Color Key Red value
       CKRED          : L2CKCR_CKRED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -692,7 +693,7 @@ package STM32_SVD.LTDC is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype L2CACR_CONSTA_Field is HAL.Byte;
+   subtype L2CACR_CONSTA_Field is HAL.UInt8;
 
    --  Layerx Constant Alpha Configuration Register
    type L2CACR_Register is record
@@ -709,10 +710,10 @@ package STM32_SVD.LTDC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype L2DCCR_DCBLUE_Field is HAL.Byte;
-   subtype L2DCCR_DCGREEN_Field is HAL.Byte;
-   subtype L2DCCR_DCRED_Field is HAL.Byte;
-   subtype L2DCCR_DCALPHA_Field is HAL.Byte;
+   subtype L2DCCR_DCBLUE_Field is HAL.UInt8;
+   subtype L2DCCR_DCGREEN_Field is HAL.UInt8;
+   subtype L2DCCR_DCRED_Field is HAL.UInt8;
+   subtype L2DCCR_DCALPHA_Field is HAL.UInt8;
 
    --  Layerx Default Color Configuration Register
    type L2DCCR_Register is record
@@ -800,10 +801,10 @@ package STM32_SVD.LTDC is
       Reserved_11_31 at 0 range 11 .. 31;
    end record;
 
-   subtype L2CLUTWR_BLUE_Field is HAL.Byte;
-   subtype L2CLUTWR_GREEN_Field is HAL.Byte;
-   subtype L2CLUTWR_RED_Field is HAL.Byte;
-   subtype L2CLUTWR_CLUTADD_Field is HAL.Byte;
+   subtype L2CLUTWR_BLUE_Field is HAL.UInt8;
+   subtype L2CLUTWR_GREEN_Field is HAL.UInt8;
+   subtype L2CLUTWR_RED_Field is HAL.UInt8;
+   subtype L2CLUTWR_CLUTADD_Field is HAL.UInt8;
 
    --  Layerx CLUT Write Register
    type L2CLUTWR_Register is record
@@ -951,6 +952,6 @@ package STM32_SVD.LTDC is
 
    --  LCD-TFT Controller
    LTDC_Periph : aliased LTDC_Peripheral
-     with Import, Address => LTDC_Base;
+     with Import, Address => System'To_Address (16#40016800#);
 
 end STM32_SVD.LTDC;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-nvic.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-nvic.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -31,7 +32,7 @@ package STM32_SVD.NVIC is
    end record;
 
    --  IPR_IPR_N array element
-   subtype IPR_IPR_N_Element is HAL.Byte;
+   subtype IPR_IPR_N_Element is HAL.UInt8;
 
    --  IPR_IPR_N array
    type IPR_IPR_N_Field_Array is array (0 .. 3) of IPR_IPR_N_Element
@@ -203,6 +204,6 @@ package STM32_SVD.NVIC is
 
    --  Nested Vectored Interrupt Controller
    NVIC_Periph : aliased NVIC_Peripheral
-     with Import, Address => NVIC_Base;
+     with Import, Address => System'To_Address (16#E000E000#);
 
 end STM32_SVD.NVIC;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-pwr.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-pwr.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -24,7 +25,7 @@ package STM32_SVD.PWR is
       --  Power down deepsleep
       PDDS           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Clear standby flag
       CSBF           : Boolean := False;
       --  Power voltage detector enable
@@ -40,7 +41,7 @@ package STM32_SVD.PWR is
       --  Main regulator in deepsleep under-drive mode
       MRUDS          : Boolean := False;
       --  unspecified
-      Reserved_12_12 : HAL.Bit := 16#0#;
+      Reserved_12_12 : HAL.UInt1 := 16#0#;
       --  ADCDC1
       ADCDC1         : Boolean := False;
       --  Regulator voltage scaling output selection
@@ -98,7 +99,7 @@ package STM32_SVD.PWR is
       --  Regulator voltage scaling output selection ready bit
       VOSRDY         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Over-drive mode ready
       ODRDY          : Boolean := False;
       --  Over-drive mode switching ready
@@ -291,6 +292,6 @@ package STM32_SVD.PWR is
 
    --  Power control
    PWR_Periph : aliased PWR_Peripheral
-     with Import, Address => PWR_Base;
+     with Import, Address => System'To_Address (16#40007000#);
 
 end STM32_SVD.PWR;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-pwr.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-pwr.ads
@@ -25,7 +25,7 @@ package STM32_SVD.PWR is
       --  Power down deepsleep
       PDDS           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Clear standby flag
       CSBF           : Boolean := False;
       --  Power voltage detector enable
@@ -41,7 +41,7 @@ package STM32_SVD.PWR is
       --  Main regulator in deepsleep under-drive mode
       MRUDS          : Boolean := False;
       --  unspecified
-      Reserved_12_12 : HAL.UInt1 := 16#0#;
+      Reserved_12_12 : HAL.Bit := 16#0#;
       --  ADCDC1
       ADCDC1         : Boolean := False;
       --  Regulator voltage scaling output selection
@@ -99,7 +99,7 @@ package STM32_SVD.PWR is
       --  Regulator voltage scaling output selection ready bit
       VOSRDY         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Over-drive mode ready
       ODRDY          : Boolean := False;
       --  Over-drive mode switching ready

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-quadspi.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-quadspi.ads
@@ -30,7 +30,7 @@ package STM32_SVD.QUADSPI is
       --  Sample shift
       SSHIFT         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Dual-flash mode
       DFM            : Boolean := False;
       --  FLASH memory selection
@@ -50,7 +50,7 @@ package STM32_SVD.QUADSPI is
       --  TimeOut interrupt enable
       TOIE           : Boolean := False;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Automatic poll mode stop
       APMS           : Boolean := False;
       --  Polling match mode
@@ -158,7 +158,7 @@ package STM32_SVD.QUADSPI is
       --  Clear transfer complete flag
       CTCF          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Clear status match flag
       CSMF          : Boolean := False;
       --  Clear timeout flag
@@ -205,7 +205,7 @@ package STM32_SVD.QUADSPI is
       --  Number of dummy cycles
       DCYC           : CCR_DCYC_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Data mode
       DMODE          : CCR_DMODE_Field := 16#0#;
       --  Functional mode
@@ -213,7 +213,7 @@ package STM32_SVD.QUADSPI is
       --  Send instruction only once mode
       SIOO           : Boolean := False;
       --  unspecified
-      Reserved_29_29 : HAL.UInt1 := 16#0#;
+      Reserved_29_29 : HAL.Bit := 16#0#;
       --  DDR hold half cycle
       DHHC           : Boolean := False;
       --  Double data rate mode

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-quadspi.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-quadspi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -14,7 +15,7 @@ package STM32_SVD.QUADSPI is
    ---------------
 
    subtype CR_FTHRES_Field is HAL.UInt5;
-   subtype CR_PRESCALER_Field is HAL.Byte;
+   subtype CR_PRESCALER_Field is HAL.UInt8;
 
    --  control register
    type CR_Register is record
@@ -29,7 +30,7 @@ package STM32_SVD.QUADSPI is
       --  Sample shift
       SSHIFT         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Dual-flash mode
       DFM            : Boolean := False;
       --  FLASH memory selection
@@ -49,7 +50,7 @@ package STM32_SVD.QUADSPI is
       --  TimeOut interrupt enable
       TOIE           : Boolean := False;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Automatic poll mode stop
       APMS           : Boolean := False;
       --  Polling match mode
@@ -157,7 +158,7 @@ package STM32_SVD.QUADSPI is
       --  Clear transfer complete flag
       CTCF          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Clear status match flag
       CSMF          : Boolean := False;
       --  Clear timeout flag
@@ -177,7 +178,7 @@ package STM32_SVD.QUADSPI is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype CCR_INSTRUCTION_Field is HAL.Byte;
+   subtype CCR_INSTRUCTION_Field is HAL.UInt8;
    subtype CCR_IMODE_Field is HAL.UInt2;
    subtype CCR_ADMODE_Field is HAL.UInt2;
    subtype CCR_ADSIZE_Field is HAL.UInt2;
@@ -204,7 +205,7 @@ package STM32_SVD.QUADSPI is
       --  Number of dummy cycles
       DCYC           : CCR_DCYC_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Data mode
       DMODE          : CCR_DMODE_Field := 16#0#;
       --  Functional mode
@@ -212,7 +213,7 @@ package STM32_SVD.QUADSPI is
       --  Send instruction only once mode
       SIOO           : Boolean := False;
       --  unspecified
-      Reserved_29_29 : HAL.Bit := 16#0#;
+      Reserved_29_29 : HAL.UInt1 := 16#0#;
       --  DDR hold half cycle
       DHHC           : Boolean := False;
       --  Double data rate mode
@@ -325,6 +326,6 @@ package STM32_SVD.QUADSPI is
 
    --  QuadSPI interface
    QUADSPI_Periph : aliased QUADSPI_Peripheral
-     with Import, Address => QUADSPI_Base;
+     with Import, Address => System'To_Address (16#A0001000#);
 
 end STM32_SVD.QUADSPI;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-rcc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-rcc.ads
@@ -24,7 +24,7 @@ package STM32_SVD.RCC is
       --  Read-only. Internal high-speed clock ready flag
       HSIRDY         : Boolean := True;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Internal high-speed clock trimming
       HSITRIM        : CR_HSITRIM_Field := 16#10#;
       --  Read-only. Internal high-speed clock calibration
@@ -90,7 +90,7 @@ package STM32_SVD.RCC is
       --  Main PLL (PLL) multiplication factor for VCO
       PLLN           : PLLCFGR_PLLN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Main PLL (PLL) division factor for main system clock
       PLLP           : PLLCFGR_PLLP_Field := 16#0#;
       --  unspecified
@@ -98,7 +98,7 @@ package STM32_SVD.RCC is
       --  Main PLL(PLL) and audio PLL (PLLI2S) entry clock source
       PLLSRC         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Main PLL (PLL) division factor for USB OTG FS, SDIO and random number
       --  generator clocks
       PLLQ           : PLLCFGR_PLLQ_Field := 16#4#;
@@ -231,7 +231,7 @@ package STM32_SVD.RCC is
       --  PLLSAI Ready Interrupt Enable
       PLLSAIRDYIE    : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Write-only. LSI ready interrupt clear
       LSIRDYC        : Boolean := False;
       --  Write-only. LSE ready interrupt clear
@@ -307,7 +307,7 @@ package STM32_SVD.RCC is
       --  IO port K reset
       GPIOKRST       : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  CRC reset
       CRCRST         : Boolean := False;
       --  unspecified
@@ -319,7 +319,7 @@ package STM32_SVD.RCC is
       --  DMA2D reset
       DMA2DRST       : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  Ethernet MAC reset
       ETHMACRST      : Boolean := False;
       --  unspecified
@@ -428,7 +428,7 @@ package STM32_SVD.RCC is
       --  Low power timer 1 reset
       LPTIM1RST      : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Window watchdog reset
       WWDGRST        : Boolean := False;
       --  unspecified
@@ -534,7 +534,7 @@ package STM32_SVD.RCC is
       --  System configuration controller reset
       SYSCFGRST      : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 reset
       TIM9RST        : Boolean := False;
       --  TIM10 reset
@@ -542,7 +542,7 @@ package STM32_SVD.RCC is
       --  TIM11 reset
       TIM11RST       : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  SPI5 reset
       SPI5RST        : Boolean := False;
       --  SPI6 reset
@@ -613,7 +613,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable
       GPIOKEN        : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  CRC clock enable
       CRCEN          : Boolean := False;
       --  unspecified
@@ -621,7 +621,7 @@ package STM32_SVD.RCC is
       --  Backup SRAM interface clock enable
       BKPSRAMEN      : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  CCM data RAM clock enable
       CCMDATARAMEN   : Boolean := True;
       --  DMA1 clock enable
@@ -631,7 +631,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable
       DMA2DEN        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  Ethernet MAC clock enable
       ETHMACEN       : Boolean := False;
       --  Ethernet Transmission clock enable
@@ -645,7 +645,7 @@ package STM32_SVD.RCC is
       --  USB OTG HSULPI clock enable
       OTGHSULPIEN    : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -752,7 +752,7 @@ package STM32_SVD.RCC is
       --  Low power timer 1 clock enable
       LPTMI1EN       : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Window watchdog clock enable
       WWDGEN         : Boolean := False;
       --  unspecified
@@ -860,7 +860,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable
       SYSCFGEN       : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 clock enable
       TIM9EN         : Boolean := False;
       --  TIM10 clock enable
@@ -868,7 +868,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable
       TIM11EN        : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  SPI5 clock enable
       SPI5ENR        : Boolean := False;
       --  SPI6 clock enable
@@ -940,7 +940,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable during Sleep mode
       GPIOKLPEN      : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  CRC clock enable during Sleep mode
       CRCLPEN        : Boolean := True;
       --  unspecified
@@ -956,7 +956,7 @@ package STM32_SVD.RCC is
       --  SRAM 3 interface clock enable during Sleep mode
       SRAM3LPEN      : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  DMA1 clock enable during Sleep mode
       DMA1LPEN       : Boolean := True;
       --  DMA2 clock enable during Sleep mode
@@ -964,7 +964,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable during Sleep mode
       DMA2DLPEN      : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  Ethernet MAC clock enable during Sleep mode
       ETHMACLPEN     : Boolean := True;
       --  Ethernet transmission clock enable during Sleep mode
@@ -978,7 +978,7 @@ package STM32_SVD.RCC is
       --  USB OTG HS ULPI clock enable during Sleep mode
       OTGHSULPILPEN  : Boolean := True;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1088,7 +1088,7 @@ package STM32_SVD.RCC is
       --  low power timer 1 clock enable during Sleep mode
       LPTIM1LPEN     : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Window watchdog clock enable during Sleep mode
       WWDGLPEN       : Boolean := True;
       --  unspecified
@@ -1196,7 +1196,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable during Sleep mode
       SYSCFGLPEN     : Boolean := True;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 clock enable during sleep mode
       TIM9LPEN       : Boolean := True;
       --  TIM10 clock enable during Sleep mode
@@ -1204,7 +1204,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable during Sleep mode
       TIM11LPEN      : Boolean := True;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  SPI 5 clock enable during Sleep mode
       SPI5LPEN       : Boolean := False;
       --  SPI 6 clock enable during Sleep mode
@@ -1397,7 +1397,7 @@ package STM32_SVD.RCC is
       --  PLLI2S division factor for I2S clocks
       PLLI2SR        : PLLI2SCFGR_PLLI2SR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1423,7 +1423,7 @@ package STM32_SVD.RCC is
       --  PLLSAI division factor for VCO
       PLLSAIN        : PLLSAICFGR_PLLSAIN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  PLLSAI division factor for 48MHz clock
       PLLSAIP        : PLLSAICFGR_PLLSAIP_Field := 16#0#;
       --  unspecified
@@ -1433,7 +1433,7 @@ package STM32_SVD.RCC is
       --  PLLSAI division factor for LCD clock
       PLLSAIR        : PLLSAICFGR_PLLSAIR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-rcc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-rcc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -14,7 +15,7 @@ package STM32_SVD.RCC is
    ---------------
 
    subtype CR_HSITRIM_Field is HAL.UInt5;
-   subtype CR_HSICAL_Field is HAL.Byte;
+   subtype CR_HSICAL_Field is HAL.UInt8;
 
    --  clock control register
    type CR_Register is record
@@ -23,7 +24,7 @@ package STM32_SVD.RCC is
       --  Read-only. Internal high-speed clock ready flag
       HSIRDY         : Boolean := True;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Internal high-speed clock trimming
       HSITRIM        : CR_HSITRIM_Field := 16#10#;
       --  Read-only. Internal high-speed clock calibration
@@ -89,7 +90,7 @@ package STM32_SVD.RCC is
       --  Main PLL (PLL) multiplication factor for VCO
       PLLN           : PLLCFGR_PLLN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Main PLL (PLL) division factor for main system clock
       PLLP           : PLLCFGR_PLLP_Field := 16#0#;
       --  unspecified
@@ -97,7 +98,7 @@ package STM32_SVD.RCC is
       --  Main PLL(PLL) and audio PLL (PLLI2S) entry clock source
       PLLSRC         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Main PLL (PLL) division factor for USB OTG FS, SDIO and random number
       --  generator clocks
       PLLQ           : PLLCFGR_PLLQ_Field := 16#4#;
@@ -230,7 +231,7 @@ package STM32_SVD.RCC is
       --  PLLSAI Ready Interrupt Enable
       PLLSAIRDYIE    : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Write-only. LSI ready interrupt clear
       LSIRDYC        : Boolean := False;
       --  Write-only. LSE ready interrupt clear
@@ -248,7 +249,7 @@ package STM32_SVD.RCC is
       --  Write-only. Clock security system interrupt clear
       CSSC           : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -306,11 +307,11 @@ package STM32_SVD.RCC is
       --  IO port K reset
       GPIOKRST       : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  CRC reset
       CRCRST         : Boolean := False;
       --  unspecified
-      Reserved_13_20 : HAL.Byte := 16#0#;
+      Reserved_13_20 : HAL.UInt8 := 16#0#;
       --  DMA2 reset
       DMA1RST        : Boolean := False;
       --  DMA2 reset
@@ -318,7 +319,7 @@ package STM32_SVD.RCC is
       --  DMA2D reset
       DMA2DRST       : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  Ethernet MAC reset
       ETHMACRST      : Boolean := False;
       --  unspecified
@@ -427,7 +428,7 @@ package STM32_SVD.RCC is
       --  Low power timer 1 reset
       LPTIM1RST      : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Window watchdog reset
       WWDGRST        : Boolean := False;
       --  unspecified
@@ -533,7 +534,7 @@ package STM32_SVD.RCC is
       --  System configuration controller reset
       SYSCFGRST      : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 reset
       TIM9RST        : Boolean := False;
       --  TIM10 reset
@@ -541,7 +542,7 @@ package STM32_SVD.RCC is
       --  TIM11 reset
       TIM11RST       : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  SPI5 reset
       SPI5RST        : Boolean := False;
       --  SPI6 reset
@@ -612,7 +613,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable
       GPIOKEN        : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  CRC clock enable
       CRCEN          : Boolean := False;
       --  unspecified
@@ -620,7 +621,7 @@ package STM32_SVD.RCC is
       --  Backup SRAM interface clock enable
       BKPSRAMEN      : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  CCM data RAM clock enable
       CCMDATARAMEN   : Boolean := True;
       --  DMA1 clock enable
@@ -630,7 +631,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable
       DMA2DEN        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  Ethernet MAC clock enable
       ETHMACEN       : Boolean := False;
       --  Ethernet Transmission clock enable
@@ -644,7 +645,7 @@ package STM32_SVD.RCC is
       --  USB OTG HSULPI clock enable
       OTGHSULPIEN    : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -751,7 +752,7 @@ package STM32_SVD.RCC is
       --  Low power timer 1 clock enable
       LPTMI1EN       : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Window watchdog clock enable
       WWDGEN         : Boolean := False;
       --  unspecified
@@ -859,7 +860,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable
       SYSCFGEN       : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 clock enable
       TIM9EN         : Boolean := False;
       --  TIM10 clock enable
@@ -867,7 +868,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable
       TIM11EN        : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  SPI5 clock enable
       SPI5ENR        : Boolean := False;
       --  SPI6 clock enable
@@ -939,7 +940,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable during Sleep mode
       GPIOKLPEN      : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  CRC clock enable during Sleep mode
       CRCLPEN        : Boolean := True;
       --  unspecified
@@ -955,7 +956,7 @@ package STM32_SVD.RCC is
       --  SRAM 3 interface clock enable during Sleep mode
       SRAM3LPEN      : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  DMA1 clock enable during Sleep mode
       DMA1LPEN       : Boolean := True;
       --  DMA2 clock enable during Sleep mode
@@ -963,7 +964,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable during Sleep mode
       DMA2DLPEN      : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  Ethernet MAC clock enable during Sleep mode
       ETHMACLPEN     : Boolean := True;
       --  Ethernet transmission clock enable during Sleep mode
@@ -977,7 +978,7 @@ package STM32_SVD.RCC is
       --  USB OTG HS ULPI clock enable during Sleep mode
       OTGHSULPILPEN  : Boolean := True;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1087,7 +1088,7 @@ package STM32_SVD.RCC is
       --  low power timer 1 clock enable during Sleep mode
       LPTIM1LPEN     : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Window watchdog clock enable during Sleep mode
       WWDGLPEN       : Boolean := True;
       --  unspecified
@@ -1195,7 +1196,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable during Sleep mode
       SYSCFGLPEN     : Boolean := True;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 clock enable during sleep mode
       TIM9LPEN       : Boolean := True;
       --  TIM10 clock enable during Sleep mode
@@ -1203,7 +1204,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable during Sleep mode
       TIM11LPEN      : Boolean := True;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  SPI 5 clock enable during Sleep mode
       SPI5LPEN       : Boolean := False;
       --  SPI 6 clock enable during Sleep mode
@@ -1396,7 +1397,7 @@ package STM32_SVD.RCC is
       --  PLLI2S division factor for I2S clocks
       PLLI2SR        : PLLI2SCFGR_PLLI2SR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1422,7 +1423,7 @@ package STM32_SVD.RCC is
       --  PLLSAI division factor for VCO
       PLLSAIN        : PLLSAICFGR_PLLSAIN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  PLLSAI division factor for 48MHz clock
       PLLSAIP        : PLLSAICFGR_PLLSAIP_Field := 16#0#;
       --  unspecified
@@ -1432,7 +1433,7 @@ package STM32_SVD.RCC is
       --  PLLSAI division factor for LCD clock
       PLLSAIR        : PLLSAICFGR_PLLSAIR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1659,6 +1660,6 @@ package STM32_SVD.RCC is
 
    --  Reset and clock control
    RCC_Periph : aliased RCC_Peripheral
-     with Import, Address => RCC_Base;
+     with Import, Address => System'To_Address (16#40023800#);
 
 end STM32_SVD.RCC;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-rng.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-rng.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -87,6 +88,6 @@ package STM32_SVD.RNG is
 
    --  Random number generator
    RNG_Periph : aliased RNG_Peripheral
-     with Import, Address => RNG_Base;
+     with Import, Address => System'To_Address (16#50060800#);
 
 end STM32_SVD.RNG;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-rtc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-rtc.ads
@@ -28,13 +28,13 @@ package STM32_SVD.RTC is
       --  Second tens in BCD format
       ST             : TR_ST_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Minute units in BCD format
       MNU            : TR_MNU_Field := 16#0#;
       --  Minute tens in BCD format
       MNT            : TR_MNT_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Hour units in BCD format
       HU             : TR_HU_Field := 16#0#;
       --  Hour tens in BCD format
@@ -119,7 +119,7 @@ package STM32_SVD.RTC is
       --  Hour format
       FMT            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Alarm A enable
       ALRAE          : Boolean := False;
       --  Alarm B enable
@@ -255,7 +255,7 @@ package STM32_SVD.RTC is
       --  Synchronous prescaler factor
       PREDIV_S       : PRER_PREDIV_S_Field := 16#FF#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Asynchronous prescaler factor
       PREDIV_A       : PRER_PREDIV_A_Field := 16#7F#;
       --  unspecified
@@ -476,13 +476,13 @@ package STM32_SVD.RTC is
       --  Read-only. Second tens in BCD format
       ST             : TSTR_ST_Field;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1;
+      Reserved_7_7   : HAL.Bit;
       --  Read-only. Minute units in BCD format
       MNU            : TSTR_MNU_Field;
       --  Read-only. Minute tens in BCD format
       MNT            : TSTR_MNT_Field;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1;
+      Reserved_15_15 : HAL.Bit;
       --  Read-only. Hour units in BCD format
       HU             : TSTR_HU_Field;
       --  Read-only. Hour tens in BCD format

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-rtc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-rtc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -27,13 +28,13 @@ package STM32_SVD.RTC is
       --  Second tens in BCD format
       ST             : TR_ST_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Minute units in BCD format
       MNU            : TR_MNU_Field := 16#0#;
       --  Minute tens in BCD format
       MNT            : TR_MNT_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Hour units in BCD format
       HU             : TR_HU_Field := 16#0#;
       --  Hour tens in BCD format
@@ -85,7 +86,7 @@ package STM32_SVD.RTC is
       --  Year tens in BCD format
       YT             : DR_YT_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -118,7 +119,7 @@ package STM32_SVD.RTC is
       --  Hour format
       FMT            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Alarm A enable
       ALRAE          : Boolean := False;
       --  Alarm B enable
@@ -254,7 +255,7 @@ package STM32_SVD.RTC is
       --  Synchronous prescaler factor
       PREDIV_S       : PRER_PREDIV_S_Field := 16#FF#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Asynchronous prescaler factor
       PREDIV_A       : PRER_PREDIV_A_Field := 16#7F#;
       --  unspecified
@@ -407,7 +408,7 @@ package STM32_SVD.RTC is
       MSK4  at 0 range 31 .. 31;
    end record;
 
-   subtype WPR_KEY_Field is HAL.Byte;
+   subtype WPR_KEY_Field is HAL.UInt8;
 
    --  write protection register
    type WPR_Register is record
@@ -475,13 +476,13 @@ package STM32_SVD.RTC is
       --  Read-only. Second tens in BCD format
       ST             : TSTR_ST_Field;
       --  unspecified
-      Reserved_7_7   : HAL.Bit;
+      Reserved_7_7   : HAL.UInt1;
       --  Read-only. Minute units in BCD format
       MNU            : TSTR_MNU_Field;
       --  Read-only. Minute tens in BCD format
       MNT            : TSTR_MNT_Field;
       --  unspecified
-      Reserved_15_15 : HAL.Bit;
+      Reserved_15_15 : HAL.UInt1;
       --  Read-only. Hour units in BCD format
       HU             : TSTR_HU_Field;
       --  Read-only. Hour tens in BCD format
@@ -921,6 +922,6 @@ package STM32_SVD.RTC is
 
    --  Real-time clock
    RTC_Periph : aliased RTC_Peripheral
-     with Import, Address => RTC_Base;
+     with Import, Address => System'To_Address (16#40002800#);
 
 end STM32_SVD.RTC;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-sai.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-sai.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -50,7 +51,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : ACR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Data size
       DS             : ACR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -70,13 +71,13 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.Bit := 16#0#;
+      Reserved_18_18 : HAL.UInt1 := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
       MCJDIV         : ACR1_MCJDIV_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -140,7 +141,7 @@ package STM32_SVD.SAI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype AFRCR_FRL_Field is HAL.Byte;
+   subtype AFRCR_FRL_Field is HAL.UInt8;
    subtype AFRCR_FSALL_Field is HAL.UInt7;
 
    --  AFRCR
@@ -150,7 +151,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : AFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -183,7 +184,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : ASLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Slot size
       SLOTSZ         : ASLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -288,7 +289,7 @@ package STM32_SVD.SAI is
       --  Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Clear anticipated frame synchronization detection flag.
@@ -325,7 +326,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : BCR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Data size
       DS             : BCR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -345,13 +346,13 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.Bit := 16#0#;
+      Reserved_18_18 : HAL.UInt1 := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
       MCJDIV         : BCR1_MCJDIV_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -415,7 +416,7 @@ package STM32_SVD.SAI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype BFRCR_FRL_Field is HAL.Byte;
+   subtype BFRCR_FRL_Field is HAL.UInt8;
    subtype BFRCR_FSALL_Field is HAL.UInt7;
 
    --  BFRCR
@@ -425,7 +426,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : BFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -458,7 +459,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : BSLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Slot size
       SLOTSZ         : BSLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -563,7 +564,7 @@ package STM32_SVD.SAI is
       --  Write-only. Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Write-only. Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Write-only. Clear anticipated frame synchronization detection flag
@@ -652,10 +653,10 @@ package STM32_SVD.SAI is
 
    --  Serial audio interface
    SAI1_Periph : aliased SAI_Peripheral
-     with Import, Address => SAI1_Base;
+     with Import, Address => System'To_Address (16#40015800#);
 
    --  Serial audio interface
    SAI2_Periph : aliased SAI_Peripheral
-     with Import, Address => SAI2_Base;
+     with Import, Address => System'To_Address (16#40015C00#);
 
 end STM32_SVD.SAI;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-sai.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-sai.ads
@@ -51,7 +51,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : ACR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Data size
       DS             : ACR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -71,7 +71,7 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.UInt1 := 16#0#;
+      Reserved_18_18 : HAL.Bit := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
@@ -151,7 +151,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : AFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -184,7 +184,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : ASLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Slot size
       SLOTSZ         : ASLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -289,7 +289,7 @@ package STM32_SVD.SAI is
       --  Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Clear anticipated frame synchronization detection flag.
@@ -326,7 +326,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : BCR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Data size
       DS             : BCR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -346,7 +346,7 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.UInt1 := 16#0#;
+      Reserved_18_18 : HAL.Bit := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
@@ -426,7 +426,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : BFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -459,7 +459,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : BSLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Slot size
       SLOTSZ         : BSLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -564,7 +564,7 @@ package STM32_SVD.SAI is
       --  Write-only. Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Write-only. Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Write-only. Clear anticipated frame synchronization detection flag

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-sdmmc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-sdmmc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -40,7 +41,7 @@ package STM32_SVD.SDMMC is
       Reserved_2_31 at 0 range 2 .. 31;
    end record;
 
-   subtype CLKCR_CLKDIV_Field is HAL.Byte;
+   subtype CLKCR_CLKDIV_Field is HAL.UInt8;
 
    --  Wide bus mode enable bit
    type CLKCR_WIDBUS_Field is
@@ -371,7 +372,7 @@ package STM32_SVD.SDMMC is
       --  Read-only. CE-ATA command completion signal received for CMD61
       CEATAEND       : Boolean;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -435,7 +436,7 @@ package STM32_SVD.SDMMC is
       --  CEATAEND flag clear bit
       CEATAENDC      : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -509,7 +510,7 @@ package STM32_SVD.SDMMC is
       --  CE-ATA command completion signal received interrupt enable
       CEATAENDIE     : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -550,7 +551,7 @@ package STM32_SVD.SDMMC is
       --  the FIFO
       FIFOCOUNT      : FIFOCNT_FIFOCOUNT_Field;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -628,6 +629,6 @@ package STM32_SVD.SDMMC is
 
    --  Secure digital input/output interface
    SDMMC_Periph : aliased SDMMC_Peripheral
-     with Import, Address => SDMMC_Base;
+     with Import, Address => System'To_Address (16#40012C00#);
 
 end STM32_SVD.SDMMC;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-spdif_rx.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-spdif_rx.ads
@@ -46,7 +46,7 @@ package STM32_SVD.SPDIF_RX is
       --  Wait For Activity
       WFA            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  input selection
       INSEL          : CR_INSEL_Field := 16#0#;
       --  unspecified
@@ -133,7 +133,7 @@ package STM32_SVD.SPDIF_RX is
       --  Read-only. Duration of 5 symbols counted with SPDIF_CLK
       WIDTH5         : SR_WIDTH5_Field;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1;
+      Reserved_31_31 : HAL.Bit;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-spdif_rx.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-spdif_rx.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -45,7 +46,7 @@ package STM32_SVD.SPDIF_RX is
       --  Wait For Activity
       WFA            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  input selection
       INSEL          : CR_INSEL_Field := 16#0#;
       --  unspecified
@@ -132,7 +133,7 @@ package STM32_SVD.SPDIF_RX is
       --  Read-only. Duration of 5 symbols counted with SPDIF_CLK
       WIDTH5         : SR_WIDTH5_Field;
       --  unspecified
-      Reserved_31_31 : HAL.Bit;
+      Reserved_31_31 : HAL.UInt1;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -213,7 +214,7 @@ package STM32_SVD.SPDIF_RX is
    end record;
 
    subtype CSR_USR_Field is HAL.UInt16;
-   subtype CSR_CS_Field is HAL.Byte;
+   subtype CSR_CS_Field is HAL.UInt8;
 
    --  Channel Status register
    type CSR_Register is record
@@ -295,6 +296,6 @@ package STM32_SVD.SPDIF_RX is
 
    --  Receiver Interface
    SPDIF_RX_Periph : aliased SPDIF_RX_Peripheral
-     with Import, Address => SPDIF_RX_Base;
+     with Import, Address => System'To_Address (16#40004000#);
 
 end STM32_SVD.SPDIF_RX;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-spi.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-spi.ads
@@ -352,7 +352,7 @@ package STM32_SVD.SPI is
       --  I2S standard selection
       I2SSTD         : I2SCFGR_I2SSTD_Field := 16#0#;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  PCM frame synchronization
       PCMSYNC        : Boolean := False;
       --  I2S configuration mode

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-spi.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-spi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -351,7 +352,7 @@ package STM32_SVD.SPI is
       --  I2S standard selection
       I2SSTD         : I2SCFGR_I2SSTD_Field := 16#0#;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  PCM frame synchronization
       PCMSYNC        : Boolean := False;
       --  I2S configuration mode
@@ -382,7 +383,7 @@ package STM32_SVD.SPI is
       Reserved_13_31 at 0 range 13 .. 31;
    end record;
 
-   subtype I2SPR_I2SDIV_Field is HAL.Byte;
+   subtype I2SPR_I2SDIV_Field is HAL.UInt8;
 
    --  I2S prescaler register
    type I2SPR_Register is record
@@ -446,26 +447,26 @@ package STM32_SVD.SPI is
 
    --  Serial peripheral interface
    SPI1_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI1_Base;
+     with Import, Address => System'To_Address (16#40013000#);
 
    --  Serial peripheral interface
    SPI2_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI2_Base;
+     with Import, Address => System'To_Address (16#40003800#);
 
    --  Serial peripheral interface
    SPI3_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI3_Base;
+     with Import, Address => System'To_Address (16#40003C00#);
 
    --  Serial peripheral interface
    SPI4_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI4_Base;
+     with Import, Address => System'To_Address (16#40013400#);
 
    --  Serial peripheral interface
    SPI5_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI5_Base;
+     with Import, Address => System'To_Address (16#40015000#);
 
    --  Serial peripheral interface
    SPI6_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI6_Base;
+     with Import, Address => System'To_Address (16#40015400#);
 
 end STM32_SVD.SPI;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-syscfg.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-syscfg.ads
@@ -26,7 +26,7 @@ package STM32_SVD.SYSCFG is
       --  Flash bank mode selection
       FB_MODE        : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  FMC memory mapping swap
       SWP_FMC        : MEMRM_SWP_FMC_Field := 16#0#;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-syscfg.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-syscfg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -25,7 +26,7 @@ package STM32_SVD.SYSCFG is
       --  Flash bank mode selection
       FB_MODE        : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  FMC memory mapping swap
       SWP_FMC        : MEMRM_SWP_FMC_Field := 16#0#;
       --  unspecified
@@ -58,7 +59,7 @@ package STM32_SVD.SYSCFG is
       --  Ethernet PHY interface selection
       MII_RMII_SEL   : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -301,6 +302,6 @@ package STM32_SVD.SYSCFG is
 
    --  System configuration controller
    SYSCFG_Periph : aliased SYSCFG_Peripheral
-     with Import, Address => SYSCFG_Base;
+     with Import, Address => System'To_Address (16#40013800#);
 
 end STM32_SVD.SYSCFG;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-tim.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-tim.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -59,7 +60,7 @@ package STM32_SVD.TIM is
       --  Capture/compare preloaded control
       CCPC           : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Capture/compare control update selection
       CCUS           : Boolean := False;
       --  Capture/compare DMA selection
@@ -115,7 +116,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection - bit[2:0]
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -225,7 +226,7 @@ package STM32_SVD.TIM is
       --  Break interrupt flag
       BIF            : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 overcapture flag
       CC1OF          : Boolean := False;
       --  Capture/compare 2 overcapture flag
@@ -566,7 +567,7 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype RCR_REP_Field is HAL.Byte;
+   subtype RCR_REP_Field is HAL.UInt8;
 
    --  repetition counter register
    type RCR_Register is record
@@ -651,7 +652,7 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype BDTR_DTG_Field is HAL.Byte;
+   subtype BDTR_DTG_Field is HAL.UInt8;
    subtype BDTR_LOCK_Field is HAL.UInt2;
 
    --  break and dead-time register
@@ -883,11 +884,11 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt enable
       CC4IE          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Trigger interrupt enable
       TIE            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Update DMA request enable
       UDE            : Boolean := False;
       --  Capture/Compare 1 DMA request enable
@@ -899,7 +900,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 DMA request enable
       CC4DE          : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  Trigger DMA request enable
       TDE            : Boolean := False;
       --  unspecified
@@ -940,7 +941,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt flag
       CC4IF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Trigger interrupt flag
       TIF            : Boolean := False;
       --  unspecified
@@ -988,7 +989,7 @@ package STM32_SVD.TIM is
       --  Write-only. Capture/compare 4 generation
       CC4G          : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  Write-only. Trigger generation
       TG            : Boolean := False;
       --  unspecified
@@ -1057,7 +1058,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP          : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1065,7 +1066,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P           : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP          : Boolean := False;
       --  Capture/Compare 3 output enable
@@ -1073,7 +1074,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC3P           : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Capture/Compare 3 output Polarity
       CC3NP          : Boolean := False;
       --  Capture/Compare 4 output enable
@@ -1081,7 +1082,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC4P           : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
@@ -1415,13 +1416,13 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
       MSM            : Boolean := False;
       --  unspecified
-      Reserved_8_15  : HAL.Byte := 16#0#;
+      Reserved_8_15  : HAL.UInt8 := 16#0#;
       --  Slave mode selection
       SMS_3          : Boolean := False;
       --  unspecified
@@ -1541,7 +1542,7 @@ package STM32_SVD.TIM is
       --  Output Compare 1 mode
       OC1M           : CCMR1_Output_OC1M_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Output_CC2S_Field := 16#0#;
       --  Output Compare 2 fast enable
@@ -1581,7 +1582,7 @@ package STM32_SVD.TIM is
       --  Input capture 1 filter
       IC1F           : CCMR1_Input_IC1F_Field_1 := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Input_CC2S_Field := 16#0#;
       --  Input capture 2 prescaler
@@ -1612,7 +1613,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1620,7 +1621,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P          : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP         : Boolean := False;
       --  unspecified
@@ -1783,7 +1784,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  unspecified
@@ -1900,11 +1901,11 @@ package STM32_SVD.TIM is
 
    --  Advanced-timers
    TIM1_Periph : aliased TIM1_Peripheral
-     with Import, Address => TIM1_Base;
+     with Import, Address => System'To_Address (16#40010000#);
 
    --  Advanced-timers
    TIM8_Periph : aliased TIM1_Peripheral
-     with Import, Address => TIM8_Base;
+     with Import, Address => System'To_Address (16#40010400#);
 
    type TIM2_Disc is
      (
@@ -1993,7 +1994,7 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM2_Periph : aliased TIM2_Peripheral
-     with Import, Address => TIM2_Base;
+     with Import, Address => System'To_Address (16#40000000#);
 
    type TIM3_Disc is
      (
@@ -2082,7 +2083,7 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM3_Periph : aliased TIM3_Peripheral
-     with Import, Address => TIM3_Base;
+     with Import, Address => System'To_Address (16#40000400#);
 
    type TIM4_Disc is
      (
@@ -2165,11 +2166,11 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM4_Periph : aliased TIM4_Peripheral
-     with Import, Address => TIM4_Base;
+     with Import, Address => System'To_Address (16#40000800#);
 
    --  General purpose timers
    TIM5_Periph : aliased TIM4_Peripheral
-     with Import, Address => TIM5_Base;
+     with Import, Address => System'To_Address (16#40000C00#);
 
    --  Basic timers
    type TIM6_Peripheral is record
@@ -2205,11 +2206,11 @@ package STM32_SVD.TIM is
 
    --  Basic timers
    TIM6_Periph : aliased TIM6_Peripheral
-     with Import, Address => TIM6_Base;
+     with Import, Address => System'To_Address (16#40001000#);
 
    --  Basic timers
    TIM7_Periph : aliased TIM6_Peripheral
-     with Import, Address => TIM7_Base;
+     with Import, Address => System'To_Address (16#40001400#);
 
    type TIM9_Disc is
      (
@@ -2271,11 +2272,11 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM9_Periph : aliased TIM9_Peripheral
-     with Import, Address => TIM9_Base;
+     with Import, Address => System'To_Address (16#40014000#);
 
    --  General purpose timers
    TIM12_Periph : aliased TIM9_Peripheral
-     with Import, Address => TIM12_Base;
+     with Import, Address => System'To_Address (16#40001800#);
 
    type TIM10_Disc is
      (
@@ -2337,18 +2338,18 @@ package STM32_SVD.TIM is
 
    --  General-purpose-timers
    TIM10_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM10_Base;
+     with Import, Address => System'To_Address (16#40014400#);
 
    --  General-purpose-timers
    TIM11_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM11_Base;
+     with Import, Address => System'To_Address (16#40014800#);
 
    --  General-purpose-timers
    TIM13_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM13_Base;
+     with Import, Address => System'To_Address (16#40001C00#);
 
    --  General-purpose-timers
    TIM14_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM14_Base;
+     with Import, Address => System'To_Address (16#40002000#);
 
 end STM32_SVD.TIM;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-tim.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-tim.ads
@@ -60,7 +60,7 @@ package STM32_SVD.TIM is
       --  Capture/compare preloaded control
       CCPC           : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Capture/compare control update selection
       CCUS           : Boolean := False;
       --  Capture/compare DMA selection
@@ -116,7 +116,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection - bit[2:0]
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -226,7 +226,7 @@ package STM32_SVD.TIM is
       --  Break interrupt flag
       BIF            : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  Capture/Compare 1 overcapture flag
       CC1OF          : Boolean := False;
       --  Capture/compare 2 overcapture flag
@@ -884,11 +884,11 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt enable
       CC4IE          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Trigger interrupt enable
       TIE            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Update DMA request enable
       UDE            : Boolean := False;
       --  Capture/Compare 1 DMA request enable
@@ -900,7 +900,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 DMA request enable
       CC4DE          : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  Trigger DMA request enable
       TDE            : Boolean := False;
       --  unspecified
@@ -941,7 +941,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt flag
       CC4IF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Trigger interrupt flag
       TIF            : Boolean := False;
       --  unspecified
@@ -989,7 +989,7 @@ package STM32_SVD.TIM is
       --  Write-only. Capture/compare 4 generation
       CC4G          : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  Write-only. Trigger generation
       TG            : Boolean := False;
       --  unspecified
@@ -1058,7 +1058,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP          : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1066,7 +1066,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P           : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP          : Boolean := False;
       --  Capture/Compare 3 output enable
@@ -1074,7 +1074,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC3P           : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Capture/Compare 3 output Polarity
       CC3NP          : Boolean := False;
       --  Capture/Compare 4 output enable
@@ -1082,7 +1082,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC4P           : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
@@ -1416,7 +1416,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -1542,7 +1542,7 @@ package STM32_SVD.TIM is
       --  Output Compare 1 mode
       OC1M           : CCMR1_Output_OC1M_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Output_CC2S_Field := 16#0#;
       --  Output Compare 2 fast enable
@@ -1582,7 +1582,7 @@ package STM32_SVD.TIM is
       --  Input capture 1 filter
       IC1F           : CCMR1_Input_IC1F_Field_1 := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Input_CC2S_Field := 16#0#;
       --  Input capture 2 prescaler
@@ -1613,7 +1613,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1621,7 +1621,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P          : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP         : Boolean := False;
       --  unspecified
@@ -1784,7 +1784,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-usart.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-usart.ads
@@ -177,7 +177,7 @@ package STM32_SVD.USART is
       --  LIN break detection interrupt enable
       LBDIE        : Boolean := False;
       --  unspecified
-      Reserved_7_7 : HAL.UInt1 := 16#0#;
+      Reserved_7_7 : HAL.Bit := 16#0#;
       --  Last bit clock pulse
       LBCL         : Boolean := False;
       --  Clock phase
@@ -276,7 +276,7 @@ package STM32_SVD.USART is
       --  Driver enable polarity selection
       DEP            : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Smartcard auto-retry count
       SCARCNT        : CR3_SCARCNT_Field := 16#0#;
       --  Wakeup from Stop mode interrupt flag selection
@@ -429,7 +429,7 @@ package STM32_SVD.USART is
       --  Read-only. EOBF
       EOBF           : Boolean;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1;
+      Reserved_13_13 : HAL.Bit;
       --  Read-only. ABRE
       ABRE           : Boolean;
       --  Read-only. ABRF
@@ -494,17 +494,17 @@ package STM32_SVD.USART is
       --  Write-only. Idle line detected clear flag
       IDLECF         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Write-only. Transmission complete clear flag
       TCCF           : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Write-only. LIN break detection clear flag
       LBDCF          : Boolean := False;
       --  Write-only. CTS clear flag
       CTSCF          : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Write-only. Receiver timeout clear flag
       RTOCF          : Boolean := False;
       --  Write-only. End of block clear flag

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-usart.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-usart.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -176,7 +177,7 @@ package STM32_SVD.USART is
       --  LIN break detection interrupt enable
       LBDIE        : Boolean := False;
       --  unspecified
-      Reserved_7_7 : HAL.Bit := 16#0#;
+      Reserved_7_7 : HAL.UInt1 := 16#0#;
       --  Last bit clock pulse
       LBCL         : Boolean := False;
       --  Clock phase
@@ -275,7 +276,7 @@ package STM32_SVD.USART is
       --  Driver enable polarity selection
       DEP            : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Smartcard auto-retry count
       SCARCNT        : CR3_SCARCNT_Field := 16#0#;
       --  Wakeup from Stop mode interrupt flag selection
@@ -333,8 +334,8 @@ package STM32_SVD.USART is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype GTPR_PSC_Field is HAL.Byte;
-   subtype GTPR_GT_Field is HAL.Byte;
+   subtype GTPR_PSC_Field is HAL.UInt8;
+   subtype GTPR_GT_Field is HAL.UInt8;
 
    --  Guard time and prescaler register
    type GTPR_Register is record
@@ -355,7 +356,7 @@ package STM32_SVD.USART is
    end record;
 
    subtype RTOR_RTO_Field is HAL.UInt24;
-   subtype RTOR_BLEN_Field is HAL.Byte;
+   subtype RTOR_BLEN_Field is HAL.UInt8;
 
    --  Receiver timeout register
    type RTOR_Register is record
@@ -428,7 +429,7 @@ package STM32_SVD.USART is
       --  Read-only. EOBF
       EOBF           : Boolean;
       --  unspecified
-      Reserved_13_13 : HAL.Bit;
+      Reserved_13_13 : HAL.UInt1;
       --  Read-only. ABRE
       ABRE           : Boolean;
       --  Read-only. ABRF
@@ -493,17 +494,17 @@ package STM32_SVD.USART is
       --  Write-only. Idle line detected clear flag
       IDLECF         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Write-only. Transmission complete clear flag
       TCCF           : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Write-only. LIN break detection clear flag
       LBDCF          : Boolean := False;
       --  Write-only. CTS clear flag
       CTSCF          : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Write-only. Receiver timeout clear flag
       RTOCF          : Boolean := False;
       --  Write-only. End of block clear flag
@@ -624,34 +625,34 @@ package STM32_SVD.USART is
 
    --  Universal synchronous asynchronous receiver transmitter
    UART4_Periph : aliased USART_Peripheral
-     with Import, Address => UART4_Base;
+     with Import, Address => System'To_Address (16#40004C00#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART5_Periph : aliased USART_Peripheral
-     with Import, Address => UART5_Base;
+     with Import, Address => System'To_Address (16#40005000#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART7_Periph : aliased USART_Peripheral
-     with Import, Address => UART7_Base;
+     with Import, Address => System'To_Address (16#40007800#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART8_Periph : aliased USART_Peripheral
-     with Import, Address => UART8_Base;
+     with Import, Address => System'To_Address (16#40007C00#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART1_Periph : aliased USART_Peripheral
-     with Import, Address => USART1_Base;
+     with Import, Address => System'To_Address (16#40011000#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART2_Periph : aliased USART_Peripheral
-     with Import, Address => USART2_Base;
+     with Import, Address => System'To_Address (16#40004400#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART3_Periph : aliased USART_Peripheral
-     with Import, Address => USART3_Base;
+     with Import, Address => System'To_Address (16#40004800#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART6_Periph : aliased USART_Peripheral
-     with Import, Address => USART6_Base;
+     with Import, Address => System'To_Address (16#40011400#);
 
 end STM32_SVD.USART;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-usb_otg_fs.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-usb_otg_fs.ads
@@ -25,7 +25,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Non-zero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Device address
       DAD            : OTG_FS_DCFG_DAD_Field := 16#0#;
       --  Periodic frame interval
@@ -127,7 +127,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Timeout condition mask (Non-isochronous endpoints)
       TOM           : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -161,7 +161,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  SETUP phase done mask
       STUPM         : Boolean := False;
       --  OUT token received when endpoint disabled mask
@@ -281,13 +281,13 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
       EPTYP          : OTG_FS_DIEPCTL0_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  STALL handshake
       STALL          : Boolean := False;
       --  TxFIFO number
@@ -330,13 +330,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  TOC
       TOC           : Boolean := False;
       --  ITTXFE
       ITTXFE        : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  INEPNE
       INEPNE        : Boolean := False;
       --  Read-only. TXFE
@@ -419,7 +419,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : OTG_FS_DIEPCTL1_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -471,7 +471,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Multi count
       MCNT           : OTG_FS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -502,7 +502,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : OTG_FS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -553,7 +553,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USBAEP
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAKSTS
       NAKSTS         : Boolean := False;
       --  Read-only. EPTYP
@@ -602,13 +602,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  STUP
       STUP          : Boolean := False;
       --  OTEPDIS
       OTEPDIS       : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  B2BSTUP
       B2BSTUP       : Boolean := False;
       --  unspecified
@@ -644,7 +644,7 @@ package STM32_SVD.USB_OTG_FS is
       --  SETUP packet count
       STUPCNT        : OTG_FS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -728,7 +728,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_FS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -887,7 +887,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Write-only. Full Speed serial transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -901,7 +901,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Force device mode
       FDMOD          : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -931,7 +931,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1002,7 +1002,7 @@ package STM32_SVD.USB_OTG_FS is
       --  transfer(Device mode)
       IPXFR_INCOMPISOOUT : Boolean := False;
       --  unspecified
-      Reserved_22_22     : HAL.UInt1 := 16#0#;
+      Reserved_22_22     : HAL.Bit := 16#0#;
       --  Reset detected interrupt
       RSTDET             : Boolean := False;
       --  Read-only. Host port interrupt
@@ -1012,7 +1012,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE              : Boolean := True;
       --  unspecified
-      Reserved_27_27     : HAL.UInt1 := 16#0#;
+      Reserved_27_27     : HAL.Bit := 16#0#;
       --  Connector ID status change
       CIDSCHG            : Boolean := False;
       --  Disconnect detected interrupt
@@ -1061,7 +1061,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS interrupt mask register (OTG_FS_GINTMSK)
    type OTG_FS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0     : HAL.UInt1 := 16#0#;
+      Reserved_0_0     : HAL.Bit := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM            : Boolean := False;
       --  OTG interrupt mask
@@ -1102,7 +1102,7 @@ package STM32_SVD.USB_OTG_FS is
       --  OUT transfer mask(Device mode)
       IPXFRM_IISOOXFRM : Boolean := False;
       --  unspecified
-      Reserved_22_22   : HAL.UInt1 := 16#0#;
+      Reserved_22_22   : HAL.Bit := 16#0#;
       --  Reset detected interrupt mask
       RSTDETM          : Boolean := False;
       --  Read-only. Host port interrupt mask
@@ -1349,7 +1349,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Top of the non-periodic transmit request queue
       NPTXQTOP       : OTG_FS_HNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1;
+      Reserved_31_31 : HAL.Bit;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1379,13 +1379,13 @@ package STM32_SVD.USB_OTG_FS is
       --  I2C ACK
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_25_25 : HAL.UInt1 := 16#1#;
+      Reserved_25_25 : HAL.Bit := 16#1#;
       --  I2C Device Address
       I2CDEVADR      : OTG_FS_GI2CCTL_I2CDEVADR_Field := 16#0#;
       --  I2C DatSe0 USB mode
       I2CDATSE0      : Boolean := False;
       --  unspecified
-      Reserved_29_29 : HAL.UInt1 := 16#0#;
+      Reserved_29_29 : HAL.Bit := 16#0#;
       --  Read/Write Indicator
       RW             : Boolean := False;
       --  I2C Busy/Done
@@ -1774,7 +1774,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_FS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1822,7 +1822,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1862,7 +1862,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted
       CHH            : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  STALL response received interrupt
       STALL          : Boolean := False;
       --  NAK response received interrupt
@@ -1870,7 +1870,7 @@ package STM32_SVD.USB_OTG_FS is
       --  ACK response received/transmitted interrupt
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  Transaction error
       TXERR          : Boolean := False;
       --  Babble error
@@ -1907,7 +1907,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted mask
       CHHM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  STALL response received interrupt mask
       STALLM         : Boolean := False;
       --  NAK response received interrupt mask
@@ -1958,7 +1958,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Data PID
       DPID           : OTG_FS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-usb_otg_fs.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-usb_otg_fs.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -24,7 +25,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Non-zero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Device address
       DAD            : OTG_FS_DCFG_DAD_Field := 16#0#;
       --  Periodic frame interval
@@ -126,7 +127,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (Non-isochronous endpoints)
       TOM           : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -160,7 +161,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  SETUP phase done mask
       STUPM         : Boolean := False;
       --  OUT token received when endpoint disabled mask
@@ -280,13 +281,13 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
       EPTYP          : OTG_FS_DIEPCTL0_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  STALL handshake
       STALL          : Boolean := False;
       --  TxFIFO number
@@ -329,13 +330,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  TOC
       TOC           : Boolean := False;
       --  ITTXFE
       ITTXFE        : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  INEPNE
       INEPNE        : Boolean := False;
       --  Read-only. TXFE
@@ -418,7 +419,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : OTG_FS_DIEPCTL1_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -470,7 +471,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Multi count
       MCNT           : OTG_FS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -501,7 +502,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : OTG_FS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -552,7 +553,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USBAEP
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAKSTS
       NAKSTS         : Boolean := False;
       --  Read-only. EPTYP
@@ -601,13 +602,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  STUP
       STUP          : Boolean := False;
       --  OTEPDIS
       OTEPDIS       : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  B2BSTUP
       B2BSTUP       : Boolean := False;
       --  unspecified
@@ -643,7 +644,7 @@ package STM32_SVD.USB_OTG_FS is
       --  SETUP packet count
       STUPCNT        : OTG_FS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -727,7 +728,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_FS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -886,7 +887,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Write-only. Full Speed serial transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -900,7 +901,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Force device mode
       FDMOD          : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -930,7 +931,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1001,7 +1002,7 @@ package STM32_SVD.USB_OTG_FS is
       --  transfer(Device mode)
       IPXFR_INCOMPISOOUT : Boolean := False;
       --  unspecified
-      Reserved_22_22     : HAL.Bit := 16#0#;
+      Reserved_22_22     : HAL.UInt1 := 16#0#;
       --  Reset detected interrupt
       RSTDET             : Boolean := False;
       --  Read-only. Host port interrupt
@@ -1011,7 +1012,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE              : Boolean := True;
       --  unspecified
-      Reserved_27_27     : HAL.Bit := 16#0#;
+      Reserved_27_27     : HAL.UInt1 := 16#0#;
       --  Connector ID status change
       CIDSCHG            : Boolean := False;
       --  Disconnect detected interrupt
@@ -1060,7 +1061,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS interrupt mask register (OTG_FS_GINTMSK)
    type OTG_FS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0     : HAL.Bit := 16#0#;
+      Reserved_0_0     : HAL.UInt1 := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM            : Boolean := False;
       --  OTG interrupt mask
@@ -1101,7 +1102,7 @@ package STM32_SVD.USB_OTG_FS is
       --  OUT transfer mask(Device mode)
       IPXFRM_IISOOXFRM : Boolean := False;
       --  unspecified
-      Reserved_22_22   : HAL.Bit := 16#0#;
+      Reserved_22_22   : HAL.UInt1 := 16#0#;
       --  Reset detected interrupt mask
       RSTDETM          : Boolean := False;
       --  Read-only. Host port interrupt mask
@@ -1335,7 +1336,7 @@ package STM32_SVD.USB_OTG_FS is
    end record;
 
    subtype OTG_FS_HNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
-   subtype OTG_FS_HNPTXSTS_NPTQXSAV_Field is HAL.Byte;
+   subtype OTG_FS_HNPTXSTS_NPTQXSAV_Field is HAL.UInt8;
    subtype OTG_FS_HNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
    --  OTG_FS non-periodic transmit FIFO/queue status register
@@ -1348,7 +1349,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Top of the non-periodic transmit request queue
       NPTXQTOP       : OTG_FS_HNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.Bit;
+      Reserved_31_31 : HAL.UInt1;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1360,8 +1361,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_31_31 at 0 range 31 .. 31;
    end record;
 
-   subtype OTG_FS_GI2CCTL_RWDATA_Field is HAL.Byte;
-   subtype OTG_FS_GI2CCTL_REGADDR_Field is HAL.Byte;
+   subtype OTG_FS_GI2CCTL_RWDATA_Field is HAL.UInt8;
+   subtype OTG_FS_GI2CCTL_REGADDR_Field is HAL.UInt8;
    subtype OTG_FS_GI2CCTL_ADDR_Field is HAL.UInt7;
    subtype OTG_FS_GI2CCTL_I2CDEVADR_Field is HAL.UInt2;
 
@@ -1378,13 +1379,13 @@ package STM32_SVD.USB_OTG_FS is
       --  I2C ACK
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_25_25 : HAL.Bit := 16#1#;
+      Reserved_25_25 : HAL.UInt1 := 16#1#;
       --  I2C Device Address
       I2CDEVADR      : OTG_FS_GI2CCTL_I2CDEVADR_Field := 16#0#;
       --  I2C DatSe0 USB mode
       I2CDATSE0      : Boolean := False;
       --  unspecified
-      Reserved_29_29 : HAL.Bit := 16#0#;
+      Reserved_29_29 : HAL.UInt1 := 16#0#;
       --  Read/Write Indicator
       RW             : Boolean := False;
       --  I2C Busy/Done
@@ -1525,7 +1526,7 @@ package STM32_SVD.USB_OTG_FS is
       --  ADP interrupt flag
       ADPIF          : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#2#;
+      Reserved_24_31 : HAL.UInt8 := 16#2#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1692,8 +1693,8 @@ package STM32_SVD.USB_OTG_FS is
    end record;
 
    subtype OTG_FS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
-   subtype OTG_FS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
-   subtype OTG_FS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
+   subtype OTG_FS_HPTXSTS_PTXQSAV_Field is HAL.UInt8;
+   subtype OTG_FS_HPTXSTS_PTXQTOP_Field is HAL.UInt8;
 
    --  OTG_FS_Host periodic transmit FIFO/queue status register
    --  (OTG_FS_HPTXSTS)
@@ -1773,7 +1774,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_FS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1821,7 +1822,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1861,7 +1862,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted
       CHH            : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  STALL response received interrupt
       STALL          : Boolean := False;
       --  NAK response received interrupt
@@ -1869,7 +1870,7 @@ package STM32_SVD.USB_OTG_FS is
       --  ACK response received/transmitted interrupt
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  Transaction error
       TXERR          : Boolean := False;
       --  Babble error
@@ -1906,7 +1907,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted mask
       CHHM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  STALL response received interrupt mask
       STALLM         : Boolean := False;
       --  NAK response received interrupt mask
@@ -1957,7 +1958,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Data PID
       DPID           : OTG_FS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2166,7 +2167,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_DEVICE_Periph : aliased OTG_FS_DEVICE_Peripheral
-     with Import, Address => OTG_FS_DEVICE_Base;
+     with Import, Address => System'To_Address (16#50000800#);
 
    type OTG_FS_GLOBAL_Disc is
      (
@@ -2280,7 +2281,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_GLOBAL_Periph : aliased OTG_FS_GLOBAL_Peripheral
-     with Import, Address => OTG_FS_GLOBAL_Base;
+     with Import, Address => System'To_Address (16#50000000#);
 
    --  USB on the go full speed
    type OTG_FS_HOST_Peripheral is record
@@ -2458,7 +2459,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_HOST_Periph : aliased OTG_FS_HOST_Peripheral
-     with Import, Address => OTG_FS_HOST_Base;
+     with Import, Address => System'To_Address (16#50000400#);
 
    --  USB on the go full speed
    type OTG_FS_PWRCLK_Peripheral is record
@@ -2473,6 +2474,6 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_PWRCLK_Periph : aliased OTG_FS_PWRCLK_Peripheral
-     with Import, Address => OTG_FS_PWRCLK_Base;
+     with Import, Address => System'To_Address (16#50000E00#);
 
 end STM32_SVD.USB_OTG_FS;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-usb_otg_hs.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-usb_otg_hs.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -25,7 +26,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Nonzero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Device address
       DAD            : OTG_HS_DCFG_DAD_Field := 16#0#;
       --  Periodic (micro)frame interval
@@ -132,7 +133,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -142,7 +143,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -174,17 +175,17 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SETUP phase done mask
       STUPM          : Boolean := False;
       --  OUT token received when endpoint disabled mask
       OTEPDM         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Back-to-back SETUP packets received mask
       B2BSTUP        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  OUT packet error mask
       OPEM           : Boolean := False;
       --  BNA interrupt mask
@@ -297,7 +298,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Receive threshold length
       RXTHRLEN       : OTG_HS_DTHRCTL_RXTHRLEN_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.Bit := 16#0#;
+      Reserved_26_26 : HAL.UInt1 := 16#0#;
       --  Arbiter parking enable
       ARPEN          : Boolean := False;
       --  unspecified
@@ -338,7 +339,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register
    type OTG_HS_DEACHINT_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  IN endpoint 1interrupt bit
       IEP1INT        : Boolean := False;
       --  unspecified
@@ -362,7 +363,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register mask
    type OTG_HS_DEACHINTMSK_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  IN Endpoint 1 interrupt mask bit
       IEP1INTM       : Boolean := False;
       --  unspecified
@@ -402,7 +403,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint type
       EPTYP          : OTG_HS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  STALL handshake
       Stall          : Boolean := False;
       --  TxFIFO number
@@ -448,13 +449,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition
       TOC            : Boolean := False;
       --  IN token received when TxFIFO is empty
       ITTXFE         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  IN endpoint NAK effective
       INEPNE         : Boolean := False;
       --  Read-only. Transmit FIFO empty
@@ -464,7 +465,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Buffer not available interrupt
       BNA            : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Packet dropped status
       PKTDRPSTS      : Boolean := False;
       --  Babble error interrupt
@@ -549,7 +550,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Multi count
       MCNT           : OTG_HS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -573,7 +574,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
@@ -622,13 +623,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SETUP phase done
       STUP           : Boolean := False;
       --  OUT token received when endpoint disabled
       OTEPDIS        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Back-to-back SETUP packets received
       B2BSTUP        : Boolean := False;
       --  unspecified
@@ -670,7 +671,7 @@ package STM32_SVD.USB_OTG_HS is
       --  SETUP packet count
       STUPCNT        : OTG_HS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -754,7 +755,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_HS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -870,7 +871,7 @@ package STM32_SVD.USB_OTG_HS is
       --  DMA enable
       DMAEN         : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  TxFIFO empty level
       TXFELVL       : Boolean := False;
       --  Periodic TxFIFO empty level
@@ -904,7 +905,7 @@ package STM32_SVD.USB_OTG_HS is
       --  transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -912,11 +913,11 @@ package STM32_SVD.USB_OTG_HS is
       --  USB turnaround time
       TRDT           : OTG_HS_GUSBCFG_TRDT_Field := 16#2#;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  PHY Low-power clock select
       PHYLPCS        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  ULPI FS/LS select
       ULPIFSLS       : Boolean := False;
       --  ULPI Auto-resume
@@ -942,7 +943,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Forced peripheral mode
       FDMOD          : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -984,7 +985,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1059,7 +1060,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended
       DATAFSUSP         : Boolean := False;
       --  unspecified
-      Reserved_23_23    : HAL.Bit := 16#0#;
+      Reserved_23_23    : HAL.UInt1 := 16#0#;
       --  Read-only. Host port interrupt
       HPRTINT           : Boolean := False;
       --  Read-only. Host channels interrupt
@@ -1067,7 +1068,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE             : Boolean := True;
       --  unspecified
-      Reserved_27_27    : HAL.Bit := 16#0#;
+      Reserved_27_27    : HAL.UInt1 := 16#0#;
       --  Connector ID status change
       CIDSCHG           : Boolean := False;
       --  Disconnect detected interrupt
@@ -1116,7 +1117,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS interrupt mask register
    type OTG_HS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0    : HAL.Bit := 16#0#;
+      Reserved_0_0    : HAL.UInt1 := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM           : Boolean := False;
       --  OTG interrupt mask
@@ -1390,7 +1391,7 @@ package STM32_SVD.USB_OTG_HS is
    end record;
 
    subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
-   subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
+   subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.UInt8;
    subtype OTG_HS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
    --  OTG_HS nonperiodic transmit FIFO/queue status register
@@ -1402,7 +1403,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Top of the nonperiodic transmit request queue
       NPTXQTOP       : OTG_HS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.Bit;
+      Reserved_31_31 : HAL.UInt1;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1615,8 +1616,8 @@ package STM32_SVD.USB_OTG_HS is
    end record;
 
    subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
-   subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
-   subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
+   subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.UInt8;
+   subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.UInt8;
 
    --  OTG_HS_Host periodic transmit FIFO/queue status register
    type OTG_HS_HPTXSTS_Register is record
@@ -1695,7 +1696,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_HS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1743,7 +1744,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1910,7 +1911,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data PID
       DPID           : OTG_HS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2227,7 +2228,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_DEVICE_Periph : aliased OTG_HS_DEVICE_Peripheral
-     with Import, Address => OTG_HS_DEVICE_Base;
+     with Import, Address => System'To_Address (16#40040800#);
 
    type OTG_HS_GLOBAL_Disc is
      (
@@ -2333,7 +2334,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_GLOBAL_Periph : aliased OTG_HS_GLOBAL_Peripheral
-     with Import, Address => OTG_HS_GLOBAL_Base;
+     with Import, Address => System'To_Address (16#40040000#);
 
    --  USB on the go high speed
    type OTG_HS_HOST_Peripheral is record
@@ -2654,7 +2655,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_HOST_Periph : aliased OTG_HS_HOST_Peripheral
-     with Import, Address => OTG_HS_HOST_Base;
+     with Import, Address => System'To_Address (16#40040400#);
 
    --  USB on the go high speed
    type OTG_HS_PWRCLK_Peripheral is record
@@ -2669,6 +2670,6 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_PWRCLK_Periph : aliased OTG_HS_PWRCLK_Peripheral
-     with Import, Address => OTG_HS_PWRCLK_Base;
+     with Import, Address => System'To_Address (16#40040E00#);
 
 end STM32_SVD.USB_OTG_HS;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-usb_otg_hs.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-usb_otg_hs.ads
@@ -26,7 +26,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Nonzero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Device address
       DAD            : OTG_HS_DCFG_DAD_Field := 16#0#;
       --  Periodic (micro)frame interval
@@ -133,7 +133,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -143,7 +143,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -175,17 +175,17 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SETUP phase done mask
       STUPM          : Boolean := False;
       --  OUT token received when endpoint disabled mask
       OTEPDM         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Back-to-back SETUP packets received mask
       B2BSTUP        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  OUT packet error mask
       OPEM           : Boolean := False;
       --  BNA interrupt mask
@@ -298,7 +298,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Receive threshold length
       RXTHRLEN       : OTG_HS_DTHRCTL_RXTHRLEN_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.UInt1 := 16#0#;
+      Reserved_26_26 : HAL.Bit := 16#0#;
       --  Arbiter parking enable
       ARPEN          : Boolean := False;
       --  unspecified
@@ -339,7 +339,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register
    type OTG_HS_DEACHINT_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  IN endpoint 1interrupt bit
       IEP1INT        : Boolean := False;
       --  unspecified
@@ -363,7 +363,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register mask
    type OTG_HS_DEACHINTMSK_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  IN Endpoint 1 interrupt mask bit
       IEP1INTM       : Boolean := False;
       --  unspecified
@@ -403,7 +403,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint type
       EPTYP          : OTG_HS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  STALL handshake
       Stall          : Boolean := False;
       --  TxFIFO number
@@ -449,13 +449,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition
       TOC            : Boolean := False;
       --  IN token received when TxFIFO is empty
       ITTXFE         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  IN endpoint NAK effective
       INEPNE         : Boolean := False;
       --  Read-only. Transmit FIFO empty
@@ -465,7 +465,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Buffer not available interrupt
       BNA            : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Packet dropped status
       PKTDRPSTS      : Boolean := False;
       --  Babble error interrupt
@@ -550,7 +550,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Multi count
       MCNT           : OTG_HS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -574,7 +574,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
@@ -623,13 +623,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SETUP phase done
       STUP           : Boolean := False;
       --  OUT token received when endpoint disabled
       OTEPDIS        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Back-to-back SETUP packets received
       B2BSTUP        : Boolean := False;
       --  unspecified
@@ -671,7 +671,7 @@ package STM32_SVD.USB_OTG_HS is
       --  SETUP packet count
       STUPCNT        : OTG_HS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -755,7 +755,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_HS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -871,7 +871,7 @@ package STM32_SVD.USB_OTG_HS is
       --  DMA enable
       DMAEN         : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  TxFIFO empty level
       TXFELVL       : Boolean := False;
       --  Periodic TxFIFO empty level
@@ -905,7 +905,7 @@ package STM32_SVD.USB_OTG_HS is
       --  transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -913,11 +913,11 @@ package STM32_SVD.USB_OTG_HS is
       --  USB turnaround time
       TRDT           : OTG_HS_GUSBCFG_TRDT_Field := 16#2#;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  PHY Low-power clock select
       PHYLPCS        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  ULPI FS/LS select
       ULPIFSLS       : Boolean := False;
       --  ULPI Auto-resume
@@ -943,7 +943,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Forced peripheral mode
       FDMOD          : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -985,7 +985,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1060,7 +1060,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended
       DATAFSUSP         : Boolean := False;
       --  unspecified
-      Reserved_23_23    : HAL.UInt1 := 16#0#;
+      Reserved_23_23    : HAL.Bit := 16#0#;
       --  Read-only. Host port interrupt
       HPRTINT           : Boolean := False;
       --  Read-only. Host channels interrupt
@@ -1068,7 +1068,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE             : Boolean := True;
       --  unspecified
-      Reserved_27_27    : HAL.UInt1 := 16#0#;
+      Reserved_27_27    : HAL.Bit := 16#0#;
       --  Connector ID status change
       CIDSCHG           : Boolean := False;
       --  Disconnect detected interrupt
@@ -1117,7 +1117,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS interrupt mask register
    type OTG_HS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0    : HAL.UInt1 := 16#0#;
+      Reserved_0_0    : HAL.Bit := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM           : Boolean := False;
       --  OTG interrupt mask
@@ -1403,7 +1403,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Top of the nonperiodic transmit request queue
       NPTXQTOP       : OTG_HS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1;
+      Reserved_31_31 : HAL.Bit;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1696,7 +1696,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_HS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1744,7 +1744,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1911,7 +1911,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data PID
       DPID           : OTG_HS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd-wwdg.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd-wwdg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -118,6 +119,6 @@ package STM32_SVD.WWDG is
 
    --  Window watchdog
    WWDG_Periph : aliased WWDG_Peripheral
-     with Import, Address => WWDG_Base;
+     with Import, Address => System'To_Address (16#40002C00#);
 
 end STM32_SVD.WWDG;

--- a/arch/ARM/STM32/svd/stm32f7x/stm32_svd.ads
+++ b/arch/ARM/STM32/svd/stm32f7x/stm32_svd.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with System;
 

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-adc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-adc.ads
@@ -135,7 +135,7 @@ package STM32_SVD.ADC is
       --  Start conversion of injected channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  External event select for regular group
       EXTSEL         : CR2_EXTSEL_Field := 16#0#;
       --  External trigger enable for regular channels
@@ -143,7 +143,7 @@ package STM32_SVD.ADC is
       --  Start conversion of regular channels
       SWSTART        : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -651,7 +651,7 @@ package STM32_SVD.ADC is
       --  Delay between 2 sampling phases
       DELAY_k        : CCR_DELAY_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.UInt1 := 16#0#;
+      Reserved_12_12 : HAL.Bit := 16#0#;
       --  DMA disable selection for multi-ADC mode
       DDS            : Boolean := False;
       --  Direct memory access mode for multi ADC mode

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-adc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-adc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -134,7 +135,7 @@ package STM32_SVD.ADC is
       --  Start conversion of injected channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  External event select for regular group
       EXTSEL         : CR2_EXTSEL_Field := 16#0#;
       --  External trigger enable for regular channels
@@ -142,7 +143,7 @@ package STM32_SVD.ADC is
       --  Start conversion of regular channels
       SWSTART        : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -388,7 +389,7 @@ package STM32_SVD.ADC is
       --  Regular channel sequence length
       L              : SQR1_L_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -650,7 +651,7 @@ package STM32_SVD.ADC is
       --  Delay between 2 sampling phases
       DELAY_k        : CCR_DELAY_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.Bit := 16#0#;
+      Reserved_12_12 : HAL.UInt1 := 16#0#;
       --  DMA disable selection for multi-ADC mode
       DDS            : Boolean := False;
       --  Direct memory access mode for multi ADC mode
@@ -664,7 +665,7 @@ package STM32_SVD.ADC is
       --  Temperature sensor and VREFINT enable
       TSVREFE        : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -785,15 +786,15 @@ package STM32_SVD.ADC is
 
    --  Analog-to-digital converter
    ADC1_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC1_Base;
+     with Import, Address => System'To_Address (16#40012000#);
 
    --  Analog-to-digital converter
    ADC2_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC2_Base;
+     with Import, Address => System'To_Address (16#40012100#);
 
    --  Analog-to-digital converter
    ADC3_Periph : aliased ADC1_Peripheral
-     with Import, Address => ADC3_Base;
+     with Import, Address => System'To_Address (16#40012200#);
 
    --  Common ADC registers
    type C_ADC_Peripheral is record
@@ -814,6 +815,6 @@ package STM32_SVD.ADC is
 
    --  Common ADC registers
    C_ADC_Periph : aliased C_ADC_Peripheral
-     with Import, Address => C_ADC_Base;
+     with Import, Address => System'To_Address (16#40012300#);
 
 end STM32_SVD.ADC;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-can.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-can.ads
@@ -230,7 +230,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP0
       FMP0          : RF0R_FMP0_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  FULL0
       FULL0         : Boolean := False;
       --  FOVR0
@@ -259,7 +259,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP1
       FMP1          : RF1R_FMP1_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  FULL1
       FULL1         : Boolean := False;
       --  FOVR1
@@ -298,7 +298,7 @@ package STM32_SVD.CAN is
       --  FOVIE1
       FOVIE1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  EWGIE
       EWGIE          : Boolean := False;
       --  EPVIE
@@ -354,7 +354,7 @@ package STM32_SVD.CAN is
       --  Read-only. BOFF
       BOFF          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  LEC
       LEC           : ESR_LEC_Field := 16#0#;
       --  unspecified
@@ -394,7 +394,7 @@ package STM32_SVD.CAN is
       --  TS2
       TS2            : BTR_TS2_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  SJW
       SJW            : BTR_SJW_Field := 16#0#;
       --  unspecified
@@ -755,7 +755,7 @@ package STM32_SVD.CAN is
    --  receive FIFO mailbox identifier register
    type RI0R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.UInt1;
+      Reserved_0_0 : HAL.Bit;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -863,7 +863,7 @@ package STM32_SVD.CAN is
    --  mailbox data high register
    type RI1R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.UInt1;
+      Reserved_0_0 : HAL.Bit;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-can.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-can.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -229,7 +230,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP0
       FMP0          : RF0R_FMP0_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  FULL0
       FULL0         : Boolean := False;
       --  FOVR0
@@ -258,7 +259,7 @@ package STM32_SVD.CAN is
       --  Read-only. FMP1
       FMP1          : RF1R_FMP1_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  FULL1
       FULL1         : Boolean := False;
       --  FOVR1
@@ -297,7 +298,7 @@ package STM32_SVD.CAN is
       --  FOVIE1
       FOVIE1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  EWGIE
       EWGIE          : Boolean := False;
       --  EPVIE
@@ -341,8 +342,8 @@ package STM32_SVD.CAN is
    end record;
 
    subtype ESR_LEC_Field is HAL.UInt3;
-   subtype ESR_TEC_Field is HAL.Byte;
-   subtype ESR_REC_Field is HAL.Byte;
+   subtype ESR_TEC_Field is HAL.UInt8;
+   subtype ESR_REC_Field is HAL.UInt8;
 
    --  interrupt enable register
    type ESR_Register is record
@@ -353,7 +354,7 @@ package STM32_SVD.CAN is
       --  Read-only. BOFF
       BOFF          : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  LEC
       LEC           : ESR_LEC_Field := 16#0#;
       --  unspecified
@@ -393,7 +394,7 @@ package STM32_SVD.CAN is
       --  TS2
       TS2            : BTR_TS2_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  SJW
       SJW            : BTR_SJW_Field := 16#0#;
       --  unspecified
@@ -473,7 +474,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL0R_DATA array element
-   subtype TDL0R_DATA_Element is HAL.Byte;
+   subtype TDL0R_DATA_Element is HAL.UInt8;
 
    --  TDL0R_DATA array
    type TDL0R_DATA_Field_Array is array (0 .. 3) of TDL0R_DATA_Element
@@ -501,7 +502,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH0R_DATA array element
-   subtype TDH0R_DATA_Element is HAL.Byte;
+   subtype TDH0R_DATA_Element is HAL.UInt8;
 
    --  TDH0R_DATA array
    type TDH0R_DATA_Field_Array is array (4 .. 7) of TDH0R_DATA_Element
@@ -583,7 +584,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL1R_DATA array element
-   subtype TDL1R_DATA_Element is HAL.Byte;
+   subtype TDL1R_DATA_Element is HAL.UInt8;
 
    --  TDL1R_DATA array
    type TDL1R_DATA_Field_Array is array (0 .. 3) of TDL1R_DATA_Element
@@ -611,7 +612,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH1R_DATA array element
-   subtype TDH1R_DATA_Element is HAL.Byte;
+   subtype TDH1R_DATA_Element is HAL.UInt8;
 
    --  TDH1R_DATA array
    type TDH1R_DATA_Field_Array is array (4 .. 7) of TDH1R_DATA_Element
@@ -693,7 +694,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDL2R_DATA array element
-   subtype TDL2R_DATA_Element is HAL.Byte;
+   subtype TDL2R_DATA_Element is HAL.UInt8;
 
    --  TDL2R_DATA array
    type TDL2R_DATA_Field_Array is array (0 .. 3) of TDL2R_DATA_Element
@@ -721,7 +722,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  TDH2R_DATA array element
-   subtype TDH2R_DATA_Element is HAL.Byte;
+   subtype TDH2R_DATA_Element is HAL.UInt8;
 
    --  TDH2R_DATA array
    type TDH2R_DATA_Field_Array is array (4 .. 7) of TDH2R_DATA_Element
@@ -754,7 +755,7 @@ package STM32_SVD.CAN is
    --  receive FIFO mailbox identifier register
    type RI0R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.Bit;
+      Reserved_0_0 : HAL.UInt1;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -776,7 +777,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype RDT0R_DLC_Field is HAL.UInt4;
-   subtype RDT0R_FMI_Field is HAL.Byte;
+   subtype RDT0R_FMI_Field is HAL.UInt8;
    subtype RDT0R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
@@ -801,7 +802,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDL0R_DATA array element
-   subtype RDL0R_DATA_Element is HAL.Byte;
+   subtype RDL0R_DATA_Element is HAL.UInt8;
 
    --  RDL0R_DATA array
    type RDL0R_DATA_Field_Array is array (0 .. 3) of RDL0R_DATA_Element
@@ -829,7 +830,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDH0R_DATA array element
-   subtype RDH0R_DATA_Element is HAL.Byte;
+   subtype RDH0R_DATA_Element is HAL.UInt8;
 
    --  RDH0R_DATA array
    type RDH0R_DATA_Field_Array is array (4 .. 7) of RDH0R_DATA_Element
@@ -862,7 +863,7 @@ package STM32_SVD.CAN is
    --  mailbox data high register
    type RI1R_Register is record
       --  unspecified
-      Reserved_0_0 : HAL.Bit;
+      Reserved_0_0 : HAL.UInt1;
       --  Read-only. RTR
       RTR          : Boolean;
       --  Read-only. IDE
@@ -884,7 +885,7 @@ package STM32_SVD.CAN is
    end record;
 
    subtype RDT1R_DLC_Field is HAL.UInt4;
-   subtype RDT1R_FMI_Field is HAL.Byte;
+   subtype RDT1R_FMI_Field is HAL.UInt8;
    subtype RDT1R_TIME_Field is HAL.UInt16;
 
    --  mailbox data high register
@@ -909,7 +910,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDL1R_DATA array element
-   subtype RDL1R_DATA_Element is HAL.Byte;
+   subtype RDL1R_DATA_Element is HAL.UInt8;
 
    --  RDL1R_DATA array
    type RDL1R_DATA_Field_Array is array (0 .. 3) of RDL1R_DATA_Element
@@ -937,7 +938,7 @@ package STM32_SVD.CAN is
    end record;
 
    --  RDH1R_DATA array element
-   subtype RDH1R_DATA_Element is HAL.Byte;
+   subtype RDH1R_DATA_Element is HAL.UInt8;
 
    --  RDH1R_DATA array
    type RDH1R_DATA_Field_Array is array (4 .. 7) of RDH1R_DATA_Element
@@ -2124,14 +2125,14 @@ package STM32_SVD.CAN is
 
    --  Controller area network
    CAN1_Periph : aliased CAN_Peripheral
-     with Import, Address => CAN1_Base;
+     with Import, Address => System'To_Address (16#40006400#);
 
    --  Controller area network
    CAN2_Periph : aliased CAN_Peripheral
-     with Import, Address => CAN2_Base;
+     with Import, Address => System'To_Address (16#40006800#);
 
    --  Controller area network
    CAN3_Periph : aliased CAN_Peripheral
-     with Import, Address => CAN3_Base;
+     with Import, Address => System'To_Address (16#40003400#);
 
 end STM32_SVD.CAN;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-cec.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-cec.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -76,7 +77,7 @@ package STM32_SVD.CEC is
       LSTN          at 0 range 31 .. 31;
    end record;
 
-   subtype TXDR_TXD_Field is HAL.Byte;
+   subtype TXDR_TXD_Field is HAL.UInt8;
 
    --  Tx data register
    type TXDR_Register is record
@@ -93,7 +94,7 @@ package STM32_SVD.CEC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype RXDR_RXDR_Field is HAL.Byte;
+   subtype RXDR_RXDR_Field is HAL.UInt8;
 
    --  Rx Data Register
    type RXDR_Register is record
@@ -244,6 +245,6 @@ package STM32_SVD.CEC is
 
    --  HDMI-CEC controller
    CEC_Periph : aliased CEC_Peripheral
-     with Import, Address => CEC_Base;
+     with Import, Address => System'To_Address (16#40006C00#);
 
 end STM32_SVD.CEC;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-crc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-crc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -13,7 +14,7 @@ package STM32_SVD.CRC is
    -- Registers --
    ---------------
 
-   subtype IDR_IDR_Field is HAL.Byte;
+   subtype IDR_IDR_Field is HAL.UInt8;
 
    --  Independent Data register
    type IDR_Register is record
@@ -52,7 +53,7 @@ package STM32_SVD.CRC is
    --  Cyclic Redundancy Check (CRC) unit
    type CRC_Peripheral is record
       --  Data register
-      DR  : HAL.UInt32;
+      DR   : HAL.UInt32;
       --  Independent Data register
       IDR  : IDR_Register;
       --  Control register
@@ -74,6 +75,6 @@ package STM32_SVD.CRC is
 
    --  Cyclic Redundancy Check (CRC) unit
    CRC_Periph : aliased CRC_Peripheral
-     with Import, Address => CRC_Base;
+     with Import, Address => System'To_Address (16#40023000#);
 
 end STM32_SVD.CRC;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-cryp.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-cryp.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -39,7 +40,7 @@ package STM32_SVD.CRYP is
       --  GCM_CCMPH
       GCM_CCMPH      : CR_GCM_CCMPH_Field := 16#0#;
       --  unspecified
-      Reserved_18_18 : HAL.Bit := 16#0#;
+      Reserved_18_18 : HAL.UInt1 := 16#0#;
       --  ALGOMODE
       ALGOMODE3      : Boolean := False;
       --  unspecified
@@ -584,6 +585,6 @@ package STM32_SVD.CRYP is
 
    --  Cryptographic processor
    CRYP_Periph : aliased CRYP_Peripheral
-     with Import, Address => CRYP_Base;
+     with Import, Address => System'To_Address (16#50060000#);
 
 end STM32_SVD.CRYP;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-cryp.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-cryp.ads
@@ -40,7 +40,7 @@ package STM32_SVD.CRYP is
       --  GCM_CCMPH
       GCM_CCMPH      : CR_GCM_CCMPH_Field := 16#0#;
       --  unspecified
-      Reserved_18_18 : HAL.UInt1 := 16#0#;
+      Reserved_18_18 : HAL.Bit := 16#0#;
       --  ALGOMODE
       ALGOMODE3      : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dac.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dac.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -160,7 +161,7 @@ package STM32_SVD.DAC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DHR8R1_DACC1DHR_Field is HAL.Byte;
+   subtype DHR8R1_DACC1DHR_Field is HAL.UInt8;
 
    --  channel1 8-bit right aligned data holding register
    type DHR8R1_Register is record
@@ -214,7 +215,7 @@ package STM32_SVD.DAC is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DHR8R2_DACC2DHR_Field is HAL.Byte;
+   subtype DHR8R2_DACC2DHR_Field is HAL.UInt8;
 
    --  channel2 8-bit right-aligned data holding register
    type DHR8R2_Register is record
@@ -279,8 +280,8 @@ package STM32_SVD.DAC is
       DACC2DHR       at 0 range 20 .. 31;
    end record;
 
-   subtype DHR8RD_DACC1DHR_Field is HAL.Byte;
-   subtype DHR8RD_DACC2DHR_Field is HAL.Byte;
+   subtype DHR8RD_DACC1DHR_Field is HAL.UInt8;
+   subtype DHR8RD_DACC2DHR_Field is HAL.UInt8;
 
    --  DUAL DAC 8-bit right aligned data holding register
    type DHR8RD_Register is record
@@ -414,6 +415,6 @@ package STM32_SVD.DAC is
 
    --  Digital-to-analog converter
    DAC_Periph : aliased DAC_Peripheral
-     with Import, Address => DAC_Base;
+     with Import, Address => System'To_Address (16#40007400#);
 
 end STM32_SVD.DAC;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dcmi.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dcmi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -193,10 +194,10 @@ package STM32_SVD.DCMI is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype ESCR_FSC_Field is HAL.Byte;
-   subtype ESCR_LSC_Field is HAL.Byte;
-   subtype ESCR_LEC_Field is HAL.Byte;
-   subtype ESCR_FEC_Field is HAL.Byte;
+   subtype ESCR_FSC_Field is HAL.UInt8;
+   subtype ESCR_LSC_Field is HAL.UInt8;
+   subtype ESCR_LEC_Field is HAL.UInt8;
+   subtype ESCR_FEC_Field is HAL.UInt8;
 
    --  embedded synchronization code register
    type ESCR_Register is record
@@ -219,10 +220,10 @@ package STM32_SVD.DCMI is
       FEC at 0 range 24 .. 31;
    end record;
 
-   subtype ESUR_FSU_Field is HAL.Byte;
-   subtype ESUR_LSU_Field is HAL.Byte;
-   subtype ESUR_LEU_Field is HAL.Byte;
-   subtype ESUR_FEU_Field is HAL.Byte;
+   subtype ESUR_FSU_Field is HAL.UInt8;
+   subtype ESUR_LSU_Field is HAL.UInt8;
+   subtype ESUR_LEU_Field is HAL.UInt8;
+   subtype ESUR_FEU_Field is HAL.UInt8;
 
    --  embedded synchronization unmask register
    type ESUR_Register is record
@@ -294,7 +295,7 @@ package STM32_SVD.DCMI is
    end record;
 
    --  DR_Byte array element
-   subtype DR_Byte_Element is HAL.Byte;
+   subtype DR_Byte_Element is HAL.UInt8;
 
    --  DR_Byte array
    type DR_Byte_Field_Array is array (0 .. 3) of DR_Byte_Element
@@ -368,6 +369,6 @@ package STM32_SVD.DCMI is
 
    --  Digital camera interface
    DCMI_Periph : aliased DCMI_Peripheral
-     with Import, Address => DCMI_Base;
+     with Import, Address => System'To_Address (16#50050000#);
 
 end STM32_SVD.DCMI;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dfsdm.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dfsdm.ads
@@ -27,7 +27,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 0
       SPICKSEL       : DFSDM_CHCFG0R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Short-circuit detector enable on channel 0
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 0
@@ -84,7 +84,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 1
       SPICKSEL       : DFSDM_CHCFG1R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Short-circuit detector enable on channel 1
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 1
@@ -141,7 +141,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 2
       SPICKSEL       : DFSDM_CHCFG2R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Short-circuit detector enable on channel 2
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 2
@@ -198,7 +198,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 3
       SPICKSEL       : DFSDM_CHCFG3R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Short-circuit detector enable on channel 3
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 3
@@ -255,7 +255,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 4
       SPICKSEL       : DFSDM_CHCFG4R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Short-circuit detector enable on channel 4
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 4
@@ -312,7 +312,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 5
       SPICKSEL       : DFSDM_CHCFG5R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Short-circuit detector enable on channel 5
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 5
@@ -369,7 +369,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 6
       SPICKSEL       : DFSDM_CHCFG6R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Short-circuit detector enable on channel 6
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 6
@@ -426,7 +426,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 7
       SPICKSEL       : DFSDM_CHCFG7R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Short-circuit detector enable on channel 7
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 7
@@ -655,7 +655,7 @@ package STM32_SVD.DFSDM is
       --  channel 0
       AWFOSR         : DFSDM_AWSCD0R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Analog watchdog Sinc filter order on channel 0
       AWFORD         : DFSDM_AWSCD0R_AWFORD_Field := 16#0#;
       --  unspecified
@@ -691,7 +691,7 @@ package STM32_SVD.DFSDM is
       --  channel 1
       AWFOSR         : DFSDM_AWSCD1R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Analog watchdog Sinc filter order on channel 1
       AWFORD         : DFSDM_AWSCD1R_AWFORD_Field := 16#0#;
       --  unspecified
@@ -727,7 +727,7 @@ package STM32_SVD.DFSDM is
       --  channel 2
       AWFOSR         : DFSDM_AWSCD2R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Analog watchdog Sinc filter order on channel 2
       AWFORD         : DFSDM_AWSCD2R_AWFORD_Field := 16#0#;
       --  unspecified
@@ -763,7 +763,7 @@ package STM32_SVD.DFSDM is
       --  channel 3
       AWFOSR         : DFSDM_AWSCD3R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Analog watchdog Sinc filter order on channel 3
       AWFORD         : DFSDM_AWSCD3R_AWFORD_Field := 16#0#;
       --  unspecified
@@ -799,7 +799,7 @@ package STM32_SVD.DFSDM is
       --  channel 4
       AWFOSR         : DFSDM_AWSCD4R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Analog watchdog Sinc filter order on channel 4
       AWFORD         : DFSDM_AWSCD4R_AWFORD_Field := 16#0#;
       --  unspecified
@@ -835,7 +835,7 @@ package STM32_SVD.DFSDM is
       --  channel 5
       AWFOSR         : DFSDM_AWSCD5R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Analog watchdog Sinc filter order on channel 5
       AWFORD         : DFSDM_AWSCD5R_AWFORD_Field := 16#0#;
       --  unspecified
@@ -871,7 +871,7 @@ package STM32_SVD.DFSDM is
       --  channel 6
       AWFOSR         : DFSDM_AWSCD6R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Analog watchdog Sinc filter order on channel 6
       AWFORD         : DFSDM_AWSCD6R_AWFORD_Field := 16#0#;
       --  unspecified
@@ -907,7 +907,7 @@ package STM32_SVD.DFSDM is
       --  channel 7
       AWFOSR         : DFSDM_AWSCD7R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Analog watchdog Sinc filter order on channel 7
       AWFORD         : DFSDM_AWSCD7R_AWFORD_Field := 16#0#;
       --  unspecified
@@ -1305,7 +1305,7 @@ package STM32_SVD.DFSDM is
       --  Start a conversion of the injected group of channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Launch an injected conversion synchronously with the DFSDM0 JSWSTART
       --  trigger
       JSYNC          : Boolean := False;
@@ -1328,7 +1328,7 @@ package STM32_SVD.DFSDM is
       --  Launch regular conversion synchronously with DFSDM0
       RSYNC          : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  DMA channel enabled to read data for the regular conversion
       RDMAEN         : Boolean := False;
       --  unspecified
@@ -1342,7 +1342,7 @@ package STM32_SVD.DFSDM is
       --  Analog watchdog fast mode select
       AWFSEL         : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1382,7 +1382,7 @@ package STM32_SVD.DFSDM is
       --  Start a conversion of the injected group of channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Launch an injected conversion synchronously with the DFSDM0 JSWSTART
       --  trigger
       JSYNC          : Boolean := False;
@@ -1405,7 +1405,7 @@ package STM32_SVD.DFSDM is
       --  Launch regular conversion synchronously with DFSDM0
       RSYNC          : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  DMA channel enabled to read data for the regular conversion
       RDMAEN         : Boolean := False;
       --  unspecified
@@ -1419,7 +1419,7 @@ package STM32_SVD.DFSDM is
       --  Analog watchdog fast mode select
       AWFSEL         : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1459,7 +1459,7 @@ package STM32_SVD.DFSDM is
       --  Start a conversion of the injected group of channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Launch an injected conversion synchronously with the DFSDM0 JSWSTART
       --  trigger
       JSYNC          : Boolean := False;
@@ -1482,7 +1482,7 @@ package STM32_SVD.DFSDM is
       --  Launch regular conversion synchronously with DFSDM0
       RSYNC          : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  DMA channel enabled to read data for the regular conversion
       RDMAEN         : Boolean := False;
       --  unspecified
@@ -1496,7 +1496,7 @@ package STM32_SVD.DFSDM is
       --  Analog watchdog fast mode select
       AWFSEL         : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1536,7 +1536,7 @@ package STM32_SVD.DFSDM is
       --  Start a conversion of the injected group of channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Launch an injected conversion synchronously with the DFSDM0 JSWSTART
       --  trigger
       JSYNC          : Boolean := False;
@@ -1559,7 +1559,7 @@ package STM32_SVD.DFSDM is
       --  Launch regular conversion synchronously with DFSDM0
       RSYNC          : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  DMA channel enabled to read data for the regular conversion
       RDMAEN         : Boolean := False;
       --  unspecified
@@ -1573,7 +1573,7 @@ package STM32_SVD.DFSDM is
       --  Analog watchdog fast mode select
       AWFSEL         : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1622,7 +1622,7 @@ package STM32_SVD.DFSDM is
       --  Clock absence interrupt enable
       CKABIE         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Extremes detector channel selection
       EXCH           : DFSDM0_CR2_EXCH_Field := 16#0#;
       --  Analog watchdog channel selection
@@ -1667,7 +1667,7 @@ package STM32_SVD.DFSDM is
       --  Clock absence interrupt enable
       CKABIE         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Extremes detector channel selection
       EXCH           : DFSDM1_CR2_EXCH_Field := 16#0#;
       --  Analog watchdog channel selection
@@ -1712,7 +1712,7 @@ package STM32_SVD.DFSDM is
       --  Clock absence interrupt enable
       CKABIE         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Extremes detector channel selection
       EXCH           : DFSDM2_CR2_EXCH_Field := 16#0#;
       --  Analog watchdog channel selection
@@ -1757,7 +1757,7 @@ package STM32_SVD.DFSDM is
       --  Clock absence interrupt enable
       CKABIE         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Extremes detector channel selection
       EXCH           : DFSDM3_CR2_EXCH_Field := 16#0#;
       --  Analog watchdog channel selection
@@ -1804,7 +1804,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Regular conversion in progress status
       RCIP           : Boolean;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1;
+      Reserved_15_15 : HAL.Bit;
       --  Read-only. Clock absence flag
       CKABF          : DFSDM0_ISR_CKABF_Field;
       --  Read-only. short-circuit detector flag
@@ -1849,7 +1849,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Regular conversion in progress status
       RCIP           : Boolean;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1;
+      Reserved_15_15 : HAL.Bit;
       --  Read-only. Clock absence flag
       CKABF          : DFSDM1_ISR_CKABF_Field;
       --  Read-only. short-circuit detector flag
@@ -1894,7 +1894,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Regular conversion in progress status
       RCIP           : Boolean;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1;
+      Reserved_15_15 : HAL.Bit;
       --  Read-only. Clock absence flag
       CKABF          : DFSDM2_ISR_CKABF_Field;
       --  Read-only. short-circuit detector flag
@@ -1939,7 +1939,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Regular conversion in progress status
       RCIP           : Boolean;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1;
+      Reserved_15_15 : HAL.Bit;
       --  Read-only. Clock absence flag
       CKABF          : DFSDM3_ISR_CKABF_Field;
       --  Read-only. short-circuit detector flag
@@ -2354,7 +2354,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Regular channel most recently converted
       RDATACH      : DFSDM0_RDATAR_RDATACH_Field;
       --  unspecified
-      Reserved_3_3 : HAL.UInt1;
+      Reserved_3_3 : HAL.Bit;
       --  Read-only. Regular channel pending data
       RPEND        : Boolean;
       --  unspecified
@@ -2381,7 +2381,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Regular channel most recently converted
       RDATACH      : DFSDM1_RDATAR_RDATACH_Field;
       --  unspecified
-      Reserved_3_3 : HAL.UInt1;
+      Reserved_3_3 : HAL.Bit;
       --  Read-only. Regular channel pending data
       RPEND        : Boolean;
       --  unspecified
@@ -2408,7 +2408,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Regular channel most recently converted
       RDATACH      : DFSDM2_RDATAR_RDATACH_Field;
       --  unspecified
-      Reserved_3_3 : HAL.UInt1;
+      Reserved_3_3 : HAL.Bit;
       --  Read-only. Regular channel pending data
       RPEND        : Boolean;
       --  unspecified
@@ -2435,7 +2435,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Regular channel most recently converted
       RDATACH      : DFSDM3_RDATAR_RDATACH_Field;
       --  unspecified
-      Reserved_3_3 : HAL.UInt1;
+      Reserved_3_3 : HAL.Bit;
       --  Read-only. Regular channel pending data
       RPEND        : Boolean;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dfsdm.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dfsdm.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -17,7 +18,7 @@ package STM32_SVD.DFSDM is
    subtype DFSDM_CHCFG0R1_SPICKSEL_Field is HAL.UInt2;
    subtype DFSDM_CHCFG0R1_DATMPX_Field is HAL.UInt2;
    subtype DFSDM_CHCFG0R1_DATPACK_Field is HAL.UInt2;
-   subtype DFSDM_CHCFG0R1_CKOUTDIV_Field is HAL.Byte;
+   subtype DFSDM_CHCFG0R1_CKOUTDIV_Field is HAL.UInt8;
 
    --  DFSDM channel configuration 0 register 1
    type DFSDM_CHCFG0R1_Register is record
@@ -26,7 +27,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 0
       SPICKSEL       : DFSDM_CHCFG0R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Short-circuit detector enable on channel 0
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 0
@@ -74,7 +75,7 @@ package STM32_SVD.DFSDM is
    subtype DFSDM_CHCFG1R1_SPICKSEL_Field is HAL.UInt2;
    subtype DFSDM_CHCFG1R1_DATMPX_Field is HAL.UInt2;
    subtype DFSDM_CHCFG1R1_DATPACK_Field is HAL.UInt2;
-   subtype DFSDM_CHCFG1R1_CKOUTDIV_Field is HAL.Byte;
+   subtype DFSDM_CHCFG1R1_CKOUTDIV_Field is HAL.UInt8;
 
    --  DFSDM channel configuration 1 register 1
    type DFSDM_CHCFG1R1_Register is record
@@ -83,7 +84,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 1
       SPICKSEL       : DFSDM_CHCFG1R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Short-circuit detector enable on channel 1
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 1
@@ -131,7 +132,7 @@ package STM32_SVD.DFSDM is
    subtype DFSDM_CHCFG2R1_SPICKSEL_Field is HAL.UInt2;
    subtype DFSDM_CHCFG2R1_DATMPX_Field is HAL.UInt2;
    subtype DFSDM_CHCFG2R1_DATPACK_Field is HAL.UInt2;
-   subtype DFSDM_CHCFG2R1_CKOUTDIV_Field is HAL.Byte;
+   subtype DFSDM_CHCFG2R1_CKOUTDIV_Field is HAL.UInt8;
 
    --  DFSDM channel configuration 2 register 1
    type DFSDM_CHCFG2R1_Register is record
@@ -140,7 +141,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 2
       SPICKSEL       : DFSDM_CHCFG2R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Short-circuit detector enable on channel 2
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 2
@@ -188,7 +189,7 @@ package STM32_SVD.DFSDM is
    subtype DFSDM_CHCFG3R1_SPICKSEL_Field is HAL.UInt2;
    subtype DFSDM_CHCFG3R1_DATMPX_Field is HAL.UInt2;
    subtype DFSDM_CHCFG3R1_DATPACK_Field is HAL.UInt2;
-   subtype DFSDM_CHCFG3R1_CKOUTDIV_Field is HAL.Byte;
+   subtype DFSDM_CHCFG3R1_CKOUTDIV_Field is HAL.UInt8;
 
    --  DFSDM channel configuration 3 register 1
    type DFSDM_CHCFG3R1_Register is record
@@ -197,7 +198,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 3
       SPICKSEL       : DFSDM_CHCFG3R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Short-circuit detector enable on channel 3
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 3
@@ -245,7 +246,7 @@ package STM32_SVD.DFSDM is
    subtype DFSDM_CHCFG4R1_SPICKSEL_Field is HAL.UInt2;
    subtype DFSDM_CHCFG4R1_DATMPX_Field is HAL.UInt2;
    subtype DFSDM_CHCFG4R1_DATPACK_Field is HAL.UInt2;
-   subtype DFSDM_CHCFG4R1_CKOUTDIV_Field is HAL.Byte;
+   subtype DFSDM_CHCFG4R1_CKOUTDIV_Field is HAL.UInt8;
 
    --  DFSDM channel configuration 4 register 1
    type DFSDM_CHCFG4R1_Register is record
@@ -254,7 +255,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 4
       SPICKSEL       : DFSDM_CHCFG4R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Short-circuit detector enable on channel 4
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 4
@@ -302,7 +303,7 @@ package STM32_SVD.DFSDM is
    subtype DFSDM_CHCFG5R1_SPICKSEL_Field is HAL.UInt2;
    subtype DFSDM_CHCFG5R1_DATMPX_Field is HAL.UInt2;
    subtype DFSDM_CHCFG5R1_DATPACK_Field is HAL.UInt2;
-   subtype DFSDM_CHCFG5R1_CKOUTDIV_Field is HAL.Byte;
+   subtype DFSDM_CHCFG5R1_CKOUTDIV_Field is HAL.UInt8;
 
    --  DFSDM channel configuration 5 register 1
    type DFSDM_CHCFG5R1_Register is record
@@ -311,7 +312,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 5
       SPICKSEL       : DFSDM_CHCFG5R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Short-circuit detector enable on channel 5
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 5
@@ -359,7 +360,7 @@ package STM32_SVD.DFSDM is
    subtype DFSDM_CHCFG6R1_SPICKSEL_Field is HAL.UInt2;
    subtype DFSDM_CHCFG6R1_DATMPX_Field is HAL.UInt2;
    subtype DFSDM_CHCFG6R1_DATPACK_Field is HAL.UInt2;
-   subtype DFSDM_CHCFG6R1_CKOUTDIV_Field is HAL.Byte;
+   subtype DFSDM_CHCFG6R1_CKOUTDIV_Field is HAL.UInt8;
 
    --  DFSDM channel configuration 6 register 1
    type DFSDM_CHCFG6R1_Register is record
@@ -368,7 +369,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 6
       SPICKSEL       : DFSDM_CHCFG6R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Short-circuit detector enable on channel 6
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 6
@@ -416,7 +417,7 @@ package STM32_SVD.DFSDM is
    subtype DFSDM_CHCFG7R1_SPICKSEL_Field is HAL.UInt2;
    subtype DFSDM_CHCFG7R1_DATMPX_Field is HAL.UInt2;
    subtype DFSDM_CHCFG7R1_DATPACK_Field is HAL.UInt2;
-   subtype DFSDM_CHCFG7R1_CKOUTDIV_Field is HAL.Byte;
+   subtype DFSDM_CHCFG7R1_CKOUTDIV_Field is HAL.UInt8;
 
    --  DFSDM channel configuration 7 register 1
    type DFSDM_CHCFG7R1_Register is record
@@ -425,7 +426,7 @@ package STM32_SVD.DFSDM is
       --  SPI clock select for channel 7
       SPICKSEL       : DFSDM_CHCFG7R1_SPICKSEL_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Short-circuit detector enable on channel 7
       SCDEN          : Boolean := False;
       --  Clock absence detector enable on channel 7
@@ -637,7 +638,7 @@ package STM32_SVD.DFSDM is
       OFFSET       at 0 range 8 .. 31;
    end record;
 
-   subtype DFSDM_AWSCD0R_SCDT_Field is HAL.Byte;
+   subtype DFSDM_AWSCD0R_SCDT_Field is HAL.UInt8;
    subtype DFSDM_AWSCD0R_BKSCD_Field is HAL.UInt4;
    subtype DFSDM_AWSCD0R_AWFOSR_Field is HAL.UInt5;
    subtype DFSDM_AWSCD0R_AWFORD_Field is HAL.UInt2;
@@ -654,11 +655,11 @@ package STM32_SVD.DFSDM is
       --  channel 0
       AWFOSR         : DFSDM_AWSCD0R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Analog watchdog Sinc filter order on channel 0
       AWFORD         : DFSDM_AWSCD0R_AWFORD_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -673,7 +674,7 @@ package STM32_SVD.DFSDM is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM_AWSCD1R_SCDT_Field is HAL.Byte;
+   subtype DFSDM_AWSCD1R_SCDT_Field is HAL.UInt8;
    subtype DFSDM_AWSCD1R_BKSCD_Field is HAL.UInt4;
    subtype DFSDM_AWSCD1R_AWFOSR_Field is HAL.UInt5;
    subtype DFSDM_AWSCD1R_AWFORD_Field is HAL.UInt2;
@@ -690,11 +691,11 @@ package STM32_SVD.DFSDM is
       --  channel 1
       AWFOSR         : DFSDM_AWSCD1R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Analog watchdog Sinc filter order on channel 1
       AWFORD         : DFSDM_AWSCD1R_AWFORD_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -709,7 +710,7 @@ package STM32_SVD.DFSDM is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM_AWSCD2R_SCDT_Field is HAL.Byte;
+   subtype DFSDM_AWSCD2R_SCDT_Field is HAL.UInt8;
    subtype DFSDM_AWSCD2R_BKSCD_Field is HAL.UInt4;
    subtype DFSDM_AWSCD2R_AWFOSR_Field is HAL.UInt5;
    subtype DFSDM_AWSCD2R_AWFORD_Field is HAL.UInt2;
@@ -726,11 +727,11 @@ package STM32_SVD.DFSDM is
       --  channel 2
       AWFOSR         : DFSDM_AWSCD2R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Analog watchdog Sinc filter order on channel 2
       AWFORD         : DFSDM_AWSCD2R_AWFORD_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -745,7 +746,7 @@ package STM32_SVD.DFSDM is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM_AWSCD3R_SCDT_Field is HAL.Byte;
+   subtype DFSDM_AWSCD3R_SCDT_Field is HAL.UInt8;
    subtype DFSDM_AWSCD3R_BKSCD_Field is HAL.UInt4;
    subtype DFSDM_AWSCD3R_AWFOSR_Field is HAL.UInt5;
    subtype DFSDM_AWSCD3R_AWFORD_Field is HAL.UInt2;
@@ -762,11 +763,11 @@ package STM32_SVD.DFSDM is
       --  channel 3
       AWFOSR         : DFSDM_AWSCD3R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Analog watchdog Sinc filter order on channel 3
       AWFORD         : DFSDM_AWSCD3R_AWFORD_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -781,7 +782,7 @@ package STM32_SVD.DFSDM is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM_AWSCD4R_SCDT_Field is HAL.Byte;
+   subtype DFSDM_AWSCD4R_SCDT_Field is HAL.UInt8;
    subtype DFSDM_AWSCD4R_BKSCD_Field is HAL.UInt4;
    subtype DFSDM_AWSCD4R_AWFOSR_Field is HAL.UInt5;
    subtype DFSDM_AWSCD4R_AWFORD_Field is HAL.UInt2;
@@ -798,11 +799,11 @@ package STM32_SVD.DFSDM is
       --  channel 4
       AWFOSR         : DFSDM_AWSCD4R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Analog watchdog Sinc filter order on channel 4
       AWFORD         : DFSDM_AWSCD4R_AWFORD_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -817,7 +818,7 @@ package STM32_SVD.DFSDM is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM_AWSCD5R_SCDT_Field is HAL.Byte;
+   subtype DFSDM_AWSCD5R_SCDT_Field is HAL.UInt8;
    subtype DFSDM_AWSCD5R_BKSCD_Field is HAL.UInt4;
    subtype DFSDM_AWSCD5R_AWFOSR_Field is HAL.UInt5;
    subtype DFSDM_AWSCD5R_AWFORD_Field is HAL.UInt2;
@@ -834,11 +835,11 @@ package STM32_SVD.DFSDM is
       --  channel 5
       AWFOSR         : DFSDM_AWSCD5R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Analog watchdog Sinc filter order on channel 5
       AWFORD         : DFSDM_AWSCD5R_AWFORD_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -853,7 +854,7 @@ package STM32_SVD.DFSDM is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM_AWSCD6R_SCDT_Field is HAL.Byte;
+   subtype DFSDM_AWSCD6R_SCDT_Field is HAL.UInt8;
    subtype DFSDM_AWSCD6R_BKSCD_Field is HAL.UInt4;
    subtype DFSDM_AWSCD6R_AWFOSR_Field is HAL.UInt5;
    subtype DFSDM_AWSCD6R_AWFORD_Field is HAL.UInt2;
@@ -870,11 +871,11 @@ package STM32_SVD.DFSDM is
       --  channel 6
       AWFOSR         : DFSDM_AWSCD6R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Analog watchdog Sinc filter order on channel 6
       AWFORD         : DFSDM_AWSCD6R_AWFORD_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -889,7 +890,7 @@ package STM32_SVD.DFSDM is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM_AWSCD7R_SCDT_Field is HAL.Byte;
+   subtype DFSDM_AWSCD7R_SCDT_Field is HAL.UInt8;
    subtype DFSDM_AWSCD7R_BKSCD_Field is HAL.UInt4;
    subtype DFSDM_AWSCD7R_AWFOSR_Field is HAL.UInt5;
    subtype DFSDM_AWSCD7R_AWFORD_Field is HAL.UInt2;
@@ -906,11 +907,11 @@ package STM32_SVD.DFSDM is
       --  channel 7
       AWFOSR         : DFSDM_AWSCD7R_AWFOSR_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Analog watchdog Sinc filter order on channel 7
       AWFORD         : DFSDM_AWSCD7R_AWFORD_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1304,7 +1305,7 @@ package STM32_SVD.DFSDM is
       --  Start a conversion of the injected group of channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Launch an injected conversion synchronously with the DFSDM0 JSWSTART
       --  trigger
       JSYNC          : Boolean := False;
@@ -1327,7 +1328,7 @@ package STM32_SVD.DFSDM is
       --  Launch regular conversion synchronously with DFSDM0
       RSYNC          : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  DMA channel enabled to read data for the regular conversion
       RDMAEN         : Boolean := False;
       --  unspecified
@@ -1341,7 +1342,7 @@ package STM32_SVD.DFSDM is
       --  Analog watchdog fast mode select
       AWFSEL         : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1381,7 +1382,7 @@ package STM32_SVD.DFSDM is
       --  Start a conversion of the injected group of channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Launch an injected conversion synchronously with the DFSDM0 JSWSTART
       --  trigger
       JSYNC          : Boolean := False;
@@ -1404,7 +1405,7 @@ package STM32_SVD.DFSDM is
       --  Launch regular conversion synchronously with DFSDM0
       RSYNC          : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  DMA channel enabled to read data for the regular conversion
       RDMAEN         : Boolean := False;
       --  unspecified
@@ -1418,7 +1419,7 @@ package STM32_SVD.DFSDM is
       --  Analog watchdog fast mode select
       AWFSEL         : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1458,7 +1459,7 @@ package STM32_SVD.DFSDM is
       --  Start a conversion of the injected group of channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Launch an injected conversion synchronously with the DFSDM0 JSWSTART
       --  trigger
       JSYNC          : Boolean := False;
@@ -1481,7 +1482,7 @@ package STM32_SVD.DFSDM is
       --  Launch regular conversion synchronously with DFSDM0
       RSYNC          : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  DMA channel enabled to read data for the regular conversion
       RDMAEN         : Boolean := False;
       --  unspecified
@@ -1495,7 +1496,7 @@ package STM32_SVD.DFSDM is
       --  Analog watchdog fast mode select
       AWFSEL         : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1535,7 +1536,7 @@ package STM32_SVD.DFSDM is
       --  Start a conversion of the injected group of channels
       JSWSTART       : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Launch an injected conversion synchronously with the DFSDM0 JSWSTART
       --  trigger
       JSYNC          : Boolean := False;
@@ -1558,7 +1559,7 @@ package STM32_SVD.DFSDM is
       --  Launch regular conversion synchronously with DFSDM0
       RSYNC          : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  DMA channel enabled to read data for the regular conversion
       RDMAEN         : Boolean := False;
       --  unspecified
@@ -1572,7 +1573,7 @@ package STM32_SVD.DFSDM is
       --  Analog watchdog fast mode select
       AWFSEL         : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1601,8 +1602,8 @@ package STM32_SVD.DFSDM is
       Reserved_31_31 at 0 range 31 .. 31;
    end record;
 
-   subtype DFSDM0_CR2_EXCH_Field is HAL.Byte;
-   subtype DFSDM0_CR2_AWDCH_Field is HAL.Byte;
+   subtype DFSDM0_CR2_EXCH_Field is HAL.UInt8;
+   subtype DFSDM0_CR2_AWDCH_Field is HAL.UInt8;
 
    --  DFSDM control register 2
    type DFSDM0_CR2_Register is record
@@ -1621,13 +1622,13 @@ package STM32_SVD.DFSDM is
       --  Clock absence interrupt enable
       CKABIE         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Extremes detector channel selection
       EXCH           : DFSDM0_CR2_EXCH_Field := 16#0#;
       --  Analog watchdog channel selection
       AWDCH          : DFSDM0_CR2_AWDCH_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1646,8 +1647,8 @@ package STM32_SVD.DFSDM is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM1_CR2_EXCH_Field is HAL.Byte;
-   subtype DFSDM1_CR2_AWDCH_Field is HAL.Byte;
+   subtype DFSDM1_CR2_EXCH_Field is HAL.UInt8;
+   subtype DFSDM1_CR2_AWDCH_Field is HAL.UInt8;
 
    --  DFSDM control register 2
    type DFSDM1_CR2_Register is record
@@ -1666,13 +1667,13 @@ package STM32_SVD.DFSDM is
       --  Clock absence interrupt enable
       CKABIE         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Extremes detector channel selection
       EXCH           : DFSDM1_CR2_EXCH_Field := 16#0#;
       --  Analog watchdog channel selection
       AWDCH          : DFSDM1_CR2_AWDCH_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1691,8 +1692,8 @@ package STM32_SVD.DFSDM is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM2_CR2_EXCH_Field is HAL.Byte;
-   subtype DFSDM2_CR2_AWDCH_Field is HAL.Byte;
+   subtype DFSDM2_CR2_EXCH_Field is HAL.UInt8;
+   subtype DFSDM2_CR2_AWDCH_Field is HAL.UInt8;
 
    --  DFSDM control register 2
    type DFSDM2_CR2_Register is record
@@ -1711,13 +1712,13 @@ package STM32_SVD.DFSDM is
       --  Clock absence interrupt enable
       CKABIE         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Extremes detector channel selection
       EXCH           : DFSDM2_CR2_EXCH_Field := 16#0#;
       --  Analog watchdog channel selection
       AWDCH          : DFSDM2_CR2_AWDCH_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1736,8 +1737,8 @@ package STM32_SVD.DFSDM is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM3_CR2_EXCH_Field is HAL.Byte;
-   subtype DFSDM3_CR2_AWDCH_Field is HAL.Byte;
+   subtype DFSDM3_CR2_EXCH_Field is HAL.UInt8;
+   subtype DFSDM3_CR2_AWDCH_Field is HAL.UInt8;
 
    --  DFSDM control register 2
    type DFSDM3_CR2_Register is record
@@ -1756,13 +1757,13 @@ package STM32_SVD.DFSDM is
       --  Clock absence interrupt enable
       CKABIE         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Extremes detector channel selection
       EXCH           : DFSDM3_CR2_EXCH_Field := 16#0#;
       --  Analog watchdog channel selection
       AWDCH          : DFSDM3_CR2_AWDCH_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1781,8 +1782,8 @@ package STM32_SVD.DFSDM is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM0_ISR_CKABF_Field is HAL.Byte;
-   subtype DFSDM0_ISR_SCDF_Field is HAL.Byte;
+   subtype DFSDM0_ISR_CKABF_Field is HAL.UInt8;
+   subtype DFSDM0_ISR_SCDF_Field is HAL.UInt8;
 
    --  DFSDM interrupt and status register
    type DFSDM0_ISR_Register is record
@@ -1797,13 +1798,13 @@ package STM32_SVD.DFSDM is
       --  Read-only. Analog watchdog
       AWDF           : Boolean;
       --  unspecified
-      Reserved_5_12  : HAL.Byte;
+      Reserved_5_12  : HAL.UInt8;
       --  Read-only. Injected conversion in progress status
       JCIP           : Boolean;
       --  Read-only. Regular conversion in progress status
       RCIP           : Boolean;
       --  unspecified
-      Reserved_15_15 : HAL.Bit;
+      Reserved_15_15 : HAL.UInt1;
       --  Read-only. Clock absence flag
       CKABF          : DFSDM0_ISR_CKABF_Field;
       --  Read-only. short-circuit detector flag
@@ -1826,8 +1827,8 @@ package STM32_SVD.DFSDM is
       SCDF           at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM1_ISR_CKABF_Field is HAL.Byte;
-   subtype DFSDM1_ISR_SCDF_Field is HAL.Byte;
+   subtype DFSDM1_ISR_CKABF_Field is HAL.UInt8;
+   subtype DFSDM1_ISR_SCDF_Field is HAL.UInt8;
 
    --  DFSDM interrupt and status register
    type DFSDM1_ISR_Register is record
@@ -1842,13 +1843,13 @@ package STM32_SVD.DFSDM is
       --  Read-only. Analog watchdog
       AWDF           : Boolean;
       --  unspecified
-      Reserved_5_12  : HAL.Byte;
+      Reserved_5_12  : HAL.UInt8;
       --  Read-only. Injected conversion in progress status
       JCIP           : Boolean;
       --  Read-only. Regular conversion in progress status
       RCIP           : Boolean;
       --  unspecified
-      Reserved_15_15 : HAL.Bit;
+      Reserved_15_15 : HAL.UInt1;
       --  Read-only. Clock absence flag
       CKABF          : DFSDM1_ISR_CKABF_Field;
       --  Read-only. short-circuit detector flag
@@ -1871,8 +1872,8 @@ package STM32_SVD.DFSDM is
       SCDF           at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM2_ISR_CKABF_Field is HAL.Byte;
-   subtype DFSDM2_ISR_SCDF_Field is HAL.Byte;
+   subtype DFSDM2_ISR_CKABF_Field is HAL.UInt8;
+   subtype DFSDM2_ISR_SCDF_Field is HAL.UInt8;
 
    --  DFSDM interrupt and status register
    type DFSDM2_ISR_Register is record
@@ -1887,13 +1888,13 @@ package STM32_SVD.DFSDM is
       --  Read-only. Analog watchdog
       AWDF           : Boolean;
       --  unspecified
-      Reserved_5_12  : HAL.Byte;
+      Reserved_5_12  : HAL.UInt8;
       --  Read-only. Injected conversion in progress status
       JCIP           : Boolean;
       --  Read-only. Regular conversion in progress status
       RCIP           : Boolean;
       --  unspecified
-      Reserved_15_15 : HAL.Bit;
+      Reserved_15_15 : HAL.UInt1;
       --  Read-only. Clock absence flag
       CKABF          : DFSDM2_ISR_CKABF_Field;
       --  Read-only. short-circuit detector flag
@@ -1916,8 +1917,8 @@ package STM32_SVD.DFSDM is
       SCDF           at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM3_ISR_CKABF_Field is HAL.Byte;
-   subtype DFSDM3_ISR_SCDF_Field is HAL.Byte;
+   subtype DFSDM3_ISR_CKABF_Field is HAL.UInt8;
+   subtype DFSDM3_ISR_SCDF_Field is HAL.UInt8;
 
    --  DFSDM interrupt and status register
    type DFSDM3_ISR_Register is record
@@ -1932,13 +1933,13 @@ package STM32_SVD.DFSDM is
       --  Read-only. Analog watchdog
       AWDF           : Boolean;
       --  unspecified
-      Reserved_5_12  : HAL.Byte;
+      Reserved_5_12  : HAL.UInt8;
       --  Read-only. Injected conversion in progress status
       JCIP           : Boolean;
       --  Read-only. Regular conversion in progress status
       RCIP           : Boolean;
       --  unspecified
-      Reserved_15_15 : HAL.Bit;
+      Reserved_15_15 : HAL.UInt1;
       --  Read-only. Clock absence flag
       CKABF          : DFSDM3_ISR_CKABF_Field;
       --  Read-only. short-circuit detector flag
@@ -1961,8 +1962,8 @@ package STM32_SVD.DFSDM is
       SCDF           at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM0_ICR_CLRCKABF_Field is HAL.Byte;
-   subtype DFSDM0_ICR_CLRSCDF_Field is HAL.Byte;
+   subtype DFSDM0_ICR_CLRCKABF_Field is HAL.UInt8;
+   subtype DFSDM0_ICR_CLRSCDF_Field is HAL.UInt8;
 
    --  DFSDM interrupt flag clear register
    type DFSDM0_ICR_Register is record
@@ -1991,8 +1992,8 @@ package STM32_SVD.DFSDM is
       CLRSCDF       at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM1_ICR_CLRCKABF_Field is HAL.Byte;
-   subtype DFSDM1_ICR_CLRSCDF_Field is HAL.Byte;
+   subtype DFSDM1_ICR_CLRCKABF_Field is HAL.UInt8;
+   subtype DFSDM1_ICR_CLRSCDF_Field is HAL.UInt8;
 
    --  DFSDM interrupt flag clear register
    type DFSDM1_ICR_Register is record
@@ -2021,8 +2022,8 @@ package STM32_SVD.DFSDM is
       CLRSCDF       at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM2_ICR_CLRCKABF_Field is HAL.Byte;
-   subtype DFSDM2_ICR_CLRSCDF_Field is HAL.Byte;
+   subtype DFSDM2_ICR_CLRCKABF_Field is HAL.UInt8;
+   subtype DFSDM2_ICR_CLRSCDF_Field is HAL.UInt8;
 
    --  DFSDM interrupt flag clear register
    type DFSDM2_ICR_Register is record
@@ -2051,8 +2052,8 @@ package STM32_SVD.DFSDM is
       CLRSCDF       at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM3_ICR_CLRCKABF_Field is HAL.Byte;
-   subtype DFSDM3_ICR_CLRSCDF_Field is HAL.Byte;
+   subtype DFSDM3_ICR_CLRCKABF_Field is HAL.UInt8;
+   subtype DFSDM3_ICR_CLRSCDF_Field is HAL.UInt8;
 
    --  DFSDM interrupt flag clear register
    type DFSDM3_ICR_Register is record
@@ -2081,7 +2082,7 @@ package STM32_SVD.DFSDM is
       CLRSCDF       at 0 range 24 .. 31;
    end record;
 
-   subtype DFSDM0_JCHGR_JCHG_Field is HAL.Byte;
+   subtype DFSDM0_JCHGR_JCHG_Field is HAL.UInt8;
 
    --  DFSDM injected channel group selection register
    type DFSDM0_JCHGR_Register is record
@@ -2098,7 +2099,7 @@ package STM32_SVD.DFSDM is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype DFSDM1_JCHGR_JCHG_Field is HAL.Byte;
+   subtype DFSDM1_JCHGR_JCHG_Field is HAL.UInt8;
 
    --  DFSDM injected channel group selection register
    type DFSDM1_JCHGR_Register is record
@@ -2115,7 +2116,7 @@ package STM32_SVD.DFSDM is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype DFSDM2_JCHGR_JCHG_Field is HAL.Byte;
+   subtype DFSDM2_JCHGR_JCHG_Field is HAL.UInt8;
 
    --  DFSDM injected channel group selection register
    type DFSDM2_JCHGR_Register is record
@@ -2132,7 +2133,7 @@ package STM32_SVD.DFSDM is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype DFSDM3_JCHGR_JCHG_Field is HAL.Byte;
+   subtype DFSDM3_JCHGR_JCHG_Field is HAL.UInt8;
 
    --  DFSDM injected channel group selection register
    type DFSDM3_JCHGR_Register is record
@@ -2149,7 +2150,7 @@ package STM32_SVD.DFSDM is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype DFSDM0_FCR_IOSR_Field is HAL.Byte;
+   subtype DFSDM0_FCR_IOSR_Field is HAL.UInt8;
    subtype DFSDM0_FCR_FOSR_Field is HAL.UInt10;
    subtype DFSDM0_FCR_FORD_Field is HAL.UInt3;
 
@@ -2158,7 +2159,7 @@ package STM32_SVD.DFSDM is
       --  Integrator oversampling ratio (averaging length)
       IOSR           : DFSDM0_FCR_IOSR_Field := 16#0#;
       --  unspecified
-      Reserved_8_15  : HAL.Byte := 16#0#;
+      Reserved_8_15  : HAL.UInt8 := 16#0#;
       --  Sinc filter oversampling ratio (decimation rate)
       FOSR           : DFSDM0_FCR_FOSR_Field := 16#0#;
       --  unspecified
@@ -2177,7 +2178,7 @@ package STM32_SVD.DFSDM is
       FORD           at 0 range 29 .. 31;
    end record;
 
-   subtype DFSDM1_FCR_IOSR_Field is HAL.Byte;
+   subtype DFSDM1_FCR_IOSR_Field is HAL.UInt8;
    subtype DFSDM1_FCR_FOSR_Field is HAL.UInt10;
    subtype DFSDM1_FCR_FORD_Field is HAL.UInt3;
 
@@ -2186,7 +2187,7 @@ package STM32_SVD.DFSDM is
       --  Integrator oversampling ratio (averaging length)
       IOSR           : DFSDM1_FCR_IOSR_Field := 16#0#;
       --  unspecified
-      Reserved_8_15  : HAL.Byte := 16#0#;
+      Reserved_8_15  : HAL.UInt8 := 16#0#;
       --  Sinc filter oversampling ratio (decimation rate)
       FOSR           : DFSDM1_FCR_FOSR_Field := 16#0#;
       --  unspecified
@@ -2205,7 +2206,7 @@ package STM32_SVD.DFSDM is
       FORD           at 0 range 29 .. 31;
    end record;
 
-   subtype DFSDM2_FCR_IOSR_Field is HAL.Byte;
+   subtype DFSDM2_FCR_IOSR_Field is HAL.UInt8;
    subtype DFSDM2_FCR_FOSR_Field is HAL.UInt10;
    subtype DFSDM2_FCR_FORD_Field is HAL.UInt3;
 
@@ -2214,7 +2215,7 @@ package STM32_SVD.DFSDM is
       --  Integrator oversampling ratio (averaging length)
       IOSR           : DFSDM2_FCR_IOSR_Field := 16#0#;
       --  unspecified
-      Reserved_8_15  : HAL.Byte := 16#0#;
+      Reserved_8_15  : HAL.UInt8 := 16#0#;
       --  Sinc filter oversampling ratio (decimation rate)
       FOSR           : DFSDM2_FCR_FOSR_Field := 16#0#;
       --  unspecified
@@ -2233,7 +2234,7 @@ package STM32_SVD.DFSDM is
       FORD           at 0 range 29 .. 31;
    end record;
 
-   subtype DFSDM3_FCR_IOSR_Field is HAL.Byte;
+   subtype DFSDM3_FCR_IOSR_Field is HAL.UInt8;
    subtype DFSDM3_FCR_FOSR_Field is HAL.UInt10;
    subtype DFSDM3_FCR_FORD_Field is HAL.UInt3;
 
@@ -2242,7 +2243,7 @@ package STM32_SVD.DFSDM is
       --  Integrator oversampling ratio (averaging length)
       IOSR           : DFSDM3_FCR_IOSR_Field := 16#0#;
       --  unspecified
-      Reserved_8_15  : HAL.Byte := 16#0#;
+      Reserved_8_15  : HAL.UInt8 := 16#0#;
       --  Sinc filter oversampling ratio (decimation rate)
       FOSR           : DFSDM3_FCR_FOSR_Field := 16#0#;
       --  unspecified
@@ -2353,7 +2354,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Regular channel most recently converted
       RDATACH      : DFSDM0_RDATAR_RDATACH_Field;
       --  unspecified
-      Reserved_3_3 : HAL.Bit;
+      Reserved_3_3 : HAL.UInt1;
       --  Read-only. Regular channel pending data
       RPEND        : Boolean;
       --  unspecified
@@ -2380,7 +2381,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Regular channel most recently converted
       RDATACH      : DFSDM1_RDATAR_RDATACH_Field;
       --  unspecified
-      Reserved_3_3 : HAL.Bit;
+      Reserved_3_3 : HAL.UInt1;
       --  Read-only. Regular channel pending data
       RPEND        : Boolean;
       --  unspecified
@@ -2407,7 +2408,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Regular channel most recently converted
       RDATACH      : DFSDM2_RDATAR_RDATACH_Field;
       --  unspecified
-      Reserved_3_3 : HAL.Bit;
+      Reserved_3_3 : HAL.UInt1;
       --  Read-only. Regular channel pending data
       RPEND        : Boolean;
       --  unspecified
@@ -2434,7 +2435,7 @@ package STM32_SVD.DFSDM is
       --  Read-only. Regular channel most recently converted
       RDATACH      : DFSDM3_RDATAR_RDATACH_Field;
       --  unspecified
-      Reserved_3_3 : HAL.Bit;
+      Reserved_3_3 : HAL.UInt1;
       --  Read-only. Regular channel pending data
       RPEND        : Boolean;
       --  unspecified
@@ -2621,8 +2622,8 @@ package STM32_SVD.DFSDM is
       AWLT         at 0 range 8 .. 31;
    end record;
 
-   subtype DFSDM0_AWSR_AWLTF_Field is HAL.Byte;
-   subtype DFSDM0_AWSR_AWHTF_Field is HAL.Byte;
+   subtype DFSDM0_AWSR_AWLTF_Field is HAL.UInt8;
+   subtype DFSDM0_AWSR_AWHTF_Field is HAL.UInt8;
 
    --  DFSDM analog watchdog status register
    type DFSDM0_AWSR_Register is record
@@ -2642,8 +2643,8 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM1_AWSR_AWLTF_Field is HAL.Byte;
-   subtype DFSDM1_AWSR_AWHTF_Field is HAL.Byte;
+   subtype DFSDM1_AWSR_AWLTF_Field is HAL.UInt8;
+   subtype DFSDM1_AWSR_AWHTF_Field is HAL.UInt8;
 
    --  DFSDM analog watchdog status register
    type DFSDM1_AWSR_Register is record
@@ -2663,8 +2664,8 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM2_AWSR_AWLTF_Field is HAL.Byte;
-   subtype DFSDM2_AWSR_AWHTF_Field is HAL.Byte;
+   subtype DFSDM2_AWSR_AWLTF_Field is HAL.UInt8;
+   subtype DFSDM2_AWSR_AWHTF_Field is HAL.UInt8;
 
    --  DFSDM analog watchdog status register
    type DFSDM2_AWSR_Register is record
@@ -2684,8 +2685,8 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM3_AWSR_AWLTF_Field is HAL.Byte;
-   subtype DFSDM3_AWSR_AWHTF_Field is HAL.Byte;
+   subtype DFSDM3_AWSR_AWLTF_Field is HAL.UInt8;
+   subtype DFSDM3_AWSR_AWHTF_Field is HAL.UInt8;
 
    --  DFSDM analog watchdog status register
    type DFSDM3_AWSR_Register is record
@@ -2705,8 +2706,8 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM0_AWCFR_CLRAWLTF_Field is HAL.Byte;
-   subtype DFSDM0_AWCFR_CLRAWHTF_Field is HAL.Byte;
+   subtype DFSDM0_AWCFR_CLRAWLTF_Field is HAL.UInt8;
+   subtype DFSDM0_AWCFR_CLRAWHTF_Field is HAL.UInt8;
 
    --  DFSDM analog watchdog clear flag register
    type DFSDM0_AWCFR_Register is record
@@ -2726,8 +2727,8 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM1_AWCFR_CLRAWLTF_Field is HAL.Byte;
-   subtype DFSDM1_AWCFR_CLRAWHTF_Field is HAL.Byte;
+   subtype DFSDM1_AWCFR_CLRAWLTF_Field is HAL.UInt8;
+   subtype DFSDM1_AWCFR_CLRAWHTF_Field is HAL.UInt8;
 
    --  DFSDM analog watchdog clear flag register
    type DFSDM1_AWCFR_Register is record
@@ -2747,8 +2748,8 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM2_AWCFR_CLRAWLTF_Field is HAL.Byte;
-   subtype DFSDM2_AWCFR_CLRAWHTF_Field is HAL.Byte;
+   subtype DFSDM2_AWCFR_CLRAWLTF_Field is HAL.UInt8;
+   subtype DFSDM2_AWCFR_CLRAWHTF_Field is HAL.UInt8;
 
    --  DFSDM analog watchdog clear flag register
    type DFSDM2_AWCFR_Register is record
@@ -2768,8 +2769,8 @@ package STM32_SVD.DFSDM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype DFSDM3_AWCFR_CLRAWLTF_Field is HAL.Byte;
-   subtype DFSDM3_AWCFR_CLRAWHTF_Field is HAL.Byte;
+   subtype DFSDM3_AWCFR_CLRAWLTF_Field is HAL.UInt8;
+   subtype DFSDM3_AWCFR_CLRAWHTF_Field is HAL.UInt8;
 
    --  DFSDM analog watchdog clear flag register
    type DFSDM3_AWCFR_Register is record
@@ -3339,6 +3340,6 @@ package STM32_SVD.DFSDM is
 
    --  Digital filter for sigma delta modulators
    DFSDM_Periph : aliased DFSDM_Peripheral
-     with Import, Address => DFSDM_Base;
+     with Import, Address => System'To_Address (16#40017400#);
 
 end STM32_SVD.DFSDM;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dma.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dma.ads
@@ -19,7 +19,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF0          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1;
+      Reserved_1_1   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF0         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -31,7 +31,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF1          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1;
+      Reserved_7_7   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF1         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -45,7 +45,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF2          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1;
+      Reserved_17_17 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF2         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -57,7 +57,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF3          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1;
+      Reserved_23_23 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF3         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -106,7 +106,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF4          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1;
+      Reserved_1_1   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF4         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -118,7 +118,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF5          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1;
+      Reserved_7_7   : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF5         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -132,7 +132,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF6          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1;
+      Reserved_17_17 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF6         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -144,7 +144,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF7          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1;
+      Reserved_23_23 : HAL.Bit;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF7         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -193,7 +193,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF0         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF0        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -205,7 +205,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF1        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -219,7 +219,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF2         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF2        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -231,7 +231,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF3         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF3        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -280,7 +280,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF4         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF4        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -292,7 +292,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF5         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF5        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -306,7 +306,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF6         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF6        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -318,7 +318,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF7         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF7        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -409,7 +409,7 @@ package STM32_SVD.DMA is
       --  Current target (only in double buffer mode)
       CT             : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Peripheral burst transfer configuration
       PBURST         : SxCR_Stream_PBURST_Field := 16#0#;
       --  Memory burst transfer configuration
@@ -475,7 +475,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : SxFCR_Stream_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dma.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dma.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -18,7 +19,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF0          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.Bit;
+      Reserved_1_1   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF0         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -30,7 +31,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF1          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.Bit;
+      Reserved_7_7   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF1         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -44,7 +45,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF2          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.Bit;
+      Reserved_17_17 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF2         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -56,7 +57,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=3..0)
       FEIF3          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.Bit;
+      Reserved_23_23 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=3..0)
       DMEIF3         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=3..0)
@@ -105,7 +106,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF4          : Boolean;
       --  unspecified
-      Reserved_1_1   : HAL.Bit;
+      Reserved_1_1   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF4         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -117,7 +118,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF5          : Boolean;
       --  unspecified
-      Reserved_7_7   : HAL.Bit;
+      Reserved_7_7   : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF5         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -131,7 +132,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF6          : Boolean;
       --  unspecified
-      Reserved_17_17 : HAL.Bit;
+      Reserved_17_17 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF6         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -143,7 +144,7 @@ package STM32_SVD.DMA is
       --  Read-only. Stream x FIFO error interrupt flag (x=7..4)
       FEIF7          : Boolean;
       --  unspecified
-      Reserved_23_23 : HAL.Bit;
+      Reserved_23_23 : HAL.UInt1;
       --  Read-only. Stream x direct mode error interrupt flag (x=7..4)
       DMEIF7         : Boolean;
       --  Read-only. Stream x transfer error interrupt flag (x=7..4)
@@ -192,7 +193,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF0         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF0        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -204,7 +205,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF1         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF1        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -218,7 +219,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF2         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF2        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -230,7 +231,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 3..0)
       CFEIF3         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 3..0)
       CDMEIF3        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 3..0)
@@ -279,7 +280,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF4         : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF4        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -291,7 +292,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF5         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF5        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -305,7 +306,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF6         : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF6        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -317,7 +318,7 @@ package STM32_SVD.DMA is
       --  Stream x clear FIFO error interrupt flag (x = 7..4)
       CFEIF7         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Stream x clear direct mode error interrupt flag (x = 7..4)
       CDMEIF7        : Boolean := False;
       --  Stream x clear transfer error interrupt flag (x = 7..4)
@@ -408,7 +409,7 @@ package STM32_SVD.DMA is
       --  Current target (only in double buffer mode)
       CT             : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Peripheral burst transfer configuration
       PBURST         : SxCR_Stream_PBURST_Field := 16#0#;
       --  Memory burst transfer configuration
@@ -474,7 +475,7 @@ package STM32_SVD.DMA is
       --  Read-only. FIFO status
       FS            : SxFCR_Stream_FS_Field := 16#4#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  FIFO error interrupt enable
       FEIE          : Boolean := False;
       --  unspecified
@@ -554,10 +555,10 @@ package STM32_SVD.DMA is
 
    --  DMA controller
    DMA1_Periph : aliased DMA_Peripheral
-     with Import, Address => DMA1_Base;
+     with Import, Address => System'To_Address (16#40026000#);
 
    --  DMA controller
    DMA2_Periph : aliased DMA_Peripheral
-     with Import, Address => DMA2_Base;
+     with Import, Address => System'To_Address (16#40026400#);
 
 end STM32_SVD.DMA;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dma2d.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dma2d.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -158,9 +159,9 @@ package STM32_SVD.DMA2D is
    end record;
 
    subtype FGPFCCR_CM_Field is HAL.UInt4;
-   subtype FGPFCCR_CS_Field is HAL.Byte;
+   subtype FGPFCCR_CS_Field is HAL.UInt8;
    subtype FGPFCCR_AM_Field is HAL.UInt2;
-   subtype FGPFCCR_ALPHA_Field is HAL.Byte;
+   subtype FGPFCCR_ALPHA_Field is HAL.UInt8;
 
    --  foreground PFC control register
    type FGPFCCR_Register is record
@@ -195,9 +196,9 @@ package STM32_SVD.DMA2D is
       ALPHA          at 0 range 24 .. 31;
    end record;
 
-   subtype FGCOLR_BLUE_Field is HAL.Byte;
-   subtype FGCOLR_GREEN_Field is HAL.Byte;
-   subtype FGCOLR_RED_Field is HAL.Byte;
+   subtype FGCOLR_BLUE_Field is HAL.UInt8;
+   subtype FGCOLR_GREEN_Field is HAL.UInt8;
+   subtype FGCOLR_RED_Field is HAL.UInt8;
 
    --  foreground color register
    type FGCOLR_Register is record
@@ -208,7 +209,7 @@ package STM32_SVD.DMA2D is
       --  Red Value
       RED            : FGCOLR_RED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -221,9 +222,9 @@ package STM32_SVD.DMA2D is
    end record;
 
    subtype BGPFCCR_CM_Field is HAL.UInt4;
-   subtype BGPFCCR_CS_Field is HAL.Byte;
+   subtype BGPFCCR_CS_Field is HAL.UInt8;
    subtype BGPFCCR_AM_Field is HAL.UInt2;
-   subtype BGPFCCR_ALPHA_Field is HAL.Byte;
+   subtype BGPFCCR_ALPHA_Field is HAL.UInt8;
 
    --  background PFC control register
    type BGPFCCR_Register is record
@@ -258,9 +259,9 @@ package STM32_SVD.DMA2D is
       ALPHA          at 0 range 24 .. 31;
    end record;
 
-   subtype BGCOLR_BLUE_Field is HAL.Byte;
-   subtype BGCOLR_GREEN_Field is HAL.Byte;
-   subtype BGCOLR_RED_Field is HAL.Byte;
+   subtype BGCOLR_BLUE_Field is HAL.UInt8;
+   subtype BGCOLR_GREEN_Field is HAL.UInt8;
+   subtype BGCOLR_RED_Field is HAL.UInt8;
 
    --  background color register
    type BGCOLR_Register is record
@@ -271,7 +272,7 @@ package STM32_SVD.DMA2D is
       --  Red Value
       RED            : BGCOLR_RED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -300,10 +301,10 @@ package STM32_SVD.DMA2D is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype OCOLR_BLUE_Field is HAL.Byte;
-   subtype OCOLR_GREEN_Field is HAL.Byte;
-   subtype OCOLR_RED_Field is HAL.Byte;
-   subtype OCOLR_APLHA_Field is HAL.Byte;
+   subtype OCOLR_BLUE_Field is HAL.UInt8;
+   subtype OCOLR_GREEN_Field is HAL.UInt8;
+   subtype OCOLR_RED_Field is HAL.UInt8;
+   subtype OCOLR_APLHA_Field is HAL.UInt8;
 
    --  output color register
    type OCOLR_Register is record
@@ -381,7 +382,7 @@ package STM32_SVD.DMA2D is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype AMTCR_DT_Field is HAL.Byte;
+   subtype AMTCR_DT_Field is HAL.UInt8;
 
    --  AHB master timer configuration register
    type AMTCR_Register is record
@@ -404,10 +405,10 @@ package STM32_SVD.DMA2D is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype FGCLUT_BLUE_Field is HAL.Byte;
-   subtype FGCLUT_GREEN_Field is HAL.Byte;
-   subtype FGCLUT_RED_Field is HAL.Byte;
-   subtype FGCLUT_APLHA_Field is HAL.Byte;
+   subtype FGCLUT_BLUE_Field is HAL.UInt8;
+   subtype FGCLUT_GREEN_Field is HAL.UInt8;
+   subtype FGCLUT_RED_Field is HAL.UInt8;
+   subtype FGCLUT_APLHA_Field is HAL.UInt8;
 
    --  FGCLUT
    type FGCLUT_Register is record
@@ -430,10 +431,10 @@ package STM32_SVD.DMA2D is
       APLHA at 0 range 24 .. 31;
    end record;
 
-   subtype BGCLUT_BLUE_Field is HAL.Byte;
-   subtype BGCLUT_GREEN_Field is HAL.Byte;
-   subtype BGCLUT_RED_Field is HAL.Byte;
-   subtype BGCLUT_APLHA_Field is HAL.Byte;
+   subtype BGCLUT_BLUE_Field is HAL.UInt8;
+   subtype BGCLUT_GREEN_Field is HAL.UInt8;
+   subtype BGCLUT_RED_Field is HAL.UInt8;
+   subtype BGCLUT_APLHA_Field is HAL.UInt8;
 
    --  BGCLUT
    type BGCLUT_Register is record
@@ -536,6 +537,6 @@ package STM32_SVD.DMA2D is
 
    --  DMA2D controller
    DMA2D_Periph : aliased DMA2D_Peripheral
-     with Import, Address => DMA2D_Base;
+     with Import, Address => System'To_Address (16#4002B000#);
 
 end STM32_SVD.DMA2D;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dsi.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dsi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -28,8 +29,8 @@ package STM32_SVD.DSI is
       Reserved_1_31 at 0 range 1 .. 31;
    end record;
 
-   subtype DSI_CCR_TXECKDIV_Field is HAL.Byte;
-   subtype DSI_CCR_TOCKDIV_Field is HAL.Byte;
+   subtype DSI_CCR_TXECKDIV_Field is HAL.UInt8;
+   subtype DSI_CCR_TOCKDIV_Field is HAL.UInt8;
 
    --  DSI HOST Clock Control Register
    type DSI_CCR_Register is record
@@ -110,19 +111,19 @@ package STM32_SVD.DSI is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype DSI_LPMCR_VLPSIZE_Field is HAL.Byte;
-   subtype DSI_LPMCR_LPSIZE_Field is HAL.Byte;
+   subtype DSI_LPMCR_VLPSIZE_Field is HAL.UInt8;
+   subtype DSI_LPMCR_LPSIZE_Field is HAL.UInt8;
 
    --  DSI Host Low-Power mode Configuration Register
    type DSI_LPMCR_Register is record
       --  VACT Largest Packet Size
       VLPSIZE        : DSI_LPMCR_VLPSIZE_Field := 16#0#;
       --  unspecified
-      Reserved_8_15  : HAL.Byte := 16#0#;
+      Reserved_8_15  : HAL.UInt8 := 16#0#;
       --  Largest Packet Size
       LPSIZE         : DSI_LPMCR_LPSIZE_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -462,7 +463,7 @@ package STM32_SVD.DSI is
       --  Generic Long Write Transmission
       GLWTX          : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  DCS Short Write Zero parameter Transmission
       DSW0TX         : Boolean := False;
       --  DCS Short Read One parameter Transmission
@@ -504,8 +505,8 @@ package STM32_SVD.DSI is
 
    subtype DSI_GHCR_DT_Field is HAL.UInt6;
    subtype DSI_GHCR_VCID_Field is HAL.UInt2;
-   subtype DSI_GHCR_WCLSB_Field is HAL.Byte;
-   subtype DSI_GHCR_WCMSB_Field is HAL.Byte;
+   subtype DSI_GHCR_WCLSB_Field is HAL.UInt8;
+   subtype DSI_GHCR_WCMSB_Field is HAL.UInt8;
 
    --  DSI Host Generic Header Configuration Register
    type DSI_GHCR_Register is record
@@ -518,7 +519,7 @@ package STM32_SVD.DSI is
       --  WordCount MSB
       WCMSB          : DSI_GHCR_WCMSB_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -532,7 +533,7 @@ package STM32_SVD.DSI is
    end record;
 
    --  DSI_GPDR_DATA array element
-   subtype DSI_GPDR_DATA_Element is HAL.Byte;
+   subtype DSI_GPDR_DATA_Element is HAL.UInt8;
 
    --  DSI_GPDR_DATA array
    type DSI_GPDR_DATA_Field_Array is array (1 .. 4) of DSI_GPDR_DATA_Element
@@ -651,7 +652,7 @@ package STM32_SVD.DSI is
       --  High-Speed Write Timeout Counter
       HSWR_TOCNT     : DSI_TCCR3_HSWR_TOCNT_Field := 16#0#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  Presp mode
       PM             : Boolean := False;
       --  unspecified
@@ -744,15 +745,15 @@ package STM32_SVD.DSI is
    end record;
 
    subtype DSI_DLTCR_MRD_TIME_Field is HAL.UInt15;
-   subtype DSI_DLTCR_LP2HS_TIME_Field is HAL.Byte;
-   subtype DSI_DLTCR_HS2LP_TIME_Field is HAL.Byte;
+   subtype DSI_DLTCR_LP2HS_TIME_Field is HAL.UInt8;
+   subtype DSI_DLTCR_HS2LP_TIME_Field is HAL.UInt8;
 
    --  DSI Host Data Lane Timer Configuration Register
    type DSI_DLTCR_Register is record
       --  Maximum Read Time
       MRD_TIME       : DSI_DLTCR_MRD_TIME_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Low-Power To High-Speed Time
       LP2HS_TIME     : DSI_DLTCR_LP2HS_TIME_Field := 16#0#;
       --  High-Speed To Low-Power Time
@@ -771,7 +772,7 @@ package STM32_SVD.DSI is
    --  DSI Host PHY Control Register
    type DSI_PCTLR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit := 16#0#;
+      Reserved_0_0  : HAL.UInt1 := 16#0#;
       --  Digital Enable
       DEN           : Boolean := False;
       --  Clock Enable
@@ -790,7 +791,7 @@ package STM32_SVD.DSI is
    end record;
 
    subtype DSI_PCONFR_NL_Field is HAL.UInt2;
-   subtype DSI_PCONFR_SW_TIME_Field is HAL.Byte;
+   subtype DSI_PCONFR_SW_TIME_Field is HAL.UInt8;
 
    --  DSI Host PHY Configuration Register
    type DSI_PCONFR_Register is record
@@ -857,7 +858,7 @@ package STM32_SVD.DSI is
    --  DSI Host PHY Status Register
    type DSI_PSR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit;
+      Reserved_0_0  : HAL.UInt1;
       --  Read-only. PHY Direction
       PD            : Boolean;
       --  Read-only. PHY Stop State Clock lane
@@ -1316,19 +1317,19 @@ package STM32_SVD.DSI is
       Reserved_9_31 at 0 range 9 .. 31;
    end record;
 
-   subtype DSI_LPMCCR_VLPSIZE_Field is HAL.Byte;
-   subtype DSI_LPMCCR_LPSIZE_Field is HAL.Byte;
+   subtype DSI_LPMCCR_VLPSIZE_Field is HAL.UInt8;
+   subtype DSI_LPMCCR_LPSIZE_Field is HAL.UInt8;
 
    --  DSI Host Low-Power mode Current Configuration Register
    type DSI_LPMCCR_Register is record
       --  Read-only. VACT Largest Packet Size
       VLPSIZE        : DSI_LPMCCR_VLPSIZE_Field;
       --  unspecified
-      Reserved_8_15  : HAL.Byte;
+      Reserved_8_15  : HAL.UInt8;
       --  Read-only. Largest Packet Size
       LPSIZE         : DSI_LPMCCR_LPSIZE_Field;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1657,7 +1658,7 @@ package STM32_SVD.DSI is
       --  Read-only. PLL Unlock Interrupt Flag
       PLLUIF         : Boolean;
       --  unspecified
-      Reserved_11_11 : HAL.Bit;
+      Reserved_11_11 : HAL.UInt1;
       --  Read-only. Regulator Ready Status
       RRS            : Boolean;
       --  Read-only. Regulator Ready Interrupt Flag
@@ -1786,11 +1787,11 @@ package STM32_SVD.DSI is
       --  Contention Detection OFF on Data Lanes
       CDOFFDL        : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Turn Disable Data Lanes
       TDDL           : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  Pull-Down Enable
       PDEN           : Boolean := False;
       --  custom time for tCLK-PREPARE Enable
@@ -1904,10 +1905,10 @@ package STM32_SVD.DSI is
       Reserved_27_31 at 0 range 27 .. 31;
    end record;
 
-   subtype DSI_WPCR3_TCLKPREP_Field is HAL.Byte;
-   subtype DSI_WPCR3_TCLKZEO_Field is HAL.Byte;
-   subtype DSI_WPCR3_THSPREP_Field is HAL.Byte;
-   subtype DSI_WPCR3_THSTRAIL_Field is HAL.Byte;
+   subtype DSI_WPCR3_TCLKPREP_Field is HAL.UInt8;
+   subtype DSI_WPCR3_TCLKZEO_Field is HAL.UInt8;
+   subtype DSI_WPCR3_THSPREP_Field is HAL.UInt8;
+   subtype DSI_WPCR3_THSTRAIL_Field is HAL.UInt8;
 
    --  DSI Wrapper PHY Configuration Register 3
    type DSI_WPCR3_Register is record
@@ -1930,10 +1931,10 @@ package STM32_SVD.DSI is
       THSTRAIL at 0 range 24 .. 31;
    end record;
 
-   subtype DSI_WPCR4_THSZERO_Field is HAL.Byte;
-   subtype DSI_WPCR4_TLPXD_Field is HAL.Byte;
-   subtype DSI_WPCR4_THSEXIT_Field is HAL.Byte;
-   subtype DSI_WPCR4_TLPXC_Field is HAL.Byte;
+   subtype DSI_WPCR4_THSZERO_Field is HAL.UInt8;
+   subtype DSI_WPCR4_TLPXD_Field is HAL.UInt8;
+   subtype DSI_WPCR4_THSEXIT_Field is HAL.UInt8;
+   subtype DSI_WPCR4_TLPXC_Field is HAL.UInt8;
 
    --  DSI_WPCR4
    type DSI_WPCR4_Register is record
@@ -1956,7 +1957,7 @@ package STM32_SVD.DSI is
       TLPXC   at 0 range 24 .. 31;
    end record;
 
-   subtype DSI_WPCR5_THSZERO_Field is HAL.Byte;
+   subtype DSI_WPCR5_THSZERO_Field is HAL.UInt8;
 
    --  DSI Wrapper PHY Configuration Register 5
    type DSI_WPCR5_Register is record
@@ -1982,7 +1983,7 @@ package STM32_SVD.DSI is
       --  PLL Enable
       PLLEN          : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  PLL Loop Division Factor
       NDIV           : DSI_WRPCR_NDIV_Field := 16#0#;
       --  unspecified
@@ -1990,7 +1991,7 @@ package STM32_SVD.DSI is
       --  PLL Input Division Factor
       IDF            : DSI_WRPCR_IDF_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  PLL Output Division Factor
       ODF            : DSI_WRPCR_ODF_Field := 16#0#;
       --  unspecified
@@ -2246,6 +2247,6 @@ package STM32_SVD.DSI is
 
    --  DSI Host
    DSI_Periph : aliased DSI_Peripheral
-     with Import, Address => DSI_Base;
+     with Import, Address => System'To_Address (16#40016C00#);
 
 end STM32_SVD.DSI;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dsi.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-dsi.ads
@@ -463,7 +463,7 @@ package STM32_SVD.DSI is
       --  Generic Long Write Transmission
       GLWTX          : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  DCS Short Write Zero parameter Transmission
       DSW0TX         : Boolean := False;
       --  DCS Short Read One parameter Transmission
@@ -753,7 +753,7 @@ package STM32_SVD.DSI is
       --  Maximum Read Time
       MRD_TIME       : DSI_DLTCR_MRD_TIME_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Low-Power To High-Speed Time
       LP2HS_TIME     : DSI_DLTCR_LP2HS_TIME_Field := 16#0#;
       --  High-Speed To Low-Power Time
@@ -772,7 +772,7 @@ package STM32_SVD.DSI is
    --  DSI Host PHY Control Register
    type DSI_PCTLR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1 := 16#0#;
+      Reserved_0_0  : HAL.Bit := 16#0#;
       --  Digital Enable
       DEN           : Boolean := False;
       --  Clock Enable
@@ -858,7 +858,7 @@ package STM32_SVD.DSI is
    --  DSI Host PHY Status Register
    type DSI_PSR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1;
+      Reserved_0_0  : HAL.Bit;
       --  Read-only. PHY Direction
       PD            : Boolean;
       --  Read-only. PHY Stop State Clock lane
@@ -1658,7 +1658,7 @@ package STM32_SVD.DSI is
       --  Read-only. PLL Unlock Interrupt Flag
       PLLUIF         : Boolean;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1;
+      Reserved_11_11 : HAL.Bit;
       --  Read-only. Regulator Ready Status
       RRS            : Boolean;
       --  Read-only. Regulator Ready Interrupt Flag
@@ -1787,11 +1787,11 @@ package STM32_SVD.DSI is
       --  Contention Detection OFF on Data Lanes
       CDOFFDL        : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Turn Disable Data Lanes
       TDDL           : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  Pull-Down Enable
       PDEN           : Boolean := False;
       --  custom time for tCLK-PREPARE Enable
@@ -1983,7 +1983,7 @@ package STM32_SVD.DSI is
       --  PLL Enable
       PLLEN          : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  PLL Loop Division Factor
       NDIV           : DSI_WRPCR_NDIV_Field := 16#0#;
       --  unspecified
@@ -1991,7 +1991,7 @@ package STM32_SVD.DSI is
       --  PLL Input Division Factor
       IDF            : DSI_WRPCR_IDF_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  PLL Output Division Factor
       ODF            : DSI_WRPCR_ODF_Field := 16#0#;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-ethernet.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-ethernet.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -111,7 +112,7 @@ package STM32_SVD.Ethernet is
       --  Read-only. no description available
       EBS            : DMASR_EBS_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.Bit := 16#0#;
+      Reserved_26_26 : HAL.UInt1 := 16#0#;
       --  Read-only. no description available
       MMCS           : Boolean := False;
       --  Read-only. no description available
@@ -157,7 +158,7 @@ package STM32_SVD.Ethernet is
    --  Ethernet DMA operation mode register
    type DMAOMR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  SR
       SR             : Boolean := False;
       --  OSF
@@ -165,7 +166,7 @@ package STM32_SVD.Ethernet is
       --  RTC
       RTC            : DMAOMR_RTC_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  FUGF
       FUGF           : Boolean := False;
       --  FEF
@@ -304,7 +305,7 @@ package STM32_SVD.Ethernet is
       Reserved_29_31 at 0 range 29 .. 31;
    end record;
 
-   subtype DMARSWTR_RSWTC_Field is HAL.Byte;
+   subtype DMARSWTR_RSWTC_Field is HAL.UInt8;
 
    --  Ethernet DMA receive status watchdog timer register
    type DMARSWTR_Register is record
@@ -339,7 +340,7 @@ package STM32_SVD.Ethernet is
       --  APCS
       APCS           : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  RD
       RD             : Boolean := False;
       --  IPCO
@@ -353,7 +354,7 @@ package STM32_SVD.Ethernet is
       --  FES
       FES            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#1#;
+      Reserved_15_15 : HAL.UInt1 := 16#1#;
       --  CSD
       CSD            : Boolean := False;
       --  IFG
@@ -365,7 +366,7 @@ package STM32_SVD.Ethernet is
       --  WD
       WD             : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  CSTF
       CSTF           : Boolean := False;
       --  unspecified
@@ -457,7 +458,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       CR             : MACMIIAR_CR_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  no description available
       MR             : MACMIIAR_MR_Field := 16#0#;
       --  no description available
@@ -511,11 +512,11 @@ package STM32_SVD.Ethernet is
       --  no description available
       PLT           : MACFCR_PLT_Field := 16#0#;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  no description available
       ZQPD          : Boolean := False;
       --  unspecified
-      Reserved_8_15 : HAL.Byte := 16#0#;
+      Reserved_8_15 : HAL.UInt8 := 16#0#;
       --  no description available
       PT            : MACFCR_PT_Field := 16#0#;
    end record
@@ -708,7 +709,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA1H         : MACA1HR_MACA1H_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA1HR_MBC_Field := 16#0#;
       --  no description available
@@ -735,7 +736,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MAC2AH         : MACA2HR_MAC2AH_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA2HR_MBC_Field := 16#0#;
       --  no description available
@@ -761,7 +762,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA2L         : MACA2LR_MACA2L_Field := 16#7FFFFFFF#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#1#;
+      Reserved_31_31 : HAL.UInt1 := 16#1#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -779,7 +780,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA3H         : MACA3HR_MACA3H_Field := 16#FFFF#;
       --  unspecified
-      Reserved_16_23 : HAL.Byte := 16#0#;
+      Reserved_16_23 : HAL.UInt8 := 16#0#;
       --  no description available
       MBC            : MACA3HR_MBC_Field := 16#0#;
       --  no description available
@@ -998,7 +999,7 @@ package STM32_SVD.Ethernet is
       Reserved_19_31 at 0 range 19 .. 31;
    end record;
 
-   subtype PTPSSIR_STSSI_Field is HAL.Byte;
+   subtype PTPSSIR_STSSI_Field is HAL.UInt8;
 
    --  Ethernet PTP subsecond increment register
    type PTPSSIR_Register is record
@@ -1141,7 +1142,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: DMA controller operation
    Ethernet_DMA_Periph : aliased Ethernet_DMA_Peripheral
-     with Import, Address => Ethernet_DMA_Base;
+     with Import, Address => System'To_Address (16#40029000#);
 
    --  Ethernet: media access control (MAC)
    type Ethernet_MAC_Peripheral is record
@@ -1216,7 +1217,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: media access control (MAC)
    Ethernet_MAC_Periph : aliased Ethernet_MAC_Peripheral
-     with Import, Address => Ethernet_MAC_Base;
+     with Import, Address => System'To_Address (16#40028000#);
 
    --  Ethernet: MAC management counters
    type Ethernet_MMC_Peripheral is record
@@ -1262,7 +1263,7 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: MAC management counters
    Ethernet_MMC_Periph : aliased Ethernet_MMC_Peripheral
-     with Import, Address => Ethernet_MMC_Base;
+     with Import, Address => System'To_Address (16#40028100#);
 
    --  Ethernet: Precision time protocol
    type Ethernet_PTP_Peripheral is record
@@ -1307,6 +1308,6 @@ package STM32_SVD.Ethernet is
 
    --  Ethernet: Precision time protocol
    Ethernet_PTP_Periph : aliased Ethernet_PTP_Peripheral
-     with Import, Address => Ethernet_PTP_Base;
+     with Import, Address => System'To_Address (16#40028700#);
 
 end STM32_SVD.Ethernet;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-ethernet.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-ethernet.ads
@@ -112,7 +112,7 @@ package STM32_SVD.Ethernet is
       --  Read-only. no description available
       EBS            : DMASR_EBS_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.UInt1 := 16#0#;
+      Reserved_26_26 : HAL.Bit := 16#0#;
       --  Read-only. no description available
       MMCS           : Boolean := False;
       --  Read-only. no description available
@@ -158,7 +158,7 @@ package STM32_SVD.Ethernet is
    --  Ethernet DMA operation mode register
    type DMAOMR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  SR
       SR             : Boolean := False;
       --  OSF
@@ -166,7 +166,7 @@ package STM32_SVD.Ethernet is
       --  RTC
       RTC            : DMAOMR_RTC_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  FUGF
       FUGF           : Boolean := False;
       --  FEF
@@ -340,7 +340,7 @@ package STM32_SVD.Ethernet is
       --  APCS
       APCS           : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  RD
       RD             : Boolean := False;
       --  IPCO
@@ -354,7 +354,7 @@ package STM32_SVD.Ethernet is
       --  FES
       FES            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#1#;
+      Reserved_15_15 : HAL.Bit := 16#1#;
       --  CSD
       CSD            : Boolean := False;
       --  IFG
@@ -366,7 +366,7 @@ package STM32_SVD.Ethernet is
       --  WD
       WD             : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  CSTF
       CSTF           : Boolean := False;
       --  unspecified
@@ -458,7 +458,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       CR             : MACMIIAR_CR_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  no description available
       MR             : MACMIIAR_MR_Field := 16#0#;
       --  no description available
@@ -512,7 +512,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       PLT           : MACFCR_PLT_Field := 16#0#;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  no description available
       ZQPD          : Boolean := False;
       --  unspecified
@@ -762,7 +762,7 @@ package STM32_SVD.Ethernet is
       --  no description available
       MACA2L         : MACA2LR_MACA2L_Field := 16#7FFFFFFF#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#1#;
+      Reserved_31_31 : HAL.Bit := 16#1#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-exti.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-exti.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -279,6 +280,6 @@ package STM32_SVD.EXTI is
 
    --  External interrupt/event controller
    EXTI_Periph : aliased EXTI_Peripheral
-     with Import, Address => EXTI_Base;
+     with Import, Address => System'To_Address (16#40013C00#);
 
 end STM32_SVD.EXTI;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-flash.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-flash.ads
@@ -152,7 +152,7 @@ package STM32_SVD.FLASH is
       --  BOR reset Level
       BOR_LEV        : OPTCR_BOR_LEV_Field := 16#3#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  WDG_SW User option bytes
       WDG_SW         : Boolean := True;
       --  nRST_STOP User option bytes

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-flash.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-flash.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -65,7 +66,7 @@ package STM32_SVD.FLASH is
       --  Programming sequence error
       PGSERR         : Boolean := False;
       --  unspecified
-      Reserved_8_15  : HAL.Byte := 16#0#;
+      Reserved_8_15  : HAL.UInt8 := 16#0#;
       --  Read-only. Busy
       BSY            : Boolean := False;
       --  unspecified
@@ -139,7 +140,7 @@ package STM32_SVD.FLASH is
    end record;
 
    subtype OPTCR_BOR_LEV_Field is HAL.UInt2;
-   subtype OPTCR_RDP_Field is HAL.Byte;
+   subtype OPTCR_RDP_Field is HAL.UInt8;
    subtype OPTCR_nWRP_Field is HAL.UInt12;
 
    --  Flash option control register
@@ -151,7 +152,7 @@ package STM32_SVD.FLASH is
       --  BOR reset Level
       BOR_LEV        : OPTCR_BOR_LEV_Field := 16#3#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  WDG_SW User option bytes
       WDG_SW         : Boolean := True;
       --  nRST_STOP User option bytes
@@ -236,6 +237,6 @@ package STM32_SVD.FLASH is
 
    --  FLASH
    FLASH_Periph : aliased FLASH_Peripheral
-     with Import, Address => FLASH_Base;
+     with Import, Address => System'To_Address (16#40023C00#);
 
 end STM32_SVD.FLASH;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-fsmc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-fsmc.ads
@@ -30,13 +30,13 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#1#;
+      Reserved_7_7   : HAL.Bit := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
       WAITPOL        : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  WAITCFG
       WAITCFG        : Boolean := False;
       --  WREN
@@ -137,7 +137,7 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#1#;
+      Reserved_7_7   : HAL.Bit := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
@@ -192,7 +192,7 @@ package STM32_SVD.FSMC is
    --  PC Card/NAND Flash control register
    type PCR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  PWAITEN
       PWAITEN        : Boolean := False;
       --  PBKEN

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-fsmc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-fsmc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -29,13 +30,13 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#1#;
+      Reserved_7_7   : HAL.UInt1 := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
       WAITPOL        : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  WAITCFG
       WAITCFG        : Boolean := False;
       --  WREN
@@ -81,7 +82,7 @@ package STM32_SVD.FSMC is
 
    subtype BTR_ADDSET_Field is HAL.UInt4;
    subtype BTR_ADDHLD_Field is HAL.UInt4;
-   subtype BTR_DATAST_Field is HAL.Byte;
+   subtype BTR_DATAST_Field is HAL.UInt8;
    subtype BTR_BUSTURN_Field is HAL.UInt4;
    subtype BTR_CLKDIV_Field is HAL.UInt4;
    subtype BTR_DATLAT_Field is HAL.UInt4;
@@ -136,7 +137,7 @@ package STM32_SVD.FSMC is
       --  FACCEN
       FACCEN         : Boolean := True;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#1#;
+      Reserved_7_7   : HAL.UInt1 := 16#1#;
       --  BURSTEN
       BURSTEN        : Boolean := False;
       --  WAITPOL
@@ -191,7 +192,7 @@ package STM32_SVD.FSMC is
    --  PC Card/NAND Flash control register
    type PCR_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  PWAITEN
       PWAITEN        : Boolean := False;
       --  PBKEN
@@ -263,10 +264,10 @@ package STM32_SVD.FSMC is
       Reserved_7_31 at 0 range 7 .. 31;
    end record;
 
-   subtype PMEM_MEMSETx_Field is HAL.Byte;
-   subtype PMEM_MEMWAITx_Field is HAL.Byte;
-   subtype PMEM_MEMHOLDx_Field is HAL.Byte;
-   subtype PMEM_MEMHIZx_Field is HAL.Byte;
+   subtype PMEM_MEMSETx_Field is HAL.UInt8;
+   subtype PMEM_MEMWAITx_Field is HAL.UInt8;
+   subtype PMEM_MEMHOLDx_Field is HAL.UInt8;
+   subtype PMEM_MEMHIZx_Field is HAL.UInt8;
 
    --  Common memory space timing register
    type PMEM_Register is record
@@ -289,10 +290,10 @@ package STM32_SVD.FSMC is
       MEMHIZx  at 0 range 24 .. 31;
    end record;
 
-   subtype PATT_ATTSETx_Field is HAL.Byte;
-   subtype PATT_ATTWAITx_Field is HAL.Byte;
-   subtype PATT_ATTHOLDx_Field is HAL.Byte;
-   subtype PATT_ATTHIZx_Field is HAL.Byte;
+   subtype PATT_ATTSETx_Field is HAL.UInt8;
+   subtype PATT_ATTWAITx_Field is HAL.UInt8;
+   subtype PATT_ATTHOLDx_Field is HAL.UInt8;
+   subtype PATT_ATTHIZx_Field is HAL.UInt8;
 
    --  Attribute memory space timing register
    type PATT_Register is record
@@ -317,7 +318,7 @@ package STM32_SVD.FSMC is
 
    subtype BWTR_ADDSET_Field is HAL.UInt4;
    subtype BWTR_ADDHLD_Field is HAL.UInt4;
-   subtype BWTR_DATAST_Field is HAL.Byte;
+   subtype BWTR_DATAST_Field is HAL.UInt8;
    subtype BWTR_CLKDIV_Field is HAL.UInt4;
    subtype BWTR_DATLAT_Field is HAL.UInt4;
    subtype BWTR_ACCMOD_Field is HAL.UInt2;
@@ -652,6 +653,6 @@ package STM32_SVD.FSMC is
 
    --  Flexible memory controller
    FMC_Periph : aliased FMC_Peripheral
-     with Import, Address => FMC_Base;
+     with Import, Address => System'To_Address (16#A0000000#);
 
 end STM32_SVD.FSMC;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-gpio.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-gpio.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -461,46 +462,46 @@ package STM32_SVD.GPIO is
 
    --  General-purpose I/Os
    GPIOA_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOA_Base;
+     with Import, Address => System'To_Address (16#40020000#);
 
    --  General-purpose I/Os
    GPIOB_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOB_Base;
+     with Import, Address => System'To_Address (16#40020400#);
 
    --  General-purpose I/Os
    GPIOC_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOC_Base;
+     with Import, Address => System'To_Address (16#40020800#);
 
    --  General-purpose I/Os
    GPIOD_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOD_Base;
+     with Import, Address => System'To_Address (16#40020C00#);
 
    --  General-purpose I/Os
    GPIOE_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOE_Base;
+     with Import, Address => System'To_Address (16#40021000#);
 
    --  General-purpose I/Os
    GPIOF_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOF_Base;
+     with Import, Address => System'To_Address (16#40021400#);
 
    --  General-purpose I/Os
    GPIOG_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOG_Base;
+     with Import, Address => System'To_Address (16#40021800#);
 
    --  General-purpose I/Os
    GPIOH_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOH_Base;
+     with Import, Address => System'To_Address (16#40021C00#);
 
    --  General-purpose I/Os
    GPIOI_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOI_Base;
+     with Import, Address => System'To_Address (16#40022000#);
 
    --  General-purpose I/Os
    GPIOJ_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOJ_Base;
+     with Import, Address => System'To_Address (16#40022400#);
 
    --  General-purpose I/Os
    GPIOK_Periph : aliased GPIO_Peripheral
-     with Import, Address => GPIOK_Base;
+     with Import, Address => System'To_Address (16#40022800#);
 
 end STM32_SVD.GPIO;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-hash.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-hash.ads
@@ -42,7 +42,7 @@ package STM32_SVD.HASH is
       --  Long key selection
       LKEY           : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.UInt1 := 16#0#;
+      Reserved_17_17 : HAL.Bit := 16#0#;
       --  ALGO
       ALGO1          : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-hash.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-hash.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -41,7 +42,7 @@ package STM32_SVD.HASH is
       --  Long key selection
       LKEY           : Boolean := False;
       --  unspecified
-      Reserved_17_17 : HAL.Bit := 16#0#;
+      Reserved_17_17 : HAL.UInt1 := 16#0#;
       --  ALGO
       ALGO1          : Boolean := False;
       --  unspecified
@@ -362,6 +363,6 @@ package STM32_SVD.HASH is
 
    --  Hash processor
    HASH_Periph : aliased HASH_Peripheral
-     with Import, Address => HASH_Base;
+     with Import, Address => System'To_Address (16#50060400#);
 
 end STM32_SVD.HASH;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-i2c.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-i2c.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -38,7 +39,7 @@ package STM32_SVD.I2C is
       --  Analog noise filter OFF
       ANFOFF         : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  DMA transmission requests enable
       TXDMAEN        : Boolean := False;
       --  DMA reception requests enable
@@ -60,7 +61,7 @@ package STM32_SVD.I2C is
       --  PEC enable
       PECEN          : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -91,7 +92,7 @@ package STM32_SVD.I2C is
    end record;
 
    subtype CR2_SADD_Field is HAL.UInt10;
-   subtype CR2_NBYTES_Field is HAL.Byte;
+   subtype CR2_NBYTES_Field is HAL.UInt8;
 
    --  Control register 2
    type CR2_Register is record
@@ -170,7 +171,7 @@ package STM32_SVD.I2C is
    --  Own address register 2
    type OAR2_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  Interface address
       OA2            : OAR2_OA2_Field := 16#0#;
       --  Own Address 2 masks
@@ -194,8 +195,8 @@ package STM32_SVD.I2C is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype TIMINGR_SCLL_Field is HAL.Byte;
-   subtype TIMINGR_SCLH_Field is HAL.Byte;
+   subtype TIMINGR_SCLL_Field is HAL.UInt8;
+   subtype TIMINGR_SCLH_Field is HAL.UInt8;
    subtype TIMINGR_SDADEL_Field is HAL.UInt4;
    subtype TIMINGR_SCLDEL_Field is HAL.UInt4;
    subtype TIMINGR_PRESC_Field is HAL.UInt4;
@@ -293,7 +294,7 @@ package STM32_SVD.I2C is
       --  Read-only. SMBus alert
       ALERT          : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Read-only. Bus busy
       BUSY           : Boolean := False;
       --  Read-only. Transfer direction (Slave mode)
@@ -301,7 +302,7 @@ package STM32_SVD.I2C is
       --  Read-only. Address match code (Slave mode)
       ADDCODE        : ISR_ADDCODE_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -373,7 +374,7 @@ package STM32_SVD.I2C is
       Reserved_14_31 at 0 range 14 .. 31;
    end record;
 
-   subtype PECR_PEC_Field is HAL.Byte;
+   subtype PECR_PEC_Field is HAL.UInt8;
 
    --  PEC register
    type PECR_Register is record
@@ -390,7 +391,7 @@ package STM32_SVD.I2C is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype RXDR_RXDATA_Field is HAL.Byte;
+   subtype RXDR_RXDATA_Field is HAL.UInt8;
 
    --  Receive data register
    type RXDR_Register is record
@@ -407,7 +408,7 @@ package STM32_SVD.I2C is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype TXDR_TXDATA_Field is HAL.Byte;
+   subtype TXDR_TXDATA_Field is HAL.UInt8;
 
    --  Transmit data register
    type TXDR_Register is record
@@ -471,18 +472,18 @@ package STM32_SVD.I2C is
 
    --  Inter-integrated circuit
    I2C1_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C1_Base;
+     with Import, Address => System'To_Address (16#40005400#);
 
    --  Inter-integrated circuit
    I2C2_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C2_Base;
+     with Import, Address => System'To_Address (16#40005800#);
 
    --  Inter-integrated circuit
    I2C3_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C3_Base;
+     with Import, Address => System'To_Address (16#40005C00#);
 
    --  Inter-integrated circuit
    I2C4_Periph : aliased I2C_Peripheral
-     with Import, Address => I2C4_Base;
+     with Import, Address => System'To_Address (16#40006000#);
 
 end STM32_SVD.I2C;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-i2c.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-i2c.ads
@@ -39,7 +39,7 @@ package STM32_SVD.I2C is
       --  Analog noise filter OFF
       ANFOFF         : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  DMA transmission requests enable
       TXDMAEN        : Boolean := False;
       --  DMA reception requests enable
@@ -171,7 +171,7 @@ package STM32_SVD.I2C is
    --  Own address register 2
    type OAR2_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  Interface address
       OA2            : OAR2_OA2_Field := 16#0#;
       --  Own Address 2 masks
@@ -294,7 +294,7 @@ package STM32_SVD.I2C is
       --  Read-only. SMBus alert
       ALERT          : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Read-only. Bus busy
       BUSY           : Boolean := False;
       --  Read-only. Transfer direction (Slave mode)

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-iwdg.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-iwdg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -128,6 +129,6 @@ package STM32_SVD.IWDG is
 
    --  Independent watchdog
    IWDG_Periph : aliased IWDG_Peripheral
-     with Import, Address => IWDG_Base;
+     with Import, Address => System'To_Address (16#40003000#);
 
 end STM32_SVD.IWDG;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-jpeg.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-jpeg.ads
@@ -39,7 +39,7 @@ package STM32_SVD.JPEG is
       --  Number of color components
       NF            : JPEG_CONFR1_NF_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Decoding Enable
       DE            : Boolean := False;
       --  Color Space
@@ -187,7 +187,7 @@ package STM32_SVD.JPEG is
    --  JPEG status register
    type JPEG_SR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1;
+      Reserved_0_0  : HAL.Bit;
       --  Read-only. Input FIFO Threshold Flag
       IFTF          : Boolean;
       --  Read-only. Input FIFO Not Full Flag

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-jpeg.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-jpeg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -38,7 +39,7 @@ package STM32_SVD.JPEG is
       --  Number of color components
       NF            : JPEG_CONFR1_NF_Field := 16#0#;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Decoding Enable
       DE            : Boolean := False;
       --  Color Space
@@ -186,7 +187,7 @@ package STM32_SVD.JPEG is
    --  JPEG status register
    type JPEG_SR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit;
+      Reserved_0_0  : HAL.UInt1;
       --  Read-only. Input FIFO Threshold Flag
       IFTF          : Boolean;
       --  Read-only. Input FIFO Not Full Flag
@@ -293,6 +294,6 @@ package STM32_SVD.JPEG is
 
    --  JPEG codec
    JPEG_Periph : aliased JPEG_Peripheral
-     with Import, Address => JPEG_Base;
+     with Import, Address => System'To_Address (16#50051000#);
 
 end STM32_SVD.JPEG;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-lptim.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-lptim.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -128,19 +129,19 @@ package STM32_SVD.LPTIM is
       --  Configurable digital filter for external clock
       CKFLT          : CFGR_CKFLT_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Configurable digital filter for trigger
       TRGFLT         : CFGR_TRGFLT_Field := 16#0#;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  Clock prescaler
       PRESC          : CFGR_PRESC_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.Bit := 16#0#;
+      Reserved_12_12 : HAL.UInt1 := 16#0#;
       --  Trigger selector
       TRIGSEL        : CFGR_TRIGSEL_Field := 16#0#;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Trigger enable and polarity
       TRIGEN         : CFGR_TRIGEN_Field := 16#0#;
       --  Timeout enable
@@ -292,6 +293,6 @@ package STM32_SVD.LPTIM is
 
    --  Low power timer
    LPTIM1_Periph : aliased LPTIM1_Peripheral
-     with Import, Address => LPTIM1_Base;
+     with Import, Address => System'To_Address (16#40002400#);
 
 end STM32_SVD.LPTIM;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-lptim.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-lptim.ads
@@ -129,19 +129,19 @@ package STM32_SVD.LPTIM is
       --  Configurable digital filter for external clock
       CKFLT          : CFGR_CKFLT_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Configurable digital filter for trigger
       TRGFLT         : CFGR_TRGFLT_Field := 16#0#;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  Clock prescaler
       PRESC          : CFGR_PRESC_Field := 16#0#;
       --  unspecified
-      Reserved_12_12 : HAL.UInt1 := 16#0#;
+      Reserved_12_12 : HAL.Bit := 16#0#;
       --  Trigger selector
       TRIGSEL        : CFGR_TRIGSEL_Field := 16#0#;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Trigger enable and polarity
       TRIGEN         : CFGR_TRIGEN_Field := 16#0#;
       --  Timeout enable

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-ltdc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-ltdc.ads
@@ -123,15 +123,15 @@ package STM32_SVD.LTDC is
       --  Read-only. Dither Blue Width
       DBW            : GCR_DBW_Field := 16#2#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Read-only. Dither Green Width
       DGW            : GCR_DGW_Field := 16#2#;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  Read-only. Dither Red Width
       DRW            : GCR_DRW_Field := 16#2#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Dither Enable
       DEN            : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-ltdc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-ltdc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -122,15 +123,15 @@ package STM32_SVD.LTDC is
       --  Read-only. Dither Blue Width
       DBW            : GCR_DBW_Field := 16#2#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Read-only. Dither Green Width
       DGW            : GCR_DGW_Field := 16#2#;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  Read-only. Dither Red Width
       DRW            : GCR_DRW_Field := 16#2#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Dither Enable
       DEN            : Boolean := False;
       --  unspecified
@@ -189,7 +190,7 @@ package STM32_SVD.LTDC is
       --  Background Color Red value
       BC             : BCCR_BC_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -402,9 +403,9 @@ package STM32_SVD.LTDC is
       Reserved_27_31 at 0 range 27 .. 31;
    end record;
 
-   subtype L1CKCR_CKBLUE_Field is HAL.Byte;
-   subtype L1CKCR_CKGREEN_Field is HAL.Byte;
-   subtype L1CKCR_CKRED_Field is HAL.Byte;
+   subtype L1CKCR_CKBLUE_Field is HAL.UInt8;
+   subtype L1CKCR_CKGREEN_Field is HAL.UInt8;
+   subtype L1CKCR_CKRED_Field is HAL.UInt8;
 
    --  Layerx Color Keying Configuration Register
    type L1CKCR_Register is record
@@ -415,7 +416,7 @@ package STM32_SVD.LTDC is
       --  Color Key Red value
       CKRED          : L1CKCR_CKRED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -444,7 +445,7 @@ package STM32_SVD.LTDC is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype L1CACR_CONSTA_Field is HAL.Byte;
+   subtype L1CACR_CONSTA_Field is HAL.UInt8;
 
    --  Layerx Constant Alpha Configuration Register
    type L1CACR_Register is record
@@ -461,10 +462,10 @@ package STM32_SVD.LTDC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype L1DCCR_DCBLUE_Field is HAL.Byte;
-   subtype L1DCCR_DCGREEN_Field is HAL.Byte;
-   subtype L1DCCR_DCRED_Field is HAL.Byte;
-   subtype L1DCCR_DCALPHA_Field is HAL.Byte;
+   subtype L1DCCR_DCBLUE_Field is HAL.UInt8;
+   subtype L1DCCR_DCGREEN_Field is HAL.UInt8;
+   subtype L1DCCR_DCRED_Field is HAL.UInt8;
+   subtype L1DCCR_DCALPHA_Field is HAL.UInt8;
 
    --  Layerx Default Color Configuration Register
    type L1DCCR_Register is record
@@ -552,10 +553,10 @@ package STM32_SVD.LTDC is
       Reserved_11_31 at 0 range 11 .. 31;
    end record;
 
-   subtype L1CLUTWR_BLUE_Field is HAL.Byte;
-   subtype L1CLUTWR_GREEN_Field is HAL.Byte;
-   subtype L1CLUTWR_RED_Field is HAL.Byte;
-   subtype L1CLUTWR_CLUTADD_Field is HAL.Byte;
+   subtype L1CLUTWR_BLUE_Field is HAL.UInt8;
+   subtype L1CLUTWR_GREEN_Field is HAL.UInt8;
+   subtype L1CLUTWR_RED_Field is HAL.UInt8;
+   subtype L1CLUTWR_CLUTADD_Field is HAL.UInt8;
 
    --  Layerx CLUT Write Register
    type L1CLUTWR_Register is record
@@ -650,7 +651,7 @@ package STM32_SVD.LTDC is
       Reserved_27_31 at 0 range 27 .. 31;
    end record;
 
-   subtype L2CKCR_CKBLUE_Field is HAL.Byte;
+   subtype L2CKCR_CKBLUE_Field is HAL.UInt8;
    subtype L2CKCR_CKGREEN_Field is HAL.UInt7;
    subtype L2CKCR_CKRED_Field is HAL.UInt9;
 
@@ -663,7 +664,7 @@ package STM32_SVD.LTDC is
       --  Color Key Red value
       CKRED          : L2CKCR_CKRED_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -692,7 +693,7 @@ package STM32_SVD.LTDC is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype L2CACR_CONSTA_Field is HAL.Byte;
+   subtype L2CACR_CONSTA_Field is HAL.UInt8;
 
    --  Layerx Constant Alpha Configuration Register
    type L2CACR_Register is record
@@ -709,10 +710,10 @@ package STM32_SVD.LTDC is
       Reserved_8_31 at 0 range 8 .. 31;
    end record;
 
-   subtype L2DCCR_DCBLUE_Field is HAL.Byte;
-   subtype L2DCCR_DCGREEN_Field is HAL.Byte;
-   subtype L2DCCR_DCRED_Field is HAL.Byte;
-   subtype L2DCCR_DCALPHA_Field is HAL.Byte;
+   subtype L2DCCR_DCBLUE_Field is HAL.UInt8;
+   subtype L2DCCR_DCGREEN_Field is HAL.UInt8;
+   subtype L2DCCR_DCRED_Field is HAL.UInt8;
+   subtype L2DCCR_DCALPHA_Field is HAL.UInt8;
 
    --  Layerx Default Color Configuration Register
    type L2DCCR_Register is record
@@ -800,10 +801,10 @@ package STM32_SVD.LTDC is
       Reserved_11_31 at 0 range 11 .. 31;
    end record;
 
-   subtype L2CLUTWR_BLUE_Field is HAL.Byte;
-   subtype L2CLUTWR_GREEN_Field is HAL.Byte;
-   subtype L2CLUTWR_RED_Field is HAL.Byte;
-   subtype L2CLUTWR_CLUTADD_Field is HAL.Byte;
+   subtype L2CLUTWR_BLUE_Field is HAL.UInt8;
+   subtype L2CLUTWR_GREEN_Field is HAL.UInt8;
+   subtype L2CLUTWR_RED_Field is HAL.UInt8;
+   subtype L2CLUTWR_CLUTADD_Field is HAL.UInt8;
 
    --  Layerx CLUT Write Register
    type L2CLUTWR_Register is record
@@ -951,6 +952,6 @@ package STM32_SVD.LTDC is
 
    --  LCD-TFT Controller
    LTDC_Periph : aliased LTDC_Peripheral
-     with Import, Address => LTDC_Base;
+     with Import, Address => System'To_Address (16#40016800#);
 
 end STM32_SVD.LTDC;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-mdios.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-mdios.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -1405,6 +1406,6 @@ package STM32_SVD.MDIOS is
 
    --  Management data input/output slave
    MDIOS_Periph : aliased MDIOS_Peripheral
-     with Import, Address => MDIOS_Base;
+     with Import, Address => System'To_Address (16#40017800#);
 
 end STM32_SVD.MDIOS;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-nvic.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-nvic.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -31,7 +32,7 @@ package STM32_SVD.NVIC is
    end record;
 
    --  IPR_IPR_N array element
-   subtype IPR_IPR_N_Element is HAL.Byte;
+   subtype IPR_IPR_N_Element is HAL.UInt8;
 
    --  IPR_IPR_N array
    type IPR_IPR_N_Field_Array is array (0 .. 3) of IPR_IPR_N_Element
@@ -203,6 +204,6 @@ package STM32_SVD.NVIC is
 
    --  Nested Vectored Interrupt Controller
    NVIC_Periph : aliased NVIC_Peripheral
-     with Import, Address => NVIC_Base;
+     with Import, Address => System'To_Address (16#E000E000#);
 
 end STM32_SVD.NVIC;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-pwr.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-pwr.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -24,7 +25,7 @@ package STM32_SVD.PWR is
       --  Power down deepsleep
       PDDS           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Clear standby flag
       CSBF           : Boolean := False;
       --  Power voltage detector enable
@@ -40,7 +41,7 @@ package STM32_SVD.PWR is
       --  Main regulator in deepsleep under-drive mode
       MRUDS          : Boolean := False;
       --  unspecified
-      Reserved_12_12 : HAL.Bit := 16#0#;
+      Reserved_12_12 : HAL.UInt1 := 16#0#;
       --  ADCDC1
       ADCDC1         : Boolean := False;
       --  Regulator voltage scaling output selection
@@ -98,7 +99,7 @@ package STM32_SVD.PWR is
       --  Regulator voltage scaling output selection ready bit
       VOSRDY         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Over-drive mode ready
       ODRDY          : Boolean := False;
       --  Over-drive mode switching ready
@@ -291,6 +292,6 @@ package STM32_SVD.PWR is
 
    --  Power control
    PWR_Periph : aliased PWR_Peripheral
-     with Import, Address => PWR_Base;
+     with Import, Address => System'To_Address (16#40007000#);
 
 end STM32_SVD.PWR;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-pwr.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-pwr.ads
@@ -25,7 +25,7 @@ package STM32_SVD.PWR is
       --  Power down deepsleep
       PDDS           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Clear standby flag
       CSBF           : Boolean := False;
       --  Power voltage detector enable
@@ -41,7 +41,7 @@ package STM32_SVD.PWR is
       --  Main regulator in deepsleep under-drive mode
       MRUDS          : Boolean := False;
       --  unspecified
-      Reserved_12_12 : HAL.UInt1 := 16#0#;
+      Reserved_12_12 : HAL.Bit := 16#0#;
       --  ADCDC1
       ADCDC1         : Boolean := False;
       --  Regulator voltage scaling output selection
@@ -99,7 +99,7 @@ package STM32_SVD.PWR is
       --  Regulator voltage scaling output selection ready bit
       VOSRDY         : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Over-drive mode ready
       ODRDY          : Boolean := False;
       --  Over-drive mode switching ready

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-quadspi.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-quadspi.ads
@@ -30,7 +30,7 @@ package STM32_SVD.QUADSPI is
       --  Sample shift
       SSHIFT         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Dual-flash mode
       DFM            : Boolean := False;
       --  FLASH memory selection
@@ -50,7 +50,7 @@ package STM32_SVD.QUADSPI is
       --  TimeOut interrupt enable
       TOIE           : Boolean := False;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Automatic poll mode stop
       APMS           : Boolean := False;
       --  Polling match mode
@@ -158,7 +158,7 @@ package STM32_SVD.QUADSPI is
       --  Clear transfer complete flag
       CTCF          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Clear status match flag
       CSMF          : Boolean := False;
       --  Clear timeout flag
@@ -205,7 +205,7 @@ package STM32_SVD.QUADSPI is
       --  Number of dummy cycles
       DCYC           : CCR_DCYC_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Data mode
       DMODE          : CCR_DMODE_Field := 16#0#;
       --  Functional mode
@@ -213,7 +213,7 @@ package STM32_SVD.QUADSPI is
       --  Send instruction only once mode
       SIOO           : Boolean := False;
       --  unspecified
-      Reserved_29_29 : HAL.UInt1 := 16#0#;
+      Reserved_29_29 : HAL.Bit := 16#0#;
       --  DDR hold half cycle
       DHHC           : Boolean := False;
       --  Double data rate mode

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-quadspi.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-quadspi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -14,7 +15,7 @@ package STM32_SVD.QUADSPI is
    ---------------
 
    subtype CR_FTHRES_Field is HAL.UInt5;
-   subtype CR_PRESCALER_Field is HAL.Byte;
+   subtype CR_PRESCALER_Field is HAL.UInt8;
 
    --  control register
    type CR_Register is record
@@ -29,7 +30,7 @@ package STM32_SVD.QUADSPI is
       --  Sample shift
       SSHIFT         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Dual-flash mode
       DFM            : Boolean := False;
       --  FLASH memory selection
@@ -49,7 +50,7 @@ package STM32_SVD.QUADSPI is
       --  TimeOut interrupt enable
       TOIE           : Boolean := False;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Automatic poll mode stop
       APMS           : Boolean := False;
       --  Polling match mode
@@ -157,7 +158,7 @@ package STM32_SVD.QUADSPI is
       --  Clear transfer complete flag
       CTCF          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Clear status match flag
       CSMF          : Boolean := False;
       --  Clear timeout flag
@@ -177,7 +178,7 @@ package STM32_SVD.QUADSPI is
       Reserved_5_31 at 0 range 5 .. 31;
    end record;
 
-   subtype CCR_INSTRUCTION_Field is HAL.Byte;
+   subtype CCR_INSTRUCTION_Field is HAL.UInt8;
    subtype CCR_IMODE_Field is HAL.UInt2;
    subtype CCR_ADMODE_Field is HAL.UInt2;
    subtype CCR_ADSIZE_Field is HAL.UInt2;
@@ -204,7 +205,7 @@ package STM32_SVD.QUADSPI is
       --  Number of dummy cycles
       DCYC           : CCR_DCYC_Field := 16#0#;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Data mode
       DMODE          : CCR_DMODE_Field := 16#0#;
       --  Functional mode
@@ -212,7 +213,7 @@ package STM32_SVD.QUADSPI is
       --  Send instruction only once mode
       SIOO           : Boolean := False;
       --  unspecified
-      Reserved_29_29 : HAL.Bit := 16#0#;
+      Reserved_29_29 : HAL.UInt1 := 16#0#;
       --  DDR hold half cycle
       DHHC           : Boolean := False;
       --  Double data rate mode
@@ -325,6 +326,6 @@ package STM32_SVD.QUADSPI is
 
    --  QuadSPI interface
    QUADSPI_Periph : aliased QUADSPI_Peripheral
-     with Import, Address => QUADSPI_Base;
+     with Import, Address => System'To_Address (16#A0001000#);
 
 end STM32_SVD.QUADSPI;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-rcc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-rcc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -14,7 +15,7 @@ package STM32_SVD.RCC is
    ---------------
 
    subtype CR_HSITRIM_Field is HAL.UInt5;
-   subtype CR_HSICAL_Field is HAL.Byte;
+   subtype CR_HSICAL_Field is HAL.UInt8;
 
    --  clock control register
    type CR_Register is record
@@ -23,7 +24,7 @@ package STM32_SVD.RCC is
       --  Read-only. Internal high-speed clock ready flag
       HSIRDY         : Boolean := True;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Internal high-speed clock trimming
       HSITRIM        : CR_HSITRIM_Field := 16#10#;
       --  Read-only. Internal high-speed clock calibration
@@ -89,7 +90,7 @@ package STM32_SVD.RCC is
       --  Main PLL (PLL) multiplication factor for VCO
       PLLN           : PLLCFGR_PLLN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Main PLL (PLL) division factor for main system clock
       PLLP           : PLLCFGR_PLLP_Field := 16#0#;
       --  unspecified
@@ -97,7 +98,7 @@ package STM32_SVD.RCC is
       --  Main PLL(PLL) and audio PLL (PLLI2S) entry clock source
       PLLSRC         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.Bit := 16#0#;
+      Reserved_23_23 : HAL.UInt1 := 16#0#;
       --  Main PLL (PLL) division factor for USB OTG FS, SDIO and random number
       --  generator clocks
       PLLQ           : PLLCFGR_PLLQ_Field := 16#4#;
@@ -230,7 +231,7 @@ package STM32_SVD.RCC is
       --  PLLSAI Ready Interrupt Enable
       PLLSAIRDYIE    : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Write-only. LSI ready interrupt clear
       LSIRDYC        : Boolean := False;
       --  Write-only. LSE ready interrupt clear
@@ -248,7 +249,7 @@ package STM32_SVD.RCC is
       --  Write-only. Clock security system interrupt clear
       CSSC           : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -306,11 +307,11 @@ package STM32_SVD.RCC is
       --  IO port K reset
       GPIOKRST       : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  CRC reset
       CRCRST         : Boolean := False;
       --  unspecified
-      Reserved_13_20 : HAL.Byte := 16#0#;
+      Reserved_13_20 : HAL.UInt8 := 16#0#;
       --  DMA2 reset
       DMA1RST        : Boolean := False;
       --  DMA2 reset
@@ -318,7 +319,7 @@ package STM32_SVD.RCC is
       --  DMA2D reset
       DMA2DRST       : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  Ethernet MAC reset
       ETHMACRST      : Boolean := False;
       --  unspecified
@@ -427,7 +428,7 @@ package STM32_SVD.RCC is
       --  Low power timer 1 reset
       LPTIM1RST      : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Window watchdog reset
       WWDGRST        : Boolean := False;
       --  unspecified
@@ -519,7 +520,7 @@ package STM32_SVD.RCC is
       --  USART6 reset
       USART6RST      : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  SDMMC2 reset
       SDMMC2RST      : Boolean := False;
       --  ADC interface reset (common to all ADCs)
@@ -535,7 +536,7 @@ package STM32_SVD.RCC is
       --  System configuration controller reset
       SYSCFGRST      : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 reset
       TIM9RST        : Boolean := False;
       --  TIM10 reset
@@ -543,7 +544,7 @@ package STM32_SVD.RCC is
       --  TIM11 reset
       TIM11RST       : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  SPI5 reset
       SPI5RST        : Boolean := False;
       --  SPI6 reset
@@ -559,13 +560,13 @@ package STM32_SVD.RCC is
       --  DSI reset
       DSIRST         : Boolean := False;
       --  unspecified
-      Reserved_28_28 : HAL.Bit := 16#0#;
+      Reserved_28_28 : HAL.UInt1 := 16#0#;
       --  DFSDM1 reset
       DFSDM1RST      : Boolean := False;
       --  MDIO reset
       MDIORST        : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -627,7 +628,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable
       GPIOKEN        : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  CRC clock enable
       CRCEN          : Boolean := False;
       --  unspecified
@@ -635,7 +636,7 @@ package STM32_SVD.RCC is
       --  Backup SRAM interface clock enable
       BKPSRAMEN      : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  CCM data RAM clock enable
       CCMDATARAMEN   : Boolean := True;
       --  DMA1 clock enable
@@ -645,7 +646,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable
       DMA2DEN        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  Ethernet MAC clock enable
       ETHMACEN       : Boolean := False;
       --  Ethernet Transmission clock enable
@@ -659,7 +660,7 @@ package STM32_SVD.RCC is
       --  USB OTG HSULPI clock enable
       OTGHSULPIEN    : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -766,7 +767,7 @@ package STM32_SVD.RCC is
       --  Low power timer 1 clock enable
       LPTMI1EN       : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Window watchdog clock enable
       WWDGEN         : Boolean := False;
       --  unspecified
@@ -858,7 +859,7 @@ package STM32_SVD.RCC is
       --  USART6 clock enable
       USART6EN       : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  SDMMC2 clock enable
       SDMMC2EN       : Boolean := False;
       --  ADC1 clock enable
@@ -876,7 +877,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable
       SYSCFGEN       : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 clock enable
       TIM9EN         : Boolean := False;
       --  TIM10 clock enable
@@ -884,7 +885,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable
       TIM11EN        : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  SPI5 clock enable
       SPI5ENR        : Boolean := False;
       --  SPI6 clock enable
@@ -900,13 +901,13 @@ package STM32_SVD.RCC is
       --  DSI clock enable
       DSIEN          : Boolean := False;
       --  unspecified
-      Reserved_28_28 : HAL.Bit := 16#0#;
+      Reserved_28_28 : HAL.UInt1 := 16#0#;
       --  DFSDM1 clock enable
       DFSDM1EN       : Boolean := False;
       --  MDIO clock enable
       MDIOEN         : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -969,7 +970,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable during Sleep mode
       GPIOKLPEN      : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       --  CRC clock enable during Sleep mode
       CRCLPEN        : Boolean := True;
       --  unspecified
@@ -985,7 +986,7 @@ package STM32_SVD.RCC is
       --  SRAM 3 interface clock enable during Sleep mode
       SRAM3LPEN      : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  DMA1 clock enable during Sleep mode
       DMA1LPEN       : Boolean := True;
       --  DMA2 clock enable during Sleep mode
@@ -993,7 +994,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable during Sleep mode
       DMA2DLPEN      : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.Bit := 16#0#;
+      Reserved_24_24 : HAL.UInt1 := 16#0#;
       --  Ethernet MAC clock enable during Sleep mode
       ETHMACLPEN     : Boolean := True;
       --  Ethernet transmission clock enable during Sleep mode
@@ -1007,7 +1008,7 @@ package STM32_SVD.RCC is
       --  USB OTG HS ULPI clock enable during Sleep mode
       OTGHSULPILPEN  : Boolean := True;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1117,7 +1118,7 @@ package STM32_SVD.RCC is
       --  low power timer 1 clock enable during Sleep mode
       LPTIM1LPEN     : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Window watchdog clock enable during Sleep mode
       WWDGLPEN       : Boolean := True;
       --  unspecified
@@ -1225,7 +1226,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable during Sleep mode
       SYSCFGLPEN     : Boolean := True;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  TIM9 clock enable during sleep mode
       TIM9LPEN       : Boolean := True;
       --  TIM10 clock enable during Sleep mode
@@ -1233,7 +1234,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable during Sleep mode
       TIM11LPEN      : Boolean := True;
       --  unspecified
-      Reserved_19_19 : HAL.Bit := 16#0#;
+      Reserved_19_19 : HAL.UInt1 := 16#0#;
       --  SPI 5 clock enable during Sleep mode
       SPI5LPEN       : Boolean := False;
       --  SPI 6 clock enable during Sleep mode
@@ -1426,7 +1427,7 @@ package STM32_SVD.RCC is
       --  PLLI2S division factor for I2S clocks
       PLLI2SR        : PLLI2SCFGR_PLLI2SR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1452,7 +1453,7 @@ package STM32_SVD.RCC is
       --  PLLSAI division factor for VCO
       PLLSAIN        : PLLSAICFGR_PLLSAIN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  PLLSAI division factor for 48MHz clock
       PLLSAIP        : PLLSAICFGR_PLLSAIP_Field := 16#0#;
       --  unspecified
@@ -1462,7 +1463,7 @@ package STM32_SVD.RCC is
       --  PLLSAI division factor for LCD clock
       PLLSAIR        : PLLSAICFGR_PLLSAIR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1689,6 +1690,6 @@ package STM32_SVD.RCC is
 
    --  Reset and clock control
    RCC_Periph : aliased RCC_Peripheral
-     with Import, Address => RCC_Base;
+     with Import, Address => System'To_Address (16#40023800#);
 
 end STM32_SVD.RCC;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-rcc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-rcc.ads
@@ -24,7 +24,7 @@ package STM32_SVD.RCC is
       --  Read-only. Internal high-speed clock ready flag
       HSIRDY         : Boolean := True;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Internal high-speed clock trimming
       HSITRIM        : CR_HSITRIM_Field := 16#10#;
       --  Read-only. Internal high-speed clock calibration
@@ -90,7 +90,7 @@ package STM32_SVD.RCC is
       --  Main PLL (PLL) multiplication factor for VCO
       PLLN           : PLLCFGR_PLLN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Main PLL (PLL) division factor for main system clock
       PLLP           : PLLCFGR_PLLP_Field := 16#0#;
       --  unspecified
@@ -98,7 +98,7 @@ package STM32_SVD.RCC is
       --  Main PLL(PLL) and audio PLL (PLLI2S) entry clock source
       PLLSRC         : Boolean := False;
       --  unspecified
-      Reserved_23_23 : HAL.UInt1 := 16#0#;
+      Reserved_23_23 : HAL.Bit := 16#0#;
       --  Main PLL (PLL) division factor for USB OTG FS, SDIO and random number
       --  generator clocks
       PLLQ           : PLLCFGR_PLLQ_Field := 16#4#;
@@ -231,7 +231,7 @@ package STM32_SVD.RCC is
       --  PLLSAI Ready Interrupt Enable
       PLLSAIRDYIE    : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Write-only. LSI ready interrupt clear
       LSIRDYC        : Boolean := False;
       --  Write-only. LSE ready interrupt clear
@@ -307,7 +307,7 @@ package STM32_SVD.RCC is
       --  IO port K reset
       GPIOKRST       : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  CRC reset
       CRCRST         : Boolean := False;
       --  unspecified
@@ -319,7 +319,7 @@ package STM32_SVD.RCC is
       --  DMA2D reset
       DMA2DRST       : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  Ethernet MAC reset
       ETHMACRST      : Boolean := False;
       --  unspecified
@@ -428,7 +428,7 @@ package STM32_SVD.RCC is
       --  Low power timer 1 reset
       LPTIM1RST      : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Window watchdog reset
       WWDGRST        : Boolean := False;
       --  unspecified
@@ -520,7 +520,7 @@ package STM32_SVD.RCC is
       --  USART6 reset
       USART6RST      : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  SDMMC2 reset
       SDMMC2RST      : Boolean := False;
       --  ADC interface reset (common to all ADCs)
@@ -536,7 +536,7 @@ package STM32_SVD.RCC is
       --  System configuration controller reset
       SYSCFGRST      : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 reset
       TIM9RST        : Boolean := False;
       --  TIM10 reset
@@ -544,7 +544,7 @@ package STM32_SVD.RCC is
       --  TIM11 reset
       TIM11RST       : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  SPI5 reset
       SPI5RST        : Boolean := False;
       --  SPI6 reset
@@ -560,13 +560,13 @@ package STM32_SVD.RCC is
       --  DSI reset
       DSIRST         : Boolean := False;
       --  unspecified
-      Reserved_28_28 : HAL.UInt1 := 16#0#;
+      Reserved_28_28 : HAL.Bit := 16#0#;
       --  DFSDM1 reset
       DFSDM1RST      : Boolean := False;
       --  MDIO reset
       MDIORST        : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -628,7 +628,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable
       GPIOKEN        : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  CRC clock enable
       CRCEN          : Boolean := False;
       --  unspecified
@@ -636,7 +636,7 @@ package STM32_SVD.RCC is
       --  Backup SRAM interface clock enable
       BKPSRAMEN      : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  CCM data RAM clock enable
       CCMDATARAMEN   : Boolean := True;
       --  DMA1 clock enable
@@ -646,7 +646,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable
       DMA2DEN        : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  Ethernet MAC clock enable
       ETHMACEN       : Boolean := False;
       --  Ethernet Transmission clock enable
@@ -660,7 +660,7 @@ package STM32_SVD.RCC is
       --  USB OTG HSULPI clock enable
       OTGHSULPIEN    : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -767,7 +767,7 @@ package STM32_SVD.RCC is
       --  Low power timer 1 clock enable
       LPTMI1EN       : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Window watchdog clock enable
       WWDGEN         : Boolean := False;
       --  unspecified
@@ -859,7 +859,7 @@ package STM32_SVD.RCC is
       --  USART6 clock enable
       USART6EN       : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  SDMMC2 clock enable
       SDMMC2EN       : Boolean := False;
       --  ADC1 clock enable
@@ -877,7 +877,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable
       SYSCFGEN       : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 clock enable
       TIM9EN         : Boolean := False;
       --  TIM10 clock enable
@@ -885,7 +885,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable
       TIM11EN        : Boolean := False;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  SPI5 clock enable
       SPI5ENR        : Boolean := False;
       --  SPI6 clock enable
@@ -901,13 +901,13 @@ package STM32_SVD.RCC is
       --  DSI clock enable
       DSIEN          : Boolean := False;
       --  unspecified
-      Reserved_28_28 : HAL.UInt1 := 16#0#;
+      Reserved_28_28 : HAL.Bit := 16#0#;
       --  DFSDM1 clock enable
       DFSDM1EN       : Boolean := False;
       --  MDIO clock enable
       MDIOEN         : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -970,7 +970,7 @@ package STM32_SVD.RCC is
       --  IO port K clock enable during Sleep mode
       GPIOKLPEN      : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       --  CRC clock enable during Sleep mode
       CRCLPEN        : Boolean := True;
       --  unspecified
@@ -986,7 +986,7 @@ package STM32_SVD.RCC is
       --  SRAM 3 interface clock enable during Sleep mode
       SRAM3LPEN      : Boolean := False;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  DMA1 clock enable during Sleep mode
       DMA1LPEN       : Boolean := True;
       --  DMA2 clock enable during Sleep mode
@@ -994,7 +994,7 @@ package STM32_SVD.RCC is
       --  DMA2D clock enable during Sleep mode
       DMA2DLPEN      : Boolean := False;
       --  unspecified
-      Reserved_24_24 : HAL.UInt1 := 16#0#;
+      Reserved_24_24 : HAL.Bit := 16#0#;
       --  Ethernet MAC clock enable during Sleep mode
       ETHMACLPEN     : Boolean := True;
       --  Ethernet transmission clock enable during Sleep mode
@@ -1008,7 +1008,7 @@ package STM32_SVD.RCC is
       --  USB OTG HS ULPI clock enable during Sleep mode
       OTGHSULPILPEN  : Boolean := True;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1118,7 +1118,7 @@ package STM32_SVD.RCC is
       --  low power timer 1 clock enable during Sleep mode
       LPTIM1LPEN     : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Window watchdog clock enable during Sleep mode
       WWDGLPEN       : Boolean := True;
       --  unspecified
@@ -1226,7 +1226,7 @@ package STM32_SVD.RCC is
       --  System configuration controller clock enable during Sleep mode
       SYSCFGLPEN     : Boolean := True;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  TIM9 clock enable during sleep mode
       TIM9LPEN       : Boolean := True;
       --  TIM10 clock enable during Sleep mode
@@ -1234,7 +1234,7 @@ package STM32_SVD.RCC is
       --  TIM11 clock enable during Sleep mode
       TIM11LPEN      : Boolean := True;
       --  unspecified
-      Reserved_19_19 : HAL.UInt1 := 16#0#;
+      Reserved_19_19 : HAL.Bit := 16#0#;
       --  SPI 5 clock enable during Sleep mode
       SPI5LPEN       : Boolean := False;
       --  SPI 6 clock enable during Sleep mode
@@ -1427,7 +1427,7 @@ package STM32_SVD.RCC is
       --  PLLI2S division factor for I2S clocks
       PLLI2SR        : PLLI2SCFGR_PLLI2SR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1453,7 +1453,7 @@ package STM32_SVD.RCC is
       --  PLLSAI division factor for VCO
       PLLSAIN        : PLLSAICFGR_PLLSAIN_Field := 16#C0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  PLLSAI division factor for 48MHz clock
       PLLSAIP        : PLLSAICFGR_PLLSAIP_Field := 16#0#;
       --  unspecified
@@ -1463,7 +1463,7 @@ package STM32_SVD.RCC is
       --  PLLSAI division factor for LCD clock
       PLLSAIR        : PLLSAICFGR_PLLSAIR_Field := 16#2#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-rng.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-rng.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -87,6 +88,6 @@ package STM32_SVD.RNG is
 
    --  Random number generator
    RNG_Periph : aliased RNG_Peripheral
-     with Import, Address => RNG_Base;
+     with Import, Address => System'To_Address (16#50060800#);
 
 end STM32_SVD.RNG;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-rtc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-rtc.ads
@@ -28,13 +28,13 @@ package STM32_SVD.RTC is
       --  Second tens in BCD format
       ST             : TR_ST_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Minute units in BCD format
       MNU            : TR_MNU_Field := 16#0#;
       --  Minute tens in BCD format
       MNT            : TR_MNT_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Hour units in BCD format
       HU             : TR_HU_Field := 16#0#;
       --  Hour tens in BCD format
@@ -119,7 +119,7 @@ package STM32_SVD.RTC is
       --  Hour format
       FMT            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Alarm A enable
       ALRAE          : Boolean := False;
       --  Alarm B enable
@@ -255,7 +255,7 @@ package STM32_SVD.RTC is
       --  Synchronous prescaler factor
       PREDIV_S       : PRER_PREDIV_S_Field := 16#FF#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Asynchronous prescaler factor
       PREDIV_A       : PRER_PREDIV_A_Field := 16#7F#;
       --  unspecified
@@ -476,13 +476,13 @@ package STM32_SVD.RTC is
       --  Read-only. Second tens in BCD format
       ST             : TSTR_ST_Field;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1;
+      Reserved_7_7   : HAL.Bit;
       --  Read-only. Minute units in BCD format
       MNU            : TSTR_MNU_Field;
       --  Read-only. Minute tens in BCD format
       MNT            : TSTR_MNT_Field;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1;
+      Reserved_15_15 : HAL.Bit;
       --  Read-only. Hour units in BCD format
       HU             : TSTR_HU_Field;
       --  Read-only. Hour tens in BCD format

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-rtc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-rtc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -27,13 +28,13 @@ package STM32_SVD.RTC is
       --  Second tens in BCD format
       ST             : TR_ST_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Minute units in BCD format
       MNU            : TR_MNU_Field := 16#0#;
       --  Minute tens in BCD format
       MNT            : TR_MNT_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Hour units in BCD format
       HU             : TR_HU_Field := 16#0#;
       --  Hour tens in BCD format
@@ -85,7 +86,7 @@ package STM32_SVD.RTC is
       --  Year tens in BCD format
       YT             : DR_YT_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -118,7 +119,7 @@ package STM32_SVD.RTC is
       --  Hour format
       FMT            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Alarm A enable
       ALRAE          : Boolean := False;
       --  Alarm B enable
@@ -254,7 +255,7 @@ package STM32_SVD.RTC is
       --  Synchronous prescaler factor
       PREDIV_S       : PRER_PREDIV_S_Field := 16#FF#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Asynchronous prescaler factor
       PREDIV_A       : PRER_PREDIV_A_Field := 16#7F#;
       --  unspecified
@@ -407,7 +408,7 @@ package STM32_SVD.RTC is
       MSK4  at 0 range 31 .. 31;
    end record;
 
-   subtype WPR_KEY_Field is HAL.Byte;
+   subtype WPR_KEY_Field is HAL.UInt8;
 
    --  write protection register
    type WPR_Register is record
@@ -475,13 +476,13 @@ package STM32_SVD.RTC is
       --  Read-only. Second tens in BCD format
       ST             : TSTR_ST_Field;
       --  unspecified
-      Reserved_7_7   : HAL.Bit;
+      Reserved_7_7   : HAL.UInt1;
       --  Read-only. Minute units in BCD format
       MNU            : TSTR_MNU_Field;
       --  Read-only. Minute tens in BCD format
       MNT            : TSTR_MNT_Field;
       --  unspecified
-      Reserved_15_15 : HAL.Bit;
+      Reserved_15_15 : HAL.UInt1;
       --  Read-only. Hour units in BCD format
       HU             : TSTR_HU_Field;
       --  Read-only. Hour tens in BCD format
@@ -921,6 +922,6 @@ package STM32_SVD.RTC is
 
    --  Real-time clock
    RTC_Periph : aliased RTC_Peripheral
-     with Import, Address => RTC_Base;
+     with Import, Address => System'To_Address (16#40002800#);
 
 end STM32_SVD.RTC;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-sai.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-sai.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -50,7 +51,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : ACR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Data size
       DS             : ACR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -70,13 +71,13 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.Bit := 16#0#;
+      Reserved_18_18 : HAL.UInt1 := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
       MCJDIV         : ACR1_MCJDIV_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -140,7 +141,7 @@ package STM32_SVD.SAI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype AFRCR_FRL_Field is HAL.Byte;
+   subtype AFRCR_FRL_Field is HAL.UInt8;
    subtype AFRCR_FSALL_Field is HAL.UInt7;
 
    --  AFRCR
@@ -150,7 +151,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : AFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -183,7 +184,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : ASLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Slot size
       SLOTSZ         : ASLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -288,7 +289,7 @@ package STM32_SVD.SAI is
       --  Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Clear anticipated frame synchronization detection flag.
@@ -325,7 +326,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : BCR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.Bit := 16#0#;
+      Reserved_4_4   : HAL.UInt1 := 16#0#;
       --  Data size
       DS             : BCR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -345,13 +346,13 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.Bit := 16#0#;
+      Reserved_18_18 : HAL.UInt1 := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
       MCJDIV         : BCR1_MCJDIV_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -415,7 +416,7 @@ package STM32_SVD.SAI is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype BFRCR_FRL_Field is HAL.Byte;
+   subtype BFRCR_FRL_Field is HAL.UInt8;
    subtype BFRCR_FSALL_Field is HAL.UInt7;
 
    --  BFRCR
@@ -425,7 +426,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : BFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -458,7 +459,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : BSLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Slot size
       SLOTSZ         : BSLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -563,7 +564,7 @@ package STM32_SVD.SAI is
       --  Write-only. Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Write-only. Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Write-only. Clear anticipated frame synchronization detection flag
@@ -652,10 +653,10 @@ package STM32_SVD.SAI is
 
    --  Serial audio interface
    SAI1_Periph : aliased SAI_Peripheral
-     with Import, Address => SAI1_Base;
+     with Import, Address => System'To_Address (16#40015800#);
 
    --  Serial audio interface
    SAI2_Periph : aliased SAI_Peripheral
-     with Import, Address => SAI2_Base;
+     with Import, Address => System'To_Address (16#40015C00#);
 
 end STM32_SVD.SAI;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-sai.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-sai.ads
@@ -51,7 +51,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : ACR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Data size
       DS             : ACR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -71,7 +71,7 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.UInt1 := 16#0#;
+      Reserved_18_18 : HAL.Bit := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
@@ -151,7 +151,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : AFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -184,7 +184,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : ASLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Slot size
       SLOTSZ         : ASLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -289,7 +289,7 @@ package STM32_SVD.SAI is
       --  Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Clear anticipated frame synchronization detection flag.
@@ -326,7 +326,7 @@ package STM32_SVD.SAI is
       --  Protocol configuration
       PRTCFG         : BCR1_PRTCFG_Field := 16#0#;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1 := 16#0#;
+      Reserved_4_4   : HAL.Bit := 16#0#;
       --  Data size
       DS             : BCR1_DS_Field := 16#2#;
       --  Least significant bit first
@@ -346,7 +346,7 @@ package STM32_SVD.SAI is
       --  DMA enable
       DMAEN          : Boolean := False;
       --  unspecified
-      Reserved_18_18 : HAL.UInt1 := 16#0#;
+      Reserved_18_18 : HAL.Bit := 16#0#;
       --  No divider
       NODIV          : Boolean := False;
       --  Master clock divider
@@ -426,7 +426,7 @@ package STM32_SVD.SAI is
       --  Frame synchronization active level length
       FSALL          : BFRCR_FSALL_Field := 16#0#;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  Frame synchronization definition
       FSDEF          : Boolean := False;
       --  Frame synchronization polarity
@@ -459,7 +459,7 @@ package STM32_SVD.SAI is
       --  First bit offset
       FBOFF          : BSLOTR_FBOFF_Field := 16#0#;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Slot size
       SLOTSZ         : BSLOTR_SLOTSZ_Field := 16#0#;
       --  Number of slots in an audio frame
@@ -564,7 +564,7 @@ package STM32_SVD.SAI is
       --  Write-only. Clear wrong clock configuration flag
       WCKCFG        : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Write-only. Clear codec not ready flag
       CNRDY         : Boolean := False;
       --  Write-only. Clear anticipated frame synchronization detection flag

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-sdmmc.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-sdmmc.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -40,7 +41,7 @@ package STM32_SVD.SDMMC is
       Reserved_2_31 at 0 range 2 .. 31;
    end record;
 
-   subtype CLKCR_CLKDIV_Field is HAL.Byte;
+   subtype CLKCR_CLKDIV_Field is HAL.UInt8;
 
    --  Wide bus mode enable bit
    type CLKCR_WIDBUS_Field is
@@ -371,7 +372,7 @@ package STM32_SVD.SDMMC is
       --  Read-only. CE-ATA command completion signal received for CMD61
       CEATAEND       : Boolean;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -435,7 +436,7 @@ package STM32_SVD.SDMMC is
       --  CEATAEND flag clear bit
       CEATAENDC      : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -509,7 +510,7 @@ package STM32_SVD.SDMMC is
       --  CE-ATA command completion signal received interrupt enable
       CEATAENDIE     : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -550,7 +551,7 @@ package STM32_SVD.SDMMC is
       --  the FIFO
       FIFOCOUNT      : FIFOCNT_FIFOCOUNT_Field;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -628,10 +629,10 @@ package STM32_SVD.SDMMC is
 
    --  Secure digital input/output interface
    SDMMC1_Periph : aliased SDMMC_Peripheral
-     with Import, Address => SDMMC1_Base;
+     with Import, Address => System'To_Address (16#40012C00#);
 
    --  Secure digital input/output interface
    SDMMC2_Periph : aliased SDMMC_Peripheral
-     with Import, Address => SDMMC2_Base;
+     with Import, Address => System'To_Address (16#40011C00#);
 
 end STM32_SVD.SDMMC;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-spdif_rx.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-spdif_rx.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -45,7 +46,7 @@ package STM32_SVD.SPDIF_RX is
       --  Wait For Activity
       WFA            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.Bit := 16#0#;
+      Reserved_15_15 : HAL.UInt1 := 16#0#;
       --  input selection
       INSEL          : CR_INSEL_Field := 16#0#;
       --  unspecified
@@ -132,7 +133,7 @@ package STM32_SVD.SPDIF_RX is
       --  Read-only. Duration of 5 symbols counted with SPDIF_CLK
       WIDTH5         : SR_WIDTH5_Field;
       --  unspecified
-      Reserved_31_31 : HAL.Bit;
+      Reserved_31_31 : HAL.UInt1;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -213,7 +214,7 @@ package STM32_SVD.SPDIF_RX is
    end record;
 
    subtype CSR_USR_Field is HAL.UInt16;
-   subtype CSR_CS_Field is HAL.Byte;
+   subtype CSR_CS_Field is HAL.UInt8;
 
    --  Channel Status register
    type CSR_Register is record
@@ -295,6 +296,6 @@ package STM32_SVD.SPDIF_RX is
 
    --  Receiver Interface
    SPDIFRX_Periph : aliased SPDIFRX_Peripheral
-     with Import, Address => SPDIFRX_Base;
+     with Import, Address => System'To_Address (16#40004000#);
 
 end STM32_SVD.SPDIF_RX;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-spdif_rx.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-spdif_rx.ads
@@ -46,7 +46,7 @@ package STM32_SVD.SPDIF_RX is
       --  Wait For Activity
       WFA            : Boolean := False;
       --  unspecified
-      Reserved_15_15 : HAL.UInt1 := 16#0#;
+      Reserved_15_15 : HAL.Bit := 16#0#;
       --  input selection
       INSEL          : CR_INSEL_Field := 16#0#;
       --  unspecified
@@ -133,7 +133,7 @@ package STM32_SVD.SPDIF_RX is
       --  Read-only. Duration of 5 symbols counted with SPDIF_CLK
       WIDTH5         : SR_WIDTH5_Field;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1;
+      Reserved_31_31 : HAL.Bit;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-spi.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-spi.ads
@@ -352,7 +352,7 @@ package STM32_SVD.SPI is
       --  I2S standard selection
       I2SSTD         : I2SCFGR_I2SSTD_Field := 16#0#;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  PCM frame synchronization
       PCMSYNC        : Boolean := False;
       --  I2S configuration mode

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-spi.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-spi.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -351,7 +352,7 @@ package STM32_SVD.SPI is
       --  I2S standard selection
       I2SSTD         : I2SCFGR_I2SSTD_Field := 16#0#;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  PCM frame synchronization
       PCMSYNC        : Boolean := False;
       --  I2S configuration mode
@@ -382,7 +383,7 @@ package STM32_SVD.SPI is
       Reserved_13_31 at 0 range 13 .. 31;
    end record;
 
-   subtype I2SPR_I2SDIV_Field is HAL.Byte;
+   subtype I2SPR_I2SDIV_Field is HAL.UInt8;
 
    --  I2S prescaler register
    type I2SPR_Register is record
@@ -446,26 +447,26 @@ package STM32_SVD.SPI is
 
    --  Serial peripheral interface
    SPI1_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI1_Base;
+     with Import, Address => System'To_Address (16#40013000#);
 
    --  Serial peripheral interface
    SPI2_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI2_Base;
+     with Import, Address => System'To_Address (16#40003800#);
 
    --  Serial peripheral interface
    SPI3_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI3_Base;
+     with Import, Address => System'To_Address (16#40003C00#);
 
    --  Serial peripheral interface
    SPI4_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI4_Base;
+     with Import, Address => System'To_Address (16#40013400#);
 
    --  Serial peripheral interface
    SPI5_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI5_Base;
+     with Import, Address => System'To_Address (16#40015000#);
 
    --  Serial peripheral interface
    SPI6_Periph : aliased SPI_Peripheral
-     with Import, Address => SPI6_Base;
+     with Import, Address => System'To_Address (16#40015400#);
 
 end STM32_SVD.SPI;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-syscfg.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-syscfg.ads
@@ -26,7 +26,7 @@ package STM32_SVD.SYSCFG is
       --  Flash bank mode selection
       FB_MODE        : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  FMC memory mapping swap
       SWP_FMC        : MEMRM_SWP_FMC_Field := 16#0#;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-syscfg.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-syscfg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -25,7 +26,7 @@ package STM32_SVD.SYSCFG is
       --  Flash bank mode selection
       FB_MODE        : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  FMC memory mapping swap
       SWP_FMC        : MEMRM_SWP_FMC_Field := 16#0#;
       --  unspecified
@@ -58,7 +59,7 @@ package STM32_SVD.SYSCFG is
       --  Ethernet PHY interface selection
       MII_RMII_SEL   : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -301,6 +302,6 @@ package STM32_SVD.SYSCFG is
 
    --  System configuration controller
    SYSCFG_Periph : aliased SYSCFG_Peripheral
-     with Import, Address => SYSCFG_Base;
+     with Import, Address => System'To_Address (16#40013800#);
 
 end STM32_SVD.SYSCFG;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-tim.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-tim.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -59,7 +60,7 @@ package STM32_SVD.TIM is
       --  Capture/compare preloaded control
       CCPC           : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.Bit := 16#0#;
+      Reserved_1_1   : HAL.UInt1 := 16#0#;
       --  Capture/compare control update selection
       CCUS           : Boolean := False;
       --  Capture/compare DMA selection
@@ -115,7 +116,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection - bit[2:0]
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -225,7 +226,7 @@ package STM32_SVD.TIM is
       --  Break interrupt flag
       BIF            : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.Bit := 16#0#;
+      Reserved_8_8   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 overcapture flag
       CC1OF          : Boolean := False;
       --  Capture/compare 2 overcapture flag
@@ -566,7 +567,7 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype RCR_REP_Field is HAL.Byte;
+   subtype RCR_REP_Field is HAL.UInt8;
 
    --  repetition counter register
    type RCR_Register is record
@@ -651,7 +652,7 @@ package STM32_SVD.TIM is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype BDTR_DTG_Field is HAL.Byte;
+   subtype BDTR_DTG_Field is HAL.UInt8;
    subtype BDTR_LOCK_Field is HAL.UInt2;
 
    --  break and dead-time register
@@ -883,11 +884,11 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt enable
       CC4IE          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Trigger interrupt enable
       TIE            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Update DMA request enable
       UDE            : Boolean := False;
       --  Capture/Compare 1 DMA request enable
@@ -899,7 +900,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 DMA request enable
       CC4DE          : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.Bit := 16#0#;
+      Reserved_13_13 : HAL.UInt1 := 16#0#;
       --  Trigger DMA request enable
       TDE            : Boolean := False;
       --  unspecified
@@ -940,7 +941,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt flag
       CC4IF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Trigger interrupt flag
       TIF            : Boolean := False;
       --  unspecified
@@ -988,7 +989,7 @@ package STM32_SVD.TIM is
       --  Write-only. Capture/compare 4 generation
       CC4G          : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  Write-only. Trigger generation
       TG            : Boolean := False;
       --  unspecified
@@ -1057,7 +1058,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP          : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1065,7 +1066,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P           : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP          : Boolean := False;
       --  Capture/Compare 3 output enable
@@ -1073,7 +1074,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC3P           : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Capture/Compare 3 output Polarity
       CC3NP          : Boolean := False;
       --  Capture/Compare 4 output enable
@@ -1081,7 +1082,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC4P           : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
@@ -1415,13 +1416,13 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
       MSM            : Boolean := False;
       --  unspecified
-      Reserved_8_15  : HAL.Byte := 16#0#;
+      Reserved_8_15  : HAL.UInt8 := 16#0#;
       --  Slave mode selection
       SMS_3          : Boolean := False;
       --  unspecified
@@ -1541,7 +1542,7 @@ package STM32_SVD.TIM is
       --  Output Compare 1 mode
       OC1M           : CCMR1_Output_OC1M_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Output_CC2S_Field := 16#0#;
       --  Output Compare 2 fast enable
@@ -1581,7 +1582,7 @@ package STM32_SVD.TIM is
       --  Input capture 1 filter
       IC1F           : CCMR1_Input_IC1F_Field_1 := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Input_CC2S_Field := 16#0#;
       --  Input capture 2 prescaler
@@ -1612,7 +1613,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1620,7 +1621,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P          : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP         : Boolean := False;
       --  unspecified
@@ -1783,7 +1784,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  unspecified
@@ -1900,11 +1901,11 @@ package STM32_SVD.TIM is
 
    --  Advanced-timers
    TIM1_Periph : aliased TIM1_Peripheral
-     with Import, Address => TIM1_Base;
+     with Import, Address => System'To_Address (16#40010000#);
 
    --  Advanced-timers
    TIM8_Periph : aliased TIM1_Peripheral
-     with Import, Address => TIM8_Base;
+     with Import, Address => System'To_Address (16#40010400#);
 
    type TIM2_Disc is
      (
@@ -1993,7 +1994,7 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM2_Periph : aliased TIM2_Peripheral
-     with Import, Address => TIM2_Base;
+     with Import, Address => System'To_Address (16#40000000#);
 
    type TIM3_Disc is
      (
@@ -2082,7 +2083,7 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM3_Periph : aliased TIM3_Peripheral
-     with Import, Address => TIM3_Base;
+     with Import, Address => System'To_Address (16#40000400#);
 
    type TIM4_Disc is
      (
@@ -2165,11 +2166,11 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM4_Periph : aliased TIM4_Peripheral
-     with Import, Address => TIM4_Base;
+     with Import, Address => System'To_Address (16#40000800#);
 
    --  General purpose timers
    TIM5_Periph : aliased TIM4_Peripheral
-     with Import, Address => TIM5_Base;
+     with Import, Address => System'To_Address (16#40000C00#);
 
    --  Basic timers
    type TIM6_Peripheral is record
@@ -2205,11 +2206,11 @@ package STM32_SVD.TIM is
 
    --  Basic timers
    TIM6_Periph : aliased TIM6_Peripheral
-     with Import, Address => TIM6_Base;
+     with Import, Address => System'To_Address (16#40001000#);
 
    --  Basic timers
    TIM7_Periph : aliased TIM6_Peripheral
-     with Import, Address => TIM7_Base;
+     with Import, Address => System'To_Address (16#40001400#);
 
    type TIM9_Disc is
      (
@@ -2271,11 +2272,11 @@ package STM32_SVD.TIM is
 
    --  General purpose timers
    TIM9_Periph : aliased TIM9_Peripheral
-     with Import, Address => TIM9_Base;
+     with Import, Address => System'To_Address (16#40014000#);
 
    --  General purpose timers
    TIM12_Periph : aliased TIM9_Peripheral
-     with Import, Address => TIM12_Base;
+     with Import, Address => System'To_Address (16#40001800#);
 
    type TIM10_Disc is
      (
@@ -2337,18 +2338,18 @@ package STM32_SVD.TIM is
 
    --  General-purpose-timers
    TIM10_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM10_Base;
+     with Import, Address => System'To_Address (16#40014400#);
 
    --  General-purpose-timers
    TIM11_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM11_Base;
+     with Import, Address => System'To_Address (16#40014800#);
 
    --  General-purpose-timers
    TIM13_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM13_Base;
+     with Import, Address => System'To_Address (16#40001C00#);
 
    --  General-purpose-timers
    TIM14_Periph : aliased TIM10_Peripheral
-     with Import, Address => TIM14_Base;
+     with Import, Address => System'To_Address (16#40002000#);
 
 end STM32_SVD.TIM;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-tim.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-tim.ads
@@ -60,7 +60,7 @@ package STM32_SVD.TIM is
       --  Capture/compare preloaded control
       CCPC           : Boolean := False;
       --  unspecified
-      Reserved_1_1   : HAL.UInt1 := 16#0#;
+      Reserved_1_1   : HAL.Bit := 16#0#;
       --  Capture/compare control update selection
       CCUS           : Boolean := False;
       --  Capture/compare DMA selection
@@ -116,7 +116,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection - bit[2:0]
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -226,7 +226,7 @@ package STM32_SVD.TIM is
       --  Break interrupt flag
       BIF            : Boolean := False;
       --  unspecified
-      Reserved_8_8   : HAL.UInt1 := 16#0#;
+      Reserved_8_8   : HAL.Bit := 16#0#;
       --  Capture/Compare 1 overcapture flag
       CC1OF          : Boolean := False;
       --  Capture/compare 2 overcapture flag
@@ -884,11 +884,11 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt enable
       CC4IE          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Trigger interrupt enable
       TIE            : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Update DMA request enable
       UDE            : Boolean := False;
       --  Capture/Compare 1 DMA request enable
@@ -900,7 +900,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 DMA request enable
       CC4DE          : Boolean := False;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1 := 16#0#;
+      Reserved_13_13 : HAL.Bit := 16#0#;
       --  Trigger DMA request enable
       TDE            : Boolean := False;
       --  unspecified
@@ -941,7 +941,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 4 interrupt flag
       CC4IF          : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Trigger interrupt flag
       TIF            : Boolean := False;
       --  unspecified
@@ -989,7 +989,7 @@ package STM32_SVD.TIM is
       --  Write-only. Capture/compare 4 generation
       CC4G          : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  Write-only. Trigger generation
       TG            : Boolean := False;
       --  unspecified
@@ -1058,7 +1058,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP          : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1066,7 +1066,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P           : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP          : Boolean := False;
       --  Capture/Compare 3 output enable
@@ -1074,7 +1074,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC3P           : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Capture/Compare 3 output Polarity
       CC3NP          : Boolean := False;
       --  Capture/Compare 4 output enable
@@ -1082,7 +1082,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 3 output Polarity
       CC4P           : Boolean := False;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  Capture/Compare 4 output Polarity
       CC4NP          : Boolean := False;
       --  unspecified
@@ -1416,7 +1416,7 @@ package STM32_SVD.TIM is
       --  Slave mode selection
       SMS            : SMCR_SMS_Field := 16#0#;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Trigger selection
       TS             : SMCR_TS_Field := 16#0#;
       --  Master/Slave mode
@@ -1542,7 +1542,7 @@ package STM32_SVD.TIM is
       --  Output Compare 1 mode
       OC1M           : CCMR1_Output_OC1M_Field := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Output_CC2S_Field := 16#0#;
       --  Output Compare 2 fast enable
@@ -1582,7 +1582,7 @@ package STM32_SVD.TIM is
       --  Input capture 1 filter
       IC1F           : CCMR1_Input_IC1F_Field_1 := 16#0#;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Capture/Compare 2 selection
       CC2S           : CCMR1_Input_CC2S_Field := 16#0#;
       --  Input capture 2 prescaler
@@ -1613,7 +1613,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  Capture/Compare 2 output enable
@@ -1621,7 +1621,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 2 output Polarity
       CC2P          : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  Capture/Compare 2 output Polarity
       CC2NP         : Boolean := False;
       --  unspecified
@@ -1784,7 +1784,7 @@ package STM32_SVD.TIM is
       --  Capture/Compare 1 output Polarity
       CC1P          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Capture/Compare 1 output Polarity
       CC1NP         : Boolean := False;
       --  unspecified

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-usart.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-usart.ads
@@ -177,7 +177,7 @@ package STM32_SVD.USART is
       --  LIN break detection interrupt enable
       LBDIE        : Boolean := False;
       --  unspecified
-      Reserved_7_7 : HAL.UInt1 := 16#0#;
+      Reserved_7_7 : HAL.Bit := 16#0#;
       --  Last bit clock pulse
       LBCL         : Boolean := False;
       --  Clock phase
@@ -276,7 +276,7 @@ package STM32_SVD.USART is
       --  Driver enable polarity selection
       DEP            : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Smartcard auto-retry count
       SCARCNT        : CR3_SCARCNT_Field := 16#0#;
       --  Wakeup from Stop mode interrupt flag selection
@@ -429,7 +429,7 @@ package STM32_SVD.USART is
       --  Read-only. EOBF
       EOBF           : Boolean;
       --  unspecified
-      Reserved_13_13 : HAL.UInt1;
+      Reserved_13_13 : HAL.Bit;
       --  Read-only. ABRE
       ABRE           : Boolean;
       --  Read-only. ABRF
@@ -494,17 +494,17 @@ package STM32_SVD.USART is
       --  Write-only. Idle line detected clear flag
       IDLECF         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Write-only. Transmission complete clear flag
       TCCF           : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  Write-only. LIN break detection clear flag
       LBDCF          : Boolean := False;
       --  Write-only. CTS clear flag
       CTSCF          : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Write-only. Receiver timeout clear flag
       RTOCF          : Boolean := False;
       --  Write-only. End of block clear flag

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-usart.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-usart.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -176,7 +177,7 @@ package STM32_SVD.USART is
       --  LIN break detection interrupt enable
       LBDIE        : Boolean := False;
       --  unspecified
-      Reserved_7_7 : HAL.Bit := 16#0#;
+      Reserved_7_7 : HAL.UInt1 := 16#0#;
       --  Last bit clock pulse
       LBCL         : Boolean := False;
       --  Clock phase
@@ -275,7 +276,7 @@ package STM32_SVD.USART is
       --  Driver enable polarity selection
       DEP            : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Smartcard auto-retry count
       SCARCNT        : CR3_SCARCNT_Field := 16#0#;
       --  Wakeup from Stop mode interrupt flag selection
@@ -333,8 +334,8 @@ package STM32_SVD.USART is
       Reserved_16_31 at 0 range 16 .. 31;
    end record;
 
-   subtype GTPR_PSC_Field is HAL.Byte;
-   subtype GTPR_GT_Field is HAL.Byte;
+   subtype GTPR_PSC_Field is HAL.UInt8;
+   subtype GTPR_GT_Field is HAL.UInt8;
 
    --  Guard time and prescaler register
    type GTPR_Register is record
@@ -355,7 +356,7 @@ package STM32_SVD.USART is
    end record;
 
    subtype RTOR_RTO_Field is HAL.UInt24;
-   subtype RTOR_BLEN_Field is HAL.Byte;
+   subtype RTOR_BLEN_Field is HAL.UInt8;
 
    --  Receiver timeout register
    type RTOR_Register is record
@@ -428,7 +429,7 @@ package STM32_SVD.USART is
       --  Read-only. EOBF
       EOBF           : Boolean;
       --  unspecified
-      Reserved_13_13 : HAL.Bit;
+      Reserved_13_13 : HAL.UInt1;
       --  Read-only. ABRE
       ABRE           : Boolean;
       --  Read-only. ABRF
@@ -493,17 +494,17 @@ package STM32_SVD.USART is
       --  Write-only. Idle line detected clear flag
       IDLECF         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Write-only. Transmission complete clear flag
       TCCF           : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  Write-only. LIN break detection clear flag
       LBDCF          : Boolean := False;
       --  Write-only. CTS clear flag
       CTSCF          : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Write-only. Receiver timeout clear flag
       RTOCF          : Boolean := False;
       --  Write-only. End of block clear flag
@@ -624,34 +625,34 @@ package STM32_SVD.USART is
 
    --  Universal synchronous asynchronous receiver transmitter
    UART4_Periph : aliased USART_Peripheral
-     with Import, Address => UART4_Base;
+     with Import, Address => System'To_Address (16#40004C00#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART5_Periph : aliased USART_Peripheral
-     with Import, Address => UART5_Base;
+     with Import, Address => System'To_Address (16#40005000#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART7_Periph : aliased USART_Peripheral
-     with Import, Address => UART7_Base;
+     with Import, Address => System'To_Address (16#40007800#);
 
    --  Universal synchronous asynchronous receiver transmitter
    UART8_Periph : aliased USART_Peripheral
-     with Import, Address => UART8_Base;
+     with Import, Address => System'To_Address (16#40007C00#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART1_Periph : aliased USART_Peripheral
-     with Import, Address => USART1_Base;
+     with Import, Address => System'To_Address (16#40011000#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART2_Periph : aliased USART_Peripheral
-     with Import, Address => USART2_Base;
+     with Import, Address => System'To_Address (16#40004400#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART3_Periph : aliased USART_Peripheral
-     with Import, Address => USART3_Base;
+     with Import, Address => System'To_Address (16#40004800#);
 
    --  Universal synchronous asynchronous receiver transmitter
    USART6_Periph : aliased USART_Peripheral
-     with Import, Address => USART6_Base;
+     with Import, Address => System'To_Address (16#40011400#);
 
 end STM32_SVD.USART;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-usb_otg_fs.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-usb_otg_fs.ads
@@ -25,7 +25,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Non-zero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Device address
       DAD            : OTG_FS_DCFG_DAD_Field := 16#0#;
       --  Periodic frame interval
@@ -127,7 +127,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Timeout condition mask (Non-isochronous endpoints)
       TOM           : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -161,7 +161,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  SETUP phase done mask
       STUPM         : Boolean := False;
       --  OUT token received when endpoint disabled mask
@@ -281,13 +281,13 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
       EPTYP          : OTG_FS_DIEPCTL0_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  STALL handshake
       STALL          : Boolean := False;
       --  TxFIFO number
@@ -330,13 +330,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  TOC
       TOC           : Boolean := False;
       --  ITTXFE
       ITTXFE        : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  INEPNE
       INEPNE        : Boolean := False;
       --  Read-only. TXFE
@@ -419,7 +419,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : OTG_FS_DIEPCTL1_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -471,7 +471,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Multi count
       MCNT           : OTG_FS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -502,7 +502,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : OTG_FS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -553,7 +553,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USBAEP
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAKSTS
       NAKSTS         : Boolean := False;
       --  Read-only. EPTYP
@@ -602,13 +602,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  STUP
       STUP          : Boolean := False;
       --  OTEPDIS
       OTEPDIS       : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.UInt1 := 16#0#;
+      Reserved_5_5  : HAL.Bit := 16#0#;
       --  B2BSTUP
       B2BSTUP       : Boolean := False;
       --  unspecified
@@ -644,7 +644,7 @@ package STM32_SVD.USB_OTG_FS is
       --  SETUP packet count
       STUPCNT        : OTG_FS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -728,7 +728,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_FS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -887,7 +887,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Write-only. Full Speed serial transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -901,7 +901,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Force device mode
       FDMOD          : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -931,7 +931,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1002,7 +1002,7 @@ package STM32_SVD.USB_OTG_FS is
       --  transfer(Device mode)
       IPXFR_INCOMPISOOUT : Boolean := False;
       --  unspecified
-      Reserved_22_22     : HAL.UInt1 := 16#0#;
+      Reserved_22_22     : HAL.Bit := 16#0#;
       --  Reset detected interrupt
       RSTDET             : Boolean := False;
       --  Read-only. Host port interrupt
@@ -1012,7 +1012,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE              : Boolean := True;
       --  unspecified
-      Reserved_27_27     : HAL.UInt1 := 16#0#;
+      Reserved_27_27     : HAL.Bit := 16#0#;
       --  Connector ID status change
       CIDSCHG            : Boolean := False;
       --  Disconnect detected interrupt
@@ -1061,7 +1061,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS interrupt mask register (OTG_FS_GINTMSK)
    type OTG_FS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0     : HAL.UInt1 := 16#0#;
+      Reserved_0_0     : HAL.Bit := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM            : Boolean := False;
       --  OTG interrupt mask
@@ -1102,7 +1102,7 @@ package STM32_SVD.USB_OTG_FS is
       --  OUT transfer mask(Device mode)
       IPXFRM_IISOOXFRM : Boolean := False;
       --  unspecified
-      Reserved_22_22   : HAL.UInt1 := 16#0#;
+      Reserved_22_22   : HAL.Bit := 16#0#;
       --  Reset detected interrupt mask
       RSTDETM          : Boolean := False;
       --  Read-only. Host port interrupt mask
@@ -1349,7 +1349,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Top of the non-periodic transmit request queue
       NPTXQTOP       : OTG_FS_HNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1;
+      Reserved_31_31 : HAL.Bit;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1379,13 +1379,13 @@ package STM32_SVD.USB_OTG_FS is
       --  I2C ACK
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_25_25 : HAL.UInt1 := 16#1#;
+      Reserved_25_25 : HAL.Bit := 16#1#;
       --  I2C Device Address
       I2CDEVADR      : OTG_FS_GI2CCTL_I2CDEVADR_Field := 16#0#;
       --  I2C DatSe0 USB mode
       I2CDATSE0      : Boolean := False;
       --  unspecified
-      Reserved_29_29 : HAL.UInt1 := 16#0#;
+      Reserved_29_29 : HAL.Bit := 16#0#;
       --  Read/Write Indicator
       RW             : Boolean := False;
       --  I2C Busy/Done
@@ -1774,7 +1774,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_FS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1822,7 +1822,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1862,7 +1862,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted
       CHH            : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  STALL response received interrupt
       STALL          : Boolean := False;
       --  NAK response received interrupt
@@ -1870,7 +1870,7 @@ package STM32_SVD.USB_OTG_FS is
       --  ACK response received/transmitted interrupt
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.UInt1 := 16#0#;
+      Reserved_6_6   : HAL.Bit := 16#0#;
       --  Transaction error
       TXERR          : Boolean := False;
       --  Babble error
@@ -1907,7 +1907,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted mask
       CHHM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  STALL response received interrupt mask
       STALLM         : Boolean := False;
       --  NAK response received interrupt mask
@@ -1958,7 +1958,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Data PID
       DPID           : OTG_FS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-usb_otg_fs.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-usb_otg_fs.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -24,7 +25,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Non-zero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Device address
       DAD            : OTG_FS_DCFG_DAD_Field := 16#0#;
       --  Periodic frame interval
@@ -126,7 +127,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (Non-isochronous endpoints)
       TOM           : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -160,7 +161,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint disabled interrupt mask
       EPDM          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  SETUP phase done mask
       STUPM         : Boolean := False;
       --  OUT token received when endpoint disabled mask
@@ -280,13 +281,13 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
       EPTYP          : OTG_FS_DIEPCTL0_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  STALL handshake
       STALL          : Boolean := False;
       --  TxFIFO number
@@ -329,13 +330,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  TOC
       TOC           : Boolean := False;
       --  ITTXFE
       ITTXFE        : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  INEPNE
       INEPNE        : Boolean := False;
       --  Read-only. TXFE
@@ -418,7 +419,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : OTG_FS_DIEPCTL1_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -470,7 +471,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Multi count
       MCNT           : OTG_FS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -501,7 +502,7 @@ package STM32_SVD.USB_OTG_FS is
       --  EPTYP
       EPTYP          : OTG_FS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  Stall
       Stall          : Boolean := False;
       --  TXFNUM
@@ -552,7 +553,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. USBAEP
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAKSTS
       NAKSTS         : Boolean := False;
       --  Read-only. EPTYP
@@ -601,13 +602,13 @@ package STM32_SVD.USB_OTG_FS is
       --  EPDISD
       EPDISD        : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  STUP
       STUP          : Boolean := False;
       --  OTEPDIS
       OTEPDIS       : Boolean := False;
       --  unspecified
-      Reserved_5_5  : HAL.Bit := 16#0#;
+      Reserved_5_5  : HAL.UInt1 := 16#0#;
       --  B2BSTUP
       B2BSTUP       : Boolean := False;
       --  unspecified
@@ -643,7 +644,7 @@ package STM32_SVD.USB_OTG_FS is
       --  SETUP packet count
       STUPCNT        : OTG_FS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -727,7 +728,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_FS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -886,7 +887,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Write-only. Full Speed serial transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -900,7 +901,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Force device mode
       FDMOD          : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -930,7 +931,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1001,7 +1002,7 @@ package STM32_SVD.USB_OTG_FS is
       --  transfer(Device mode)
       IPXFR_INCOMPISOOUT : Boolean := False;
       --  unspecified
-      Reserved_22_22     : HAL.Bit := 16#0#;
+      Reserved_22_22     : HAL.UInt1 := 16#0#;
       --  Reset detected interrupt
       RSTDET             : Boolean := False;
       --  Read-only. Host port interrupt
@@ -1011,7 +1012,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE              : Boolean := True;
       --  unspecified
-      Reserved_27_27     : HAL.Bit := 16#0#;
+      Reserved_27_27     : HAL.UInt1 := 16#0#;
       --  Connector ID status change
       CIDSCHG            : Boolean := False;
       --  Disconnect detected interrupt
@@ -1060,7 +1061,7 @@ package STM32_SVD.USB_OTG_FS is
    --  OTG_FS interrupt mask register (OTG_FS_GINTMSK)
    type OTG_FS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0     : HAL.Bit := 16#0#;
+      Reserved_0_0     : HAL.UInt1 := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM            : Boolean := False;
       --  OTG interrupt mask
@@ -1101,7 +1102,7 @@ package STM32_SVD.USB_OTG_FS is
       --  OUT transfer mask(Device mode)
       IPXFRM_IISOOXFRM : Boolean := False;
       --  unspecified
-      Reserved_22_22   : HAL.Bit := 16#0#;
+      Reserved_22_22   : HAL.UInt1 := 16#0#;
       --  Reset detected interrupt mask
       RSTDETM          : Boolean := False;
       --  Read-only. Host port interrupt mask
@@ -1335,7 +1336,7 @@ package STM32_SVD.USB_OTG_FS is
    end record;
 
    subtype OTG_FS_HNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
-   subtype OTG_FS_HNPTXSTS_NPTQXSAV_Field is HAL.Byte;
+   subtype OTG_FS_HNPTXSTS_NPTQXSAV_Field is HAL.UInt8;
    subtype OTG_FS_HNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
    --  OTG_FS non-periodic transmit FIFO/queue status register
@@ -1348,7 +1349,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Read-only. Top of the non-periodic transmit request queue
       NPTXQTOP       : OTG_FS_HNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.Bit;
+      Reserved_31_31 : HAL.UInt1;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1360,8 +1361,8 @@ package STM32_SVD.USB_OTG_FS is
       Reserved_31_31 at 0 range 31 .. 31;
    end record;
 
-   subtype OTG_FS_GI2CCTL_RWDATA_Field is HAL.Byte;
-   subtype OTG_FS_GI2CCTL_REGADDR_Field is HAL.Byte;
+   subtype OTG_FS_GI2CCTL_RWDATA_Field is HAL.UInt8;
+   subtype OTG_FS_GI2CCTL_REGADDR_Field is HAL.UInt8;
    subtype OTG_FS_GI2CCTL_ADDR_Field is HAL.UInt7;
    subtype OTG_FS_GI2CCTL_I2CDEVADR_Field is HAL.UInt2;
 
@@ -1378,13 +1379,13 @@ package STM32_SVD.USB_OTG_FS is
       --  I2C ACK
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_25_25 : HAL.Bit := 16#1#;
+      Reserved_25_25 : HAL.UInt1 := 16#1#;
       --  I2C Device Address
       I2CDEVADR      : OTG_FS_GI2CCTL_I2CDEVADR_Field := 16#0#;
       --  I2C DatSe0 USB mode
       I2CDATSE0      : Boolean := False;
       --  unspecified
-      Reserved_29_29 : HAL.Bit := 16#0#;
+      Reserved_29_29 : HAL.UInt1 := 16#0#;
       --  Read/Write Indicator
       RW             : Boolean := False;
       --  I2C Busy/Done
@@ -1525,7 +1526,7 @@ package STM32_SVD.USB_OTG_FS is
       --  ADP interrupt flag
       ADPIF          : Boolean := False;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#2#;
+      Reserved_24_31 : HAL.UInt8 := 16#2#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1692,8 +1693,8 @@ package STM32_SVD.USB_OTG_FS is
    end record;
 
    subtype OTG_FS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
-   subtype OTG_FS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
-   subtype OTG_FS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
+   subtype OTG_FS_HPTXSTS_PTXQSAV_Field is HAL.UInt8;
+   subtype OTG_FS_HPTXSTS_PTXQTOP_Field is HAL.UInt8;
 
    --  OTG_FS_Host periodic transmit FIFO/queue status register
    --  (OTG_FS_HPTXSTS)
@@ -1773,7 +1774,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_FS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1821,7 +1822,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1861,7 +1862,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted
       CHH            : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  STALL response received interrupt
       STALL          : Boolean := False;
       --  NAK response received interrupt
@@ -1869,7 +1870,7 @@ package STM32_SVD.USB_OTG_FS is
       --  ACK response received/transmitted interrupt
       ACK            : Boolean := False;
       --  unspecified
-      Reserved_6_6   : HAL.Bit := 16#0#;
+      Reserved_6_6   : HAL.UInt1 := 16#0#;
       --  Transaction error
       TXERR          : Boolean := False;
       --  Babble error
@@ -1906,7 +1907,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Channel halted mask
       CHHM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  STALL response received interrupt mask
       STALLM         : Boolean := False;
       --  NAK response received interrupt mask
@@ -1957,7 +1958,7 @@ package STM32_SVD.USB_OTG_FS is
       --  Data PID
       DPID           : OTG_FS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2166,7 +2167,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_DEVICE_Periph : aliased OTG_FS_DEVICE_Peripheral
-     with Import, Address => OTG_FS_DEVICE_Base;
+     with Import, Address => System'To_Address (16#50000800#);
 
    type OTG_FS_GLOBAL_Disc is
      (
@@ -2280,7 +2281,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_GLOBAL_Periph : aliased OTG_FS_GLOBAL_Peripheral
-     with Import, Address => OTG_FS_GLOBAL_Base;
+     with Import, Address => System'To_Address (16#50000000#);
 
    --  USB on the go full speed
    type OTG_FS_HOST_Peripheral is record
@@ -2458,7 +2459,7 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_HOST_Periph : aliased OTG_FS_HOST_Peripheral
-     with Import, Address => OTG_FS_HOST_Base;
+     with Import, Address => System'To_Address (16#50000400#);
 
    --  USB on the go full speed
    type OTG_FS_PWRCLK_Peripheral is record
@@ -2473,6 +2474,6 @@ package STM32_SVD.USB_OTG_FS is
 
    --  USB on the go full speed
    OTG_FS_PWRCLK_Periph : aliased OTG_FS_PWRCLK_Peripheral
-     with Import, Address => OTG_FS_PWRCLK_Base;
+     with Import, Address => System'To_Address (16#50000E00#);
 
 end STM32_SVD.USB_OTG_FS;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-usb_otg_hs.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-usb_otg_hs.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -25,7 +26,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Nonzero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  Device address
       DAD            : OTG_HS_DCFG_DAD_Field := 16#0#;
       --  Periodic (micro)frame interval
@@ -132,7 +133,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -142,7 +143,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -174,17 +175,17 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SETUP phase done mask
       STUPM          : Boolean := False;
       --  OUT token received when endpoint disabled mask
       OTEPDM         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Back-to-back SETUP packets received mask
       B2BSTUP        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  OUT packet error mask
       OPEM           : Boolean := False;
       --  BNA interrupt mask
@@ -297,7 +298,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Receive threshold length
       RXTHRLEN       : OTG_HS_DTHRCTL_RXTHRLEN_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.Bit := 16#0#;
+      Reserved_26_26 : HAL.UInt1 := 16#0#;
       --  Arbiter parking enable
       ARPEN          : Boolean := False;
       --  unspecified
@@ -338,7 +339,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register
    type OTG_HS_DEACHINT_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  IN endpoint 1interrupt bit
       IEP1INT        : Boolean := False;
       --  unspecified
@@ -362,7 +363,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register mask
    type OTG_HS_DEACHINTMSK_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.Bit := 16#0#;
+      Reserved_0_0   : HAL.UInt1 := 16#0#;
       --  IN Endpoint 1 interrupt mask bit
       IEP1INTM       : Boolean := False;
       --  unspecified
@@ -402,7 +403,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint type
       EPTYP          : OTG_HS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.Bit := 16#0#;
+      Reserved_20_20 : HAL.UInt1 := 16#0#;
       --  STALL handshake
       Stall          : Boolean := False;
       --  TxFIFO number
@@ -448,13 +449,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Timeout condition
       TOC            : Boolean := False;
       --  IN token received when TxFIFO is empty
       ITTXFE         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  IN endpoint NAK effective
       INEPNE         : Boolean := False;
       --  Read-only. Transmit FIFO empty
@@ -464,7 +465,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Buffer not available interrupt
       BNA            : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.Bit := 16#0#;
+      Reserved_10_10 : HAL.UInt1 := 16#0#;
       --  Packet dropped status
       PKTDRPSTS      : Boolean := False;
       --  Babble error interrupt
@@ -549,7 +550,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Multi count
       MCNT           : OTG_HS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -573,7 +574,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
@@ -622,13 +623,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  SETUP phase done
       STUP           : Boolean := False;
       --  OUT token received when endpoint disabled
       OTEPDIS        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.Bit := 16#0#;
+      Reserved_5_5   : HAL.UInt1 := 16#0#;
       --  Back-to-back SETUP packets received
       B2BSTUP        : Boolean := False;
       --  unspecified
@@ -670,7 +671,7 @@ package STM32_SVD.USB_OTG_HS is
       --  SETUP packet count
       STUPCNT        : OTG_HS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -754,7 +755,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_HS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -870,7 +871,7 @@ package STM32_SVD.USB_OTG_HS is
       --  DMA enable
       DMAEN         : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.Bit := 16#0#;
+      Reserved_6_6  : HAL.UInt1 := 16#0#;
       --  TxFIFO empty level
       TXFELVL       : Boolean := False;
       --  Periodic TxFIFO empty level
@@ -904,7 +905,7 @@ package STM32_SVD.USB_OTG_HS is
       --  transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.Bit := 16#0#;
+      Reserved_7_7   : HAL.UInt1 := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -912,11 +913,11 @@ package STM32_SVD.USB_OTG_HS is
       --  USB turnaround time
       TRDT           : OTG_HS_GUSBCFG_TRDT_Field := 16#2#;
       --  unspecified
-      Reserved_14_14 : HAL.Bit := 16#0#;
+      Reserved_14_14 : HAL.UInt1 := 16#0#;
       --  PHY Low-power clock select
       PHYLPCS        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  ULPI FS/LS select
       ULPIFSLS       : Boolean := False;
       --  ULPI Auto-resume
@@ -942,7 +943,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Forced peripheral mode
       FDMOD          : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -984,7 +985,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.Bit := 16#0#;
+      Reserved_3_3   : HAL.UInt1 := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1059,7 +1060,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended
       DATAFSUSP         : Boolean := False;
       --  unspecified
-      Reserved_23_23    : HAL.Bit := 16#0#;
+      Reserved_23_23    : HAL.UInt1 := 16#0#;
       --  Read-only. Host port interrupt
       HPRTINT           : Boolean := False;
       --  Read-only. Host channels interrupt
@@ -1067,7 +1068,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE             : Boolean := True;
       --  unspecified
-      Reserved_27_27    : HAL.Bit := 16#0#;
+      Reserved_27_27    : HAL.UInt1 := 16#0#;
       --  Connector ID status change
       CIDSCHG           : Boolean := False;
       --  Disconnect detected interrupt
@@ -1116,7 +1117,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS interrupt mask register
    type OTG_HS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0    : HAL.Bit := 16#0#;
+      Reserved_0_0    : HAL.UInt1 := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM           : Boolean := False;
       --  OTG interrupt mask
@@ -1390,7 +1391,7 @@ package STM32_SVD.USB_OTG_HS is
    end record;
 
    subtype OTG_HS_GNPTXSTS_NPTXFSAV_Field is HAL.UInt16;
-   subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.Byte;
+   subtype OTG_HS_GNPTXSTS_NPTQXSAV_Field is HAL.UInt8;
    subtype OTG_HS_GNPTXSTS_NPTXQTOP_Field is HAL.UInt7;
 
    --  OTG_HS nonperiodic transmit FIFO/queue status register
@@ -1402,7 +1403,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Top of the nonperiodic transmit request queue
       NPTXQTOP       : OTG_HS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.Bit;
+      Reserved_31_31 : HAL.UInt1;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1615,8 +1616,8 @@ package STM32_SVD.USB_OTG_HS is
    end record;
 
    subtype OTG_HS_HPTXSTS_PTXFSAVL_Field is HAL.UInt16;
-   subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.Byte;
-   subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.Byte;
+   subtype OTG_HS_HPTXSTS_PTXQSAV_Field is HAL.UInt8;
+   subtype OTG_HS_HPTXSTS_PTXQTOP_Field is HAL.UInt8;
 
    --  OTG_HS_Host periodic transmit FIFO/queue status register
    type OTG_HS_HPTXSTS_Register is record
@@ -1695,7 +1696,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_HS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1743,7 +1744,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.Bit := 16#0#;
+      Reserved_16_16 : HAL.UInt1 := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1910,7 +1911,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data PID
       DPID           : OTG_HS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -2227,7 +2228,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_DEVICE_Periph : aliased OTG_HS_DEVICE_Peripheral
-     with Import, Address => OTG_HS_DEVICE_Base;
+     with Import, Address => System'To_Address (16#40040800#);
 
    type OTG_HS_GLOBAL_Disc is
      (
@@ -2333,7 +2334,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_GLOBAL_Periph : aliased OTG_HS_GLOBAL_Peripheral
-     with Import, Address => OTG_HS_GLOBAL_Base;
+     with Import, Address => System'To_Address (16#40040000#);
 
    --  USB on the go high speed
    type OTG_HS_HOST_Peripheral is record
@@ -2654,7 +2655,7 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_HOST_Periph : aliased OTG_HS_HOST_Peripheral
-     with Import, Address => OTG_HS_HOST_Base;
+     with Import, Address => System'To_Address (16#40040400#);
 
    --  USB on the go high speed
    type OTG_HS_PWRCLK_Peripheral is record
@@ -2669,6 +2670,6 @@ package STM32_SVD.USB_OTG_HS is
 
    --  USB on the go high speed
    OTG_HS_PWRCLK_Periph : aliased OTG_HS_PWRCLK_Peripheral
-     with Import, Address => OTG_HS_PWRCLK_Base;
+     with Import, Address => System'To_Address (16#40040E00#);
 
 end STM32_SVD.USB_OTG_HS;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-usb_otg_hs.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-usb_otg_hs.ads
@@ -26,7 +26,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Nonzero-length status OUT handshake
       NZLSOHSK       : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  Device address
       DAD            : OTG_HS_DCFG_DAD_Field := 16#0#;
       --  Periodic (micro)frame interval
@@ -133,7 +133,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition mask (nonisochronous endpoints)
       TOM            : Boolean := False;
       --  IN token received when TxFIFO empty mask
@@ -143,7 +143,7 @@ package STM32_SVD.USB_OTG_HS is
       --  IN endpoint NAK effective mask
       INEPNEM        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  FIFO underrun mask
       TXFURM         : Boolean := False;
       --  BNA interrupt mask
@@ -175,17 +175,17 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt mask
       EPDM           : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SETUP phase done mask
       STUPM          : Boolean := False;
       --  OUT token received when endpoint disabled mask
       OTEPDM         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Back-to-back SETUP packets received mask
       B2BSTUP        : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  OUT packet error mask
       OPEM           : Boolean := False;
       --  BNA interrupt mask
@@ -298,7 +298,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Receive threshold length
       RXTHRLEN       : OTG_HS_DTHRCTL_RXTHRLEN_Field := 16#0#;
       --  unspecified
-      Reserved_26_26 : HAL.UInt1 := 16#0#;
+      Reserved_26_26 : HAL.Bit := 16#0#;
       --  Arbiter parking enable
       ARPEN          : Boolean := False;
       --  unspecified
@@ -339,7 +339,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register
    type OTG_HS_DEACHINT_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  IN endpoint 1interrupt bit
       IEP1INT        : Boolean := False;
       --  unspecified
@@ -363,7 +363,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS device each endpoint interrupt register mask
    type OTG_HS_DEACHINTMSK_Register is record
       --  unspecified
-      Reserved_0_0   : HAL.UInt1 := 16#0#;
+      Reserved_0_0   : HAL.Bit := 16#0#;
       --  IN Endpoint 1 interrupt mask bit
       IEP1INTM       : Boolean := False;
       --  unspecified
@@ -403,7 +403,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint type
       EPTYP          : OTG_HS_DIEPCTL_EPTYP_Field := 16#0#;
       --  unspecified
-      Reserved_20_20 : HAL.UInt1 := 16#0#;
+      Reserved_20_20 : HAL.Bit := 16#0#;
       --  STALL handshake
       Stall          : Boolean := False;
       --  TxFIFO number
@@ -449,13 +449,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Timeout condition
       TOC            : Boolean := False;
       --  IN token received when TxFIFO is empty
       ITTXFE         : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  IN endpoint NAK effective
       INEPNE         : Boolean := False;
       --  Read-only. Transmit FIFO empty
@@ -465,7 +465,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Buffer not available interrupt
       BNA            : Boolean := False;
       --  unspecified
-      Reserved_10_10 : HAL.UInt1 := 16#0#;
+      Reserved_10_10 : HAL.Bit := 16#0#;
       --  Packet dropped status
       PKTDRPSTS      : Boolean := False;
       --  Babble error interrupt
@@ -550,7 +550,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Multi count
       MCNT           : OTG_HS_DIEPTSIZ_MCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -574,7 +574,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. USB active endpoint
       USBAEP         : Boolean := True;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Read-only. NAK status
       NAKSTS         : Boolean := False;
       --  Read-only. Endpoint type
@@ -623,13 +623,13 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint disabled interrupt
       EPDISD         : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  SETUP phase done
       STUP           : Boolean := False;
       --  OUT token received when endpoint disabled
       OTEPDIS        : Boolean := False;
       --  unspecified
-      Reserved_5_5   : HAL.UInt1 := 16#0#;
+      Reserved_5_5   : HAL.Bit := 16#0#;
       --  Back-to-back SETUP packets received
       B2BSTUP        : Boolean := False;
       --  unspecified
@@ -671,7 +671,7 @@ package STM32_SVD.USB_OTG_HS is
       --  SETUP packet count
       STUPCNT        : OTG_HS_DOEPTSIZ0_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -755,7 +755,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Received data PID/SETUP packet count
       RXDPID_STUPCNT : OTG_HS_DOEPTSIZ_RXDPID_STUPCNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -871,7 +871,7 @@ package STM32_SVD.USB_OTG_HS is
       --  DMA enable
       DMAEN         : Boolean := False;
       --  unspecified
-      Reserved_6_6  : HAL.UInt1 := 16#0#;
+      Reserved_6_6  : HAL.Bit := 16#0#;
       --  TxFIFO empty level
       TXFELVL       : Boolean := False;
       --  Periodic TxFIFO empty level
@@ -905,7 +905,7 @@ package STM32_SVD.USB_OTG_HS is
       --  transceiver select
       PHYSEL         : Boolean := False;
       --  unspecified
-      Reserved_7_7   : HAL.UInt1 := 16#0#;
+      Reserved_7_7   : HAL.Bit := 16#0#;
       --  SRP-capable
       SRPCAP         : Boolean := False;
       --  HNP-capable
@@ -913,11 +913,11 @@ package STM32_SVD.USB_OTG_HS is
       --  USB turnaround time
       TRDT           : OTG_HS_GUSBCFG_TRDT_Field := 16#2#;
       --  unspecified
-      Reserved_14_14 : HAL.UInt1 := 16#0#;
+      Reserved_14_14 : HAL.Bit := 16#0#;
       --  PHY Low-power clock select
       PHYLPCS        : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  ULPI FS/LS select
       ULPIFSLS       : Boolean := False;
       --  ULPI Auto-resume
@@ -943,7 +943,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Forced peripheral mode
       FDMOD          : Boolean := False;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -985,7 +985,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Host frame counter reset
       FCRST          : Boolean := False;
       --  unspecified
-      Reserved_3_3   : HAL.UInt1 := 16#0#;
+      Reserved_3_3   : HAL.Bit := 16#0#;
       --  RxFIFO flush
       RXFFLSH        : Boolean := False;
       --  TxFIFO flush
@@ -1060,7 +1060,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data fetch suspended
       DATAFSUSP         : Boolean := False;
       --  unspecified
-      Reserved_23_23    : HAL.UInt1 := 16#0#;
+      Reserved_23_23    : HAL.Bit := 16#0#;
       --  Read-only. Host port interrupt
       HPRTINT           : Boolean := False;
       --  Read-only. Host channels interrupt
@@ -1068,7 +1068,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Periodic TxFIFO empty
       PTXFE             : Boolean := True;
       --  unspecified
-      Reserved_27_27    : HAL.UInt1 := 16#0#;
+      Reserved_27_27    : HAL.Bit := 16#0#;
       --  Connector ID status change
       CIDSCHG           : Boolean := False;
       --  Disconnect detected interrupt
@@ -1117,7 +1117,7 @@ package STM32_SVD.USB_OTG_HS is
    --  OTG_HS interrupt mask register
    type OTG_HS_GINTMSK_Register is record
       --  unspecified
-      Reserved_0_0    : HAL.UInt1 := 16#0#;
+      Reserved_0_0    : HAL.Bit := 16#0#;
       --  Mode mismatch interrupt mask
       MMISM           : Boolean := False;
       --  OTG interrupt mask
@@ -1403,7 +1403,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Read-only. Top of the nonperiodic transmit request queue
       NPTXQTOP       : OTG_HS_GNPTXSTS_NPTXQTOP_Field;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1;
+      Reserved_31_31 : HAL.Bit;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -1696,7 +1696,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Port reset
       PRST           : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. Port line status
       PLSTS          : OTG_HS_HPRT_PLSTS_Field := 16#0#;
       --  Port power
@@ -1744,7 +1744,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Endpoint direction
       EPDIR          : Boolean := False;
       --  unspecified
-      Reserved_16_16 : HAL.UInt1 := 16#0#;
+      Reserved_16_16 : HAL.Bit := 16#0#;
       --  Low-speed device
       LSDEV          : Boolean := False;
       --  Endpoint type
@@ -1911,7 +1911,7 @@ package STM32_SVD.USB_OTG_HS is
       --  Data PID
       DPID           : OTG_HS_HCTSIZ_DPID_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-wwdg.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd-wwdg.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -118,6 +119,6 @@ package STM32_SVD.WWDG is
 
    --  Window watchdog
    WWDG_Periph : aliased WWDG_Peripheral
-     with Import, Address => WWDG_Base;
+     with Import, Address => System'To_Address (16#40002C00#);
 
 end STM32_SVD.WWDG;

--- a/arch/ARM/STM32/svd/stm32f7x9/stm32_svd.ads
+++ b/arch/ARM/STM32/svd/stm32f7x9/stm32_svd.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with System;
 

--- a/arch/ARM/cortex_m/src/cache/cortex_m-cache.adb
+++ b/arch/ARM/cortex_m/src/cache/cortex_m-cache.adb
@@ -90,10 +90,10 @@ package body Cortex_M.Cache is
 
       declare
          function To_U32 is new Ada.Unchecked_Conversion
-           (System.Address, Unsigned_32);
+           (System.Address, UInt32);
 
          Op_Size   : Integer_32 := Integer_32 (Len);
-         Op_Addr   : Unsigned_32 := To_U32 (Start);
+         Op_Addr   : UInt32 := To_U32 (Start);
          Reg       : UInt32 with Volatile, Address => Reg_Address;
 
       begin

--- a/arch/ARM/cortex_m/src/cm0/cortex_m_svd-debug.ads
+++ b/arch/ARM/cortex_m/src/cm0/cortex_m_svd-debug.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -25,9 +26,9 @@ package Cortex_M_SVD.Debug is
       --  cause of the exception.
       VCATCH        : Boolean := False;
       --  An asynchronous exception generated due to the assertion of EDBGRQ.
-      EXTERNAL      : Boolean := True;
+      EXTERNAL      : Boolean := False;
       --  unspecified
-      Reserved_5_31 : HAL.UInt27 := 16#2745C87#;
+      Reserved_5_31 : HAL.UInt27 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -55,7 +56,7 @@ package Cortex_M_SVD.Debug is
       --  Read-only.
       C_MASKINTS     : Boolean;
       --  unspecified
-      Reserved_4_4   : HAL.Bit;
+      Reserved_4_4   : HAL.UInt1;
       --  Read-only.
       C_SNAPSTALL    : Boolean;
       --  unspecified
@@ -110,15 +111,15 @@ package Cortex_M_SVD.Debug is
       --  Write-only.
       C_MASKINTS    : Boolean := False;
       --  unspecified
-      Reserved_4_4  : HAL.Bit := 16#1#;
+      Reserved_4_4  : HAL.UInt1 := 16#0#;
       --  Write-only.
-      C_SNAPSTALL   : Boolean := True;
+      C_SNAPSTALL   : Boolean := False;
       --  unspecified
-      Reserved_6_15 : HAL.UInt10 := 16#243#;
+      Reserved_6_15 : HAL.UInt10 := 16#0#;
       --  Write-only. Debug Key. The value 0xA05F must be written to enable
       --  write accesses to bits [15:0], otherwise the write access will be
       --  ignored. Read behavior of bits [31:16] is as listed below.
-      S_RESET_ST    : Write_DHCSR_S_RESET_ST_Field := 16#4E8B#;
+      S_RESET_ST    : Write_DHCSR_S_RESET_ST_Field := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -218,13 +219,13 @@ package Cortex_M_SVD.Debug is
    --  register is only accessible from Debug state.
    type DCRSR_Register is record
       --  Write-only.
-      HALTED         : DCRSR_HALTED_Field := Cortex_M_SVD.Debug.XPsr;
+      HALTED         : DCRSR_HALTED_Field := Cortex_M_SVD.Debug.Register_0;
       --  unspecified
-      Reserved_5_15  : HAL.UInt11 := 16#487#;
+      Reserved_5_15  : HAL.UInt11 := 16#0#;
       --  Write-only.
-      REGWnR         : DCRSR_REGWnR_Field := Cortex_M_SVD.Debug.Write;
+      REGWnR         : DCRSR_REGWnR_Field := Cortex_M_SVD.Debug.Read;
       --  unspecified
-      Reserved_17_31 : HAL.UInt15 := 16#2745#;
+      Reserved_17_31 : HAL.UInt15 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -241,24 +242,24 @@ package Cortex_M_SVD.Debug is
       VC_CORERESET   : Boolean := False;
       --  unspecified
       Reserved_1_3   : HAL.UInt3 := 16#0#;
-      VC_MMERR       : Boolean := True;
-      VC_NOCPERR     : Boolean := True;
-      VC_CHKERR      : Boolean := True;
-      VC_STATERR     : Boolean := True;
+      VC_MMERR       : Boolean := False;
+      VC_NOCPERR     : Boolean := False;
+      VC_CHKERR      : Boolean := False;
+      VC_STATERR     : Boolean := False;
       VC_BUSERR      : Boolean := False;
       VC_INTERR      : Boolean := False;
       VC_HARDERR     : Boolean := False;
       --  unspecified
-      Reserved_11_15 : HAL.UInt5 := 16#12#;
-      MON_EN         : Boolean := True;
-      MON_PEND       : Boolean := True;
+      Reserved_11_15 : HAL.UInt5 := 16#0#;
+      MON_EN         : Boolean := False;
+      MON_PEND       : Boolean := False;
       MON_STEP       : Boolean := False;
-      MON_REQ        : Boolean := True;
+      MON_REQ        : Boolean := False;
       --  unspecified
-      Reserved_20_23 : HAL.UInt4 := 16#8#;
+      Reserved_20_23 : HAL.UInt4 := 16#0#;
       TRCENA         : Boolean := False;
       --  unspecified
-      Reserved_25_31 : HAL.UInt7 := 16#27#;
+      Reserved_25_31 : HAL.UInt7 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/cortex_m/src/cm0/cortex_m_svd-debug.ads
+++ b/arch/ARM/cortex_m/src/cm0/cortex_m_svd-debug.ads
@@ -56,7 +56,7 @@ package Cortex_M_SVD.Debug is
       --  Read-only.
       C_MASKINTS     : Boolean;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1;
+      Reserved_4_4   : HAL.Bit;
       --  Read-only.
       C_SNAPSTALL    : Boolean;
       --  unspecified
@@ -111,7 +111,7 @@ package Cortex_M_SVD.Debug is
       --  Write-only.
       C_MASKINTS    : Boolean := False;
       --  unspecified
-      Reserved_4_4  : HAL.UInt1 := 16#0#;
+      Reserved_4_4  : HAL.Bit := 16#0#;
       --  Write-only.
       C_SNAPSTALL   : Boolean := False;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm0/cortex_m_svd-nvic.ads
+++ b/arch/ARM/cortex_m/src/cm0/cortex_m_svd-nvic.ads
@@ -17,7 +17,7 @@ package Cortex_M_SVD.NVIC is
    --  Interrupt Priority Register
 
    --  Interrupt Priority Register
-   type NVIC_IPR_Registers is array (0 .. 31) of HAL.UInt8;
+   type NVIC_IPR_Registers is array (0 .. 7) of HAL.UInt32;
 
    -----------------
    -- Peripherals --

--- a/arch/ARM/cortex_m/src/cm0/cortex_m_svd-nvic.ads
+++ b/arch/ARM/cortex_m/src/cm0/cortex_m_svd-nvic.ads
@@ -5,6 +5,7 @@ pragma Ada_2012;
 pragma Style_Checks (Off);
 
 with HAL;
+with System;
 
 package Cortex_M_SVD.NVIC is
    pragma Preelaborate;

--- a/arch/ARM/cortex_m/src/cm0/cortex_m_svd-nvic.ads
+++ b/arch/ARM/cortex_m/src/cm0/cortex_m_svd-nvic.ads
@@ -2,8 +2,10 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
+with System;
 
 package Cortex_M_SVD.NVIC is
    pragma Preelaborate;
@@ -15,7 +17,7 @@ package Cortex_M_SVD.NVIC is
    --  Interrupt Priority Register
 
    --  Interrupt Priority Register
-   type NVIC_IPR_Registers is array (0 .. 31) of HAL.Byte;
+   type NVIC_IPR_Registers is array (0 .. 31) of HAL.UInt8;
 
    -----------------
    -- Peripherals --

--- a/arch/ARM/cortex_m/src/cm0/cortex_m_svd-nvic.ads
+++ b/arch/ARM/cortex_m/src/cm0/cortex_m_svd-nvic.ads
@@ -5,7 +5,6 @@ pragma Ada_2012;
 pragma Style_Checks (Off);
 
 with HAL;
-with System;
 
 package Cortex_M_SVD.NVIC is
    pragma Preelaborate;

--- a/arch/ARM/cortex_m/src/cm0/cortex_m_svd-scb.ads
+++ b/arch/ARM/cortex_m/src/cm0/cortex_m_svd-scb.ads
@@ -167,7 +167,7 @@ package Cortex_M_SVD.SCB is
    --  Application Interrupt and Reset Control Register
    type AIRCR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1 := 16#0#;
+      Reserved_0_0  : HAL.Bit := 16#0#;
       --  Write-only. Reserved for debug use. This bit reads as 0. When writing
       --  to the register youmust write 0 to this bit, otherwise behavior is
       --  Unpredictable.
@@ -199,7 +199,7 @@ package Cortex_M_SVD.SCB is
    --  System Control Register
    type SCR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1 := 16#0#;
+      Reserved_0_0  : HAL.Bit := 16#0#;
       --  Indicates sleep-on-exit when returning from Handler mode to Thread
       --  mode
       SLEEPONEXIT   : Boolean := False;
@@ -207,7 +207,7 @@ package Cortex_M_SVD.SCB is
       --  low-power mode
       SLEEPDEEP     : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.UInt1 := 16#0#;
+      Reserved_3_3  : HAL.Bit := 16#0#;
       --  Send event on pending bit
       SEVONPEND     : Boolean := False;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm0/cortex_m_svd-scb.ads
+++ b/arch/ARM/cortex_m/src/cm0/cortex_m_svd-scb.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -166,7 +167,7 @@ package Cortex_M_SVD.SCB is
    --  Application Interrupt and Reset Control Register
    type AIRCR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit := 16#0#;
+      Reserved_0_0  : HAL.UInt1 := 16#0#;
       --  Write-only. Reserved for debug use. This bit reads as 0. When writing
       --  to the register youmust write 0 to this bit, otherwise behavior is
       --  Unpredictable.
@@ -198,7 +199,7 @@ package Cortex_M_SVD.SCB is
    --  System Control Register
    type SCR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit := 16#0#;
+      Reserved_0_0  : HAL.UInt1 := 16#0#;
       --  Indicates sleep-on-exit when returning from Handler mode to Thread
       --  mode
       SLEEPONEXIT   : Boolean := False;
@@ -206,7 +207,7 @@ package Cortex_M_SVD.SCB is
       --  low-power mode
       SLEEPDEEP     : Boolean := False;
       --  unspecified
-      Reserved_3_3  : HAL.Bit := 16#0#;
+      Reserved_3_3  : HAL.UInt1 := 16#0#;
       --  Send event on pending bit
       SEVONPEND     : Boolean := False;
       --  unspecified
@@ -249,7 +250,7 @@ package Cortex_M_SVD.SCB is
       Reserved_10_31 at 0 range 10 .. 31;
    end record;
 
-   subtype SHPR2_PRI_11_Field is HAL.Byte;
+   subtype SHPR2_PRI_11_Field is HAL.UInt8;
 
    --  System Handler Priority Register 2
    type SHPR2_Register is record
@@ -266,8 +267,8 @@ package Cortex_M_SVD.SCB is
       PRI_11        at 0 range 24 .. 31;
    end record;
 
-   subtype SHPR3_PRI_14_Field is HAL.Byte;
-   subtype SHPR3_PRI_15_Field is HAL.Byte;
+   subtype SHPR3_PRI_14_Field is HAL.UInt8;
+   subtype SHPR3_PRI_15_Field is HAL.UInt8;
 
    --  System Handler Priority Register 3
    type SHPR3_Register is record
@@ -322,6 +323,6 @@ package Cortex_M_SVD.SCB is
 
    --  System control block
    SCB_Periph : aliased SCB_Peripheral
-     with Import, Address => SCB_Base;
+     with Import, Address => System'To_Address (16#E000ED00#);
 
 end Cortex_M_SVD.SCB;

--- a/arch/ARM/cortex_m/src/cm0/cortex_m_svd-systick.ads
+++ b/arch/ARM/cortex_m/src/cm0/cortex_m_svd-systick.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -85,7 +86,7 @@ package Cortex_M_SVD.SysTick is
       --  Value to auto reload SysTick after reaching zero
       RELOAD         : SYST_RVR_RELOAD_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -102,7 +103,7 @@ package Cortex_M_SVD.SysTick is
       --  Current value
       CURRENT        : SYST_CVR_CURRENT_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/cortex_m/src/cm0/cortex_m_svd.ads
+++ b/arch/ARM/cortex_m/src/cm0/cortex_m_svd.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with System;
 

--- a/arch/ARM/cortex_m/src/cm4/cortex_m_svd-debug.ads
+++ b/arch/ARM/cortex_m/src/cm4/cortex_m_svd-debug.ads
@@ -56,7 +56,7 @@ package Cortex_M_SVD.Debug is
       --  Read-only.
       C_MASKINTS     : Boolean;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1;
+      Reserved_4_4   : HAL.Bit;
       --  Read-only.
       C_SNAPSTALL    : Boolean;
       --  unspecified
@@ -111,7 +111,7 @@ package Cortex_M_SVD.Debug is
       --  Write-only.
       C_MASKINTS    : Boolean := False;
       --  unspecified
-      Reserved_4_4  : HAL.UInt1 := 16#0#;
+      Reserved_4_4  : HAL.Bit := 16#0#;
       --  Write-only.
       C_SNAPSTALL   : Boolean := False;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm4/cortex_m_svd-debug.ads
+++ b/arch/ARM/cortex_m/src/cm4/cortex_m_svd-debug.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -27,7 +28,7 @@ package Cortex_M_SVD.Debug is
       --  An asynchronous exception generated due to the assertion of EDBGRQ.
       EXTERNAL      : Boolean := False;
       --  unspecified
-      Reserved_5_31 : HAL.UInt27 := 16#214C8A3#;
+      Reserved_5_31 : HAL.UInt27 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -55,7 +56,7 @@ package Cortex_M_SVD.Debug is
       --  Read-only.
       C_MASKINTS     : Boolean;
       --  unspecified
-      Reserved_4_4   : HAL.Bit;
+      Reserved_4_4   : HAL.UInt1;
       --  Read-only.
       C_SNAPSTALL    : Boolean;
       --  unspecified
@@ -110,15 +111,15 @@ package Cortex_M_SVD.Debug is
       --  Write-only.
       C_MASKINTS    : Boolean := False;
       --  unspecified
-      Reserved_4_4  : HAL.Bit := 16#0#;
+      Reserved_4_4  : HAL.UInt1 := 16#0#;
       --  Write-only.
-      C_SNAPSTALL   : Boolean := True;
+      C_SNAPSTALL   : Boolean := False;
       --  unspecified
-      Reserved_6_15 : HAL.UInt10 := 16#51#;
+      Reserved_6_15 : HAL.UInt10 := 16#0#;
       --  Write-only. Debug Key. The value 0xA05F must be written to enable
       --  write accesses to bits [15:0], otherwise the write access will be
       --  ignored. Read behavior of bits [31:16] is as listed below.
-      S_RESET_ST    : Write_DHCSR_S_RESET_ST_Field := 16#4299#;
+      S_RESET_ST    : Write_DHCSR_S_RESET_ST_Field := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -220,11 +221,11 @@ package Cortex_M_SVD.Debug is
       --  Write-only.
       HALTED         : DCRSR_HALTED_Field := Cortex_M_SVD.Debug.Register_0;
       --  unspecified
-      Reserved_5_15  : HAL.UInt11 := 16#A3#;
+      Reserved_5_15  : HAL.UInt11 := 16#0#;
       --  Write-only.
-      REGWnR         : DCRSR_REGWnR_Field := Cortex_M_SVD.Debug.Write;
+      REGWnR         : DCRSR_REGWnR_Field := Cortex_M_SVD.Debug.Read;
       --  unspecified
-      Reserved_17_31 : HAL.UInt15 := 16#214C#;
+      Reserved_17_31 : HAL.UInt15 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -242,23 +243,23 @@ package Cortex_M_SVD.Debug is
       --  unspecified
       Reserved_1_3   : HAL.UInt3 := 16#0#;
       VC_MMERR       : Boolean := False;
-      VC_NOCPERR     : Boolean := True;
-      VC_CHKERR      : Boolean := True;
+      VC_NOCPERR     : Boolean := False;
+      VC_CHKERR      : Boolean := False;
       VC_STATERR     : Boolean := False;
       VC_BUSERR      : Boolean := False;
       VC_INTERR      : Boolean := False;
-      VC_HARDERR     : Boolean := True;
+      VC_HARDERR     : Boolean := False;
       --  unspecified
-      Reserved_11_15 : HAL.UInt5 := 16#2#;
-      MON_EN         : Boolean := True;
+      Reserved_11_15 : HAL.UInt5 := 16#0#;
+      MON_EN         : Boolean := False;
       MON_PEND       : Boolean := False;
       MON_STEP       : Boolean := False;
-      MON_REQ        : Boolean := True;
+      MON_REQ        : Boolean := False;
       --  unspecified
-      Reserved_20_23 : HAL.UInt4 := 16#9#;
+      Reserved_20_23 : HAL.UInt4 := 16#0#;
       TRCENA         : Boolean := False;
       --  unspecified
-      Reserved_25_31 : HAL.UInt7 := 16#21#;
+      Reserved_25_31 : HAL.UInt7 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/cortex_m/src/cm4/cortex_m_svd-mpu.ads
+++ b/arch/ARM/cortex_m/src/cm4/cortex_m_svd-mpu.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -24,8 +25,8 @@ package Cortex_M_SVD.MPU is
    for TYPE_SEPARATE_Field use
      (Unified => 0);
 
-   subtype MPU_TYPE_DREGION_Field is HAL.Byte;
-   subtype MPU_TYPE_IREGION_Field is HAL.Byte;
+   subtype MPU_TYPE_DREGION_Field is HAL.UInt8;
+   subtype MPU_TYPE_IREGION_Field is HAL.UInt8;
 
    --  MPU Type Register
    type MPU_TYPE_Register is record
@@ -42,7 +43,7 @@ package Cortex_M_SVD.MPU is
       --  by the DREGION field.
       IREGION        : MPU_TYPE_IREGION_Field;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -77,7 +78,7 @@ package Cortex_M_SVD.MPU is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype MPU_RNR_REGION_Field is HAL.Byte;
+   subtype MPU_RNR_REGION_Field is HAL.UInt8;
 
    --  MPU Region Number Register
    type MPU_RNR_Register is record
@@ -141,7 +142,7 @@ package Cortex_M_SVD.MPU is
       case As_Array is
          when False =>
             --  SRD as a value
-            Val : HAL.Byte;
+            Val : HAL.UInt8;
          when True =>
             --  SRD as an array
             Arr : MPU_RASR_SRD_Field_Array;
@@ -220,7 +221,7 @@ package Cortex_M_SVD.MPU is
       --  Access permission field
       AP             : RASR_AP_Field := Cortex_M_SVD.MPU.No_Access;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Instruction access disable bit
       XN             : RASR_XN_Field := Cortex_M_SVD.MPU.I_Enabled;
       --  unspecified
@@ -291,7 +292,7 @@ package Cortex_M_SVD.MPU is
       case As_Array is
          when False =>
             --  SRD as a value
-            Val : HAL.Byte;
+            Val : HAL.UInt8;
          when True =>
             --  SRD as an array
             Arr : RASR_A_SRD_Field_Array;
@@ -369,7 +370,7 @@ package Cortex_M_SVD.MPU is
       --  Access permission field
       AP             : RASR_A1_AP_Field := Cortex_M_SVD.MPU.No_Access;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Instruction access disable bit
       XN             : RASR_A1_XN_Field := Cortex_M_SVD.MPU.I_Enabled;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm4/cortex_m_svd-mpu.ads
+++ b/arch/ARM/cortex_m/src/cm4/cortex_m_svd-mpu.ads
@@ -221,7 +221,7 @@ package Cortex_M_SVD.MPU is
       --  Access permission field
       AP             : RASR_AP_Field := Cortex_M_SVD.MPU.No_Access;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Instruction access disable bit
       XN             : RASR_XN_Field := Cortex_M_SVD.MPU.I_Enabled;
       --  unspecified
@@ -370,7 +370,7 @@ package Cortex_M_SVD.MPU is
       --  Access permission field
       AP             : RASR_A1_AP_Field := Cortex_M_SVD.MPU.No_Access;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Instruction access disable bit
       XN             : RASR_A1_XN_Field := Cortex_M_SVD.MPU.I_Enabled;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm4/cortex_m_svd-nvic.ads
+++ b/arch/ARM/cortex_m/src/cm4/cortex_m_svd-nvic.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -49,9 +50,9 @@ package Cortex_M_SVD.NVIC is
    type STIR_Register is record
       --  Write-only. Interrupt ID of the interrupt to trigger, in the range
       --  0-239.
-      INTID         : STIR_INTID_Field := 16#60#;
+      INTID         : STIR_INTID_Field := 16#0#;
       --  unspecified
-      Reserved_9_31 : HAL.UInt23 := 16#214C8A#;
+      Reserved_9_31 : HAL.UInt23 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/cortex_m/src/cm4/cortex_m_svd-scb.ads
+++ b/arch/ARM/cortex_m/src/cm4/cortex_m_svd-scb.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -429,7 +430,7 @@ package Cortex_M_SVD.SCB is
       --  pending enabled exception.
       VECTPENDING    : ICSR_VECTPENDING_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Interrupt pending flag, excluding NMI and Faults
       ISRPENDING     : Boolean := False;
       --  unspecified
@@ -559,12 +560,12 @@ package Cortex_M_SVD.SCB is
    --  System Control Register
    type SCR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit := 16#0#;
+      Reserved_0_0  : HAL.UInt1 := 16#0#;
       --  Indicates sleep-on-exit when returning from Handler mode to Thread
       --  mode
       SLEEPONEXIT   : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Controls whether the processor uses sleep or deep sleep as its
       --  low-power mode
       SLEEPDEEP     : Boolean := False;
@@ -586,7 +587,7 @@ package Cortex_M_SVD.SCB is
    end record;
 
    --  Indicates how the processor enters Thread mode
-   type CCR_NONBASETHERADENA_Field is
+   type CCR_NONBASETHREADENA_Field is
      (
       --  Processor can enter Thread mode only when no exception is active
       No_Active_Exception,
@@ -594,19 +595,19 @@ package Cortex_M_SVD.SCB is
       --  an EXC_RETURN value
       On_Exc_Return)
      with Size => 1;
-   for CCR_NONBASETHERADENA_Field use
+   for CCR_NONBASETHREADENA_Field use
      (No_Active_Exception => 0,
       On_Exc_Return => 1);
 
    --  Configuration and Control Register
    type CCR_Register is record
       --  Indicates how the processor enters Thread mode
-      NONBASETHERADENA : CCR_NONBASETHERADENA_Field :=
+      NONBASETHREADENA : CCR_NONBASETHREADENA_Field :=
                           Cortex_M_SVD.SCB.No_Active_Exception;
       --  Enables unprivileged software access to the STIR
       USERSETMPEND     : Boolean := False;
       --  unspecified
-      Reserved_2_2     : HAL.Bit := 16#0#;
+      Reserved_2_2     : HAL.UInt1 := 16#0#;
       --  Enables unalign access traps.
       UNALIGNED_TRP    : Boolean := False;
       --  Enables faulting or halting when the processor executes an SDIF or
@@ -634,7 +635,7 @@ package Cortex_M_SVD.SCB is
           Bit_Order => System.Low_Order_First;
 
    for CCR_Register use record
-      NONBASETHERADENA at 0 range 0 .. 0;
+      NONBASETHREADENA at 0 range 0 .. 0;
       USERSETMPEND     at 0 range 1 .. 1;
       Reserved_2_2     at 0 range 2 .. 2;
       UNALIGNED_TRP    at 0 range 3 .. 3;
@@ -648,9 +649,9 @@ package Cortex_M_SVD.SCB is
       Reserved_18_31   at 0 range 18 .. 31;
    end record;
 
-   subtype SHPR1_PRI_4_Field is HAL.Byte;
-   subtype SHPR1_PRI_5_Field is HAL.Byte;
-   subtype SHPR1_PRI_6_Field is HAL.Byte;
+   subtype SHPR1_PRI_4_Field is HAL.UInt8;
+   subtype SHPR1_PRI_5_Field is HAL.UInt8;
+   subtype SHPR1_PRI_6_Field is HAL.UInt8;
 
    --  System Handler Priority Register 1
    type SHPR1_Register is record
@@ -661,7 +662,7 @@ package Cortex_M_SVD.SCB is
       --  Priority of the system handler, UsageFault
       PRI_6          : SHPR1_PRI_6_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -673,7 +674,7 @@ package Cortex_M_SVD.SCB is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype SHPR2_PRI_11_Field is HAL.Byte;
+   subtype SHPR2_PRI_11_Field is HAL.UInt8;
 
    --  System Handler Priority Register 2
    type SHPR2_Register is record
@@ -690,8 +691,8 @@ package Cortex_M_SVD.SCB is
       PRI_11        at 0 range 24 .. 31;
    end record;
 
-   subtype SHPR3_PRI_14_Field is HAL.Byte;
-   subtype SHPR3_PRI_15_Field is HAL.Byte;
+   subtype SHPR3_PRI_14_Field is HAL.UInt8;
+   subtype SHPR3_PRI_15_Field is HAL.UInt8;
 
    --  System Handler Priority Register 3
    type SHPR3_Register is record
@@ -720,7 +721,7 @@ package Cortex_M_SVD.SCB is
       --  active.
       BUSFAULTACT    : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Read-only. UsageFault exception active bit, reads as 1 if exception
       --  is active.
       USGFAULTACT    : Boolean := False;
@@ -732,7 +733,7 @@ package Cortex_M_SVD.SCB is
       --  active.
       MONITORACT     : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. PendSV exception active bit, reads as 1 if exception is
       --  active.
       PENDSVACT      : Boolean := False;
@@ -790,7 +791,7 @@ package Cortex_M_SVD.SCB is
       --  Data access violation flag
       DACCVIOL     : Boolean := False;
       --  unspecified
-      Reserved_2_2 : HAL.Bit := 16#0#;
+      Reserved_2_2 : HAL.UInt1 := 16#0#;
       --  MemManage fault on unstacking for a return from exception
       MUNSTKERR    : Boolean := False;
       --  MemManage fault on stacking for exception entry
@@ -798,7 +799,7 @@ package Cortex_M_SVD.SCB is
       --  MemManage fault during floating-point lazy state preservation.
       MLSPERR      : Boolean := False;
       --  unspecified
-      Reserved_6_6 : HAL.Bit := 16#0#;
+      Reserved_6_6 : HAL.UInt1 := 16#0#;
       --  MemManage fault address register valid flag.
       MMARVALID    : Boolean := False;
    end record
@@ -830,7 +831,7 @@ package Cortex_M_SVD.SCB is
       --  BusFault on floating-point lazy state preservation.
       LSPERR       : Boolean := False;
       --  unspecified
-      Reserved_6_6 : HAL.Bit := 16#0#;
+      Reserved_6_6 : HAL.UInt1 := 16#0#;
       --  BusFault Address Register valid flag.
       BFARVALID    : Boolean := False;
    end record
@@ -884,7 +885,7 @@ package Cortex_M_SVD.SCB is
    --  HardFault Status Register
    type HFSR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit := 16#0#;
+      Reserved_0_0  : HAL.UInt1 := 16#0#;
       --  Indicates a BusFault on a vector table read during exception
       --  processing.
       VECTTBL       : Boolean := False;
@@ -979,6 +980,6 @@ package Cortex_M_SVD.SCB is
 
    --  System control block
    SCB_Periph : aliased SCB_Peripheral
-     with Import, Address => SCB_Base;
+     with Import, Address => System'To_Address (16#E000E000#);
 
 end Cortex_M_SVD.SCB;

--- a/arch/ARM/cortex_m/src/cm4/cortex_m_svd-scb.ads
+++ b/arch/ARM/cortex_m/src/cm4/cortex_m_svd-scb.ads
@@ -430,7 +430,7 @@ package Cortex_M_SVD.SCB is
       --  pending enabled exception.
       VECTPENDING    : ICSR_VECTPENDING_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Interrupt pending flag, excluding NMI and Faults
       ISRPENDING     : Boolean := False;
       --  unspecified
@@ -560,12 +560,12 @@ package Cortex_M_SVD.SCB is
    --  System Control Register
    type SCR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1 := 16#0#;
+      Reserved_0_0  : HAL.Bit := 16#0#;
       --  Indicates sleep-on-exit when returning from Handler mode to Thread
       --  mode
       SLEEPONEXIT   : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Controls whether the processor uses sleep or deep sleep as its
       --  low-power mode
       SLEEPDEEP     : Boolean := False;
@@ -607,7 +607,7 @@ package Cortex_M_SVD.SCB is
       --  Enables unprivileged software access to the STIR
       USERSETMPEND     : Boolean := False;
       --  unspecified
-      Reserved_2_2     : HAL.UInt1 := 16#0#;
+      Reserved_2_2     : HAL.Bit := 16#0#;
       --  Enables unalign access traps.
       UNALIGNED_TRP    : Boolean := False;
       --  Enables faulting or halting when the processor executes an SDIF or
@@ -721,7 +721,7 @@ package Cortex_M_SVD.SCB is
       --  active.
       BUSFAULTACT    : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Read-only. UsageFault exception active bit, reads as 1 if exception
       --  is active.
       USGFAULTACT    : Boolean := False;
@@ -733,7 +733,7 @@ package Cortex_M_SVD.SCB is
       --  active.
       MONITORACT     : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. PendSV exception active bit, reads as 1 if exception is
       --  active.
       PENDSVACT      : Boolean := False;
@@ -791,7 +791,7 @@ package Cortex_M_SVD.SCB is
       --  Data access violation flag
       DACCVIOL     : Boolean := False;
       --  unspecified
-      Reserved_2_2 : HAL.UInt1 := 16#0#;
+      Reserved_2_2 : HAL.Bit := 16#0#;
       --  MemManage fault on unstacking for a return from exception
       MUNSTKERR    : Boolean := False;
       --  MemManage fault on stacking for exception entry
@@ -799,7 +799,7 @@ package Cortex_M_SVD.SCB is
       --  MemManage fault during floating-point lazy state preservation.
       MLSPERR      : Boolean := False;
       --  unspecified
-      Reserved_6_6 : HAL.UInt1 := 16#0#;
+      Reserved_6_6 : HAL.Bit := 16#0#;
       --  MemManage fault address register valid flag.
       MMARVALID    : Boolean := False;
    end record
@@ -831,7 +831,7 @@ package Cortex_M_SVD.SCB is
       --  BusFault on floating-point lazy state preservation.
       LSPERR       : Boolean := False;
       --  unspecified
-      Reserved_6_6 : HAL.UInt1 := 16#0#;
+      Reserved_6_6 : HAL.Bit := 16#0#;
       --  BusFault Address Register valid flag.
       BFARVALID    : Boolean := False;
    end record
@@ -885,7 +885,7 @@ package Cortex_M_SVD.SCB is
    --  HardFault Status Register
    type HFSR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1 := 16#0#;
+      Reserved_0_0  : HAL.Bit := 16#0#;
       --  Indicates a BusFault on a vector table read during exception
       --  processing.
       VECTTBL       : Boolean := False;

--- a/arch/ARM/cortex_m/src/cm4/cortex_m_svd-systick.ads
+++ b/arch/ARM/cortex_m/src/cm4/cortex_m_svd-systick.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -84,7 +85,7 @@ package Cortex_M_SVD.SysTick is
       --  Value to auto reload SysTick after reaching zero
       RELOAD         : SYST_RVR_RELOAD_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -101,7 +102,7 @@ package Cortex_M_SVD.SysTick is
       --  Current value
       CURRENT        : SYST_CVR_CURRENT_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/cortex_m/src/cm4/cortex_m_svd.ads
+++ b/arch/ARM/cortex_m/src/cm4/cortex_m_svd.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with System;
 

--- a/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-debug.ads
+++ b/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-debug.ads
@@ -56,7 +56,7 @@ package Cortex_M_SVD.Debug is
       --  Read-only.
       C_MASKINTS     : Boolean;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1;
+      Reserved_4_4   : HAL.Bit;
       --  Read-only.
       C_SNAPSTALL    : Boolean;
       --  unspecified
@@ -111,7 +111,7 @@ package Cortex_M_SVD.Debug is
       --  Write-only.
       C_MASKINTS    : Boolean := False;
       --  unspecified
-      Reserved_4_4  : HAL.UInt1 := 16#0#;
+      Reserved_4_4  : HAL.Bit := 16#0#;
       --  Write-only.
       C_SNAPSTALL   : Boolean := False;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-debug.ads
+++ b/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-debug.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -27,7 +28,7 @@ package Cortex_M_SVD.Debug is
       --  An asynchronous exception generated due to the assertion of EDBGRQ.
       EXTERNAL      : Boolean := False;
       --  unspecified
-      Reserved_5_31 : HAL.UInt27 := 16#2B45D72#;
+      Reserved_5_31 : HAL.UInt27 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -55,7 +56,7 @@ package Cortex_M_SVD.Debug is
       --  Read-only.
       C_MASKINTS     : Boolean;
       --  unspecified
-      Reserved_4_4   : HAL.Bit;
+      Reserved_4_4   : HAL.UInt1;
       --  Read-only.
       C_SNAPSTALL    : Boolean;
       --  unspecified
@@ -110,15 +111,15 @@ package Cortex_M_SVD.Debug is
       --  Write-only.
       C_MASKINTS    : Boolean := False;
       --  unspecified
-      Reserved_4_4  : HAL.Bit := 16#0#;
+      Reserved_4_4  : HAL.UInt1 := 16#0#;
       --  Write-only.
       C_SNAPSTALL   : Boolean := False;
       --  unspecified
-      Reserved_6_15 : HAL.UInt10 := 16#2B9#;
+      Reserved_6_15 : HAL.UInt10 := 16#0#;
       --  Write-only. Debug Key. The value 0xA05F must be written to enable
       --  write accesses to bits [15:0], otherwise the write access will be
       --  ignored. Read behavior of bits [31:16] is as listed below.
-      S_RESET_ST    : Write_DHCSR_S_RESET_ST_Field := 16#568B#;
+      S_RESET_ST    : Write_DHCSR_S_RESET_ST_Field := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -220,11 +221,11 @@ package Cortex_M_SVD.Debug is
       --  Write-only.
       HALTED         : DCRSR_HALTED_Field := Cortex_M_SVD.Debug.Register_0;
       --  unspecified
-      Reserved_5_15  : HAL.UInt11 := 16#572#;
+      Reserved_5_15  : HAL.UInt11 := 16#0#;
       --  Write-only.
-      REGWnR         : DCRSR_REGWnR_Field := Cortex_M_SVD.Debug.Write;
+      REGWnR         : DCRSR_REGWnR_Field := Cortex_M_SVD.Debug.Read;
       --  unspecified
-      Reserved_17_31 : HAL.UInt15 := 16#2B45#;
+      Reserved_17_31 : HAL.UInt15 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -243,22 +244,22 @@ package Cortex_M_SVD.Debug is
       Reserved_1_3   : HAL.UInt3 := 16#0#;
       VC_MMERR       : Boolean := False;
       VC_NOCPERR     : Boolean := False;
-      VC_CHKERR      : Boolean := True;
+      VC_CHKERR      : Boolean := False;
       VC_STATERR     : Boolean := False;
       VC_BUSERR      : Boolean := False;
-      VC_INTERR      : Boolean := True;
-      VC_HARDERR     : Boolean := True;
+      VC_INTERR      : Boolean := False;
+      VC_HARDERR     : Boolean := False;
       --  unspecified
-      Reserved_11_15 : HAL.UInt5 := 16#15#;
-      MON_EN         : Boolean := True;
-      MON_PEND       : Boolean := True;
+      Reserved_11_15 : HAL.UInt5 := 16#0#;
+      MON_EN         : Boolean := False;
+      MON_PEND       : Boolean := False;
       MON_STEP       : Boolean := False;
-      MON_REQ        : Boolean := True;
+      MON_REQ        : Boolean := False;
       --  unspecified
-      Reserved_20_23 : HAL.UInt4 := 16#8#;
+      Reserved_20_23 : HAL.UInt4 := 16#0#;
       TRCENA         : Boolean := False;
       --  unspecified
-      Reserved_25_31 : HAL.UInt7 := 16#2B#;
+      Reserved_25_31 : HAL.UInt7 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-fpu.ads
+++ b/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-fpu.ads
@@ -81,7 +81,7 @@ package Cortex_M_SVD.FPU is
       --  stack frame was allocated.
       USER          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Read-only. If set, the mode was Thread Mode when the floating-point
       --  stack frame was allocated.
       THREAD        : Boolean := False;
@@ -98,7 +98,7 @@ package Cortex_M_SVD.FPU is
       --  stack frame was allocated.
       BFRDY         : Boolean := False;
       --  unspecified
-      Reserved_7_7  : HAL.UInt1 := 16#0#;
+      Reserved_7_7  : HAL.Bit := 16#0#;
       --  Read-only. If set, DebugMonitor is enabled and priority permitted
       --  setting the DebugMonitor handler to the pending state when the
       --  floating-point stack frame was allocated.

--- a/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-fpu.ads
+++ b/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-fpu.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -61,7 +62,7 @@ package Cortex_M_SVD.FPU is
       --  Access privileges for coprocessor 10.
       CP             : CPACR_CP_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -80,7 +81,7 @@ package Cortex_M_SVD.FPU is
       --  stack frame was allocated.
       USER          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Read-only. If set, the mode was Thread Mode when the floating-point
       --  stack frame was allocated.
       THREAD        : Boolean := False;
@@ -97,7 +98,7 @@ package Cortex_M_SVD.FPU is
       --  stack frame was allocated.
       BFRDY         : Boolean := False;
       --  unspecified
-      Reserved_7_7  : HAL.Bit := 16#0#;
+      Reserved_7_7  : HAL.UInt1 := 16#0#;
       --  Read-only. If set, DebugMonitor is enabled and priority permitted
       --  setting the DebugMonitor handler to the pending state when the
       --  floating-point stack frame was allocated.

--- a/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-mpu.ads
+++ b/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-mpu.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -24,8 +25,8 @@ package Cortex_M_SVD.MPU is
    for TYPE_SEPARATE_Field use
      (Unified => 0);
 
-   subtype MPU_TYPE_DREGION_Field is HAL.Byte;
-   subtype MPU_TYPE_IREGION_Field is HAL.Byte;
+   subtype MPU_TYPE_DREGION_Field is HAL.UInt8;
+   subtype MPU_TYPE_IREGION_Field is HAL.UInt8;
 
    --  MPU Type Register
    type MPU_TYPE_Register is record
@@ -42,7 +43,7 @@ package Cortex_M_SVD.MPU is
       --  by the DREGION field.
       IREGION        : MPU_TYPE_IREGION_Field;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -77,7 +78,7 @@ package Cortex_M_SVD.MPU is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype MPU_RNR_REGION_Field is HAL.Byte;
+   subtype MPU_RNR_REGION_Field is HAL.UInt8;
 
    --  MPU Region Number Register
    type MPU_RNR_Register is record
@@ -141,7 +142,7 @@ package Cortex_M_SVD.MPU is
       case As_Array is
          when False =>
             --  SRD as a value
-            Val : HAL.Byte;
+            Val : HAL.UInt8;
          when True =>
             --  SRD as an array
             Arr : MPU_RASR_SRD_Field_Array;
@@ -220,7 +221,7 @@ package Cortex_M_SVD.MPU is
       --  Access permission field
       AP             : RASR_AP_Field := Cortex_M_SVD.MPU.No_Access;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Instruction access disable bit
       XN             : RASR_XN_Field := Cortex_M_SVD.MPU.I_Enabled;
       --  unspecified
@@ -291,7 +292,7 @@ package Cortex_M_SVD.MPU is
       case As_Array is
          when False =>
             --  SRD as a value
-            Val : HAL.Byte;
+            Val : HAL.UInt8;
          when True =>
             --  SRD as an array
             Arr : RASR_A_SRD_Field_Array;
@@ -369,7 +370,7 @@ package Cortex_M_SVD.MPU is
       --  Access permission field
       AP             : RASR_A1_AP_Field := Cortex_M_SVD.MPU.No_Access;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Instruction access disable bit
       XN             : RASR_A1_XN_Field := Cortex_M_SVD.MPU.I_Enabled;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-mpu.ads
+++ b/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-mpu.ads
@@ -221,7 +221,7 @@ package Cortex_M_SVD.MPU is
       --  Access permission field
       AP             : RASR_AP_Field := Cortex_M_SVD.MPU.No_Access;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Instruction access disable bit
       XN             : RASR_XN_Field := Cortex_M_SVD.MPU.I_Enabled;
       --  unspecified
@@ -370,7 +370,7 @@ package Cortex_M_SVD.MPU is
       --  Access permission field
       AP             : RASR_A1_AP_Field := Cortex_M_SVD.MPU.No_Access;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Instruction access disable bit
       XN             : RASR_A1_XN_Field := Cortex_M_SVD.MPU.I_Enabled;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-nvic.ads
+++ b/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-nvic.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -49,9 +50,9 @@ package Cortex_M_SVD.NVIC is
    type STIR_Register is record
       --  Write-only. Interrupt ID of the interrupt to trigger, in the range
       --  0-239.
-      INTID         : STIR_INTID_Field := 16#40#;
+      INTID         : STIR_INTID_Field := 16#0#;
       --  unspecified
-      Reserved_9_31 : HAL.UInt23 := 16#2B45D7#;
+      Reserved_9_31 : HAL.UInt23 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-scb.ads
+++ b/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-scb.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -429,7 +430,7 @@ package Cortex_M_SVD.SCB is
       --  pending enabled exception.
       VECTPENDING    : ICSR_VECTPENDING_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Interrupt pending flag, excluding NMI and Faults
       ISRPENDING     : Boolean := False;
       --  unspecified
@@ -559,12 +560,12 @@ package Cortex_M_SVD.SCB is
    --  System Control Register
    type SCR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit := 16#0#;
+      Reserved_0_0  : HAL.UInt1 := 16#0#;
       --  Indicates sleep-on-exit when returning from Handler mode to Thread
       --  mode
       SLEEPONEXIT   : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Controls whether the processor uses sleep or deep sleep as its
       --  low-power mode
       SLEEPDEEP     : Boolean := False;
@@ -586,7 +587,7 @@ package Cortex_M_SVD.SCB is
    end record;
 
    --  Indicates how the processor enters Thread mode
-   type CCR_NONBASETHERADENA_Field is
+   type CCR_NONBASETHREADENA_Field is
      (
       --  Processor can enter Thread mode only when no exception is active
       No_Active_Exception,
@@ -594,19 +595,19 @@ package Cortex_M_SVD.SCB is
       --  an EXC_RETURN value
       On_Exc_Return)
      with Size => 1;
-   for CCR_NONBASETHERADENA_Field use
+   for CCR_NONBASETHREADENA_Field use
      (No_Active_Exception => 0,
       On_Exc_Return => 1);
 
    --  Configuration and Control Register
    type CCR_Register is record
       --  Indicates how the processor enters Thread mode
-      NONBASETHERADENA : CCR_NONBASETHERADENA_Field :=
+      NONBASETHREADENA : CCR_NONBASETHREADENA_Field :=
                           Cortex_M_SVD.SCB.No_Active_Exception;
       --  Enables unprivileged software access to the STIR
       USERSETMPEND     : Boolean := False;
       --  unspecified
-      Reserved_2_2     : HAL.Bit := 16#0#;
+      Reserved_2_2     : HAL.UInt1 := 16#0#;
       --  Enables unalign access traps.
       UNALIGNED_TRP    : Boolean := False;
       --  Enables faulting or halting when the processor executes an SDIF or
@@ -634,7 +635,7 @@ package Cortex_M_SVD.SCB is
           Bit_Order => System.Low_Order_First;
 
    for CCR_Register use record
-      NONBASETHERADENA at 0 range 0 .. 0;
+      NONBASETHREADENA at 0 range 0 .. 0;
       USERSETMPEND     at 0 range 1 .. 1;
       Reserved_2_2     at 0 range 2 .. 2;
       UNALIGNED_TRP    at 0 range 3 .. 3;
@@ -648,9 +649,9 @@ package Cortex_M_SVD.SCB is
       Reserved_18_31   at 0 range 18 .. 31;
    end record;
 
-   subtype SHPR1_PRI_4_Field is HAL.Byte;
-   subtype SHPR1_PRI_5_Field is HAL.Byte;
-   subtype SHPR1_PRI_6_Field is HAL.Byte;
+   subtype SHPR1_PRI_4_Field is HAL.UInt8;
+   subtype SHPR1_PRI_5_Field is HAL.UInt8;
+   subtype SHPR1_PRI_6_Field is HAL.UInt8;
 
    --  System Handler Priority Register 1
    type SHPR1_Register is record
@@ -661,7 +662,7 @@ package Cortex_M_SVD.SCB is
       --  Priority of the system handler, UsageFault
       PRI_6          : SHPR1_PRI_6_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -673,7 +674,7 @@ package Cortex_M_SVD.SCB is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype SHPR2_PRI_11_Field is HAL.Byte;
+   subtype SHPR2_PRI_11_Field is HAL.UInt8;
 
    --  System Handler Priority Register 2
    type SHPR2_Register is record
@@ -690,8 +691,8 @@ package Cortex_M_SVD.SCB is
       PRI_11        at 0 range 24 .. 31;
    end record;
 
-   subtype SHPR3_PRI_14_Field is HAL.Byte;
-   subtype SHPR3_PRI_15_Field is HAL.Byte;
+   subtype SHPR3_PRI_14_Field is HAL.UInt8;
+   subtype SHPR3_PRI_15_Field is HAL.UInt8;
 
    --  System Handler Priority Register 3
    type SHPR3_Register is record
@@ -720,7 +721,7 @@ package Cortex_M_SVD.SCB is
       --  active.
       BUSFAULTACT    : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Read-only. UsageFault exception active bit, reads as 1 if exception
       --  is active.
       USGFAULTACT    : Boolean := False;
@@ -732,7 +733,7 @@ package Cortex_M_SVD.SCB is
       --  active.
       MONITORACT     : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. PendSV exception active bit, reads as 1 if exception is
       --  active.
       PENDSVACT      : Boolean := False;
@@ -790,7 +791,7 @@ package Cortex_M_SVD.SCB is
       --  Data access violation flag
       DACCVIOL     : Boolean := False;
       --  unspecified
-      Reserved_2_2 : HAL.Bit := 16#0#;
+      Reserved_2_2 : HAL.UInt1 := 16#0#;
       --  MemManage fault on unstacking for a return from exception
       MUNSTKERR    : Boolean := False;
       --  MemManage fault on stacking for exception entry
@@ -798,7 +799,7 @@ package Cortex_M_SVD.SCB is
       --  MemManage fault during floating-point lazy state preservation.
       MLSPERR      : Boolean := False;
       --  unspecified
-      Reserved_6_6 : HAL.Bit := 16#0#;
+      Reserved_6_6 : HAL.UInt1 := 16#0#;
       --  MemManage fault address register valid flag.
       MMARVALID    : Boolean := False;
    end record
@@ -830,7 +831,7 @@ package Cortex_M_SVD.SCB is
       --  BusFault on floating-point lazy state preservation.
       LSPERR       : Boolean := False;
       --  unspecified
-      Reserved_6_6 : HAL.Bit := 16#0#;
+      Reserved_6_6 : HAL.UInt1 := 16#0#;
       --  BusFault Address Register valid flag.
       BFARVALID    : Boolean := False;
    end record
@@ -884,7 +885,7 @@ package Cortex_M_SVD.SCB is
    --  HardFault Status Register
    type HFSR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit := 16#0#;
+      Reserved_0_0  : HAL.UInt1 := 16#0#;
       --  Indicates a BusFault on a vector table read during exception
       --  processing.
       VECTTBL       : Boolean := False;
@@ -979,6 +980,6 @@ package Cortex_M_SVD.SCB is
 
    --  System control block
    SCB_Periph : aliased SCB_Peripheral
-     with Import, Address => SCB_Base;
+     with Import, Address => System'To_Address (16#E000E000#);
 
 end Cortex_M_SVD.SCB;

--- a/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-scb.ads
+++ b/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-scb.ads
@@ -430,7 +430,7 @@ package Cortex_M_SVD.SCB is
       --  pending enabled exception.
       VECTPENDING    : ICSR_VECTPENDING_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Interrupt pending flag, excluding NMI and Faults
       ISRPENDING     : Boolean := False;
       --  unspecified
@@ -560,12 +560,12 @@ package Cortex_M_SVD.SCB is
    --  System Control Register
    type SCR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1 := 16#0#;
+      Reserved_0_0  : HAL.Bit := 16#0#;
       --  Indicates sleep-on-exit when returning from Handler mode to Thread
       --  mode
       SLEEPONEXIT   : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Controls whether the processor uses sleep or deep sleep as its
       --  low-power mode
       SLEEPDEEP     : Boolean := False;
@@ -607,7 +607,7 @@ package Cortex_M_SVD.SCB is
       --  Enables unprivileged software access to the STIR
       USERSETMPEND     : Boolean := False;
       --  unspecified
-      Reserved_2_2     : HAL.UInt1 := 16#0#;
+      Reserved_2_2     : HAL.Bit := 16#0#;
       --  Enables unalign access traps.
       UNALIGNED_TRP    : Boolean := False;
       --  Enables faulting or halting when the processor executes an SDIF or
@@ -721,7 +721,7 @@ package Cortex_M_SVD.SCB is
       --  active.
       BUSFAULTACT    : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Read-only. UsageFault exception active bit, reads as 1 if exception
       --  is active.
       USGFAULTACT    : Boolean := False;
@@ -733,7 +733,7 @@ package Cortex_M_SVD.SCB is
       --  active.
       MONITORACT     : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. PendSV exception active bit, reads as 1 if exception is
       --  active.
       PENDSVACT      : Boolean := False;
@@ -791,7 +791,7 @@ package Cortex_M_SVD.SCB is
       --  Data access violation flag
       DACCVIOL     : Boolean := False;
       --  unspecified
-      Reserved_2_2 : HAL.UInt1 := 16#0#;
+      Reserved_2_2 : HAL.Bit := 16#0#;
       --  MemManage fault on unstacking for a return from exception
       MUNSTKERR    : Boolean := False;
       --  MemManage fault on stacking for exception entry
@@ -799,7 +799,7 @@ package Cortex_M_SVD.SCB is
       --  MemManage fault during floating-point lazy state preservation.
       MLSPERR      : Boolean := False;
       --  unspecified
-      Reserved_6_6 : HAL.UInt1 := 16#0#;
+      Reserved_6_6 : HAL.Bit := 16#0#;
       --  MemManage fault address register valid flag.
       MMARVALID    : Boolean := False;
    end record
@@ -831,7 +831,7 @@ package Cortex_M_SVD.SCB is
       --  BusFault on floating-point lazy state preservation.
       LSPERR       : Boolean := False;
       --  unspecified
-      Reserved_6_6 : HAL.UInt1 := 16#0#;
+      Reserved_6_6 : HAL.Bit := 16#0#;
       --  BusFault Address Register valid flag.
       BFARVALID    : Boolean := False;
    end record
@@ -885,7 +885,7 @@ package Cortex_M_SVD.SCB is
    --  HardFault Status Register
    type HFSR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1 := 16#0#;
+      Reserved_0_0  : HAL.Bit := 16#0#;
       --  Indicates a BusFault on a vector table read during exception
       --  processing.
       VECTTBL       : Boolean := False;

--- a/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-systick.ads
+++ b/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-systick.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -84,7 +85,7 @@ package Cortex_M_SVD.SysTick is
       --  Value to auto reload SysTick after reaching zero
       RELOAD         : SYST_RVR_RELOAD_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -101,7 +102,7 @@ package Cortex_M_SVD.SysTick is
       --  Current value
       CURRENT        : SYST_CVR_CURRENT_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/cortex_m/src/cm4f/cortex_m_svd.ads
+++ b/arch/ARM/cortex_m/src/cm4f/cortex_m_svd.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with System;
 

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-cache.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-cache.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-debug.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-debug.ads
@@ -56,7 +56,7 @@ package Cortex_M_SVD.Debug is
       --  Read-only.
       C_MASKINTS     : Boolean;
       --  unspecified
-      Reserved_4_4   : HAL.UInt1;
+      Reserved_4_4   : HAL.Bit;
       --  Read-only.
       C_SNAPSTALL    : Boolean;
       --  unspecified
@@ -111,7 +111,7 @@ package Cortex_M_SVD.Debug is
       --  Write-only.
       C_MASKINTS    : Boolean := False;
       --  unspecified
-      Reserved_4_4  : HAL.UInt1 := 16#0#;
+      Reserved_4_4  : HAL.Bit := 16#0#;
       --  Write-only.
       C_SNAPSTALL   : Boolean := False;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-debug.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-debug.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -15,19 +16,19 @@ package Cortex_M_SVD.Debug is
 
    --  Debug Fault Status Register
    type DFSR_Register is record
-      HALTED        : Boolean := True;
+      HALTED        : Boolean := False;
       --  BKPT instruction executed or breakpoint match in FPB.
-      BKPT          : Boolean := True;
+      BKPT          : Boolean := False;
       --  Data Watchpoint and Trace trap. Indicates that the core halted due to
       --  at least one DWT trap event.
-      DWTTRAP       : Boolean := True;
+      DWTTRAP       : Boolean := False;
       --  Vector catch triggered. Corresponding FSR will contain the primary
       --  cause of the exception.
-      VCATCH        : Boolean := True;
+      VCATCH        : Boolean := False;
       --  An asynchronous exception generated due to the assertion of EDBGRQ.
       EXTERNAL      : Boolean := False;
       --  unspecified
-      Reserved_5_31 : HAL.UInt27 := 16#6438000#;
+      Reserved_5_31 : HAL.UInt27 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -55,7 +56,7 @@ package Cortex_M_SVD.Debug is
       --  Read-only.
       C_MASKINTS     : Boolean;
       --  unspecified
-      Reserved_4_4   : HAL.Bit;
+      Reserved_4_4   : HAL.UInt1;
       --  Read-only.
       C_SNAPSTALL    : Boolean;
       --  unspecified
@@ -102,15 +103,15 @@ package Cortex_M_SVD.Debug is
 
    type Write_DHCSR_Register is record
       --  Write-only.
-      C_DEBUGGEN    : Boolean := True;
+      C_DEBUGGEN    : Boolean := False;
       --  Write-only.
-      C_HALT        : Boolean := True;
+      C_HALT        : Boolean := False;
       --  Write-only.
-      C_STEP        : Boolean := True;
+      C_STEP        : Boolean := False;
       --  Write-only.
-      C_MASKINTS    : Boolean := True;
+      C_MASKINTS    : Boolean := False;
       --  unspecified
-      Reserved_4_4  : HAL.Bit := 16#0#;
+      Reserved_4_4  : HAL.UInt1 := 16#0#;
       --  Write-only.
       C_SNAPSTALL   : Boolean := False;
       --  unspecified
@@ -118,7 +119,7 @@ package Cortex_M_SVD.Debug is
       --  Write-only. Debug Key. The value 0xA05F must be written to enable
       --  write accesses to bits [15:0], otherwise the write access will be
       --  ignored. Read behavior of bits [31:16] is as listed below.
-      S_RESET_ST    : Write_DHCSR_S_RESET_ST_Field := 16#C870#;
+      S_RESET_ST    : Write_DHCSR_S_RESET_ST_Field := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -218,14 +219,13 @@ package Cortex_M_SVD.Debug is
    --  register is only accessible from Debug state.
    type DCRSR_Register is record
       --  Write-only.
-      HALTED         : DCRSR_HALTED_Field :=
-                        Cortex_M_SVD.Debug.Debug_Return_Address;
+      HALTED         : DCRSR_HALTED_Field := Cortex_M_SVD.Debug.Register_0;
       --  unspecified
       Reserved_5_15  : HAL.UInt11 := 16#0#;
       --  Write-only.
       REGWnR         : DCRSR_REGWnR_Field := Cortex_M_SVD.Debug.Read;
       --  unspecified
-      Reserved_17_31 : HAL.UInt15 := 16#6438#;
+      Reserved_17_31 : HAL.UInt15 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -239,9 +239,9 @@ package Cortex_M_SVD.Debug is
 
    --  Debug Exception and Monitor Control Register
    type DEMCR_Register is record
-      VC_CORERESET   : Boolean := True;
+      VC_CORERESET   : Boolean := False;
       --  unspecified
-      Reserved_1_3   : HAL.UInt3 := 16#7#;
+      Reserved_1_3   : HAL.UInt3 := 16#0#;
       VC_MMERR       : Boolean := False;
       VC_NOCPERR     : Boolean := False;
       VC_CHKERR      : Boolean := False;
@@ -256,10 +256,10 @@ package Cortex_M_SVD.Debug is
       MON_STEP       : Boolean := False;
       MON_REQ        : Boolean := False;
       --  unspecified
-      Reserved_20_23 : HAL.UInt4 := 16#7#;
+      Reserved_20_23 : HAL.UInt4 := 16#0#;
       TRCENA         : Boolean := False;
       --  unspecified
-      Reserved_25_31 : HAL.UInt7 := 16#64#;
+      Reserved_25_31 : HAL.UInt7 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-fpu.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-fpu.ads
@@ -81,7 +81,7 @@ package Cortex_M_SVD.FPU is
       --  stack frame was allocated.
       USER          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Read-only. If set, the mode was Thread Mode when the floating-point
       --  stack frame was allocated.
       THREAD        : Boolean := False;
@@ -98,7 +98,7 @@ package Cortex_M_SVD.FPU is
       --  stack frame was allocated.
       BFRDY         : Boolean := False;
       --  unspecified
-      Reserved_7_7  : HAL.UInt1 := 16#0#;
+      Reserved_7_7  : HAL.Bit := 16#0#;
       --  Read-only. If set, DebugMonitor is enabled and priority permitted
       --  setting the DebugMonitor handler to the pending state when the
       --  floating-point stack frame was allocated.

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-fpu.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-fpu.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -61,7 +62,7 @@ package Cortex_M_SVD.FPU is
       --  Access privileges for coprocessor 10.
       CP             : CPACR_CP_Field := (As_Array => False, Val => 16#0#);
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -80,7 +81,7 @@ package Cortex_M_SVD.FPU is
       --  stack frame was allocated.
       USER          : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Read-only. If set, the mode was Thread Mode when the floating-point
       --  stack frame was allocated.
       THREAD        : Boolean := False;
@@ -97,7 +98,7 @@ package Cortex_M_SVD.FPU is
       --  stack frame was allocated.
       BFRDY         : Boolean := False;
       --  unspecified
-      Reserved_7_7  : HAL.Bit := 16#0#;
+      Reserved_7_7  : HAL.UInt1 := 16#0#;
       --  Read-only. If set, DebugMonitor is enabled and priority permitted
       --  setting the DebugMonitor handler to the pending state when the
       --  floating-point stack frame was allocated.

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-mpu.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-mpu.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -24,8 +25,8 @@ package Cortex_M_SVD.MPU is
    for TYPE_SEPARATE_Field use
      (Unified => 0);
 
-   subtype MPU_TYPE_DREGION_Field is HAL.Byte;
-   subtype MPU_TYPE_IREGION_Field is HAL.Byte;
+   subtype MPU_TYPE_DREGION_Field is HAL.UInt8;
+   subtype MPU_TYPE_IREGION_Field is HAL.UInt8;
 
    --  MPU Type Register
    type MPU_TYPE_Register is record
@@ -42,7 +43,7 @@ package Cortex_M_SVD.MPU is
       --  by the DREGION field.
       IREGION        : MPU_TYPE_IREGION_Field;
       --  unspecified
-      Reserved_24_31 : HAL.Byte;
+      Reserved_24_31 : HAL.UInt8;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -77,7 +78,7 @@ package Cortex_M_SVD.MPU is
       Reserved_3_31 at 0 range 3 .. 31;
    end record;
 
-   subtype MPU_RNR_REGION_Field is HAL.Byte;
+   subtype MPU_RNR_REGION_Field is HAL.UInt8;
 
    --  MPU Region Number Register
    type MPU_RNR_Register is record
@@ -141,7 +142,7 @@ package Cortex_M_SVD.MPU is
       case As_Array is
          when False =>
             --  SRD as a value
-            Val : HAL.Byte;
+            Val : HAL.UInt8;
          when True =>
             --  SRD as an array
             Arr : MPU_RASR_SRD_Field_Array;
@@ -220,7 +221,7 @@ package Cortex_M_SVD.MPU is
       --  Access permission field
       AP             : RASR_AP_Field := Cortex_M_SVD.MPU.No_Access;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Instruction access disable bit
       XN             : RASR_XN_Field := Cortex_M_SVD.MPU.I_Enabled;
       --  unspecified
@@ -291,7 +292,7 @@ package Cortex_M_SVD.MPU is
       case As_Array is
          when False =>
             --  SRD as a value
-            Val : HAL.Byte;
+            Val : HAL.UInt8;
          when True =>
             --  SRD as an array
             Arr : RASR_A_SRD_Field_Array;
@@ -369,7 +370,7 @@ package Cortex_M_SVD.MPU is
       --  Access permission field
       AP             : RASR_A1_AP_Field := Cortex_M_SVD.MPU.No_Access;
       --  unspecified
-      Reserved_27_27 : HAL.Bit := 16#0#;
+      Reserved_27_27 : HAL.UInt1 := 16#0#;
       --  Instruction access disable bit
       XN             : RASR_A1_XN_Field := Cortex_M_SVD.MPU.I_Enabled;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-mpu.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-mpu.ads
@@ -221,7 +221,7 @@ package Cortex_M_SVD.MPU is
       --  Access permission field
       AP             : RASR_AP_Field := Cortex_M_SVD.MPU.No_Access;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Instruction access disable bit
       XN             : RASR_XN_Field := Cortex_M_SVD.MPU.I_Enabled;
       --  unspecified
@@ -370,7 +370,7 @@ package Cortex_M_SVD.MPU is
       --  Access permission field
       AP             : RASR_A1_AP_Field := Cortex_M_SVD.MPU.No_Access;
       --  unspecified
-      Reserved_27_27 : HAL.UInt1 := 16#0#;
+      Reserved_27_27 : HAL.Bit := 16#0#;
       --  Instruction access disable bit
       XN             : RASR_A1_XN_Field := Cortex_M_SVD.MPU.I_Enabled;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-nvic.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-nvic.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -49,9 +50,9 @@ package Cortex_M_SVD.NVIC is
    type STIR_Register is record
       --  Write-only. Interrupt ID of the interrupt to trigger, in the range
       --  0-239.
-      INTID         : STIR_INTID_Field := 16#F#;
+      INTID         : STIR_INTID_Field := 16#0#;
       --  unspecified
-      Reserved_9_31 : HAL.UInt23 := 16#643800#;
+      Reserved_9_31 : HAL.UInt23 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-pf.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-pf.ads
@@ -124,7 +124,7 @@ package Cortex_M_SVD.PF is
       --  Read-only. Cache Writable Granule.
       CWG            : CTR_CWG_Field;
       --  unspecified
-      Reserved_28_28 : HAL.UInt1;
+      Reserved_28_28 : HAL.Bit;
       --  Read-only. Cache Writable Granule.
       Format         : CTR_Format_Field;
    end record

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-pf.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-pf.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -123,7 +124,7 @@ package Cortex_M_SVD.PF is
       --  Read-only. Cache Writable Granule.
       CWG            : CTR_CWG_Field;
       --  unspecified
-      Reserved_28_28 : HAL.Bit;
+      Reserved_28_28 : HAL.UInt1;
       --  Read-only. Cache Writable Granule.
       Format         : CTR_Format_Field;
    end record

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-scb.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-scb.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -429,7 +430,7 @@ package Cortex_M_SVD.SCB is
       --  pending enabled exception.
       VECTPENDING    : ICSR_VECTPENDING_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.Bit := 16#0#;
+      Reserved_21_21 : HAL.UInt1 := 16#0#;
       --  Interrupt pending flag, excluding NMI and Faults
       ISRPENDING     : Boolean := False;
       --  unspecified
@@ -559,12 +560,12 @@ package Cortex_M_SVD.SCB is
    --  System Control Register
    type SCR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit := 16#0#;
+      Reserved_0_0  : HAL.UInt1 := 16#0#;
       --  Indicates sleep-on-exit when returning from Handler mode to Thread
       --  mode
       SLEEPONEXIT   : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.Bit := 16#0#;
+      Reserved_2_2  : HAL.UInt1 := 16#0#;
       --  Controls whether the processor uses sleep or deep sleep as its
       --  low-power mode
       SLEEPDEEP     : Boolean := False;
@@ -586,7 +587,7 @@ package Cortex_M_SVD.SCB is
    end record;
 
    --  Indicates how the processor enters Thread mode
-   type CCR_NONBASETHERADENA_Field is
+   type CCR_NONBASETHREADENA_Field is
      (
       --  Processor can enter Thread mode only when no exception is active
       No_Active_Exception,
@@ -594,19 +595,19 @@ package Cortex_M_SVD.SCB is
       --  an EXC_RETURN value
       On_Exc_Return)
      with Size => 1;
-   for CCR_NONBASETHERADENA_Field use
+   for CCR_NONBASETHREADENA_Field use
      (No_Active_Exception => 0,
       On_Exc_Return => 1);
 
    --  Configuration and Control Register
    type CCR_Register is record
       --  Indicates how the processor enters Thread mode
-      NONBASETHERADENA : CCR_NONBASETHERADENA_Field :=
+      NONBASETHREADENA : CCR_NONBASETHREADENA_Field :=
                           Cortex_M_SVD.SCB.No_Active_Exception;
       --  Enables unprivileged software access to the STIR
       USERSETMPEND     : Boolean := False;
       --  unspecified
-      Reserved_2_2     : HAL.Bit := 16#0#;
+      Reserved_2_2     : HAL.UInt1 := 16#0#;
       --  Enables unalign access traps.
       UNALIGNED_TRP    : Boolean := False;
       --  Enables faulting or halting when the processor executes an SDIF or
@@ -634,7 +635,7 @@ package Cortex_M_SVD.SCB is
           Bit_Order => System.Low_Order_First;
 
    for CCR_Register use record
-      NONBASETHERADENA at 0 range 0 .. 0;
+      NONBASETHREADENA at 0 range 0 .. 0;
       USERSETMPEND     at 0 range 1 .. 1;
       Reserved_2_2     at 0 range 2 .. 2;
       UNALIGNED_TRP    at 0 range 3 .. 3;
@@ -648,9 +649,9 @@ package Cortex_M_SVD.SCB is
       Reserved_18_31   at 0 range 18 .. 31;
    end record;
 
-   subtype SHPR1_PRI_4_Field is HAL.Byte;
-   subtype SHPR1_PRI_5_Field is HAL.Byte;
-   subtype SHPR1_PRI_6_Field is HAL.Byte;
+   subtype SHPR1_PRI_4_Field is HAL.UInt8;
+   subtype SHPR1_PRI_5_Field is HAL.UInt8;
+   subtype SHPR1_PRI_6_Field is HAL.UInt8;
 
    --  System Handler Priority Register 1
    type SHPR1_Register is record
@@ -661,7 +662,7 @@ package Cortex_M_SVD.SCB is
       --  Priority of the system handler, UsageFault
       PRI_6          : SHPR1_PRI_6_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -673,7 +674,7 @@ package Cortex_M_SVD.SCB is
       Reserved_24_31 at 0 range 24 .. 31;
    end record;
 
-   subtype SHPR2_PRI_11_Field is HAL.Byte;
+   subtype SHPR2_PRI_11_Field is HAL.UInt8;
 
    --  System Handler Priority Register 2
    type SHPR2_Register is record
@@ -690,8 +691,8 @@ package Cortex_M_SVD.SCB is
       PRI_11        at 0 range 24 .. 31;
    end record;
 
-   subtype SHPR3_PRI_14_Field is HAL.Byte;
-   subtype SHPR3_PRI_15_Field is HAL.Byte;
+   subtype SHPR3_PRI_14_Field is HAL.UInt8;
+   subtype SHPR3_PRI_15_Field is HAL.UInt8;
 
    --  System Handler Priority Register 3
    type SHPR3_Register is record
@@ -720,7 +721,7 @@ package Cortex_M_SVD.SCB is
       --  active.
       BUSFAULTACT    : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.Bit := 16#0#;
+      Reserved_2_2   : HAL.UInt1 := 16#0#;
       --  Read-only. UsageFault exception active bit, reads as 1 if exception
       --  is active.
       USGFAULTACT    : Boolean := False;
@@ -732,7 +733,7 @@ package Cortex_M_SVD.SCB is
       --  active.
       MONITORACT     : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.Bit := 16#0#;
+      Reserved_9_9   : HAL.UInt1 := 16#0#;
       --  Read-only. PendSV exception active bit, reads as 1 if exception is
       --  active.
       PENDSVACT      : Boolean := False;
@@ -790,7 +791,7 @@ package Cortex_M_SVD.SCB is
       --  Data access violation flag
       DACCVIOL     : Boolean := False;
       --  unspecified
-      Reserved_2_2 : HAL.Bit := 16#0#;
+      Reserved_2_2 : HAL.UInt1 := 16#0#;
       --  MemManage fault on unstacking for a return from exception
       MUNSTKERR    : Boolean := False;
       --  MemManage fault on stacking for exception entry
@@ -798,7 +799,7 @@ package Cortex_M_SVD.SCB is
       --  MemManage fault during floating-point lazy state preservation.
       MLSPERR      : Boolean := False;
       --  unspecified
-      Reserved_6_6 : HAL.Bit := 16#0#;
+      Reserved_6_6 : HAL.UInt1 := 16#0#;
       --  MemManage fault address register valid flag.
       MMARVALID    : Boolean := False;
    end record
@@ -830,7 +831,7 @@ package Cortex_M_SVD.SCB is
       --  BusFault on floating-point lazy state preservation.
       LSPERR       : Boolean := False;
       --  unspecified
-      Reserved_6_6 : HAL.Bit := 16#0#;
+      Reserved_6_6 : HAL.UInt1 := 16#0#;
       --  BusFault Address Register valid flag.
       BFARVALID    : Boolean := False;
    end record
@@ -884,7 +885,7 @@ package Cortex_M_SVD.SCB is
    --  HardFault Status Register
    type HFSR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.Bit := 16#0#;
+      Reserved_0_0  : HAL.UInt1 := 16#0#;
       --  Indicates a BusFault on a vector table read during exception
       --  processing.
       VECTTBL       : Boolean := False;
@@ -979,6 +980,6 @@ package Cortex_M_SVD.SCB is
 
    --  System control block
    SCB_Periph : aliased SCB_Peripheral
-     with Import, Address => SCB_Base;
+     with Import, Address => System'To_Address (16#E000E000#);
 
 end Cortex_M_SVD.SCB;

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-scb.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-scb.ads
@@ -430,7 +430,7 @@ package Cortex_M_SVD.SCB is
       --  pending enabled exception.
       VECTPENDING    : ICSR_VECTPENDING_Field := 16#0#;
       --  unspecified
-      Reserved_21_21 : HAL.UInt1 := 16#0#;
+      Reserved_21_21 : HAL.Bit := 16#0#;
       --  Interrupt pending flag, excluding NMI and Faults
       ISRPENDING     : Boolean := False;
       --  unspecified
@@ -560,12 +560,12 @@ package Cortex_M_SVD.SCB is
    --  System Control Register
    type SCR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1 := 16#0#;
+      Reserved_0_0  : HAL.Bit := 16#0#;
       --  Indicates sleep-on-exit when returning from Handler mode to Thread
       --  mode
       SLEEPONEXIT   : Boolean := False;
       --  unspecified
-      Reserved_2_2  : HAL.UInt1 := 16#0#;
+      Reserved_2_2  : HAL.Bit := 16#0#;
       --  Controls whether the processor uses sleep or deep sleep as its
       --  low-power mode
       SLEEPDEEP     : Boolean := False;
@@ -607,7 +607,7 @@ package Cortex_M_SVD.SCB is
       --  Enables unprivileged software access to the STIR
       USERSETMPEND     : Boolean := False;
       --  unspecified
-      Reserved_2_2     : HAL.UInt1 := 16#0#;
+      Reserved_2_2     : HAL.Bit := 16#0#;
       --  Enables unalign access traps.
       UNALIGNED_TRP    : Boolean := False;
       --  Enables faulting or halting when the processor executes an SDIF or
@@ -721,7 +721,7 @@ package Cortex_M_SVD.SCB is
       --  active.
       BUSFAULTACT    : Boolean := False;
       --  unspecified
-      Reserved_2_2   : HAL.UInt1 := 16#0#;
+      Reserved_2_2   : HAL.Bit := 16#0#;
       --  Read-only. UsageFault exception active bit, reads as 1 if exception
       --  is active.
       USGFAULTACT    : Boolean := False;
@@ -733,7 +733,7 @@ package Cortex_M_SVD.SCB is
       --  active.
       MONITORACT     : Boolean := False;
       --  unspecified
-      Reserved_9_9   : HAL.UInt1 := 16#0#;
+      Reserved_9_9   : HAL.Bit := 16#0#;
       --  Read-only. PendSV exception active bit, reads as 1 if exception is
       --  active.
       PENDSVACT      : Boolean := False;
@@ -791,7 +791,7 @@ package Cortex_M_SVD.SCB is
       --  Data access violation flag
       DACCVIOL     : Boolean := False;
       --  unspecified
-      Reserved_2_2 : HAL.UInt1 := 16#0#;
+      Reserved_2_2 : HAL.Bit := 16#0#;
       --  MemManage fault on unstacking for a return from exception
       MUNSTKERR    : Boolean := False;
       --  MemManage fault on stacking for exception entry
@@ -799,7 +799,7 @@ package Cortex_M_SVD.SCB is
       --  MemManage fault during floating-point lazy state preservation.
       MLSPERR      : Boolean := False;
       --  unspecified
-      Reserved_6_6 : HAL.UInt1 := 16#0#;
+      Reserved_6_6 : HAL.Bit := 16#0#;
       --  MemManage fault address register valid flag.
       MMARVALID    : Boolean := False;
    end record
@@ -831,7 +831,7 @@ package Cortex_M_SVD.SCB is
       --  BusFault on floating-point lazy state preservation.
       LSPERR       : Boolean := False;
       --  unspecified
-      Reserved_6_6 : HAL.UInt1 := 16#0#;
+      Reserved_6_6 : HAL.Bit := 16#0#;
       --  BusFault Address Register valid flag.
       BFARVALID    : Boolean := False;
    end record
@@ -885,7 +885,7 @@ package Cortex_M_SVD.SCB is
    --  HardFault Status Register
    type HFSR_Register is record
       --  unspecified
-      Reserved_0_0  : HAL.UInt1 := 16#0#;
+      Reserved_0_0  : HAL.Bit := 16#0#;
       --  Indicates a BusFault on a vector table read during exception
       --  processing.
       VECTTBL       : Boolean := False;

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-systick.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-systick.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with HAL;
 with System;
@@ -84,7 +85,7 @@ package Cortex_M_SVD.SysTick is
       --  Value to auto reload SysTick after reaching zero
       RELOAD         : SYST_RVR_RELOAD_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;
@@ -101,7 +102,7 @@ package Cortex_M_SVD.SysTick is
       --  Current value
       CURRENT        : SYST_CVR_CURRENT_Field := 16#0#;
       --  unspecified
-      Reserved_24_31 : HAL.Byte := 16#0#;
+      Reserved_24_31 : HAL.UInt8 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd.ads
@@ -2,6 +2,7 @@
 
 pragma Restrictions (No_Elaboration_Code);
 pragma Ada_2012;
+pragma Style_Checks (Off);
 
 with System;
 

--- a/arch/ARM/cortex_m/src/fpu/cortex_m-fpu.ads
+++ b/arch/ARM/cortex_m/src/fpu/cortex_m-fpu.ads
@@ -79,7 +79,7 @@ package Cortex_M.FPU is
       --  rounding mode
       RM        : Rounding_Mode;
       Reserved2 : Bits_6;
-      Reserved3 : Byte;
+      Reserved3 : UInt8;
       --  flush to zero
       IDC       : Boolean;
       Reserved4 : Bits_2;

--- a/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.adb
+++ b/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.adb
@@ -52,8 +52,25 @@ package body Cortex_M.NVIC is
      (IRQn     : Interrupt_ID;
       Priority : Interrupt_Priority)
    is
+      type As_Array (As_Arr : Boolean := True) is record
+         case As_Arr is
+            when True =>
+               Arr : UInt8_Array (0 .. 3);
+            when False =>
+               IPR : UInt32;
+         end case;
+      end record with Unchecked_Union, Pack, Size => 32;
+
+      IPR_Index : constant Natural := IRQn / 4;
+      IP_Index  : constant Natural := IRQn mod 4;
+      IPR       : As_Array;
    begin
-      NVIC_Periph.NVIC_IPR (IRQn) := Priority;
+
+      IPR.IPR := NVIC_Periph.NVIC_IPR (IPR_Index);
+
+      IPR.Arr (IP_Index) := Priority;
+
+      NVIC_Periph.NVIC_IPR (IPR_Index) := IPR.IPR;
    end Set_Priority;
 
    -------------

--- a/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.adb
+++ b/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.adb
@@ -40,7 +40,6 @@
 ------------------------------------------------------------------------------
 
 with Cortex_M_SVD.NVIC; use Cortex_M_SVD.NVIC;
-with Interfaces; use Interfaces;
 
 package body Cortex_M.NVIC is
 

--- a/arch/ARM/cortex_m/src/nvic_cm4_cm7/cortex_m-nvic.adb
+++ b/arch/ARM/cortex_m/src/nvic_cm4_cm7/cortex_m-nvic.adb
@@ -85,7 +85,7 @@ package body Cortex_M.NVIC is
    begin
       --  IRQ numbers are never less than 0 in the current definition, hence
       --  the code is different from that in the CMSIS.
-      NVIC.IP (Index) := Byte (Value);
+      NVIC.IP (Index) := UInt8 (Value);
    end Set_Priority;
 
    ----------------------

--- a/arch/ARM/cortex_m/src/nvic_cm4_cm7/cortex_m-nvic.ads
+++ b/arch/ARM/cortex_m/src/nvic_cm4_cm7/cortex_m-nvic.ads
@@ -43,9 +43,8 @@
 --  STM32F4 (ARM Cortex M4F) microcontrollers from ST Microelectronics.
 
 with System;
-with Interfaces;           use Interfaces;
-with HAL;                  use HAL;
-with Ada.Interrupts;       use Ada.Interrupts;
+with HAL;            use HAL;
+with Ada.Interrupts; use Ada.Interrupts;
 
 package Cortex_M.NVIC is  -- the Nested Vectored Interrupt Controller
 
@@ -102,7 +101,7 @@ package Cortex_M.NVIC is  -- the Nested Vectored Interrupt Controller
 private
 
    type Words is array (Natural range <>) of UInt32;
-   type Bytes is array (Natural range <>) of Byte;
+   type UInt8s is array (Natural range <>) of UInt8;
 
 
    type Nested_Vectored_Interrupt_Controller is record
@@ -121,7 +120,7 @@ private
       IABR      : Words (0 .. 7);
       --  Interrupt Active Bit Register
       Reserved4 : Words (0 .. 55);
-      IP        : Bytes (0 .. 239);
+      IP        : UInt8s (0 .. 239);
       --  Interrupt Priority Register
       Reserved5 : Words (0 .. 643);
       STIR      : UInt32;
@@ -130,19 +129,19 @@ private
      with Volatile;
 
    for Nested_Vectored_Interrupt_Controller use record
-      ISER      at 0    range 0 .. 255;    -- 32 bytes
-      Reserved0 at 32   range 0 .. 767;    -- 96 bytes
-      ICER      at 128  range 0 .. 255;    -- 32 bytes
-      Reserved1 at 160  range 0 .. 767;    -- 96 bytes
-      ISPR      at 256  range 0 .. 255;    -- 32 bytes
-      Reserved2 at 288  range 0 .. 767;    -- 96 bytes
-      ICPR      at 384  range 0 .. 255;    -- 32 bytes
-      Reserved3 at 416  range 0 .. 767;    -- 96 bytes
-      IABR      at 512  range 0 .. 255;    -- 32 bytes
-      Reserved4 at 544  range 0 .. 1791;   -- 220 bytes
-      IP        at 768  range 0 .. 1919;   -- 240 bytes
-      Reserved5 at 1008 range 0 .. 20607;  -- 2576 bytes
-      STIR      at 3584 range 0 .. 31;     -- 4 bytes
+      ISER      at 0    range 0 .. 255;    -- 32 UInt8s
+      Reserved0 at 32   range 0 .. 767;    -- 96 UInt8s
+      ICER      at 128  range 0 .. 255;    -- 32 UInt8s
+      Reserved1 at 160  range 0 .. 767;    -- 96 UInt8s
+      ISPR      at 256  range 0 .. 255;    -- 32 UInt8s
+      Reserved2 at 288  range 0 .. 767;    -- 96 UInt8s
+      ICPR      at 384  range 0 .. 255;    -- 32 UInt8s
+      Reserved3 at 416  range 0 .. 767;    -- 96 UInt8s
+      IABR      at 512  range 0 .. 255;    -- 32 UInt8s
+      Reserved4 at 544  range 0 .. 1791;   -- 220 UInt8s
+      IP        at 768  range 0 .. 1919;   -- 240 UInt8s
+      Reserved5 at 1008 range 0 .. 20607;  -- 2576 UInt8s
+      STIR      at 3584 range 0 .. 31;     -- 4 UInt8s
    end record;
 
 
@@ -159,7 +158,7 @@ private
       --  System Control Register
       CCR       : UInt32;
       --  Configuration Control Register
-      SHP       : Bytes (0 .. 11);
+      SHP       : UInt8s (0 .. 11);
       --  System Handlers Priority Registers (4-7, 8-11, 12-15)
       SHCSR     : UInt32;
       --  System Handler Control and State Register

--- a/arch/ARM/cortex_m/src/semihosting-filesystem.adb
+++ b/arch/ARM/cortex_m/src/semihosting-filesystem.adb
@@ -201,7 +201,7 @@ package body Semihosting.Filesystem is
 
    overriding function Read
      (This : in out SHFS_File_Handle;
-      Data : out Byte_Array)
+      Data : out UInt8_Array)
       return Status_Kind
    is
    begin
@@ -225,7 +225,7 @@ package body Semihosting.Filesystem is
 
    overriding function Write
      (This : in out SHFS_File_Handle;
-      Data : Byte_Array)
+      Data : UInt8_Array)
       return Status_Kind
    is
       pragma Unreferenced (Data);

--- a/arch/ARM/cortex_m/src/semihosting-filesystem.ads
+++ b/arch/ARM/cortex_m/src/semihosting-filesystem.ads
@@ -99,12 +99,12 @@ private
 
    overriding
    function Read (This : in out SHFS_File_Handle;
-                  Data : out Byte_Array)
+                  Data : out UInt8_Array)
                   return Status_Kind;
 
    overriding
    function Write (This : in out SHFS_File_Handle;
-                   Data : Byte_Array)
+                   Data : UInt8_Array)
                    return Status_Kind;
 
    overriding

--- a/arch/ARM/cortex_m/src/semihosting.adb
+++ b/arch/ARM/cortex_m/src/semihosting.adb
@@ -262,7 +262,7 @@ package body Semihosting is
    -------------
 
    procedure Write_0 (Str : String) is
-      Data : Byte_Array (Str'First .. Str'Last + 1);
+      Data : UInt8_Array (Str'First .. Str'Last + 1);
       Ret  : SH_Word with Unreferenced;
    begin
       if not Semihosting_Enabled then

--- a/arch/ARM/cortex_m/src/semihosting.ads
+++ b/arch/ARM/cortex_m/src/semihosting.ads
@@ -30,11 +30,11 @@
 ------------------------------------------------------------------------------
 
 with System;
-with Interfaces;
+with HAL;
 
 package Semihosting is
 
-   type SH_Word is new Interfaces.Unsigned_32;
+   type SH_Word is new HAL.UInt32;
 
    subtype Flag is SH_Word;
 

--- a/arch/RISC-V/SiFive/svd/FE310/fe310_svd-pwm.ads
+++ b/arch/RISC-V/SiFive/svd/FE310/fe310_svd-pwm.ads
@@ -25,7 +25,7 @@ package FE310_SVD.PWM is
       ZEROCMP        : Boolean := False;
       DEGLITCH       : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.UInt1 := 16#0#;
+      Reserved_11_11 : HAL.Bit := 16#0#;
       ENALWAYS       : Boolean := False;
       ENONESHOT      : Boolean := False;
       --  unspecified
@@ -79,7 +79,7 @@ package FE310_SVD.PWM is
    type COUNT_16_Register is record
       CNT            : COUNT_16_CNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.UInt1 := 16#0#;
+      Reserved_31_31 : HAL.Bit := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/RISC-V/SiFive/svd/FE310/fe310_svd-pwm.ads
+++ b/arch/RISC-V/SiFive/svd/FE310/fe310_svd-pwm.ads
@@ -25,7 +25,7 @@ package FE310_SVD.PWM is
       ZEROCMP        : Boolean := False;
       DEGLITCH       : Boolean := False;
       --  unspecified
-      Reserved_11_11 : HAL.Bit := 16#0#;
+      Reserved_11_11 : HAL.UInt1 := 16#0#;
       ENALWAYS       : Boolean := False;
       ENONESHOT      : Boolean := False;
       --  unspecified
@@ -79,7 +79,7 @@ package FE310_SVD.PWM is
    type COUNT_16_Register is record
       CNT            : COUNT_16_CNT_Field := 16#0#;
       --  unspecified
-      Reserved_31_31 : HAL.Bit := 16#0#;
+      Reserved_31_31 : HAL.UInt1 := 16#0#;
    end record
      with Volatile_Full_Access, Size => 32,
           Bit_Order => System.Low_Order_First;

--- a/arch/RISC-V/SiFive/svd/FE310/fe310_svd-uart.ads
+++ b/arch/RISC-V/SiFive/svd/FE310/fe310_svd-uart.ads
@@ -14,7 +14,7 @@ package FE310_SVD.UART is
    -- Registers --
    ---------------
 
-   subtype TXDATA_DATA_Field is HAL.Byte;
+   subtype TXDATA_DATA_Field is HAL.UInt8;
 
    --  Transmit Data Register.
    type TXDATA_Register is record
@@ -32,7 +32,7 @@ package FE310_SVD.UART is
       FULL          at 0 range 31 .. 31;
    end record;
 
-   subtype RXDATA_DATA_Field is HAL.Byte;
+   subtype RXDATA_DATA_Field is HAL.UInt8;
 
    --  Receive Data Register.
    type RXDATA_Register is record

--- a/arch/svd.mk
+++ b/arch/svd.mk
@@ -1,6 +1,8 @@
-SVD2ADA_DIR?=~/src/svd2ada
-CORTEX_DIR=$(PWD)/cortex_m/src
-STM_DIR=$(PWD)/STM32/svd
+SVD2ADA_DIR?=~/src/github/svd2ada
+CORTEX_DIR=$(PWD)/ARM/cortex_m/src
+STM_DIR=$(PWD)/ARM/STM32/svd
+NORDIC_DIR=$(PWD)/ARM/Nordic/svd
+SIFIVE_DIR=$(PWD)/RISC-V/SiFive/svd
 
 all: svd
 
@@ -13,6 +15,13 @@ svd:
 	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F7x9.svd --boolean -o $(STM_DIR)/stm32f7x9 -p STM32_SVD --base-types-package HAL
 
 	rm -rf $(CORTEX_DIR)/cm*
+	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Cortex_M/cm0.svd --boolean -o $(CORTEX_DIR)/cm0 -p Cortex_M_SVD --base-types-package HAL
 	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Cortex_M/cm7.svd --boolean -o $(CORTEX_DIR)/cm7 -p Cortex_M_SVD --base-types-package HAL
 	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Cortex_M/cm4.svd --boolean -o $(CORTEX_DIR)/cm4 -p Cortex_M_SVD --base-types-package HAL
 	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Cortex_M/cm4f.svd --boolean -o $(CORTEX_DIR)/cm4f -p Cortex_M_SVD --base-types-package HAL
+
+	rm -rf $(NORIC_DIR)/nrf*
+	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Nordic/nrf51.svd --boolean -o $(NORDIC_DIR)/nrf51 -p NRF51_SVD --base-types-package HAL
+
+	rm -rf $(SIFIVE_DIR)/FE*
+	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/SiFive/FE310.svd --boolean -o $(SIFIVE_DIR)/FE310 -p FE310_SVD --base-types-package HAL

--- a/boards/MicroBit/src/microbit-time.adb
+++ b/boards/MicroBit/src/microbit-time.adb
@@ -29,7 +29,6 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Interfaces;       use Interfaces;
 with nRF51.Clock;
 with nRF51.Device;     use nRF51.Device;
 with nRF51.RTC;        use nRF51.RTC;

--- a/boards/OpenMV2/src/openmv-sensor.adb
+++ b/boards/OpenMV2/src/openmv-sensor.adb
@@ -34,7 +34,6 @@ with STM32.DMA;     use STM32.DMA;
 with Ada.Real_Time; use Ada.Real_Time;
 with OV2640;        use OV2640;
 with OV7725;        use OV7725;
-with Interfaces;    use Interfaces;
 with HAL.I2C;       use HAL.I2C;
 with HAL.Bitmap;    use HAL.Bitmap;
 with HAL;           use HAL;
@@ -49,7 +48,7 @@ package body OpenMV.Sensor is
    --  REG_VER : constant := 16#0B#;
 
    CLK_PWM_Mod    : PWM_Modulator (SENSOR_CLK_TIM'Access);
-   Camera_PID     : HAL.Byte := 0;
+   Camera_PID     : HAL.UInt8 := 0;
    Camera_2640    : OV2640_Camera (Sensor_I2C'Access);
    Camera_7725    : OV7725_Camera (Sensor_I2C'Access);
    Is_Initialized : Boolean := False;
@@ -318,8 +317,7 @@ package body OpenMV.Sensor is
 
    procedure Snapshot (BM : not null HAL.Bitmap.Any_Bitmap_Buffer) is
       Status : DMA_Error_Code;
-      Cnt : constant Interfaces.Unsigned_16 :=
-        Interfaces.Unsigned_16 ((BM.Width * BM.Height) / 2);
+      Cnt : constant UInt16 := UInt16 ((BM.Width * BM.Height) / 2);
    begin
       if BM.Width /= Image_Width
         or else

--- a/boards/native/src/native-filesystem.adb
+++ b/boards/native/src/native-filesystem.adb
@@ -401,7 +401,7 @@ package body Native.Filesystem is
 
    overriding function Read
      (This : in out Native_File_Handle;
-      Data : out Byte_Array)
+      Data : out UInt8_Array)
       return Status_Kind
    is
    begin
@@ -423,7 +423,7 @@ package body Native.Filesystem is
 
    overriding function Write
      (This : in out Native_File_Handle;
-      Data : Byte_Array)
+      Data : UInt8_Array)
       return Status_Kind
    is
    begin

--- a/boards/native/src/native-filesystem.ads
+++ b/boards/native/src/native-filesystem.ads
@@ -85,12 +85,12 @@ package Native.Filesystem is
 
    overriding function Read
      (This : in out Native_File_Handle;
-      Data : out Byte_Array)
+      Data : out UInt8_Array)
       return Status_Kind;
 
    overriding function Write
      (This : in out Native_File_Handle;
-      Data : Byte_Array)
+      Data : UInt8_Array)
       return Status_Kind;
 
    overriding function Seek
@@ -147,7 +147,7 @@ package Native.Filesystem is
 
 private
 
-   package Byte_IO is new Ada.Direct_IO (Byte);
+   package Byte_IO is new Ada.Direct_IO (UInt8);
 
    type Native_FS_Driver is limited new FS_Driver with record
       Root_Dir          : Ada.Strings.Unbounded.Unbounded_String;

--- a/boards/stm32_common/ltdc/framebuffer_ltdc.adb
+++ b/boards/stm32_common/ltdc/framebuffer_ltdc.adb
@@ -240,7 +240,7 @@ package body Framebuffer_LTDC is
    --------------------
 
    overriding procedure Set_Background
-     (Display : Frame_Buffer; R, G, B : Byte)
+     (Display : Frame_Buffer; R, G, B : UInt8)
    is
       pragma Unreferenced (Display);
    begin

--- a/boards/stm32_common/ltdc/framebuffer_ltdc.ads
+++ b/boards/stm32_common/ltdc/framebuffer_ltdc.ads
@@ -87,7 +87,7 @@ package Framebuffer_LTDC is
      (Display : Frame_Buffer) return Boolean;
 
    overriding procedure Set_Background
-     (Display : Frame_Buffer; R, G, B : Byte)
+     (Display : Frame_Buffer; R, G, B : UInt8)
      with Pre => Display.Initialized;
 
    overriding procedure Initialize_Layer

--- a/boards/stm32f469_discovery/src/audio.adb
+++ b/boards/stm32f469_discovery/src/audio.adb
@@ -35,6 +35,7 @@
 with Ada.Real_Time;        use Ada.Real_Time;
 with Interfaces;           use Interfaces;
 
+with HAL;                  use HAL;
 with STM32;                use STM32;
 with STM32.Board;          use STM32.Board;
 with STM32.Device;         use STM32.Device;
@@ -227,7 +228,7 @@ package body Audio is
       This.Reset;
       This.Device.Init
         (Output    => CS43L22.Auto,
-         Volume    => Unsigned_8 (Volume),
+         Volume    => UInt8 (Volume),
          Frequency =>
            HAL.Audio.Audio_Frequency'Enum_Val
              (Audio_Frequency'Enum_Rep (Frequency)));
@@ -315,7 +316,7 @@ package body Audio is
       Volume : Audio_Volume)
    is
    begin
-      This.Device.Set_Volume (Unsigned_8 (Volume));
+      This.Device.Set_Volume (UInt8 (Volume));
    end Set_Volume;
 
    -------------------

--- a/boards/stm32f469_discovery/src/framebuffer_otm8009a.adb
+++ b/boards/stm32f469_discovery/src/framebuffer_otm8009a.adb
@@ -233,7 +233,7 @@ package body Framebuffer_OTM8009A is
    --------------------
 
    overriding procedure Set_Background
-     (Display : Frame_Buffer; R, G, B : Byte)
+     (Display : Frame_Buffer; R, G, B : UInt8)
    is
       pragma Unreferenced (Display);
    begin

--- a/boards/stm32f469_discovery/src/framebuffer_otm8009a.ads
+++ b/boards/stm32f469_discovery/src/framebuffer_otm8009a.ads
@@ -81,7 +81,7 @@ package Framebuffer_OTM8009A is
      (Display : Frame_Buffer) return Boolean;
 
    overriding procedure Set_Background
-     (Display : Frame_Buffer; R, G, B : Byte);
+     (Display : Frame_Buffer; R, G, B : UInt8);
 
    overriding procedure Initialize_Layer
      (Display : in out Frame_Buffer;

--- a/boards/stm32f469_discovery/src/sdcard.adb
+++ b/boards/stm32f469_discovery/src/sdcard.adb
@@ -471,7 +471,7 @@ package body SDCard is
 
    overriding function Write
      (Controller   : in out SDCard_Controller;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : Block) return Boolean
    is
       Ret     : SD_Error;
@@ -537,7 +537,7 @@ package body SDCard is
 
    overriding function Read
      (Controller   : in out SDCard_Controller;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : out Block) return Boolean
    is
       Ret     : Boolean;

--- a/boards/stm32f469_discovery/src/sdcard.ads
+++ b/boards/stm32f469_discovery/src/sdcard.ads
@@ -34,6 +34,7 @@ with Ada.Interrupts.Names;
 
 with STM32.SDMMC;
 
+with HAL;               use HAL;
 with HAL.Block_Drivers; use HAL.Block_Drivers;
 
 package SDCard is
@@ -72,7 +73,7 @@ package SDCard is
 
    overriding function Read
      (Controller   : in out SDCard_Controller;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : out Block) return Boolean
      with Pre => (Data'Size mod Controller.Block_Size) = 0
                  and then Data'Size < 2 ** 16;
@@ -82,7 +83,7 @@ package SDCard is
 
    overriding function Write
      (Controller   : in out SDCard_Controller;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : Block) return Boolean
      with Pre => (Data'Size mod Controller.Block_Size) = 0
                  and then Data'Size < 2 ** 16;

--- a/boards/stm32f746_discovery/src/audio.adb
+++ b/boards/stm32f746_discovery/src/audio.adb
@@ -32,14 +32,13 @@
 --   @author  MCD Application Team                                          --
 ------------------------------------------------------------------------------
 
-with Interfaces;           use Interfaces;
-
-with STM32;                use STM32;
-with STM32.Device;         use STM32.Device;
-with STM32.Board;          use STM32.Board;
-with STM32.GPIO;           use STM32.GPIO;
-with STM32.DMA;            use STM32.DMA;
-with STM32.SAI;            use STM32.SAI;
+with HAL;          use HAL;
+with STM32;        use STM32;
+with STM32.Device; use STM32.Device;
+with STM32.Board;  use STM32.Board;
+with STM32.GPIO;   use STM32.GPIO;
+with STM32.DMA;    use STM32.DMA;
+with STM32.SAI;    use STM32.SAI;
 
 package body Audio is
 
@@ -215,7 +214,7 @@ package body Audio is
       This.Device.Init
         (Input     => WM8994.No_Input,
          Output    => WM8994.Auto,
-         Volume    => Unsigned_8 (Volume),
+         Volume    => UInt8 (Volume),
          Frequency =>
            WM8994.Audio_Frequency'Enum_Val
              (Audio_Frequency'Enum_Rep (Frequency)));
@@ -293,7 +292,7 @@ package body Audio is
       Volume : Audio_Volume)
    is
    begin
-      This.Device.Set_Volume (Unsigned_8 (Volume));
+      This.Device.Set_Volume (UInt8 (Volume));
    end Set_Volume;
 
    -------------------

--- a/boards/stm32f746_discovery/src/sdcard.adb
+++ b/boards/stm32f746_discovery/src/sdcard.adb
@@ -473,7 +473,7 @@ package body SDCard is
 
    overriding function Write
      (Controller   : in out SDCard_Controller;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : Block) return Boolean
    is
       Ret     : SD_Error;
@@ -539,7 +539,7 @@ package body SDCard is
 
    overriding function Read
      (Controller   : in out SDCard_Controller;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : out Block) return Boolean
    is
       Ret     : Boolean;

--- a/boards/stm32f746_discovery/src/sdcard.ads
+++ b/boards/stm32f746_discovery/src/sdcard.ads
@@ -37,6 +37,7 @@ with Ada.Interrupts.Names;
 
 with STM32.SDMMC;
 
+with HAL;               use HAL;
 with HAL.Block_Drivers; use HAL.Block_Drivers;
 
 package SDCard is
@@ -75,7 +76,7 @@ package SDCard is
 
    overriding function Read
      (Controller   : in out SDCard_Controller;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : out Block) return Boolean
      with Pre => (Data'Size mod Controller.Block_Size) = 0
                  and then Data'Size < 2 ** 16;
@@ -85,7 +86,7 @@ package SDCard is
 
    overriding function Write
      (Controller   : in out SDCard_Controller;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : Block) return Boolean
      with Pre => (Data'Size mod Controller.Block_Size) = 0
                  and then Data'Size < 2 ** 16;

--- a/boards/stm32f769_discovery/src/audio.adb
+++ b/boards/stm32f769_discovery/src/audio.adb
@@ -32,14 +32,13 @@
 --   @author  MCD Application Team                                          --
 ------------------------------------------------------------------------------
 
-with Interfaces;           use Interfaces;
-
-with STM32;                use STM32;
-with STM32.Device;         use STM32.Device;
-with STM32.Board;          use STM32.Board;
-with STM32.GPIO;           use STM32.GPIO;
-with STM32.DMA;            use STM32.DMA;
-with STM32.SAI;            use STM32.SAI;
+with HAL;          use HAL;
+with STM32;        use STM32;
+with STM32.Device; use STM32.Device;
+with STM32.Board;  use STM32.Board;
+with STM32.GPIO;   use STM32.GPIO;
+with STM32.DMA;    use STM32.DMA;
+with STM32.SAI;    use STM32.SAI;
 
 package body Audio is
 
@@ -217,7 +216,7 @@ package body Audio is
       This.Device.Init
         (Input     => WM8994.No_Input,
          Output    => WM8994.Auto,
-         Volume    => Unsigned_8 (Volume),
+         Volume    => UInt8 (Volume),
          Frequency =>
            WM8994.Audio_Frequency'Enum_Val
              (Audio_Frequency'Enum_Rep (Frequency)));
@@ -295,7 +294,7 @@ package body Audio is
       Volume : Audio_Volume)
    is
    begin
-      This.Device.Set_Volume (Unsigned_8 (Volume));
+      This.Device.Set_Volume (UInt8 (Volume));
    end Set_Volume;
 
    -------------------

--- a/boards/stm32f769_discovery/src/framebuffer_otm8009a.adb
+++ b/boards/stm32f769_discovery/src/framebuffer_otm8009a.adb
@@ -235,7 +235,7 @@ package body Framebuffer_OTM8009A is
    --------------------
 
    overriding procedure Set_Background
-     (Display : Frame_Buffer; R, G, B : Byte)
+     (Display : Frame_Buffer; R, G, B : UInt8)
    is
       pragma Unreferenced (Display);
    begin

--- a/boards/stm32f769_discovery/src/framebuffer_otm8009a.ads
+++ b/boards/stm32f769_discovery/src/framebuffer_otm8009a.ads
@@ -81,7 +81,7 @@ package Framebuffer_OTM8009A is
      (Display : Frame_Buffer) return Boolean;
 
    overriding procedure Set_Background
-     (Display : Frame_Buffer; R, G, B : Byte);
+     (Display : Frame_Buffer; R, G, B : UInt8);
 
    overriding procedure Initialize_Layer
      (Display : in out Frame_Buffer;

--- a/boards/stm32f769_discovery/src/sdcard.adb
+++ b/boards/stm32f769_discovery/src/sdcard.adb
@@ -480,7 +480,7 @@ package body SDCard is
 
    overriding function Write
      (Controller   : in out SDCard_Controller;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : Block) return Boolean
    is
       Ret     : SD_Error;
@@ -546,7 +546,7 @@ package body SDCard is
 
    overriding function Read
      (Controller   : in out SDCard_Controller;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : out Block) return Boolean
    is
       Ret     : Boolean;

--- a/boards/stm32f769_discovery/src/sdcard.ads
+++ b/boards/stm32f769_discovery/src/sdcard.ads
@@ -37,6 +37,7 @@ with Ada.Interrupts.Names;
 
 with STM32.SDMMC;
 
+with HAL;               use HAL;
 with HAL.Block_Drivers; use HAL.Block_Drivers;
 
 package SDCard is
@@ -75,7 +76,7 @@ package SDCard is
 
    overriding function Read
      (Controller   : in out SDCard_Controller;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : out Block) return Boolean
      with Pre => (Data'Size mod Controller.Block_Size) = 0
                  and then Data'Size < 2 ** 16;
@@ -85,7 +86,7 @@ package SDCard is
 
    overriding function Write
      (Controller   : in out SDCard_Controller;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : Block) return Boolean
      with Pre => (Data'Size mod Controller.Block_Size) = 0
                  and then Data'Size < 2 ** 16;

--- a/components/src/audio/CS43L22/cs43l22.adb
+++ b/components/src/audio/CS43L22/cs43l22.adb
@@ -36,15 +36,15 @@ package body CS43L22 is
    ---------------
 
    procedure I2C_Write (This  : in out CS43L22_Device;
-                        Reg   : Byte;
-                        Value : Byte)
+                        Reg   : UInt8;
+                        Value : UInt8)
    is
       Status : I2C_Status with Unreferenced;
 
    begin
       This.Port.Mem_Write
         (Addr          => CS43L22_I2C_Addr,
-         Mem_Addr      => Unsigned_16 (Reg),
+         Mem_Addr      => UInt16 (Reg),
          Mem_Addr_Size => Memory_Size_8b,
          Data          => (1 => Value),
          Status        => Status);
@@ -55,8 +55,8 @@ package body CS43L22 is
    --------------
 
    function I2C_Read (This : in out CS43L22_Device;
-                      Reg : Byte)
-                      return Byte
+                      Reg : UInt8)
+                      return UInt8
    is
       Status : I2C_Status;
       Data   : I2C_Data (1 .. 1);
@@ -64,7 +64,7 @@ package body CS43L22 is
    begin
       This.Port.Mem_Read
         (Addr          => CS43L22_I2C_Addr,
-         Mem_Addr      => Unsigned_16 (Reg),
+         Mem_Addr      => UInt16 (Reg),
          Mem_Addr_Size => Memory_Size_8b,
          Data          => Data,
          Status        => Status);
@@ -135,7 +135,7 @@ package body CS43L22 is
    -- Read_ID --
    -------------
 
-   function Read_ID (This : in out CS43L22_Device) return Unsigned_8 is
+   function Read_ID (This : in out CS43L22_Device) return UInt8 is
    begin
       return This.I2C_Read (CS43L22_REG_ID) and CS43L22_ID_MASK;
    end Read_ID;
@@ -217,8 +217,8 @@ package body CS43L22 is
    procedure Set_Volume (This : in out CS43L22_Device; Volume : Volume_Level)
    is
       --  Actual Volume in range 0 .. 16#3F#
-      Converted_Volume : Unsigned_8 :=
-                           Unsigned_8 (Unsigned_16 (Volume) * 200 / 100);
+      Converted_Volume : UInt8 :=
+                           UInt8 (UInt16 (Volume) * 200 / 100);
 
    begin
       --  range goes the following:

--- a/components/src/audio/CS43L22/cs43l22.ads
+++ b/components/src/audio/CS43L22/cs43l22.ads
@@ -31,10 +31,9 @@
 
 --  Driver for the WM8994 CODEC
 
-with Interfaces; use Interfaces;
-with HAL;        use HAL;
-with HAL.I2C;    use HAL.I2C;
-with HAL.Audio;  use HAL.Audio;
+with HAL;       use HAL;
+with HAL.I2C;   use HAL.I2C;
+with HAL.Audio; use HAL.Audio;
 with HAL.Time;
 
 package CS43L22 is
@@ -55,7 +54,7 @@ package CS43L22 is
      (Mute_On,
       Mute_Off);
 
-   subtype Volume_Level is Unsigned_8 range 0 .. 100;
+   subtype Volume_Level is UInt8 range 0 .. 100;
 
    type CS43L22_Device (Port : not null Any_I2C_Port;
                         Time : not null HAL.Time.Any_Delays) is
@@ -66,7 +65,7 @@ package CS43L22 is
                    Volume    : Volume_Level;
                    Frequency : Audio_Frequency);
 
-   function Read_ID (This : in out CS43L22_Device) return Unsigned_8;
+   function Read_ID (This : in out CS43L22_Device) return UInt8;
    procedure Play (This : in out CS43L22_Device);
    procedure Pause (This : in out CS43L22_Device);
    procedure Resume (This : in out CS43L22_Device);
@@ -124,14 +123,14 @@ private
                         Time : not null HAL.Time.Any_Delays) is
      tagged limited record
       Output_Enabled : Boolean := False;
-      Output_Dev     : Byte := 0;
+      Output_Dev     : UInt8 := 0;
    end record;
 
    procedure I2C_Write (This  : in out CS43L22_Device;
-                        Reg   : Byte;
-                        Value : Byte);
+                        Reg   : UInt8;
+                        Value : UInt8);
    function I2C_Read (This : in out CS43L22_Device;
-                      Reg  : Byte)
-                      return Byte;
+                      Reg  : UInt8)
+                      return UInt8;
 
 end CS43L22;

--- a/components/src/audio/W8994/wm8994.adb
+++ b/components/src/audio/W8994/wm8994.adb
@@ -51,8 +51,8 @@ package body WM8994 is
       Check  : UInt16 with Unreferenced;
    begin
       --  Device is MSB first
-      Data (1) := Byte (Shift_Right (Value and 16#FF00#, 8));
-      Data (2) := Byte (Value and 16#FF#);
+      Data (1) := UInt8 (Shift_Right (Value and 16#FF00#, 8));
+      Data (2) := UInt8 (Value and 16#FF#);
 
       This.Port.Mem_Write
         (Addr          => This.I2C_Addr,
@@ -97,10 +97,10 @@ package body WM8994 is
      (This      : in out WM8994_Device;
       Input     : Input_Device;
       Output    : Output_Device;
-      Volume    : Unsigned_8;
+      Volume    : UInt8;
       Frequency : Audio_Frequency)
    is
-      Power_Mgnt_Reg_1 : Unsigned_16 := 0;
+      Power_Mgnt_Reg_1 : UInt16 := 0;
 
    begin
       --  WM8994 Errata work-arounds
@@ -308,7 +308,7 @@ package body WM8994 is
    -- Read_ID --
    -------------
 
-   function Read_ID (This : in out WM8994_Device) return Unsigned_16 is
+   function Read_ID (This : in out WM8994_Device) return UInt16 is
    begin
       return This.I2C_Read (WM8994_CHIPID_ADDR);
    end Read_ID;
@@ -387,9 +387,9 @@ package body WM8994 is
    procedure Set_Volume (This : in out WM8994_Device; Volume : Volume_Level)
    is
       --  Actual Volume in range 0 .. 16#3F#
-      Converted_Volume : constant Unsigned_16 :=
+      Converted_Volume : constant UInt16 :=
                            (if Volume = 100 then 63
-                            else Unsigned_16 (Volume) * 63 / 100);
+                            else UInt16 (Volume) * 63 / 100);
 
    begin
       if Volume = 0 then

--- a/components/src/audio/W8994/wm8994.ads
+++ b/components/src/audio/W8994/wm8994.ads
@@ -31,9 +31,8 @@
 
 --  Driver for the WM8994 CODEC
 
-with Interfaces; use Interfaces;
-with HAL;        use HAL;
-with HAL.I2C;    use HAL.I2C;
+with HAL;      use HAL;
+with HAL.I2C;  use HAL.I2C;
 with HAL.Time;
 
 package WM8994 is
@@ -85,7 +84,7 @@ package WM8994 is
    --  is set to default configuration (user should re-Initialize the codec in
    --  order to play again the audio stream).
 
-   subtype Volume_Level is Unsigned_8 range 0 .. 100;
+   subtype Volume_Level is UInt8 range 0 .. 100;
 
    type WM8994_Device
      (Port     : not null Any_I2C_Port;
@@ -96,10 +95,10 @@ package WM8994 is
    procedure Init (This      : in out WM8994_Device;
                    Input     : Input_Device;
                    Output    : Output_Device;
-                   Volume    : Unsigned_8;
+                   Volume    : UInt8;
                    Frequency : Audio_Frequency);
 
-   function Read_ID (This : in out WM8994_Device) return Unsigned_16;
+   function Read_ID (This : in out WM8994_Device) return UInt16;
    procedure Play (This : in out WM8994_Device);
    procedure Pause (This : in out WM8994_Device);
    procedure Resume (This : in out WM8994_Device);

--- a/components/src/camera/OV2640/bit_fields.adb
+++ b/components/src/camera/OV2640/bit_fields.adb
@@ -33,7 +33,7 @@ package body Bit_Fields is
    type Convert_8 (As_Array : Boolean := False) is record
       case As_Array is
          when False =>
-            Value : Byte;
+            Value : UInt8;
          when True =>
             Bits : Bit_Field (0 .. 7);
       end case;
@@ -96,15 +96,15 @@ package body Bit_Fields is
    end To_UInt16;
 
    -------------
-   -- To_Byte --
+   -- To_UInt8 --
    -------------
 
-   function To_Byte (Bits : Bit_Field) return Byte is
+   function To_UInt8 (Bits : Bit_Field) return UInt8 is
       Tmp : Convert_8;
    begin
       Tmp.Bits := Bits;
       return Tmp.Value;
-   end To_Byte;
+   end To_UInt8;
 
    ------------------
    -- To_Bit_Field --
@@ -132,7 +132,7 @@ package body Bit_Fields is
    -- To_Bit_Field --
    ------------------
 
-   function To_Bit_Field (Value : Byte) return Bit_Field is
+   function To_Bit_Field (Value : UInt8) return Bit_Field is
       Tmp : Convert_8;
    begin
       Tmp.Value := Value;

--- a/components/src/camera/OV2640/bit_fields.ads
+++ b/components/src/camera/OV2640/bit_fields.ads
@@ -32,7 +32,7 @@
 with HAL; use HAL;
 
 package Bit_Fields is
-   type Bit_Field is array (Natural range <>) of UInt1
+   type Bit_Field is array (Natural range <>) of Bit
      with Component_Size => 1;
 
    function To_Word (Bits : Bit_Field) return UInt32;

--- a/components/src/camera/OV2640/bit_fields.ads
+++ b/components/src/camera/OV2640/bit_fields.ads
@@ -32,12 +32,12 @@
 with HAL; use HAL;
 
 package Bit_Fields is
-   type Bit_Field is array (Natural range <>) of Bit
+   type Bit_Field is array (Natural range <>) of UInt1
      with Component_Size => 1;
 
    function To_Word (Bits : Bit_Field) return UInt32;
    function To_UInt16 (Bits : Bit_Field) return UInt16;
-   function To_Byte (Bits : Bit_Field) return Byte;
+   function To_UInt8 (Bits : Bit_Field) return UInt8;
 
    function To_Bit_Field (Value : UInt32) return Bit_Field
      with Post => To_Bit_Field'Result'First = 0
@@ -47,7 +47,7 @@ package Bit_Fields is
      with Post => To_Bit_Field'Result'First = 0
      and then
        To_Bit_Field'Result'Last = 15;
-   function To_Bit_Field (Value : Byte) return Bit_Field
+   function To_Bit_Field (Value : UInt8) return Bit_Field
      with Post => To_Bit_Field'Result'First = 0
      and then
        To_Bit_Field'Result'Last = 7;

--- a/components/src/camera/OV2640/ov2640.adb
+++ b/components/src/camera/OV2640/ov2640.adb
@@ -39,13 +39,12 @@
 --  OV2640 driver.
 --
 
-with Interfaces; use Interfaces;
 with Bit_Fields; use Bit_Fields;
 
 package body OV2640 is
 
    type Addr_And_Data is record
-      Addr, Data : Byte;
+      Addr, Data : UInt8;
    end record;
 
    type Command_Array is array (Natural range <>) of Addr_And_Data;
@@ -243,8 +242,8 @@ package body OV2640 is
       (16#00#,     16#00#)
      );
 
-   procedure Write (This : OV2640_Camera; Addr, Data : Byte);
-   function Read (This : OV2640_Camera; Addr : Byte) return Byte;
+   procedure Write (This : OV2640_Camera; Addr, Data : UInt8);
+   function Read (This : OV2640_Camera; Addr : UInt8) return UInt8;
    procedure Select_Sensor_Bank (This : OV2640_Camera);
    procedure Select_DSP_Bank (This : OV2640_Camera);
    procedure Enable_DSP (This : OV2640_Camera; Enable : Boolean);
@@ -253,7 +252,7 @@ package body OV2640 is
    -- Write --
    -----------
 
-   procedure Write (This : OV2640_Camera; Addr, Data : Byte) is
+   procedure Write (This : OV2640_Camera; Addr, Data : UInt8) is
       Status : I2C_Status;
    begin
       This.I2C.Mem_Write (Addr          => This.Addr,
@@ -270,7 +269,7 @@ package body OV2640 is
    -- Read --
    ----------
 
-   function Read (This : OV2640_Camera; Addr : Byte) return Byte is
+   function Read (This : OV2640_Camera; Addr : UInt8) return UInt8 is
       Data : I2C_Data (1 .. 1);
       Status : I2C_Status;
    begin
@@ -372,12 +371,12 @@ package body OV2640 is
       Enable_DSP (This, False);
       --  DSP bank selected
 
-      Write (This, REG_DSP_ZMOW, Byte ((Width / 4) and 16#FF#));
-      Write (This, REG_DSP_ZMOH, Byte ((Height / 4) and 16#FF#));
+      Write (This, REG_DSP_ZMOW, UInt8 ((Width / 4) and 16#FF#));
+      Write (This, REG_DSP_ZMOH, UInt8 ((Height / 4) and 16#FF#));
       Write (This, REG_DSP_ZMHH,
-             Byte (Shift_Right (Width, 10) and 16#3#)
+             UInt8 (Shift_Right (Width, 10) and 16#3#)
              or
-             Byte (Shift_Right (Height, 8) and 16#4#));
+             UInt8 (Shift_Right (Height, 8) and 16#4#));
 
       Select_Sensor_Bank (This);
       Write (This, REG_SENSOR_CLKRC, (if CLK_Divider then 16#81# else 16#80#));
@@ -422,24 +421,24 @@ package body OV2640 is
       end if;
 
       --  Real HSIZE[10..3]
-      Write (This, REG_DSP_HSIZE8, To_Byte (H_SIZE (3 .. 10)));
+      Write (This, REG_DSP_HSIZE8, To_UInt8 (H_SIZE (3 .. 10)));
       --  Real VSIZE[10..3]
-      Write (This, REG_DSP_VSIZE8, To_Byte (V_SIZE (3 .. 10)));
+      Write (This, REG_DSP_VSIZE8, To_UInt8 (V_SIZE (3 .. 10)));
 
       --  Real HSIZE[11] real HSIZE[2..0]
       Write (This, REG_DSP_SIZEL,
-             To_Byte (V_SIZE (0 .. 2) & H_SIZE (0 .. 2) & (H_SIZE (11), 0)));
+             To_UInt8 (V_SIZE (0 .. 2) & H_SIZE (0 .. 2) & (H_SIZE (11), 0)));
 
       H_SIZE := To_Bit_Field (To_UInt16 (H_SIZE) / 4);
       V_SIZE := To_Bit_Field (To_UInt16 (V_SIZE) / 4);
 
       Write (This, REG_DSP_XOFFL, 0);
       Write (This, REG_DSP_YOFFL, 0);
-      Write (This, REG_DSP_HSIZE, To_Byte (H_SIZE (0 .. 7)));
-      Write (This, REG_DSP_VSIZE, To_Byte (V_SIZE (0 .. 7)));
+      Write (This, REG_DSP_HSIZE, To_UInt8 (H_SIZE (0 .. 7)));
+      Write (This, REG_DSP_VSIZE, To_UInt8 (V_SIZE (0 .. 7)));
 
       Write (This, REG_DSP_VHYX,
-             To_Byte ((0 => 0,
+             To_UInt8 ((0 => 0,
                        1 => 0,
                        2 => 0,
                        3 => H_SIZE (8),
@@ -448,7 +447,7 @@ package body OV2640 is
                        6 => 0,
                        7 => V_SIZE (8))));
       Write (This, REG_DSP_TEST,
-             To_Byte ((0 => 0,
+             To_UInt8 ((0 => 0,
                        1 => 0,
                        2 => 0,
                        3 => 0,
@@ -485,7 +484,7 @@ package body OV2640 is
    -- Get_PID --
    -------------
 
-   function Get_PID (This : OV2640_Camera) return Byte is
+   function Get_PID (This : OV2640_Camera) return UInt8 is
    begin
       Select_Sensor_Bank (This);
       return Read (This, REG_SENSOR_PID);
@@ -498,7 +497,7 @@ package body OV2640 is
    procedure Enable_Auto_Gain_Control (This   : OV2640_Camera;
                                        Enable : Boolean := True)
    is
-      COM8 : Byte;
+      COM8 : UInt8;
    begin
       Select_Sensor_Bank (This);
       COM8 := Read (This, REG_SENSOR_COM8);
@@ -518,7 +517,7 @@ package body OV2640 is
    procedure Enable_Auto_White_Balance (This   : OV2640_Camera;
                                         Enable : Boolean := True)
    is
-      CTRL1 : Byte;
+      CTRL1 : UInt8;
    begin
       Select_DSP_Bank (This);
       CTRL1 := Read (This, REG_DSP_CTRL1);
@@ -538,7 +537,7 @@ package body OV2640 is
    procedure Enable_Auto_Exposure_Control (This   : OV2640_Camera;
                                            Enable : Boolean := True)
    is
-      CTRL0 : Byte;
+      CTRL0 : UInt8;
    begin
       Select_DSP_Bank (This);
       CTRL0 := Read (This, REG_DSP_CTRL0);
@@ -558,7 +557,7 @@ package body OV2640 is
    procedure Enable_Auto_Band_Filter (This   : OV2640_Camera;
                                       Enable : Boolean := True)
    is
-      COM8 : Byte;
+      COM8 : UInt8;
    begin
       Select_Sensor_Bank (This);
       COM8 := Read (This, REG_SENSOR_COM8);

--- a/components/src/camera/OV2640/ov2640.ads
+++ b/components/src/camera/OV2640/ov2640.ads
@@ -75,7 +75,7 @@ package OV2640 is
    procedure Set_Frame_Rate (This : OV2640_Camera;
                              FR   : Frame_Rate);
 
-   function Get_PID (This : OV2640_Camera) return Byte;
+   function Get_PID (This : OV2640_Camera) return UInt8;
 
    procedure Enable_Auto_Gain_Control (This   : OV2640_Camera;
                                        Enable : Boolean := True);

--- a/components/src/camera/OV7725/ov7725.adb
+++ b/components/src/camera/OV7725/ov7725.adb
@@ -29,10 +29,9 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Interfaces; use Interfaces;
 package body OV7725 is
    type Addr_And_Data is record
-      Addr, Data : Byte;
+      Addr, Data : UInt8;
    end record;
 
    type Command_Array is array (Natural range <>) of Addr_And_Data;
@@ -127,18 +126,18 @@ package body OV7725 is
       (REG_COM5,          16#D5#));
 
    function Read (This     : OV7725_Camera;
-                  Mem_Addr : UInt8) return Byte;
+                  Mem_Addr : UInt8) return UInt8;
 
    procedure Write (This     : OV7725_Camera;
                     Mem_Addr : UInt8;
-                    Data     : Byte);
+                    Data     : UInt8);
 
    ----------
    -- Read --
    ----------
 
    function Read (This     : OV7725_Camera;
-                  Mem_Addr : UInt8) return Byte
+                  Mem_Addr : UInt8) return UInt8
    is
       Status : I2C_Status;
       Data   : I2C_Data (1 .. 1);
@@ -165,7 +164,7 @@ package body OV7725 is
 
    procedure Write (This     : OV7725_Camera;
                     Mem_Addr : UInt8;
-                    Data     : Byte)
+                    Data     : UInt8)
    is
       Status : I2C_Status;
    begin
@@ -200,7 +199,7 @@ package body OV7725 is
      (This : OV7725_Camera;
       Pix  : Pixel_Format)
    is
-      Reg : Byte := Read (This, REG_COM7);
+      Reg : UInt8 := Read (This, REG_COM7);
    begin
       Reg := Reg and 2#1111_00_11#;
       case Pix is
@@ -251,7 +250,7 @@ package body OV7725 is
    -- Get_PID --
    -------------
 
-   function Get_PID (This : OV7725_Camera) return Byte is
+   function Get_PID (This : OV7725_Camera) return UInt8 is
    begin
       return Read (This, REG_PID);
    end Get_PID;

--- a/components/src/camera/OV7725/ov7725.ads
+++ b/components/src/camera/OV7725/ov7725.ads
@@ -50,7 +50,7 @@ package OV7725 is
    procedure Set_Frame_Size (This : OV7725_Camera;
                              Res  : OV2640.Frame_Size);
 
-   function Get_PID (This : OV7725_Camera) return Byte;
+   function Get_PID (This : OV7725_Camera) return UInt8;
 
 private
 

--- a/components/src/io_expander/MCP23xxx/mcp23x08-i2c.adb
+++ b/components/src/io_expander/MCP23xxx/mcp23x08-i2c.adb
@@ -41,7 +41,7 @@ package body MCP23x08.I2C is
    procedure IO_Write
      (This      : in out MCP23008_IO_Expander;
       WriteAddr : Register_Address;
-      Value     : Byte)
+      Value     : UInt8)
    is
       Status : I2C_Status;
    begin
@@ -67,7 +67,7 @@ package body MCP23x08.I2C is
    procedure IO_Read
      (This     : MCP23008_IO_Expander;
       ReadAddr : Register_Address;
-      Value    : out Byte)
+      Value    : out UInt8)
    is
       Ret    : I2C_Data (1 .. 1);
       Status : I2C_Status;

--- a/components/src/io_expander/MCP23xxx/mcp23x08-i2c.ads
+++ b/components/src/io_expander/MCP23xxx/mcp23x08-i2c.ads
@@ -47,13 +47,13 @@ private
    procedure IO_Write
      (This      : in out MCP23008_IO_Expander;
       WriteAddr : Register_Address;
-      Value     : Byte);
+      Value     : UInt8);
 
    overriding
    procedure IO_Read
      (This     : MCP23008_IO_Expander;
       ReadAddr : Register_Address;
-      Value    : out Byte);
+      Value    : out UInt8);
 
    BASE_ADDRESS : constant HAL.I2C.I2C_Address := 16#40#;
 end MCP23x08.I2C;

--- a/components/src/io_expander/MCP23xxx/mcp23x08.adb
+++ b/components/src/io_expander/MCP23xxx/mcp23x08.adb
@@ -29,28 +29,27 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Interfaces; use Interfaces;
 with Ada.Unchecked_Conversion;
 with HAL.GPIO;                   use HAL.GPIO;
 
 package body MCP23x08 is
 
-   function To_Byte is
+   function To_UInt8 is
       new Ada.Unchecked_Conversion (Source => ALl_IO_Array,
-                                    Target => Byte);
+                                    Target => UInt8);
    function To_All_IO_Array is
-      new Ada.Unchecked_Conversion (Source => Byte,
+      new Ada.Unchecked_Conversion (Source => UInt8,
                                     Target => ALl_IO_Array);
    procedure Loc_IO_Write
      (This      : in out MCP23x08_IO_Expander'Class;
       WriteAddr : Register_Address;
-      Value     : Byte)
+      Value     : UInt8)
      with Inline_Always;
 
    procedure Loc_IO_Read
      (This     : MCP23x08_IO_Expander'Class;
       ReadAddr : Register_Address;
-      Value    : out Byte)
+      Value    : out UInt8)
      with Inline_Always;
 
    procedure Set_Bit
@@ -76,7 +75,7 @@ package body MCP23x08 is
    procedure Loc_IO_Write
      (This      : in out MCP23x08_IO_Expander'Class;
       WriteAddr : Register_Address;
-      Value     : Byte)
+      Value     : UInt8)
    is
 
    begin
@@ -90,7 +89,7 @@ package body MCP23x08 is
    procedure Loc_IO_Read
      (This     : MCP23x08_IO_Expander'Class;
       ReadAddr : Register_Address;
-      Value    : out Byte)
+      Value    : out UInt8)
       is
    begin
       IO_Read (This, ReadAddr, Value);
@@ -105,7 +104,7 @@ package body MCP23x08 is
       RegAddr : Register_Address;
       Pin     : MCP23x08_Pin)
    is
-      Prev, Next : Byte;
+      Prev, Next : UInt8;
    begin
       Loc_IO_Read (This, RegAddr, Prev);
       Next := Prev or Pin'Enum_Rep;
@@ -123,7 +122,7 @@ package body MCP23x08 is
       RegAddr : Register_Address;
       Pin     : MCP23x08_Pin)
    is
-      Prev, Next : Byte;
+      Prev, Next : UInt8;
    begin
       Loc_IO_Read (This, RegAddr, Prev);
       Next := Prev and (not  Pin'Enum_Rep);
@@ -142,7 +141,7 @@ package body MCP23x08 is
       Pin     : MCP23x08_Pin)
       return Boolean
    is
-      Reg : Byte;
+      Reg : UInt8;
    begin
       Loc_IO_Read (This, RegAddr, Reg);
       return (Reg and Pin'Enum_Rep) /= 0;
@@ -221,7 +220,7 @@ package body MCP23x08 is
    function Set (This  : MCP23x08_IO_Expander;
                  Pin   : MCP23x08_Pin) return Boolean
    is
-      Val : Byte;
+      Val : UInt8;
    begin
       Loc_IO_Read (This, LOGIC_LEVLEL_REG, Val);
       return (Pin'Enum_Rep and Val) /= 0;
@@ -269,7 +268,7 @@ package body MCP23x08 is
    ------------
 
    function All_IO (This : in out MCP23x08_IO_Expander) return ALl_IO_Array is
-      Val : Byte;
+      Val : UInt8;
    begin
       Loc_IO_Read (This, LOGIC_LEVLEL_REG, Val);
       return To_All_IO_Array (Val);
@@ -281,7 +280,7 @@ package body MCP23x08 is
 
    procedure Set_All_IO (This : in out MCP23x08_IO_Expander; IOs : ALl_IO_Array) is
    begin
-      Loc_IO_Write (This, LOGIC_LEVLEL_REG, To_Byte (IOs));
+      Loc_IO_Write (This, LOGIC_LEVLEL_REG, To_UInt8 (IOs));
    end Set_All_IO;
 
    -------------------

--- a/components/src/io_expander/MCP23xxx/mcp23x08.ads
+++ b/components/src/io_expander/MCP23xxx/mcp23x08.ads
@@ -162,18 +162,18 @@ private
    -- IO private subprograms --
    ----------------------------
 
-   type Register_Address is new Byte;
+   type Register_Address is new UInt8;
 
    procedure IO_Write
      (This      : in out MCP23x08_IO_Expander;
       WriteAddr : Register_Address;
-      Value     : Byte) is null;
+      Value     : UInt8) is null;
    --  This procedure must be overridden by the I2C or SPI implementation
 
    procedure IO_Read
      (This     : MCP23x08_IO_Expander;
       ReadAddr : Register_Address;
-      Value    : out Byte) is null;
+      Value    : out UInt8) is null;
    --  This procedure must be overridden by the I2C or SPI implementation
 
    IO_DIRECTION_REG     : constant Register_Address := 16#00#;

--- a/components/src/io_expander/ht16k33/ht16k33.adb
+++ b/components/src/io_expander/ht16k33/ht16k33.adb
@@ -34,23 +34,23 @@ with Interfaces; use Interfaces;
 package body HT16K33 is
 
    HT16K33_Base_Addr : constant I2C_Address := 2#1110_0000#;
-   Reg_Display_Setup : constant Byte := 16#80#;
-   Reg_Dimming       : constant Byte := 16#E0#;
+   Reg_Display_Setup : constant UInt8 := 16#80#;
+   Reg_Dimming       : constant UInt8 := 16#E0#;
 
    function I2C_Addr (This : HT16K33_Device) return I2C_Address;
 
    procedure I2C_Read (This   : in out HT16K33_Device;
-                       Reg    : Byte;
+                       Reg    : UInt8;
                        Data   : out I2C_Data;
                        Status : out Boolean);
 
    procedure I2C_Write (This   : in out HT16K33_Device;
-                        Reg    : Byte;
+                        Reg    : UInt8;
                         Data   : I2C_Data;
                         Status : out Boolean);
 
    procedure I2C_Command (This : in out HT16K33_Device;
-                          Cmd  : Byte;
+                          Cmd  : UInt8;
                           Status : out Boolean);
 
 
@@ -68,7 +68,7 @@ package body HT16K33 is
    --------------
 
    procedure I2C_Read (This   : in out HT16K33_Device;
-                      Reg    : Byte;
+                      Reg    : UInt8;
                       Data   : out I2C_Data;
                       Status : out Boolean)
    is
@@ -89,7 +89,7 @@ package body HT16K33 is
    ---------------
 
    procedure I2C_Write (This   : in out HT16K33_Device;
-                        Reg    : Byte;
+                        Reg    : UInt8;
                         Data   : I2C_Data;
                         Status : out Boolean)
    is
@@ -110,7 +110,7 @@ package body HT16K33 is
    -----------------
 
    procedure I2C_Command (This : in out HT16K33_Device;
-                          Cmd  : Byte;
+                          Cmd  : UInt8;
                           Status : out Boolean)
    is
       Data : constant I2C_Data (1 .. 1) := (others => Cmd);
@@ -130,8 +130,8 @@ package body HT16K33 is
 
    procedure Update_Setup_Reg (This : in out HT16K33_Device) is
       Status  : Boolean;
-      Enabled : constant Byte := (if This.Enabled then 1 else 0);
-      Blink   : constant Byte :=
+      Enabled : constant UInt8 := (if This.Enabled then 1 else 0);
+      Blink   : constant UInt8 :=
         Shift_Left (HT16K33_Blink'Enum_Rep (This.Blink), 1);
    begin
       I2C_Command (This, Reg_Display_Setup or Blink or Enabled, Status);
@@ -171,7 +171,7 @@ package body HT16K33 is
       Status : Boolean;
    begin
 
-      I2C_Command (This, Reg_Dimming or (Byte (Brightness) - 1), Status);
+      I2C_Command (This, Reg_Dimming or (UInt8 (Brightness) - 1), Status);
 
       if not Status then
          raise Program_Error;
@@ -217,7 +217,7 @@ package body HT16K33 is
 
    procedure Set_Row (This : in out HT16K33_Device;
                       Addr : LED_Row_Addr;
-                      Row  : Byte)
+                      Row  : UInt8)
    is
    begin
       This.LEDs (Integer (Addr)) := Row;

--- a/components/src/io_expander/ht16k33/ht16k33.adb
+++ b/components/src/io_expander/ht16k33/ht16k33.adb
@@ -29,8 +29,6 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Interfaces; use Interfaces;
-
 package body HT16K33 is
 
    HT16K33_Base_Addr : constant I2C_Address := 2#1110_0000#;

--- a/components/src/io_expander/ht16k33/ht16k33.ads
+++ b/components/src/io_expander/ht16k33/ht16k33.ads
@@ -64,7 +64,7 @@ package HT16K33 is
 
    procedure Set_Row (This : in out HT16K33_Device;
                       Addr : LED_Row_Addr;
-                      Row  : Byte);
+                      Row  : UInt8);
    --  This procedure only changes the internal buffer, use the Update_LEDs
    --  procedure to actually update the LEDs state on the device.
 

--- a/components/src/io_expander/stmpe1600/stmpe1600.adb
+++ b/components/src/io_expander/stmpe1600/stmpe1600.adb
@@ -29,14 +29,13 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Interfaces; use Interfaces;
-with HAL;        use HAL;
+with HAL; use HAL;
 
 with Ada.Unchecked_Conversion;
 
 package body STMPE1600 is
 
-   subtype BA_2 is Byte_Array (1 .. 2);
+   subtype BA_2 is UInt8_Array (1 .. 2);
    function To_Pins is new Ada.Unchecked_Conversion (BA_2, STMPE1600_Pins);
    function From_Pins is new Ada.Unchecked_Conversion (STMPE1600_Pins, BA_2);
 
@@ -46,8 +45,8 @@ package body STMPE1600 is
 
    procedure Read
      (This   : STMPE1600_Expander;
-      Reg    : Byte;
-      Data   : out Byte_Array;
+      Reg    : UInt8;
+      Data   : out UInt8_Array;
       Status : out Boolean)
    is
       S : HAL.I2C.I2C_Status;
@@ -69,8 +68,8 @@ package body STMPE1600 is
 
    procedure Write
      (This   : STMPE1600_Expander;
-      Reg    : Byte;
-      Data   : Byte_Array;
+      Reg    : UInt8;
+      Data   : UInt8_Array;
       Status : out Boolean)
    is
       S : HAL.I2C.I2C_Status;
@@ -94,7 +93,7 @@ package body STMPE1600 is
      (This   : in out STMPE1600_Expander;
       Status : out Boolean)
    is
-      Identifier : Byte_Array (1 .. 2);
+      Identifier : UInt8_Array (1 .. 2);
    begin
       Read (This, STMPE1600_REG_ChipID, Identifier, Status);
 
@@ -116,7 +115,7 @@ package body STMPE1600 is
       Status   : out Boolean)
    is
       Sys_Ctrl : aliased STMPE1600_SYS_CTRL;
-      BA       : aliased Byte_Array (1 .. 1) with Address => Sys_Ctrl'Address;
+      BA       : aliased UInt8_Array (1 .. 1) with Address => Sys_Ctrl'Address;
    begin
       Read (This, STMPE1600_REG_System_Ctrl, BA, Status);
       if Status then
@@ -135,7 +134,7 @@ package body STMPE1600 is
       Mask : STMPE1600_Pins;
       Status : out Boolean)
    is
-      BA : aliased Byte_Array (1 .. 2) with Address => Mask'Address;
+      BA : aliased UInt8_Array (1 .. 2) with Address => Mask'Address;
    begin
       Write (This, STMPE1600_REG_IEGPIOR_0, BA, Status);
    end Set_Interrupt_Mask;
@@ -147,7 +146,7 @@ package body STMPE1600 is
    function Interrupt_Mask
      (This   : STMPE1600_Expander) return STMPE1600_Pins
    is
-      BA  : aliased Byte_Array (1 .. 2);
+      BA  : aliased UInt8_Array (1 .. 2);
       Status : Boolean;
 
    begin
@@ -162,7 +161,7 @@ package body STMPE1600 is
    function Interrupt_State
      (This : STMPE1600_Expander) return STMPE1600_Pins
    is
-      BA  : aliased Byte_Array (1 .. 2);
+      BA  : aliased UInt8_Array (1 .. 2);
       Status : Boolean;
 
    begin
@@ -177,7 +176,7 @@ package body STMPE1600 is
    function Pins_State
      (This : in out STMPE1600_Expander) return STMPE1600_Pins
    is
-      BA  : aliased Byte_Array (1 .. 2);
+      BA  : aliased UInt8_Array (1 .. 2);
       Status : Boolean;
 
    begin
@@ -206,7 +205,7 @@ package body STMPE1600 is
      (This : in out STMPE1600_Expander;
       Pins : STMPE1600_Pins)
    is
-      BA     : constant Byte_Array (1 .. 2) := From_Pins (Pins);
+      BA     : constant UInt8_Array (1 .. 2) := From_Pins (Pins);
       Status : Boolean with Unreferenced;
 
    begin
@@ -236,7 +235,7 @@ package body STMPE1600 is
      (This      : STMPE1600_Expander;
       Pins      : STMPE1600_Pins_Direction)
    is
-      BA     : aliased Byte_Array (1 .. 2) with Address => Pins'Address;
+      BA     : aliased UInt8_Array (1 .. 2) with Address => Pins'Address;
       Status : Boolean with Unreferenced;
    begin
       Write (This, STMPE1600_REG_GPDR_0, BA, Status);
@@ -252,7 +251,7 @@ package body STMPE1600 is
       Direction : STMPE1600_Pin_Direction)
    is
       Pins      : aliased STMPE1600_Pins;
-      BA        : aliased Byte_Array (1 .. 2) with Address => Pins'Address;
+      BA        : aliased UInt8_Array (1 .. 2) with Address => Pins'Address;
       Status    : Boolean with Unreferenced;
       New_State : constant Boolean := Direction = Output;
 
@@ -277,7 +276,7 @@ package body STMPE1600 is
       return STMPE1600_Pin_Direction
    is
       Pins      : aliased STMPE1600_Pins;
-      BA        : aliased Byte_Array (1 .. 2) with Address => Pins'Address;
+      BA        : aliased UInt8_Array (1 .. 2) with Address => Pins'Address;
       Status    : Boolean with Unreferenced;
 
    begin
@@ -295,7 +294,7 @@ package body STMPE1600 is
       Inversion_State : Boolean)
    is
       Pins      : aliased STMPE1600_Pins;
-      BA        : aliased Byte_Array (1 .. 2) with Address => Pins'Address;
+      BA        : aliased UInt8_Array (1 .. 2) with Address => Pins'Address;
       Status    : Boolean with Unreferenced;
 
    begin

--- a/components/src/io_expander/stmpe1600/stmpe1600.ads
+++ b/components/src/io_expander/stmpe1600/stmpe1600.ads
@@ -125,7 +125,7 @@ private
 
    type STMPE1600_SYS_CTRL is record
       INT_Polarity : STMPE1600_Pin_Polarity := Low;
-      Reserved_1   : HAL.UInt1 := 0;
+      Reserved_1   : HAL.Bit := 0;
       INT_Enable   : Boolean := False;
       Reserved_3_4 : HAL.UInt2 := 0;
       Wakeup_En    : Boolean := False;

--- a/components/src/io_expander/stmpe1600/stmpe1600.ads
+++ b/components/src/io_expander/stmpe1600/stmpe1600.ads
@@ -125,7 +125,7 @@ private
 
    type STMPE1600_SYS_CTRL is record
       INT_Polarity : STMPE1600_Pin_Polarity := Low;
-      Reserved_1   : HAL.Bit := 0;
+      Reserved_1   : HAL.UInt1 := 0;
       INT_Enable   : Boolean := False;
       Reserved_3_4 : HAL.UInt2 := 0;
       Wakeup_En    : Boolean := False;
@@ -207,14 +207,14 @@ private
 
    procedure Read
      (This   : STMPE1600_Expander;
-      Reg    : HAL.Byte;
-      Data   : out HAL.Byte_Array;
+      Reg    : HAL.UInt8;
+      Data   : out HAL.UInt8_Array;
       Status : out Boolean);
 
    procedure Write
      (This   : STMPE1600_Expander;
-      Reg    : HAL.Byte;
-      Data   : HAL.Byte_Array;
+      Reg    : HAL.UInt8;
+      Data   : HAL.UInt8_Array;
       Status : out Boolean);
 
 end STMPE1600;

--- a/components/src/motion/ak8963/ak8963.adb
+++ b/components/src/motion/ak8963/ak8963.adb
@@ -72,7 +72,7 @@ package body AK8963 is
 
    function I2C_Read
      (Device : AK8963_Device;
-      Reg    : UInt16) return Byte;
+      Reg    : UInt16) return UInt8;
 
    function I2C_Read
      (Device : AK8963_Device;
@@ -82,7 +82,7 @@ package body AK8963 is
    procedure I2C_Write
      (Device : AK8963_Device;
       Reg    : UInt16;
-      Data   : Byte);
+      Data   : UInt8);
 
    procedure I2C_Write
      (Device : AK8963_Device;
@@ -96,7 +96,7 @@ package body AK8963 is
 
    function I2C_Read
      (Device : AK8963_Device;
-      Reg    : UInt16) return Byte
+      Reg    : UInt16) return UInt8
    is
       Data   : I2C_Data (1 .. 1);
       Status : I2C_Status;
@@ -119,8 +119,8 @@ package body AK8963 is
       Reg    : UInt16;
       Bit    : Natural) return Boolean
    is
-      Mask : constant Byte := 2 ** Bit;
-      Data : constant Byte := I2C_Read (Device, Reg);
+      Mask : constant UInt8 := 2 ** Bit;
+      Data : constant UInt8 := I2C_Read (Device, Reg);
    begin
       return (Data and Mask) /= 0;
    end I2C_Read;
@@ -132,7 +132,7 @@ package body AK8963 is
    procedure I2C_Write
      (Device : AK8963_Device;
       Reg    : UInt16;
-      Data   : Byte)
+      Data   : UInt8)
    is
       Status : I2C_Status with Unreferenced;
    begin
@@ -154,8 +154,8 @@ package body AK8963 is
       Bit    : Natural;
       State  : Boolean)
    is
-      Val  : Byte := I2C_Read (Device, Reg);
-      Mask : constant Byte := 2 ** Bit;
+      Val  : UInt8 := I2C_Read (Device, Reg);
+      Mask : constant UInt8 := 2 ** Bit;
    begin
       if State then
          Val := Val or Mask;
@@ -212,7 +212,7 @@ package body AK8963 is
    function Self_Test (Device : in out AK8963_Device) return Boolean
    is
       Mx, My, Mz : Gauss;
-      Conf_Save  : Byte;
+      Conf_Save  : UInt8;
       Retry      : Natural := 20;
       Ret        : Boolean;
       Dead       : Boolean with Unreferenced;
@@ -273,7 +273,7 @@ package body AK8963 is
       Operation_Mode : AK8963_Operation_Mode;
       Sampling_Mode  : AK8963_Sampling_Mode)
    is
-      Mode   : constant Byte :=
+      Mode   : constant UInt8 :=
                  AK8963_Operation_Mode'Enum_Rep (Operation_Mode)
                    or AK8963_Sampling_Mode'Enum_Rep (Sampling_Mode);
    begin
@@ -288,7 +288,7 @@ package body AK8963 is
      (Device         : in out AK8963_Device;
       Operation_Mode : AK8963_Operation_Mode)
    is
-      Mode   : constant Byte :=
+      Mode   : constant UInt8 :=
                  AK8963_Operation_Mode'Enum_Rep (Operation_Mode);
    begin
       I2C_Write (Device, AK8963_RA_CNTL, Mode);
@@ -316,7 +316,7 @@ package body AK8963 is
       Buffer : I2C_Data (1 .. 6);
       Status : I2C_Status;
       function To_Signed is new
-        Ada.Unchecked_Conversion (Unsigned_16, Integer_16);
+        Ada.Unchecked_Conversion (UInt16, Integer_16);
 
    begin
       Mem_Read
@@ -333,14 +333,14 @@ package body AK8963 is
          Mz := 0.0;
       else
          Mx :=
-           Float (To_Signed (Shift_Left (Unsigned_16 (Buffer (2)), 8)
-                  or Unsigned_16 (Buffer (1)))) * MAG_TO_GAUSS;
+           Float (To_Signed (Shift_Left (UInt16 (Buffer (2)), 8)
+                  or UInt16 (Buffer (1)))) * MAG_TO_GAUSS;
          My :=
-           Float (To_Signed (Shift_Left (Unsigned_16 (Buffer (4)), 8)
-                  or Unsigned_16 (Buffer (3)))) * MAG_TO_GAUSS;
+           Float (To_Signed (Shift_Left (UInt16 (Buffer (4)), 8)
+                  or UInt16 (Buffer (3)))) * MAG_TO_GAUSS;
          Mz :=
-           Float (To_Signed (Shift_Left (Unsigned_16 (Buffer (6)), 8)
-                  or Unsigned_16 (Buffer (5)))) * MAG_TO_GAUSS;
+           Float (To_Signed (Shift_Left (UInt16 (Buffer (6)), 8)
+                  or UInt16 (Buffer (5)))) * MAG_TO_GAUSS;
 
          --  Read the sensitivity adjustment data
          Mem_Read

--- a/components/src/motion/bno055/bosch_bno055.adb
+++ b/components/src/motion/bno055/bosch_bno055.adb
@@ -37,7 +37,7 @@ package body Bosch_BNO055 is
 
    function Value_At
      (This : in out BNO055_9DOF_IMU;  MSB, LSB : Register_Address)
-      return Unsigned_16 with Inline;
+      return UInt16 with Inline;
    --  MSB and LSB are the *register addresses* from which to get the values,
    --  not the values themselves
 
@@ -393,8 +393,8 @@ package body Bosch_BNO055 is
       end case;
 
       Read_Buffer (This.Port, Source, Buffer);
-      --  By reading multiple bytes, the device ensures data consistency,
-      --  whereas reading single bytes individually does not have that
+      --  By reading multiple UInt8s, the device ensures data consistency,
+      --  whereas reading single UInt8s individually does not have that
       --  guarantee. See the Datasheet, section 3.7 "Data register shadowing"
 
       New_X := To_Integer_16 (LSB => Buffer (0), MSB => Buffer (1));
@@ -444,8 +444,8 @@ package body Bosch_BNO055 is
       Scale  : constant Float := 1.0 / Float (2 ** 14); -- see section 3.6.5.5
    begin
       Read_Buffer (This.Port, BNO055_QUATERNION_DATA_W_LSB_ADDR, Buffer);
-      --  By reading multiple bytes, the device ensures data consistency,
-      --  whereas reading single bytes individually does not have that
+      --  By reading multiple UInt8s, the device ensures data consistency,
+      --  whereas reading single UInt8s individually does not have that
       --  guarantee. See the Datasheet, section 3.7 "Data register shadowing"
 
       New_W := To_Integer_16 (MSB => Buffer (1), LSB => Buffer (0));
@@ -522,60 +522,60 @@ package body Bosch_BNO055 is
       Offsets : Sensor_Offset_Values)
    is
       Previous_Mode : constant Operating_Modes := This.Mode;
-      Outgoing      : Unsigned_16;
+      Outgoing      : UInt16;
    begin
       Set_Mode (This, Operating_Mode_Config);
       Delay_Milliseconds (25);
 
-      Outgoing := Unsigned_16'Mod (Offsets.Accel_Offset_X);
+      Outgoing := UInt16'Mod (Offsets.Accel_Offset_X);
       Write (This.Port, ACCEL_OFFSET_X_LSB_ADDR, Value => UInt8 (Outgoing and 16#FF#));
       Write (This.Port, ACCEL_OFFSET_X_MSB_ADDR, Value => UInt8 (Shift_Right (Outgoing, 8)));
 
-      Outgoing := Unsigned_16'Mod (Offsets.Accel_Offset_Y);
+      Outgoing := UInt16'Mod (Offsets.Accel_Offset_Y);
       Write (This.Port, ACCEL_OFFSET_Y_LSB_ADDR, Value => UInt8 (Outgoing and 16#FF#));
       Write (This.Port, ACCEL_OFFSET_Y_MSB_ADDR, Value => UInt8 (Shift_Right (Outgoing, 8)));
 
-      Outgoing := Unsigned_16'Mod (Offsets.Accel_Offset_Z);
+      Outgoing := UInt16'Mod (Offsets.Accel_Offset_Z);
       Write (This.Port, ACCEL_OFFSET_Z_LSB_ADDR, Value => UInt8 (Outgoing and 16#FF#));
       Write (This.Port, ACCEL_OFFSET_Z_MSB_ADDR, Value => UInt8 (Shift_Right (Outgoing, 8)));
       --  The Datasheet, section 3.6.4.1 "Accelerometer offset" says the
       --  configuration only occurs when the MSB of the Z offset is written
 
-      Outgoing := Unsigned_16'Mod (Offsets.Gyro_Offset_X);
+      Outgoing := UInt16'Mod (Offsets.Gyro_Offset_X);
       Write (This.Port, GYRO_OFFSET_X_LSB_ADDR, Value => UInt8 (Outgoing and 16#FF#));
       Write (This.Port, GYRO_OFFSET_X_MSB_ADDR, Value => UInt8 (Shift_Right (Outgoing, 8)));
 
-      Outgoing := Unsigned_16'Mod (Offsets.Gyro_Offset_Y);
+      Outgoing := UInt16'Mod (Offsets.Gyro_Offset_Y);
       Write (This.Port, GYRO_OFFSET_Y_LSB_ADDR, Value => UInt8 (Outgoing and 16#FF#));
       Write (This.Port, GYRO_OFFSET_Y_MSB_ADDR, Value => UInt8 (Shift_Right (Outgoing, 8)));
 
-      Outgoing := Unsigned_16'Mod (Offsets.Gyro_Offset_Z);
+      Outgoing := UInt16'Mod (Offsets.Gyro_Offset_Z);
       Write (This.Port, GYRO_OFFSET_Z_LSB_ADDR, Value => UInt8 (Outgoing and 16#FF#));
       Write (This.Port, GYRO_OFFSET_Z_MSB_ADDR, Value => UInt8 (Shift_Right (Outgoing, 8)));
       --  The Datasheet, section 3.6.4.3 "Gyroscope offset" says the
       --  configuration only occurs when the MSB of the Z offset is written
 
-      Outgoing := Unsigned_16'Mod (Offsets.Mag_Offset_X);
+      Outgoing := UInt16'Mod (Offsets.Mag_Offset_X);
       Write (This.Port, MAG_OFFSET_X_LSB_ADDR, Value => UInt8 (Outgoing and 16#FF#));
       Write (This.Port, MAG_OFFSET_X_MSB_ADDR, Value => UInt8 (Shift_Right (Outgoing, 8)));
 
-      Outgoing := Unsigned_16'Mod (Offsets.Mag_Offset_Y);
+      Outgoing := UInt16'Mod (Offsets.Mag_Offset_Y);
       Write (This.Port, MAG_OFFSET_Y_LSB_ADDR, Value => UInt8 (Outgoing and 16#FF#));
       Write (This.Port, MAG_OFFSET_Y_MSB_ADDR, Value => UInt8 (Shift_Right (Outgoing, 8)));
 
-      Outgoing := Unsigned_16'Mod (Offsets.Mag_Offset_Z);
+      Outgoing := UInt16'Mod (Offsets.Mag_Offset_Z);
       Write (This.Port, MAG_OFFSET_Z_LSB_ADDR, Value => UInt8 (Outgoing and 16#FF#));
       Write (This.Port, MAG_OFFSET_Z_MSB_ADDR, Value => UInt8 (Shift_Right (Outgoing, 8)));
       --  The Datasheet, section 3.6.4.2 "Magnetometer offset" says the
       --  configuration only occurs when the MSB of the Z offset is written
 
-      Outgoing := Unsigned_16'Mod (Offsets.Accel_Radius);
+      Outgoing := UInt16'Mod (Offsets.Accel_Radius);
       Write (This.Port, ACCEL_RADIUS_LSB_ADDR, Value => UInt8 (Outgoing and 16#FF#));
       Write (This.Port, ACCEL_RADIUS_MSB_ADDR, Value => UInt8 (Shift_Right (Outgoing, 8)));
       --  The Datasheet, section 3.6.4.4 "Radius" says the
       --  configuration only occurs when the MSB of the radius is written
 
-      Outgoing := Unsigned_16'Mod (Offsets.Mag_Radius);
+      Outgoing := UInt16'Mod (Offsets.Mag_Radius);
       Write (This.Port, MAG_RADIUS_LSB_ADDR, Value => UInt8 (Outgoing and 16#FF#));
       Write (This.Port, MAG_RADIUS_MSB_ADDR, Value => UInt8 (Shift_Right (Outgoing, 8)));
       --  The Datasheet, section 3.6.4.4 "Radius" says the
@@ -671,15 +671,15 @@ package body Bosch_BNO055 is
    -- Value_At --
    --------------
 
-   function Value_At (This : in out BNO055_9DOF_IMU; MSB, LSB : Register_Address) return Unsigned_16 is
+   function Value_At (This : in out BNO055_9DOF_IMU; MSB, LSB : Register_Address) return UInt16 is
       High, Low : UInt8;
-      Result    : Unsigned_16;
+      Result    : UInt16;
    begin
       Read (This.Port, Register => MSB, Value => High);
       Read (This.Port, Register => LSB, Value => Low);
-      Result := Unsigned_16 (High);
+      Result := UInt16 (High);
       Result := Shift_Left (Result, 8);
-      Result := Result or Unsigned_16 (Low);
+      Result := Result or UInt16 (Low);
       return Result;
    end Value_At;
 

--- a/components/src/motion/bno055/bosch_bno055.ads
+++ b/components/src/motion/bno055/bosch_bno055.ads
@@ -283,7 +283,7 @@ package Bosch_BNO055 is
       Accelerometer : UInt8;
       Magnetometer  : UInt8;
       Gyroscope     : UInt8;
-      Software      : Unsigned_16;
+      Software      : UInt16;
       Bootloader    : UInt8;
    end record;
 

--- a/components/src/motion/l3gd20/l3gd20.adb
+++ b/components/src/motion/l3gd20/l3gd20.adb
@@ -53,7 +53,7 @@ package body L3GD20 is
    Sensitivity_2000dps : constant := 70.0 * 0.001; -- mdps/digit
 
    ReadWrite_CMD : constant := 16#80#;
-   MultiByte_CMD       : constant := 16#40#;
+   MultiUInt8_CMD       : constant := 16#40#;
 
    --  bit definitions for the CTRL_REG3 register
 
@@ -93,7 +93,7 @@ package body L3GD20 is
    Logically_And_Or_Events_Bit : constant := 2#1000_0000#;
    Int1_Latch_Enable_Bit       : constant := 2#0100_0000#;
 
-   Axes_Interrupt_Enablers : constant array (Axes_Interrupts) of Byte :=
+   Axes_Interrupt_Enablers : constant array (Axes_Interrupts) of UInt8 :=
      (Z_High_Interrupt => 2#0010_0000#,
       Z_Low_Interrupt  => 2#0001_0000#,
       Y_High_Interrupt => 2#0000_1000#,
@@ -101,42 +101,42 @@ package body L3GD20 is
       X_High_Interrupt => 2#0000_0010#,
       X_Low_Interrupt  => 2#0000_0001#);
 
-   function As_Byte is new Ada.Unchecked_Conversion
-     (Source => High_Pass_Filter_Mode, Target => Byte);
+   function As_UInt8 is new Ada.Unchecked_Conversion
+     (Source => High_Pass_Filter_Mode, Target => UInt8);
 
-   function As_Byte is new Ada.Unchecked_Conversion
-     (Source => High_Pass_Cutoff_Frequency, Target => Byte);
+   function As_UInt8 is new Ada.Unchecked_Conversion
+     (Source => High_Pass_Cutoff_Frequency, Target => UInt8);
 
-   function As_Byte is new Ada.Unchecked_Conversion
-     (Source => Power_Mode_Selection, Target => Byte);
+   function As_UInt8 is new Ada.Unchecked_Conversion
+     (Source => Power_Mode_Selection, Target => UInt8);
 
-   function As_Byte is new Ada.Unchecked_Conversion
-     (Source => Output_Data_Rate_Selection, Target => Byte);
+   function As_UInt8 is new Ada.Unchecked_Conversion
+     (Source => Output_Data_Rate_Selection, Target => UInt8);
 
-   function As_Byte is new Ada.Unchecked_Conversion
-     (Source => Axes_Selection, Target => Byte);
+   function As_UInt8 is new Ada.Unchecked_Conversion
+     (Source => Axes_Selection, Target => UInt8);
 
-   function As_Byte is new Ada.Unchecked_Conversion
-     (Source => Bandwidth_Selection, Target => Byte);
+   function As_UInt8 is new Ada.Unchecked_Conversion
+     (Source => Bandwidth_Selection, Target => UInt8);
 
-   function As_Byte is new Ada.Unchecked_Conversion
-     (Source => Block_Data_Update_Selection, Target => Byte);
+   function As_UInt8 is new Ada.Unchecked_Conversion
+     (Source => Block_Data_Update_Selection, Target => UInt8);
 
-   function As_Byte is new Ada.Unchecked_Conversion
-     (Source => Endian_Data_Selection, Target => Byte);
+   function As_UInt8 is new Ada.Unchecked_Conversion
+     (Source => Endian_Data_Selection, Target => UInt8);
 
-   function As_Byte is new Ada.Unchecked_Conversion
-     (Source => Full_Scale_Selection, Target => Byte);
+   function As_UInt8 is new Ada.Unchecked_Conversion
+     (Source => Full_Scale_Selection, Target => UInt8);
 
    type Angle_Rate_Pointer is access all Angle_Rate with Storage_Size => 0;
 
    function As_Angle_Rate_Pointer is new Ada.Unchecked_Conversion
      (Source => System.Address, Target => Angle_Rate_Pointer);
-   --  So that we can treat the address of a byte as a pointer to a two-byte
+   --  So that we can treat the address of a UInt8 as a pointer to a two-UInt8
    --  sequence representing a signed integer quantity.
 
    procedure Swap2 (Location : System.Address) with Inline;
-   --  Swaps the two bytes at Location and Location+1
+   --  Swaps the two UInt8s at Location and Location+1
 
    procedure SPI_Mode (This : Three_Axis_Gyroscope; Enabled : Boolean);
    --  Enable or disable SPI mode communication with the device. This is named
@@ -179,13 +179,13 @@ package body L3GD20 is
    -- Write --
    -----------
 
-   procedure Write (This : Three_Axis_Gyroscope; Addr : Register;  Data : Byte)
+   procedure Write (This : Three_Axis_Gyroscope; Addr : Register;  Data : UInt8)
    is
       Status : SPI_Status;
    begin
       SPI_Mode (This, Enabled => True);
 
-      This.Port.Transmit (SPI_Data_8b'(1 => Byte (Addr)), Status);
+      This.Port.Transmit (SPI_Data_8b'(1 => UInt8 (Addr)), Status);
       if Status /= Ok then
          raise Program_Error;
       end if;
@@ -205,14 +205,14 @@ package body L3GD20 is
    procedure Read
      (This : Three_Axis_Gyroscope;
       Addr : Register;
-      Data : out Byte)
+      Data : out UInt8)
    is
       Status : SPI_Status;
       Tmp_Data : SPI_Data_8b (1 .. 1);
    begin
       SPI_Mode (This, Enabled => True);
 
-      This.Port.Transmit (SPI_Data_8b'(1 => Byte (Addr) or ReadWrite_CMD),
+      This.Port.Transmit (SPI_Data_8b'(1 => UInt8 (Addr) or ReadWrite_CMD),
                          Status);
       if Status /= Ok then
          raise Program_Error;
@@ -228,10 +228,10 @@ package body L3GD20 is
    end Read;
 
    ----------------
-   -- Read_Bytes --
+   -- Read_UInt8s --
    ----------------
 
-   procedure Read_Bytes
+   procedure Read_UInt8s
      (This   : Three_Axis_Gyroscope;
       Addr   : Register;
       Buffer : out SPI_Data_8b;
@@ -244,7 +244,7 @@ package body L3GD20 is
       SPI_Mode (This, Enabled => True);
 
       This.Port.Transmit
-        (SPI_Data_8b'(1 => Byte (Addr) or ReadWrite_CMD or MultiByte_CMD),
+        (SPI_Data_8b'(1 => UInt8 (Addr) or ReadWrite_CMD or MultiUInt8_CMD),
          Status);
 
       if Status /= Ok then
@@ -261,7 +261,7 @@ package body L3GD20 is
       end loop;
 
       SPI_Mode (This, Enabled => False);
-   end Read_Bytes;
+   end Read_UInt8s;
 
    ---------------
    -- Configure --
@@ -277,17 +277,17 @@ package body L3GD20 is
       Endianness       : Endian_Data_Selection;
       Full_Scale       : Full_Scale_Selection)
    is
-      Ctrl1 : Byte;
-      Ctrl4 : Byte;
+      Ctrl1 : UInt8;
+      Ctrl4 : UInt8;
    begin
-      Ctrl1 := As_Byte (Power_Mode)       or
-               As_Byte (Output_Data_Rate) or
-               As_Byte (Axes_Enable)      or
-               As_Byte (Bandwidth);
+      Ctrl1 := As_UInt8 (Power_Mode)       or
+               As_UInt8 (Output_Data_Rate) or
+               As_UInt8 (Axes_Enable)      or
+               As_UInt8 (Bandwidth);
 
-      Ctrl4 := As_Byte (BlockData_Update) or
-               As_Byte (Endianness)       or
-               As_Byte (Full_Scale);
+      Ctrl4 := As_UInt8 (BlockData_Update) or
+               As_UInt8 (Endianness)       or
+               As_UInt8 (Full_Scale);
 
       Write (This, CTRL_REG1, Ctrl1);
       Write (This, CTRL_REG4, Ctrl4);
@@ -298,7 +298,7 @@ package body L3GD20 is
    -----------
 
    procedure Sleep (This : in out Three_Axis_Gyroscope) is
-      Ctrl1      : Byte;
+      Ctrl1      : UInt8;
       Sleep_Mode : constant := 2#1000#;  -- per the Datasheet, Table 22, pg 32
    begin
       Read (This, CTRL_REG1, Ctrl1);
@@ -315,10 +315,10 @@ package body L3GD20 is
       Mode_Selection   : High_Pass_Filter_Mode;
       Cutoff_Frequency : High_Pass_Cutoff_Frequency)
    is
-      Ctrl2 : Byte;
+      Ctrl2 : UInt8;
    begin
       --  note that the two high-order bits must remain zero, per the datasheet
-      Ctrl2 := As_Byte (Mode_Selection) or As_Byte (Cutoff_Frequency);
+      Ctrl2 := As_UInt8 (Mode_Selection) or As_UInt8 (Cutoff_Frequency);
       Write (This, CTRL_REG2, Ctrl2);
    end Configure_High_Pass_Filter;
 
@@ -327,7 +327,7 @@ package body L3GD20 is
    -----------------------------
 
    procedure Enable_High_Pass_Filter (This : in out Three_Axis_Gyroscope) is
-      Ctrl5 : Byte;
+      Ctrl5 : UInt8;
    begin
       Read (This, CTRL_REG5, Ctrl5);
       --  set HPen bit
@@ -340,7 +340,7 @@ package body L3GD20 is
    ------------------------------
 
    procedure Disable_High_Pass_Filter (This : in out Three_Axis_Gyroscope) is
-      Ctrl5 : Byte;
+      Ctrl5 : UInt8;
    begin
       Read (This, CTRL_REG5, Ctrl5);
       --  clear HPen bit
@@ -353,7 +353,7 @@ package body L3GD20 is
    ----------------------------
 
    procedure Enable_Low_Pass_Filter (This : in out Three_Axis_Gyroscope) is
-      Ctrl5 : Byte;
+      Ctrl5 : UInt8;
    begin
       Read (This, CTRL_REG5, Ctrl5);
       Ctrl5 := Ctrl5 or LowPass_Filter_Enable;
@@ -365,7 +365,7 @@ package body L3GD20 is
    -----------------------------
 
    procedure Disable_Low_Pass_Filter (This : in out Three_Axis_Gyroscope) is
-      Ctrl5 : Byte;
+      Ctrl5 : UInt8;
    begin
       Read (This, CTRL_REG5, Ctrl5);
       --  clear HPen bit
@@ -377,8 +377,8 @@ package body L3GD20 is
    -- Reference_Value --
    ---------------------
 
-   function Reference_Value (This : Three_Axis_Gyroscope) return Byte is
-      Result : Byte;
+   function Reference_Value (This : Three_Axis_Gyroscope) return UInt8 is
+      Result : UInt8;
    begin
       Read (This, Reference, Result);
       return Result;
@@ -388,7 +388,7 @@ package body L3GD20 is
    -- Set_Reference --
    -------------------
 
-   procedure Set_Reference (This : in out Three_Axis_Gyroscope; Value : Byte) is
+   procedure Set_Reference (This : in out Three_Axis_Gyroscope; Value : UInt8) is
    begin
       Write (This, Reference, Value);
    end Set_Reference;
@@ -398,9 +398,9 @@ package body L3GD20 is
    -----------------
 
    function Data_Status (This : Three_Axis_Gyroscope) return Gyro_Data_Status is
-      Result : Byte;
+      Result : UInt8;
       function As_Gyro_Data_Status is
-        new Ada.Unchecked_Conversion (Source => Byte,
+        new Ada.Unchecked_Conversion (Source => UInt8,
                                       Target => Gyro_Data_Status);
    begin
       Read (This, Status, Result);
@@ -411,8 +411,8 @@ package body L3GD20 is
    -- Device_Id --
    ---------------
 
-   function Device_Id (This : Three_Axis_Gyroscope) return Byte is
-      Result : Byte;
+   function Device_Id (This : Three_Axis_Gyroscope) return UInt8 is
+      Result : UInt8;
    begin
       Read (This, Who_Am_I, Result);
       return Result;
@@ -422,8 +422,8 @@ package body L3GD20 is
    -- Temperature --
    -----------------
 
-   function Temperature (This : Three_Axis_Gyroscope) return Byte is
-      Result : Byte;
+   function Temperature (This : Three_Axis_Gyroscope) return UInt8 is
+      Result : UInt8;
    begin
       Read (This, OUT_Temp, Result);
       return Result;
@@ -434,7 +434,7 @@ package body L3GD20 is
    ------------
 
    procedure Reboot (This : Three_Axis_Gyroscope) is
-      Ctrl5 : Byte;
+      Ctrl5 : UInt8;
    begin
       Read (This, CTRL_REG5, Ctrl5);
       --  set the boot bit
@@ -447,9 +447,9 @@ package body L3GD20 is
    ----------------------------
 
    function Full_Scale_Sensitivity (This : Three_Axis_Gyroscope) return Float is
-      Ctrl4  : Byte;
+      Ctrl4  : UInt8;
       Result : Float;
-      Fullscale_Selection : Byte;
+      Fullscale_Selection : UInt8;
    begin
       Read (This, CTRL_REG4, Ctrl4);
 
@@ -475,17 +475,17 @@ package body L3GD20 is
       Rates : out Angle_Rates)
    is
 
-      Ctrl4 : Byte;
+      Ctrl4 : UInt8;
 
-      Bytes_To_Read : constant Integer := 6;  -- ie, three 2-byte integers
-      --  the number of bytes in an Angle_Rates record object
+      UInt8s_To_Read : constant Integer := 6;  -- ie, three 2-UInt8 integers
+      --  the number of UInt8s in an Angle_Rates record object
 
-      Received : SPI_Data_8b (1 .. Bytes_To_Read);
+      Received : SPI_Data_8b (1 .. UInt8s_To_Read);
 
    begin
       Read (This, CTRL_REG4, Ctrl4);
 
-      Read_Bytes (This, OUT_X_L, Received, Bytes_To_Read);
+      Read_UInt8s (This, OUT_X_L, Received, UInt8s_To_Read);
       --  The above has the effect of separate reads, as follows:
       --    Read (This, OUT_X_L, Received (1));
       --    Read (This, OUT_X_H, Received (2));
@@ -517,8 +517,8 @@ package body L3GD20 is
       Combine_Events : Boolean := False;
       Sample_Count   : Sample_Counter := 0)
    is
-      Config : Byte;
-      Ctrl3  : Byte;
+      Config : UInt8;
+      Ctrl3  : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 and 16#DF#;
@@ -559,7 +559,7 @@ package body L3GD20 is
      (This : in out Three_Axis_Gyroscope;
       Mode : Pin_Modes)
    is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 and (not Interrupt_Pin_Mode_Bit);
@@ -572,7 +572,7 @@ package body L3GD20 is
    -----------------------
 
    procedure Enable_Interrupt1 (This : in out Three_Axis_Gyroscope) is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 or INT1_Interrupt_Enable;
@@ -584,7 +584,7 @@ package body L3GD20 is
    ------------------------
 
    procedure Disable_Interrupt1 (This : in out Three_Axis_Gyroscope) is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 and (not INT1_Interrupt_Enable);
@@ -596,9 +596,9 @@ package body L3GD20 is
    -----------------------
 
    function Interrupt1_Source (This : Three_Axis_Gyroscope) return Interrupt1_Sources is
-      Result : Byte;
+      Result : UInt8;
       function As_Interrupt_Source is new Ada.Unchecked_Conversion
-        (Source => Byte, Target => Interrupt1_Sources);
+        (Source => UInt8, Target => Interrupt1_Sources);
    begin
       Read (This, INT1_SRC, Result);
       return As_Interrupt_Source (Result);
@@ -614,7 +614,7 @@ package body L3GD20 is
    is
       Wait_Bit : constant := 2#1000_0000#;
    begin
-      Write (This, INT1_Duration, Byte (Value) or Wait_Bit);
+      Write (This, INT1_Duration, UInt8 (Value) or Wait_Bit);
    end Set_Duration_Counter;
 
    ------------------
@@ -625,7 +625,7 @@ package body L3GD20 is
      (This  : in out Three_Axis_Gyroscope;
       Event : Axes_Interrupts)
    is
-      Config : Byte;
+      Config : UInt8;
    begin
       Read (This, INT1_CFG, Config);
       Config := Config or Axes_Interrupt_Enablers (Event);
@@ -640,7 +640,7 @@ package body L3GD20 is
      (This  : in out Three_Axis_Gyroscope;
       Event : Axes_Interrupts)
    is
-      Config : Byte;
+      Config : UInt8;
    begin
       Read (This, INT1_CFG, Config);
       Config := Config and (not Axes_Interrupt_Enablers (Event));
@@ -659,16 +659,16 @@ package body L3GD20 is
    begin
       case Event is
          when Z_High_Interrupt | Z_Low_Interrupt =>
-            Write (This, INT1_TSH_ZL, Byte (Value));
-            Write (This, INT1_TSH_ZH, Byte (Shift_Right (Value, 8)));
+            Write (This, INT1_TSH_ZL, UInt8 (Value));
+            Write (This, INT1_TSH_ZH, UInt8 (Shift_Right (Value, 8)));
 
          when Y_High_Interrupt | Y_Low_Interrupt =>
-            Write (This, INT1_TSH_YL, Byte (Value));
-            Write (This, INT1_TSH_YH, Byte (Shift_Right (Value, 8)));
+            Write (This, INT1_TSH_YL, UInt8 (Value));
+            Write (This, INT1_TSH_YH, UInt8 (Shift_Right (Value, 8)));
 
          when X_High_Interrupt | X_Low_Interrupt =>
-            Write (This, INT1_TSH_XL, Byte (Value));
-            Write (This, INT1_TSH_XH, Byte (Shift_Right (Value, 8)));
+            Write (This, INT1_TSH_XL, UInt8 (Value));
+            Write (This, INT1_TSH_XH, UInt8 (Shift_Right (Value, 8)));
       end case;
    end Set_Threshold;
 
@@ -680,7 +680,7 @@ package body L3GD20 is
      (This : in out Three_Axis_Gyroscope;
       Mode : FIFO_Modes)
    is
-      FIFO  : Byte;
+      FIFO  : UInt8;
    begin
       Read (This, FIFO_CTRL, FIFO);
       FIFO := FIFO and (not FIFO_Mode_Bits);  -- clear the current bits
@@ -693,7 +693,7 @@ package body L3GD20 is
    -----------------
 
    procedure Enable_FIFO (This : in out Three_Axis_Gyroscope) is
-      Ctrl5 : Byte;
+      Ctrl5 : UInt8;
    begin
       Read (This, CTRL_REG5, Ctrl5);
       Ctrl5 := Ctrl5 or FIFO_Enable_Bit;
@@ -705,7 +705,7 @@ package body L3GD20 is
    ------------------
 
    procedure Disable_FIFO (This : in out Three_Axis_Gyroscope) is
-      Ctrl5 : Byte;
+      Ctrl5 : UInt8;
    begin
       Read (This, CTRL_REG5, Ctrl5);
       Ctrl5 := Ctrl5 and (not FIFO_Enable_Bit);
@@ -720,11 +720,11 @@ package body L3GD20 is
      (This  : in out Three_Axis_Gyroscope;
       Level : FIFO_Level)
    is
-      Value : Byte;
+      Value : UInt8;
    begin
       Read (This, FIFO_CTRL, Value);
       Value := Value and (not Watermark_Threshold_Bits); -- clear the bits
-      Value := Value or Byte (Level);
+      Value := Value or UInt8 (Level);
       Write (This, FIFO_CTRL, Value);
    end Set_FIFO_Watermark;
 
@@ -736,16 +736,16 @@ package body L3GD20 is
      (This   : in out Three_Axis_Gyroscope;
       Buffer : out Angle_Rates_FIFO_Buffer)
    is
-      Ctrl4 : Byte;
+      Ctrl4 : UInt8;
 
-      Angle_Rate_Size : constant Integer := 6;  -- bytes
-      Bytes_To_Read   : constant Integer := Buffer'Length * Angle_Rate_Size;
-      Received        : SPI_Data_8b (0 .. Bytes_To_Read - 1)
+      Angle_Rate_Size : constant Integer := 6;  -- UInt8s
+      UInt8s_To_Read   : constant Integer := Buffer'Length * Angle_Rate_Size;
+      Received        : SPI_Data_8b (0 .. UInt8s_To_Read - 1)
         with Alignment => 2;
    begin
       Read (This, CTRL_REG4, Ctrl4);
 
-      Read_Bytes (This, OUT_X_L, Received, Bytes_To_Read);
+      Read_UInt8s (This, OUT_X_L, Received, UInt8s_To_Read);
 
       if (Ctrl4 and Endian_Selection_Mask) = L3GD20_Big_Endian'Enum_Rep then
          declare
@@ -777,7 +777,7 @@ package body L3GD20 is
    ------------------------
 
    function Current_FIFO_Depth (This : Three_Axis_Gyroscope) return FIFO_Level is
-      Result : Byte;
+      Result : UInt8;
    begin
       Read (This, FIFO_SRC, Result);
       Result := Result and FIFO_Depth_Bits;
@@ -789,7 +789,7 @@ package body L3GD20 is
    --------------------------
 
    function FIFO_Below_Watermark (This : Three_Axis_Gyroscope) return Boolean is
-      Result : Byte;
+      Result : UInt8;
    begin
       Read (This, FIFO_SRC, Result);
       Result := Result and Watermark_Status_Bit;
@@ -801,7 +801,7 @@ package body L3GD20 is
    ----------------
 
    function FIFO_Empty (This : Three_Axis_Gyroscope) return Boolean is
-      Result : Byte;
+      Result : UInt8;
    begin
       Read (This, FIFO_SRC, Result);
       Result := Result and FIFO_Empty_Bit;
@@ -813,7 +813,7 @@ package body L3GD20 is
    ------------------
 
    function FIFO_Overrun (This : Three_Axis_Gyroscope) return Boolean is
-      Result : Byte;
+      Result : UInt8;
    begin
       Read (This, FIFO_SRC, Result);
       Result := Result and FIFO_Overrun_Bit;
@@ -825,7 +825,7 @@ package body L3GD20 is
    ---------------------------------
 
    procedure Enable_Data_Ready_Interrupt (This : in out Three_Axis_Gyroscope) is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 or INT2_Data_Ready_Interrupt_Enable;
@@ -837,7 +837,7 @@ package body L3GD20 is
    ----------------------------------
 
    procedure Disable_Data_Ready_Interrupt (This : in out Three_Axis_Gyroscope) is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 and (not INT2_Data_Ready_Interrupt_Enable);
@@ -849,7 +849,7 @@ package body L3GD20 is
    -------------------------------------
 
    procedure Enable_FIFO_Watermark_Interrupt (This : in out Three_Axis_Gyroscope) is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 or INT2_Watermark_Interrupt_Enable;
@@ -861,7 +861,7 @@ package body L3GD20 is
    -----------------------------
 
    procedure Disable_Int1_Interrupts (This : in out Three_Axis_Gyroscope) is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 and 2#0001_1111#;
@@ -873,7 +873,7 @@ package body L3GD20 is
    -----------------------------
 
    procedure Disable_Int2_Interrupts (This : in out Three_Axis_Gyroscope) is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 and 2#1111_0000#;
@@ -887,7 +887,7 @@ package body L3GD20 is
    procedure Disable_FIFO_Watermark_Interrupt
      (This : in out Three_Axis_Gyroscope)
    is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 and (not INT2_Watermark_Interrupt_Enable);
@@ -901,7 +901,7 @@ package body L3GD20 is
    procedure Enable_FIFO_Overrun_Interrupt
      (This : in out Three_Axis_Gyroscope)
    is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 or INT2_Overrun_Interrupt_Enable;
@@ -915,7 +915,7 @@ package body L3GD20 is
    procedure Disable_FIFO_Overrun_Interrupt
      (This : in out Three_Axis_Gyroscope)
    is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 and (not INT2_Overrun_Interrupt_Enable);
@@ -929,7 +929,7 @@ package body L3GD20 is
    procedure Enable_FIFO_Empty_Interrupt
      (This : in out Three_Axis_Gyroscope)
    is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 or INT2_FIFO_Empty_Interrupt_Enable;
@@ -943,7 +943,7 @@ package body L3GD20 is
    procedure Disable_FIFO_Empty_Interrupt
      (This : in out Three_Axis_Gyroscope)
    is
-      Ctrl3 : Byte;
+      Ctrl3 : UInt8;
    begin
       Read (This, CTRL_REG3, Ctrl3);
       Ctrl3 := Ctrl3 and (not INT2_FIFO_Empty_Interrupt_Enable);

--- a/components/src/motion/l3gd20/l3gd20.ads
+++ b/components/src/motion/l3gd20/l3gd20.ads
@@ -249,11 +249,11 @@ package L3GD20 is
 
    function Reference_Value
      (This : Three_Axis_Gyroscope)
-      return Byte
+      return UInt8
      with Inline;
 
    procedure Set_Reference
-     (This : in out Three_Axis_Gyroscope; Value : Byte)
+     (This : in out Three_Axis_Gyroscope; Value : UInt8)
      with Inline;
 
    --  Basic data access functionality
@@ -302,7 +302,7 @@ package L3GD20 is
    procedure Get_Raw_Angle_Rates
      (This  : Three_Axis_Gyroscope;
       Rates : out Angle_Rates);
-   --  Returns the latest data, swapping bytes if required by the endianess
+   --  Returns the latest data, swapping UInt8s if required by the endianess
    --  selected by a previous call to Configure.
    --  NB: does NOT check whether the gyro status indicates data are ready.
    --  NB: does NOT apply any sensitity scaling.
@@ -342,7 +342,7 @@ package L3GD20 is
    procedure Get_Raw_Angle_Rates_FIFO
      (This   : in out Three_Axis_Gyroscope;
       Buffer : out Angle_Rates_FIFO_Buffer);
-   --  Returns the latest raw data in the FIFO, swapping bytes if required by
+   --  Returns the latest raw data in the FIFO, swapping UInt8s if required by
    --  the endianess selected by a previous call to Configure. Fills the entire
    --  buffer passed.
    --  NB: does NOT apply any sensitity scaling.
@@ -415,7 +415,7 @@ package L3GD20 is
      (This  : in out Three_Axis_Gyroscope;
       Event : Axes_Interrupts;
       Value : Axis_Sample_Threshold);
-   --  Writes the two-byte threshold value into the two threshold registers for
+   --  Writes the two-UInt8 threshold value into the two threshold registers for
    --  the specified interrupt event.  Does not enable the event itself.
 
    type Threshold_Event is record
@@ -519,10 +519,10 @@ package L3GD20 is
 
    I_Am_L3GD20 : constant := 16#D4#;
 
-   function Device_Id (This : Three_Axis_Gyroscope) return Byte;
+   function Device_Id (This : Three_Axis_Gyroscope) return UInt8;
    --  Will return I_Am_L3GD20 when functioning properly
 
-   function Temperature (This : Three_Axis_Gyroscope) return Byte;
+   function Temperature (This : Three_Axis_Gyroscope) return UInt8;
    --  the temperature of the chip itself
 
 private
@@ -532,23 +532,23 @@ private
       CS   : Any_GPIO_Point;
    end record;
 
-   type Register is new Byte;
+   type Register is new UInt8;
 
    procedure Write
      (This : Three_Axis_Gyroscope;
       Addr : Register;
-      Data : Byte)
+      Data : UInt8)
      with Inline;
    --  Writes Data to the specified register within the gyro chip
 
    procedure Read
      (This : Three_Axis_Gyroscope;
       Addr : Register;
-      Data : out Byte)
+      Data : out UInt8)
      with Inline;
    --  Reads Data from the specified register within the gyro chip
 
-   procedure Read_Bytes
+   procedure Read_UInt8s
      (This   : Three_Axis_Gyroscope;
       Addr   : Register;
       Buffer : out SPI_Data_8b;
@@ -566,12 +566,12 @@ private
    Reference     : constant Register := 16#25#; --  Reference
    OUT_Temp      : constant Register := 16#26#; --  Temperature
    Status        : constant Register := 16#27#; --  Status
-   OUT_X_L       : constant Register := 16#28#; --  Output X low byte
-   OUT_X_H       : constant Register := 16#29#; --  Output X high byte
-   OUT_Y_L       : constant Register := 16#2A#; --  Output Y low byte
-   OUT_Y_H       : constant Register := 16#2B#; --  Output Y high byte
-   OUT_Z_L       : constant Register := 16#2C#; --  Output Z low byte
-   OUT_Z_H       : constant Register := 16#2D#; --  Output Z high byte
+   OUT_X_L       : constant Register := 16#28#; --  Output X low UInt8
+   OUT_X_H       : constant Register := 16#29#; --  Output X high UInt8
+   OUT_Y_L       : constant Register := 16#2A#; --  Output Y low UInt8
+   OUT_Y_H       : constant Register := 16#2B#; --  Output Y high UInt8
+   OUT_Z_L       : constant Register := 16#2C#; --  Output Z low UInt8
+   OUT_Z_H       : constant Register := 16#2D#; --  Output Z high UInt8
    FIFO_CTRL     : constant Register := 16#2E#; --  FIFO control
    FIFO_SRC      : constant Register := 16#2F#; --  FIFO src
    INT1_CFG      : constant Register := 16#30#; --  Interrupt 1 configuration

--- a/components/src/motion/lis3dsh/lis3dsh-spi.adb
+++ b/components/src/motion/lis3dsh/lis3dsh-spi.adb
@@ -52,13 +52,13 @@ package body LIS3DSH.SPI is
    overriding
    procedure IO_Write
      (This      : in out Three_Axis_Accelerometer_SPI;
-      Value     : Byte;
+      Value     : UInt8;
       WriteAddr : Register_Address)
    is
       Status : SPI_Status;
    begin
       This.Chip_Select.Clear;
-      This.Port.Transmit (SPI_Data_8b'(Byte (WriteAddr or SPI_Write_Flag),
+      This.Port.Transmit (SPI_Data_8b'(UInt8 (WriteAddr or SPI_Write_Flag),
                           Value),
                           Status);
       This.Chip_Select.Set;
@@ -76,14 +76,14 @@ package body LIS3DSH.SPI is
    overriding
    procedure IO_Read
      (This     : Three_Axis_Accelerometer_SPI;
-      Value    : out Byte;
+      Value    : out UInt8;
       ReadAddr : Register_Address)
    is
       Data : SPI_Data_8b (1 .. 1);
       Status : SPI_Status;
    begin
       This.Chip_Select.Clear;
-      This.Port.Transmit (SPI_Data_8b'(1 => Byte (ReadAddr or SPI_Read_Flag)),
+      This.Port.Transmit (SPI_Data_8b'(1 => UInt8 (ReadAddr or SPI_Read_Flag)),
                           Status);
       if Status /= Ok then
          --  No error handling...

--- a/components/src/motion/lis3dsh/lis3dsh-spi.ads
+++ b/components/src/motion/lis3dsh/lis3dsh-spi.ads
@@ -56,13 +56,13 @@ package LIS3DSH.SPI is
    overriding
    procedure IO_Write
      (This      : in out Three_Axis_Accelerometer_SPI;
-      Value     : Byte;
+      Value     : UInt8;
       WriteAddr : Register_Address);
 
    overriding
    procedure IO_Read
      (This     : Three_Axis_Accelerometer_SPI;
-      Value    : out Byte;
+      Value    : out UInt8;
       ReadAddr : Register_Address);
 
 private

--- a/components/src/motion/lis3dsh/lis3dsh.adb
+++ b/components/src/motion/lis3dsh/lis3dsh.adb
@@ -46,21 +46,21 @@ with Interfaces; use Interfaces;
 
 package body LIS3DSH is
 
-   Full_Scale_Selection_Mask : constant Byte := 2#0011_1000#;
+   Full_Scale_Selection_Mask : constant UInt8 := 2#0011_1000#;
    --  bits 3..5 of CTRL5
 
-   Data_Rate_Selection_Mask : constant Byte := 2#0111_0000#;
+   Data_Rate_Selection_Mask : constant UInt8 := 2#0111_0000#;
    --  bits 4..6 of CTRL4
 
    procedure Loc_IO_Write
      (This      : in out Three_Axis_Accelerometer;
-      Value     : Byte;
+      Value     : UInt8;
       WriteAddr : Register_Address)
      with Inline_Always;
 
    procedure Loc_IO_Read
      (This     : Three_Axis_Accelerometer;
-      Value    : out Byte;
+      Value    : out UInt8;
       ReadAddr : Register_Address)
      with Inline_Always;
 
@@ -70,7 +70,7 @@ package body LIS3DSH is
 
    procedure Loc_IO_Write
      (This      : in out Three_Axis_Accelerometer;
-      Value     : Byte;
+      Value     : UInt8;
       WriteAddr : Register_Address)
    is
 
@@ -86,7 +86,7 @@ package body LIS3DSH is
 
    procedure Loc_IO_Read
      (This     : Three_Axis_Accelerometer;
-      Value    : out Byte;
+      Value    : out UInt8;
       ReadAddr : Register_Address)
       is
    begin
@@ -111,7 +111,7 @@ package body LIS3DSH is
       Axes : out Axes_Accelerations)
    is
 
-      Buffer : array (0 .. 5) of Byte with Alignment => 2, Size => 48;
+      Buffer : array (0 .. 5) of UInt8 with Alignment => 2, Size => 48;
       Scaled : Float;
 
       type Integer16_Pointer is access all Integer_16
@@ -119,7 +119,7 @@ package body LIS3DSH is
 
       function As_Pointer is new Ada.Unchecked_Conversion
         (Source => System.Address, Target => Integer16_Pointer);
-      --  So that we can treat the address of a byte as a pointer to a two-byte
+      --  So that we can treat the address of a UInt8 as a pointer to a two-UInt8
       --  sequence representing a signed Integer_16 quantity
 
    begin
@@ -166,7 +166,7 @@ package body LIS3DSH is
       Filter_BW       : Anti_Aliasing_Filter_Bandwidth)
    is
       Temp  : UInt16;
-      Value : Byte;
+      Value : UInt8;
    begin
       Temp := Output_DataRate'Enum_Rep or
               Axes_Enable'Enum_Rep     or
@@ -175,10 +175,10 @@ package body LIS3DSH is
               Full_Scale'Enum_Rep      or
               Filter_BW'Enum_Rep;
 
-      Value := Byte (Temp); -- the low byte of the half-word
+      Value := UInt8 (Temp); -- the low UInt8 of the half-word
       This.Loc_IO_Write (Value, CTRL_REG4);
 
-      Value := Byte (Shift_Right (Temp, 8)); -- the high byte
+      Value := UInt8 (Shift_Right (Temp, 8)); -- the high UInt8
       This.Loc_IO_Write (Value, CTRL_REG5);
 
       case Full_Scale is
@@ -201,8 +201,8 @@ package body LIS3DSH is
    -- Device_Id --
    ---------------
 
-   function Device_Id (This : Three_Axis_Accelerometer) return Byte is
-      Response : Byte;
+   function Device_Id (This : Three_Axis_Accelerometer) return UInt8 is
+      Response : UInt8;
    begin
       This.Loc_IO_Read (Response, WHO_AM_I);
       return Response;
@@ -213,8 +213,8 @@ package body LIS3DSH is
    ------------
 
    procedure Reboot (This : in out Three_Axis_Accelerometer) is
-      Value : Byte;
-      Force_Reboot : constant Byte := 2#1000_0000#;
+      Value : UInt8;
+      Force_Reboot : constant UInt8 := 2#1000_0000#;
    begin
       This.Loc_IO_Read (Value, CTRL_REG6);
       Value := Value or Force_Reboot;
@@ -235,7 +235,7 @@ package body LIS3DSH is
       State_Machine2_Enable      : Boolean;
       State_Machine2_Interrupt   : State_Machine_Routed_Interrupt)
    is
-      CTRL : Byte;
+      CTRL : UInt8;
    begin
       CTRL := Interrupt_Selection_Enable'Enum_Rep or
               Interrupt_Request'Enum_Rep          or
@@ -300,7 +300,7 @@ package body LIS3DSH is
      (This : in out Three_Axis_Accelerometer;
       Mode : Data_Rate_Power_Mode_Selection)
    is
-      Value : Byte;
+      Value : UInt8;
    begin
       This.Loc_IO_Read (Value, CTRL_REG4);
       Value := Value and (not Data_Rate_Selection_Mask); -- clear bits
@@ -316,7 +316,7 @@ package body LIS3DSH is
      (This     : in out Three_Axis_Accelerometer;
       DataRate : Data_Rate_Power_Mode_Selection)
    is
-      Value : Byte;
+      Value : UInt8;
    begin
       This.Loc_IO_Read (Value, CTRL_REG4);
       Value := Value and (not Data_Rate_Selection_Mask); -- clear bits
@@ -332,7 +332,7 @@ package body LIS3DSH is
      (This : in out Three_Axis_Accelerometer;
       Scale : Full_Scale_Selection)
    is
-      Value : Byte;
+      Value : UInt8;
    begin
       This.Loc_IO_Read (Value, CTRL_REG5);
       Value := Value and (not Full_Scale_Selection_Mask); -- clear bits
@@ -345,7 +345,7 @@ package body LIS3DSH is
    -------------------
 
    function As_Full_Scale is new Ada.Unchecked_Conversion
-     (Source => Byte, Target => Full_Scale_Selection);
+     (Source => UInt8, Target => Full_Scale_Selection);
 
    --------------------------
    -- Selected_Sensitivity --
@@ -354,7 +354,7 @@ package body LIS3DSH is
    function Selected_Sensitivity (This : Three_Axis_Accelerometer)
                                   return Float
    is
-      CTRL5 : Byte;
+      CTRL5 : UInt8;
    begin
       This.Loc_IO_Read (CTRL5, CTRL_REG5);
       case As_Full_Scale (CTRL5 and Full_Scale_Selection_Mask) is
@@ -375,8 +375,8 @@ package body LIS3DSH is
    -- Temperature --
    -----------------
 
-   function Temperature (This : Three_Axis_Accelerometer) return Byte is
-      Result : Byte;
+   function Temperature (This : Three_Axis_Accelerometer) return UInt8 is
+      Result : UInt8;
    begin
 
       This.Loc_IO_Read (Result, Out_T);

--- a/components/src/motion/lis3dsh/lis3dsh.ads
+++ b/components/src/motion/lis3dsh/lis3dsh.ads
@@ -77,7 +77,7 @@ package LIS3DSH is
    --  axis runs through the chip itself, orthogonal to the plane of the board,
    --  and will indicate 1G when the board is resting level.
 
-   function Device_Id (This : Three_Axis_Accelerometer) return Byte;
+   function Device_Id (This : Three_Axis_Accelerometer) return UInt8;
 
    I_Am_LIS3DSH : constant := 16#3F#;
 
@@ -95,7 +95,7 @@ package LIS3DSH is
       Fullscale_6g,   --  6 g
       Fullscale_8g,   --  8 g
       Fullscale_16g)  --  16 g
-   with Size => Byte'Size;
+   with Size => UInt8'Size;
 
    for Full_Scale_Selection use -- bits 3..5 of CTRL5
      (Fullscale_2g  => 16#00#,
@@ -261,12 +261,12 @@ package LIS3DSH is
    procedure Configure_Click_Interrupt (This : in out Three_Axis_Accelerometer)
      with Pre => Configured (This);
 
-   function Temperature (This : Three_Axis_Accelerometer) return Byte;
+   function Temperature (This : Three_Axis_Accelerometer) return UInt8;
    --   Zero corresponds to approx. 25 degrees Celsius
 
    function Configured (This : Three_Axis_Accelerometer) return Boolean;
 
-   type Register_Address is new Byte;
+   type Register_Address is new UInt8;
    --  Prevent accidentally mixing addresses and data in I/O calls
 
    -----------------------------
@@ -275,12 +275,12 @@ package LIS3DSH is
 
    procedure IO_Write
      (This      : in out Three_Axis_Accelerometer;
-      Value     : Byte;
+      Value     : UInt8;
       WriteAddr : Register_Address) is abstract;
 
    procedure IO_Read
      (This     : Three_Axis_Accelerometer;
-      Value    : out Byte;
+      Value    : out UInt8;
       ReadAddr : Register_Address) is abstract;
 
 private
@@ -632,7 +632,7 @@ private
    --             0: disable (Default)
    --             1: enable
    --  4 IF_ADD_INC: Register address automatically increased during a
-   --                multiple byte access with a serial interface (I2C or SPI)
+   --                multiple UInt8 access with a serial interface (I2C or SPI)
    --                0: disable (Default)
    --                1: enable
    --  3 I1_EMPTY: Enable FIFO Empty indication on INT1 pin.

--- a/components/src/motion/mpu9250/mpu9250.adb
+++ b/components/src/motion/mpu9250/mpu9250.adb
@@ -136,9 +136,9 @@ package body MPU9250 is
 
    function MPU9250_Test_Connection (Device : MPU9250_Device) return Boolean
    is
-      Who_Am_I : Byte;
+      Who_Am_I : UInt8;
    begin
-      MPU9250_Read_Byte_At_Register
+      MPU9250_Read_UInt8_At_Register
         (Device   => Device,
          Reg_Addr => MPU9250_RA_WHO_AM_I,
          Data     => Who_Am_I);
@@ -170,32 +170,32 @@ package body MPU9250 is
       Factory_Trim : T_Int32_Array_6 := (others => 0);
       Acc_Diff     : Float_Array_3;
       Gyro_Diff    : Float_Array_3;
-      FS           : constant Unsigned_8 := 0;
+      FS           : constant UInt8 := 0;
 
       Test_Status : Boolean;
    begin
       --  Save old configuration
-      MPU9250_Read_Byte_At_Register
+      MPU9250_Read_UInt8_At_Register
         (Device, MPU9250_RA_SMPLRT_DIV, Saved_Reg (1));
-      MPU9250_Read_Byte_At_Register
+      MPU9250_Read_UInt8_At_Register
         (Device, MPU9250_RA_CONFIG, Saved_Reg (2));
-      MPU9250_Read_Byte_At_Register
+      MPU9250_Read_UInt8_At_Register
         (Device, MPU9250_RA_GYRO_CONFIG, Saved_Reg (3));
-      MPU9250_Read_Byte_At_Register
+      MPU9250_Read_UInt8_At_Register
         (Device, MPU9250_RA_ACCEL_CONFIG_2, Saved_Reg (4));
-      MPU9250_Read_Byte_At_Register
+      MPU9250_Read_UInt8_At_Register
         (Device, MPU9250_RA_ACCEL_CONFIG, Saved_Reg (5));
 
       --  Write test configuration
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_SMPLRT_DIV, 16#00#);
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_CONFIG, 16#02#);
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_GYRO_CONFIG, Shift_Left (FS, 3));
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_ACCEL_CONFIG_2, 16#02#);
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_ACCEL_CONFIG, Shift_Left (FS, 3));
 
       --  Get average current values of gyro and accelerometer
@@ -236,9 +236,9 @@ package body MPU9250 is
       end loop;
 
       --  Configure the acceleromter for self test
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_ACCEL_CONFIG, 16#E0#);
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_GYRO_CONFIG, 16#E0#);
 
       --  Delay a while to let the device stabilize
@@ -282,26 +282,26 @@ package body MPU9250 is
       end loop;
 
       --  Configure the gyro and accelerometer for normal operation
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_ACCEL_CONFIG, 16#00#);
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_GYRO_CONFIG, 16#00#);
 
       --  Delay a while to let the device stabilize
       Device.Time.Delay_Milliseconds (25);
 
       --  Retrieve Accelerometer and Gyro Factory Self - Test Code From USR_Reg
-      MPU9250_Read_Byte_At_Register
+      MPU9250_Read_UInt8_At_Register
         (Device, MPU9250_RA_ST_X_ACCEL, Self_Test (1));
-      MPU9250_Read_Byte_At_Register
+      MPU9250_Read_UInt8_At_Register
         (Device, MPU9250_RA_ST_Y_ACCEL, Self_Test (2));
-      MPU9250_Read_Byte_At_Register
+      MPU9250_Read_UInt8_At_Register
         (Device, MPU9250_RA_ST_Z_ACCEL, Self_Test (3));
-      MPU9250_Read_Byte_At_Register
+      MPU9250_Read_UInt8_At_Register
         (Device, MPU9250_RA_ST_X_GYRO, Self_Test (4));
-      MPU9250_Read_Byte_At_Register
+      MPU9250_Read_UInt8_At_Register
         (Device, MPU9250_RA_ST_Y_GYRO, Self_Test (5));
-      MPU9250_Read_Byte_At_Register
+      MPU9250_Read_UInt8_At_Register
         (Device, MPU9250_RA_ST_Z_GYRO, Self_Test (6));
 
       for I in 1 .. 6 loop
@@ -328,15 +328,15 @@ package body MPU9250 is
       end loop;
 
       --  Restore old configuration
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_SMPLRT_DIV, Saved_Reg (1));
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_CONFIG, Saved_Reg (2));
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_GYRO_CONFIG, Saved_Reg (3));
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_ACCEL_CONFIG_2, Saved_Reg (4));
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device, MPU9250_RA_ACCEL_CONFIG, Saved_Reg (5));
 
       --  Check result
@@ -514,15 +514,15 @@ package body MPU9250 is
       Value  : Boolean)
    is
    begin
-      --  Full register byte for all interrupts, for quick reading.
+      --  Full register UInt8 for all interrupts, for quick reading.
       --  Each bit should be set 0 for disabled, 1 for enabled.
       if Value then
-         MPU9250_Write_Byte_At_Register
+         MPU9250_Write_UInt8_At_Register
            (Device   => Device,
             Reg_Addr => MPU9250_RA_INT_ENABLE,
             Data     => 16#FF#);
       else
-         MPU9250_Write_Byte_At_Register
+         MPU9250_Write_UInt8_At_Register
            (Device   => Device,
             Reg_Addr => MPU9250_RA_INT_ENABLE,
             Data     => 16#00#);
@@ -535,10 +535,10 @@ package body MPU9250 is
 
    procedure MPU9250_Set_Rate
      (Device   : in out MPU9250_Device;
-      Rate_Div : Byte)
+      Rate_Div : UInt8)
    is
    begin
-      MPU9250_Write_Byte_At_Register
+      MPU9250_Write_UInt8_At_Register
         (Device   => Device,
          Reg_Addr => MPU9250_RA_SMPLRT_DIV,
          Data     => Rate_Div);
@@ -628,7 +628,7 @@ package body MPU9250 is
 
    procedure MPU9250_Read_Register
      (Device   : MPU9250_Device;
-      Reg_Addr : Byte;
+      Reg_Addr : UInt8;
       Data     : in out I2C_Data)
    is
       Status : I2C_Status;
@@ -642,13 +642,13 @@ package body MPU9250 is
    end MPU9250_Read_Register;
 
    -----------------------------------
-   -- MPU9250_Read_Byte_At_Register --
+   -- MPU9250_Read_UInt8_At_Register --
    -----------------------------------
 
-   procedure MPU9250_Read_Byte_At_Register
+   procedure MPU9250_Read_UInt8_At_Register
      (Device   : MPU9250_Device;
-      Reg_Addr : Byte;
-      Data     : out Byte)
+      Reg_Addr : UInt8;
+      Data     : out UInt8)
    is
       Status : I2C_Status;
       I_Data : I2C_Data (1 .. 1);
@@ -660,7 +660,7 @@ package body MPU9250 is
          Data          => I_Data,
          Status        => Status);
       Data := I_Data (1);
-   end MPU9250_Read_Byte_At_Register;
+   end MPU9250_Read_UInt8_At_Register;
 
    ----------------------------------
    -- MPU9250_Read_Bit_At_Register --
@@ -668,12 +668,12 @@ package body MPU9250 is
 
    function MPU9250_Read_Bit_At_Register
      (Device   : MPU9250_Device;
-      Reg_Addr : Byte;
+      Reg_Addr : UInt8;
       Bit_Pos  : T_Bit_Pos_8) return Boolean
    is
-      Register_Value : Byte;
+      Register_Value : UInt8;
    begin
-      MPU9250_Read_Byte_At_Register (Device, Reg_Addr, Register_Value);
+      MPU9250_Read_UInt8_At_Register (Device, Reg_Addr, Register_Value);
 
       return (Register_Value and Shift_Left (1, Bit_Pos)) /= 0;
    end MPU9250_Read_Bit_At_Register;
@@ -684,7 +684,7 @@ package body MPU9250 is
 
    procedure MPU9250_Write_Register
      (Device   : MPU9250_Device;
-      Reg_Addr : Byte;
+      Reg_Addr : UInt8;
       Data     : I2C_Data)
    is
       Status : I2C_Status;
@@ -698,13 +698,13 @@ package body MPU9250 is
    end MPU9250_Write_Register;
 
    ------------------------------------
-   -- MPU9250_Write_Byte_At_Register --
+   -- MPU9250_Write_UInt8_At_Register --
    ------------------------------------
 
-   procedure MPU9250_Write_Byte_At_Register
+   procedure MPU9250_Write_UInt8_At_Register
      (Device   : MPU9250_Device;
-      Reg_Addr : Byte;
-      Data     : Byte)
+      Reg_Addr : UInt8;
+      Data     : UInt8)
    is
       Status : I2C_Status;
    begin
@@ -714,7 +714,7 @@ package body MPU9250 is
          Mem_Addr_Size => Memory_Size_8b,
          Data          => (1 => Data),
          Status        => Status);
-   end MPU9250_Write_Byte_At_Register;
+   end MPU9250_Write_UInt8_At_Register;
 
    -----------------------------------
    -- MPU9250_Write_Bit_At_Register --
@@ -722,20 +722,20 @@ package body MPU9250 is
 
    procedure MPU9250_Write_Bit_At_Register
      (Device    : MPU9250_Device;
-      Reg_Addr  : Byte;
+      Reg_Addr  : UInt8;
       Bit_Pos   : T_Bit_Pos_8;
       Bit_Value : Boolean)
    is
-      Register_Value : Byte;
+      Register_Value : UInt8;
    begin
-      MPU9250_Read_Byte_At_Register (Device, Reg_Addr, Register_Value);
+      MPU9250_Read_UInt8_At_Register (Device, Reg_Addr, Register_Value);
 
       Register_Value := (if Bit_Value then
                             Register_Value or (Shift_Left (1, Bit_Pos))
                          else
                             Register_Value and not (Shift_Left (1, Bit_Pos)));
 
-      MPU9250_Write_Byte_At_Register (Device, Reg_Addr, Register_Value);
+      MPU9250_Write_UInt8_At_Register (Device, Reg_Addr, Register_Value);
    end MPU9250_Write_Bit_At_Register;
 
    ------------------------------------
@@ -744,16 +744,16 @@ package body MPU9250 is
 
    procedure MPU9250_Write_Bits_At_Register
      (Device        : MPU9250_Device;
-      Reg_Addr      : Byte;
+      Reg_Addr      : UInt8;
       Start_Bit_Pos : T_Bit_Pos_8;
-      Data          : Byte;
+      Data          : UInt8;
       Length        : T_Bit_Pos_8)
    is
-      Register_Value : Byte;
-      Mask           : Byte;
-      Data_Aux       : Byte := Data;
+      Register_Value : UInt8;
+      Mask           : UInt8;
+      Data_Aux       : UInt8 := Data;
    begin
-      MPU9250_Read_Byte_At_Register (Device, Reg_Addr, Register_Value);
+      MPU9250_Read_UInt8_At_Register (Device, Reg_Addr, Register_Value);
 
       Mask := Shift_Left
         ((Shift_Left (1, Length) - 1), Start_Bit_Pos - Length + 1);
@@ -763,7 +763,7 @@ package body MPU9250 is
       Register_Value := Register_Value and not Mask;
       Register_Value := Register_Value or Data_Aux;
 
-      MPU9250_Write_Byte_At_Register (Device, Reg_Addr, Register_Value);
+      MPU9250_Write_UInt8_At_Register (Device, Reg_Addr, Register_Value);
    end MPU9250_Write_Bits_At_Register;
 
    --------------------------------------
@@ -771,20 +771,20 @@ package body MPU9250 is
    --------------------------------------
 
    function Fuse_Low_And_High_Register_Parts
-     (High : Byte;
-      Low  : Byte) return Integer_16
+     (High : UInt8;
+      Low  : UInt8) return Integer_16
    is
       ---------------------
       -- Uint16_To_Int16 --
       ---------------------
 
       function Uint16_To_Int16 is new Ada.Unchecked_Conversion
-        (Unsigned_16, Integer_16);
+        (UInt16, Integer_16);
 
-      Register : Unsigned_16;
+      Register : UInt16;
    begin
-      Register := Shift_Left (Unsigned_16 (High), 8);
-      Register := Register or Unsigned_16 (Low);
+      Register := Shift_Left (UInt16 (High), 8);
+      Register := Register or UInt16 (Low);
 
       return Uint16_To_Int16 (Register);
    end Fuse_Low_And_High_Register_Parts;

--- a/components/src/motion/mpu9250/mpu9250.ads
+++ b/components/src/motion/mpu9250/mpu9250.ads
@@ -203,7 +203,7 @@ package MPU9250 is
    --  Set gyroscope sample rate divider
    procedure MPU9250_Set_Rate
      (Device   : in out MPU9250_Device;
-      Rate_Div : Byte);
+      Rate_Div : UInt8);
 
    --  Set sleep mode status.
    procedure MPU9250_Set_Sleep_Enabled
@@ -448,7 +448,7 @@ private
    MPU9250_I2C_SLV_ADDR_BIT    : constant := 6;
    MPU9250_I2C_SLV_ADDR_LENGTH : constant := 7;
    MPU9250_I2C_SLV_EN_BIT      : constant := 7;
-   MPU9250_I2C_SLV_BYTE_SW_BIT : constant := 6;
+   MPU9250_I2C_SLV_UInt8_SW_BIT : constant := 6;
    MPU9250_I2C_SLV_REG_DIS_BIT : constant := 5;
    MPU9250_I2C_SLV_GRP_BIT     : constant := 4;
    MPU9250_I2C_SLV_LEN_BIT     : constant := 3;
@@ -595,7 +595,7 @@ private
    MPU9250_ST_ACCEL_LOW          : constant := (-14.0);
    MPU9250_ST_ACCEL_HIGH         : constant := 14.0;
 
-   MPU9250_ST_TB : constant array (1 .. 256) of Unsigned_16
+   MPU9250_ST_TB : constant array (1 .. 256) of UInt16
      := (
          2620, 2646, 2672, 2699, 2726, 2753, 2781, 2808,
          2837, 2865, 2894, 2923, 2952, 2981, 3011, 3041,
@@ -636,37 +636,37 @@ private
    --  Read data to the specified MPU9250 register
    procedure MPU9250_Read_Register
      (Device   : MPU9250_Device;
-      Reg_Addr    : Byte;
+      Reg_Addr    : UInt8;
       Data        : in out I2C_Data);
 
-   --  Read one byte at the specified MPU9250 register
-   procedure MPU9250_Read_Byte_At_Register
+   --  Read one UInt8 at the specified MPU9250 register
+   procedure MPU9250_Read_UInt8_At_Register
      (Device   : MPU9250_Device;
-      Reg_Addr : Byte;
-      Data     : out Byte);
+      Reg_Addr : UInt8;
+      Data     : out UInt8);
 
    --  Read one but at the specified MPU9250 register
    function MPU9250_Read_Bit_At_Register
      (Device    : MPU9250_Device;
-      Reg_Addr  : Byte;
+      Reg_Addr  : UInt8;
       Bit_Pos   : T_Bit_Pos_8) return Boolean;
 
    --  Write data to the specified MPU9250 register
    procedure MPU9250_Write_Register
      (Device      : MPU9250_Device;
-      Reg_Addr    : Byte;
+      Reg_Addr    : UInt8;
       Data        : I2C_Data);
 
-   --  Write one byte at the specified MPU9250 register
-   procedure MPU9250_Write_Byte_At_Register
+   --  Write one UInt8 at the specified MPU9250 register
+   procedure MPU9250_Write_UInt8_At_Register
      (Device   : MPU9250_Device;
-      Reg_Addr : Byte;
-      Data     : Byte);
+      Reg_Addr : UInt8;
+      Data     : UInt8);
 
    --  Write one bit at the specified MPU9250 register
    procedure MPU9250_Write_Bit_At_Register
      (Device    : MPU9250_Device;
-      Reg_Addr  : Byte;
+      Reg_Addr  : UInt8;
       Bit_Pos   : T_Bit_Pos_8;
       Bit_Value : Boolean);
 
@@ -674,14 +674,14 @@ private
    --  bit specified in Start_Bit_Pos
    procedure MPU9250_Write_Bits_At_Register
      (Device    : MPU9250_Device;
-      Reg_Addr      : Byte;
+      Reg_Addr      : UInt8;
       Start_Bit_Pos : T_Bit_Pos_8;
-      Data          : Byte;
+      Data          : UInt8;
       Length        : T_Bit_Pos_8);
 
    function Fuse_Low_And_High_Register_Parts
-     (High : Byte;
-      Low  : Byte) return Integer_16;
+     (High : UInt8;
+      Low  : UInt8) return Integer_16;
    pragma Inline (Fuse_Low_And_High_Register_Parts);
 
 end MPU9250;

--- a/components/src/printer/adafruit_thermal_printer/adafruit-thermal_printer.adb
+++ b/components/src/printer/adafruit_thermal_printer/adafruit-thermal_printer.adb
@@ -31,14 +31,13 @@
 
 with Ada.Unchecked_Conversion;
 with HAL.UART; use HAL.UART;
-with Interfaces; use Interfaces;
 
 package body AdaFruit.Thermal_Printer is
 
-   function To_Char is new Ada.Unchecked_Conversion (Source => Byte,
+   function To_Char is new Ada.Unchecked_Conversion (Source => UInt8,
                                                      Target => Character);
-   function To_Byte is new Ada.Unchecked_Conversion (Source => Character,
-                                                     Target => Byte);
+   function To_UInt8 is new Ada.Unchecked_Conversion (Source => Character,
+                                                     Target => UInt8);
 
    procedure Write (This : in out TP_Device; Cmd : String);
    procedure Read (This : in out TP_Device; Str : out String);
@@ -53,7 +52,7 @@ package body AdaFruit.Thermal_Printer is
    begin
 
       for Index in Cmd'Range loop
-         Data (Index) := To_Byte (Cmd (Index));
+         Data (Index) := To_UInt8 (Cmd (Index));
       end loop;
 
       This.Port.Transmit (Data, Status);
@@ -88,7 +87,7 @@ package body AdaFruit.Thermal_Printer is
    -- Set_Line_Spacing --
    ----------------------
 
-   procedure Set_Line_Spacing (This : in out TP_Device; Spacing : Byte) is
+   procedure Set_Line_Spacing (This : in out TP_Device; Spacing : UInt8) is
    begin
       Write (This, ASCII.ESC & '3' & To_Char (Spacing));
    end Set_Line_Spacing;
@@ -113,7 +112,7 @@ package body AdaFruit.Thermal_Printer is
    ----------------------
 
    procedure Set_Font_Enlarge (This : in out TP_Device; Height, Width : Boolean) is
-      Data : Byte := 0;
+      Data : UInt8 := 0;
    begin
       if Height then
          Data := Data or 16#01#;
@@ -186,7 +185,7 @@ package body AdaFruit.Thermal_Printer is
    -- Feed --
    ----------
 
-   procedure Feed (This : in out TP_Device; Rows : Byte) is
+   procedure Feed (This : in out TP_Device; Rows : UInt8) is
    begin
       Write (This, ASCII.ESC & 'd' & To_Char (Rows));
    end Feed;
@@ -204,15 +203,15 @@ package body AdaFruit.Thermal_Printer is
    begin
 
       Write (This, ASCII.DC2 & 'v' &
-               To_Char (Byte (Nbr_Of_Rows rem 256)) &
-               To_Char (Byte (Nbr_Of_Rows / 256)));
+               To_Char (UInt8 (Nbr_Of_Rows rem 256)) &
+               To_Char (UInt8 (Nbr_Of_Rows / 256)));
 
       for Row in 0 .. Nbr_Of_Rows - 1 loop
          for Colum in 0 .. (Nbr_Of_Columns / 8) - 1 loop
             declare
                BM_Index  : constant Natural := BM'First (1) + Colum * 8;
                Str_Index : constant Natural := Str'First + Colum;
-               B : Byte := 0;
+               B : UInt8 := 0;
             begin
                for X in 0 .. 7 loop
                   B := B or (if BM (BM_Index + X,
@@ -303,7 +302,7 @@ package body AdaFruit.Thermal_Printer is
    -- Set_Density --
    -----------------
 
-   procedure Set_Density (This : in out TP_Device; Density, Breaktime : Byte) is
+   procedure Set_Density (This : in out TP_Device; Density, Breaktime : UInt8) is
    begin
       Write (This,
              ASCII.DC2 & '#' & To_Char (Shift_Left (Breaktime, 5) or Density));

--- a/components/src/printer/adafruit_thermal_printer/adafruit-thermal_printer.ads
+++ b/components/src/printer/adafruit_thermal_printer/adafruit-thermal_printer.ads
@@ -43,7 +43,7 @@ package AdaFruit.Thermal_Printer is
    --  use 9_600.
 
    --  Sets the line spacing to n dots. The default value is 32
-   procedure Set_Line_Spacing (This : in out TP_Device; Spacing : Byte);
+   procedure Set_Line_Spacing (This : in out TP_Device; Spacing : UInt8);
 
    type Text_Align is (Right, Center, Left);
    procedure Set_Align (This : in out TP_Device; Align : Text_Align);
@@ -58,7 +58,7 @@ package AdaFruit.Thermal_Printer is
 
    procedure Set_Reversed (This : in out TP_Device; Reversed : Boolean);
 
-   subtype Underline_Height is Byte range 0 .. 2;
+   subtype Underline_Height is UInt8 range 0 .. 2;
    procedure Set_Underline_Height (This : in out TP_Device; Height : Underline_Height);
 
    type Character_Set is (USA, France, Germany, UK, Denmark1, Sweden, Italy,
@@ -66,7 +66,7 @@ package AdaFruit.Thermal_Printer is
                           Latin_Americam, Korea);
    procedure Set_Character_Set (This : in out TP_Device; Set : Character_Set);
 
-   procedure Feed (This : in out TP_Device; Rows : Byte);
+   procedure Feed (This : in out TP_Device; Rows : UInt8);
 
    type Thermal_Printer_Bitmap is array (Natural range <>,
                                          Natural range <>) of Boolean
@@ -90,14 +90,14 @@ package AdaFruit.Thermal_Printer is
 
    type Printer_Settings is record
       --  Unit: 8 dots,  Default: 7 (64 dots))
-      Max_Printing_Dots : Byte;
+      Max_Printing_Dots : UInt8;
       --  Unit 10us, Default: 80 (800us)
-      Heating_Time      : Byte;
+      Heating_Time      : UInt8;
       --  Unit 10us, Default: 2 (20us)
-      Heating_Interval  : Byte;
+      Heating_Interval  : UInt8;
    end record;
 
-   procedure Set_Density (This : in out TP_Device; Density, Breaktime : Byte);
+   procedure Set_Density (This : in out TP_Device; Density, Breaktime : UInt8);
    procedure Set_Printer_Settings (This : in out TP_Device; Settings : Printer_Settings);
 
    procedure Print_Test_Page (This : in out TP_Device);

--- a/components/src/screen/ST7735R/st7735r-ram_framebuffer.adb
+++ b/components/src/screen/ST7735R/st7735r-ram_framebuffer.adb
@@ -29,8 +29,6 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Interfaces; use Interfaces;
-
 package body ST7735R.RAM_Framebuffer is
 
    ----------------------

--- a/components/src/screen/ST7735R/st7735r-ram_framebuffer.adb
+++ b/components/src/screen/ST7735R/st7735r-ram_framebuffer.adb
@@ -90,9 +90,9 @@ package body ST7735R.RAM_Framebuffer is
       end if;
       Set_Address (Display,
                    X_Start => 0,
-                   X_End   => Unsigned_16 (Display.Layer.Width - 1),
+                   X_End   => UInt16 (Display.Layer.Width - 1),
                    Y_Start => 0,
-                   Y_End   => Unsigned_16 (Display.Layer.Height - 1));
+                   Y_End   => UInt16 (Display.Layer.Height - 1));
       Display.Write_Raw_Pixels (Display.Layer_Data);
    end Update_Layer;
 

--- a/components/src/screen/ST7735R/st7735r.adb
+++ b/components/src/screen/ST7735R/st7735r.adb
@@ -60,19 +60,19 @@ package body ST7735R is
       MY        at 0 range 7 .. 7;
    end record;
 
-   function To_Byte is new Ada.Unchecked_Conversion (MADCTL, Byte);
+   function To_UInt8 is new Ada.Unchecked_Conversion (MADCTL, UInt8);
 
    procedure Write_Command (LCD : ST7735R_Device;
-                            Cmd : Byte);
+                            Cmd : UInt8);
    procedure Write_Command (LCD  : ST7735R_Device;
-                            Cmd  : Byte;
-                            Data : HAL.Byte_Array);
+                            Cmd  : UInt8;
+                            Data : HAL.UInt8_Array);
 
    procedure Write_Data (LCD : ST7735R_Device;
-                         Data : Byte);
+                         Data : UInt8);
    pragma Unreferenced (Write_Data);
    procedure Write_Data (LCD  : ST7735R_Device;
-                         Data : HAL.Byte_Array);
+                         Data : HAL.UInt8_Array);
    procedure Write_Data (LCD  : ST7735R_Device;
                          Data : HAL.UInt16_Array);
 
@@ -125,7 +125,7 @@ package body ST7735R is
    -------------------
 
    procedure Write_Command (LCD : ST7735R_Device;
-                            Cmd : Byte)
+                            Cmd : UInt8)
    is
       Status : SPI_Status;
    begin
@@ -145,8 +145,8 @@ package body ST7735R is
    -------------------
 
    procedure Write_Command (LCD  : ST7735R_Device;
-                            Cmd  : Byte;
-                            Data : HAL.Byte_Array)
+                            Cmd  : UInt8;
+                            Data : HAL.UInt8_Array)
    is
    begin
       Write_Command (LCD, Cmd);
@@ -158,7 +158,7 @@ package body ST7735R is
    ----------------
 
    procedure Write_Data (LCD : ST7735R_Device;
-                         Data : Byte)
+                         Data : UInt8)
    is
       Status : SPI_Status;
    begin
@@ -178,7 +178,7 @@ package body ST7735R is
    ----------------
 
    procedure Write_Data (LCD  : ST7735R_Device;
-                         Data : HAL.Byte_Array)
+                         Data : HAL.UInt8_Array)
    is
       Status : SPI_Status;
    begin
@@ -202,14 +202,14 @@ package body ST7735R is
    procedure Write_Data (LCD  : ST7735R_Device;
                          Data : HAL.UInt16_Array)
    is
-      B1, B2 : Byte;
+      B1, B2 : UInt8;
       Status : SPI_Status;
    begin
       Start_Transaction (LCD);
       Set_Data_Mode (LCD);
       for Elt of Data loop
-         B1 := Byte (Interfaces.Shift_Right (Elt, 8));
-         B2 := Byte (Elt and 16#FF#);
+         B1 := UInt8 (Shift_Right (Elt, 8));
+         B2 := UInt8 (Elt and 16#FF#);
          LCD.Port.Transmit (SPI_Data_8b'(B1, B2),
                             Status);
          if Status /= Ok then
@@ -316,7 +316,7 @@ package body ST7735R is
 
    procedure Gamma_Set (LCD : ST7735R_Device; Gamma_Curve : UInt4) is
    begin
-      Write_Command (LCD, 16#26#, (0 => Byte (Gamma_Curve)));
+      Write_Command (LCD, 16#26#, (0 => UInt8 (Gamma_Curve)));
    end Gamma_Set;
 
    ----------------------
@@ -324,7 +324,7 @@ package body ST7735R is
    ----------------------
 
    procedure Set_Pixel_Format (LCD : ST7735R_Device; Pix_Fmt : Pixel_Format) is
-      Value : constant Byte := (case Pix_Fmt is
+      Value : constant UInt8 := (case Pix_Fmt is
                                    when Pixel_12bits => 2#011#,
                                    when Pixel_16bits => 2#101#,
                                    when Pixel_18bits => 2#110#);
@@ -354,7 +354,7 @@ package body ST7735R is
       Value.ML := Vertical;
       Value.RGB := Color_Order;
       Value.MH := Horizontal;
-      Write_Command (LCD, 16#36#, (0 => To_Byte (Value)));
+      Write_Command (LCD, 16#36#, (0 => To_UInt8 (Value)));
    end Set_Memory_Data_Access;
 
    ---------------------------
@@ -369,7 +369,7 @@ package body ST7735R is
    is
    begin
       Write_Command (LCD, 16#B1#,
-                     (Byte (RTN), Byte (Front_Porch), Byte (Back_Porch)));
+                     (UInt8 (RTN), UInt8 (Front_Porch), UInt8 (Back_Porch)));
    end Set_Frame_Rate_Normal;
 
    -------------------------
@@ -384,7 +384,7 @@ package body ST7735R is
    is
    begin
       Write_Command (LCD, 16#B2#,
-                     (Byte (RTN), Byte (Front_Porch), Byte (Back_Porch)));
+                     (UInt8 (RTN), UInt8 (Front_Porch), UInt8 (Back_Porch)));
    end Set_Frame_Rate_Idle;
 
    ---------------------------------
@@ -402,12 +402,12 @@ package body ST7735R is
    is
    begin
       Write_Command (LCD, 16#B3#,
-                     (Byte (RTN_Part),
-                      Byte (Front_Porch_Part),
-                      Byte (Back_Porch_Part),
-                      Byte (RTN_Full),
-                      Byte (Front_Porch_Full),
-                      Byte (Back_Porch_Full)));
+                     (UInt8 (RTN_Part),
+                      UInt8 (Front_Porch_Part),
+                      UInt8 (Back_Porch_Part),
+                      UInt8 (RTN_Full),
+                      UInt8 (Front_Porch_Full),
+                      UInt8 (Back_Porch_Full)));
    end Set_Frame_Rate_Partial_Full;
 
    ---------------------------
@@ -418,7 +418,7 @@ package body ST7735R is
      (LCD : ST7735R_Device;
       Normal, Idle, Full_Partial : Inversion_Control)
    is
-      Value : Byte := 0;
+      Value : UInt8 := 0;
    begin
       if Normal = Line_Inversion then
          Value := Value or 2#100#;
@@ -443,11 +443,11 @@ package body ST7735R is
       VRHN : UInt5;
       MODE : UInt2)
    is
-      P1, P2, P3 : Byte;
+      P1, P2, P3 : UInt8;
    begin
-      P1 := Interfaces.Shift_Left (Byte (AVDD), 5) or Byte (VRHP);
-      P2 := Byte (VRHN);
-      P3 := Interfaces.Shift_Left (Byte (MODE), 6) or 2#00_0100#;
+      P1 := Shift_Left (UInt8 (AVDD), 5) or UInt8 (VRHP);
+      P2 := UInt8 (VRHN);
+      P3 := Shift_Left (UInt8 (MODE), 6) or 2#00_0100#;
       Write_Command (LCD, 16#C0#, (P1, P2, P3));
    end Set_Power_Control_1;
 
@@ -461,11 +461,11 @@ package body ST7735R is
       VGSEL : UInt2;
       VGHBT : UInt2)
    is
-      P1 : Byte;
+      P1 : UInt8;
    begin
-      P1 := Interfaces.Shift_Left (Byte (VGH25), 6) or
-        Interfaces.Shift_Left (Byte (VGSEL), 2) or
-        Byte (VGHBT);
+      P1 := Shift_Left (UInt8 (VGH25), 6) or
+        Shift_Left (UInt8 (VGSEL), 2) or
+        UInt8 (VGHBT);
       Write_Command (LCD, 16#C1#, (0 => P1));
    end Set_Power_Control_2;
 
@@ -475,7 +475,7 @@ package body ST7735R is
 
    procedure Set_Power_Control_3
      (LCD : ST7735R_Device;
-      P1, P2 : Byte)
+      P1, P2 : UInt8)
    is
    begin
       Write_Command (LCD, 16#C2#, (P1, P2));
@@ -487,7 +487,7 @@ package body ST7735R is
 
    procedure Set_Power_Control_4
      (LCD : ST7735R_Device;
-      P1, P2 : Byte)
+      P1, P2 : UInt8)
    is
    begin
       Write_Command (LCD, 16#C3#, (P1, P2));
@@ -499,7 +499,7 @@ package body ST7735R is
 
    procedure Set_Power_Control_5
      (LCD : ST7735R_Device;
-      P1, P2 : Byte)
+      P1, P2 : UInt8)
    is
    begin
       Write_Command (LCD, 16#C4#, (P1, P2));
@@ -511,7 +511,7 @@ package body ST7735R is
 
    procedure Set_Vcom (LCD : ST7735R_Device; VCOMS : UInt6) is
    begin
-      Write_Command (LCD, 16#C5#, (0 => Byte (VCOMS)));
+      Write_Command (LCD, 16#C5#, (0 => UInt8 (VCOMS)));
    end Set_Vcom;
 
    ------------------------
@@ -520,12 +520,12 @@ package body ST7735R is
 
    procedure Set_Column_Address (LCD : ST7735R_Device; X_Start, X_End : UInt16)
    is
-      P1, P2, P3, P4 : Byte;
+      P1, P2, P3, P4 : UInt8;
    begin
-      P1 := Byte (Shift_Right (X_Start and 16#FF#, 8));
-      P2 := Byte (X_Start and 16#FF#);
-      P3 := Byte (Shift_Right (X_End and 16#FF#, 8));
-      P4 := Byte (X_End and 16#FF#);
+      P1 := UInt8 (Shift_Right (X_Start and 16#FF#, 8));
+      P2 := UInt8 (X_Start and 16#FF#);
+      P3 := UInt8 (Shift_Right (X_End and 16#FF#, 8));
+      P4 := UInt8 (X_End and 16#FF#);
       Write_Command (LCD, 16#2A#, (P1, P2, P3, P4));
    end Set_Column_Address;
 
@@ -535,12 +535,12 @@ package body ST7735R is
 
    procedure Set_Row_Address (LCD : ST7735R_Device; Y_Start, Y_End : UInt16)
    is
-      P1, P2, P3, P4 : Byte;
+      P1, P2, P3, P4 : UInt8;
    begin
-      P1 := Byte (Shift_Right (Y_Start and 16#FF#, 8));
-      P2 := Byte (Y_Start and 16#FF#);
-      P3 := Byte (Shift_Right (Y_End and 16#FF#, 8));
-      P4 := Byte (Y_End and 16#FF#);
+      P1 := UInt8 (Shift_Right (Y_Start and 16#FF#, 8));
+      P2 := UInt8 (Y_Start and 16#FF#);
+      P3 := UInt8 (Shift_Right (Y_End and 16#FF#, 8));
+      P4 := UInt8 (Y_End and 16#FF#);
       Write_Command (LCD, 16#2B#, (P1, P2, P3, P4));
    end Set_Row_Address;
 
@@ -591,7 +591,7 @@ package body ST7735R is
    ----------------------
 
    procedure Write_Raw_Pixels (LCD  : ST7735R_Device;
-                               Data : HAL.Byte_Array)
+                               Data : HAL.UInt8_Array)
    is
    begin
       Write_Command (LCD, 16#2C#);
@@ -684,7 +684,7 @@ package body ST7735R is
 
    overriding
    procedure Set_Background
-     (Display : ST7735R_Device; R, G, B : Byte)
+     (Display : ST7735R_Device; R, G, B : UInt8)
    is
    begin
       --  Does it make sense when there's no alpha channel...

--- a/components/src/screen/ST7735R/st7735r.adb
+++ b/components/src/screen/ST7735R/st7735r.adb
@@ -30,7 +30,6 @@
 ------------------------------------------------------------------------------
 
 with Ada.Unchecked_Conversion;
-with Interfaces;               use Interfaces;
 with Bitmap_Color_Conversion;  use Bitmap_Color_Conversion;
 
 package body ST7735R is

--- a/components/src/screen/ST7735R/st7735r.ads
+++ b/components/src/screen/ST7735R/st7735r.ads
@@ -136,15 +136,15 @@ package ST7735R is
 
    procedure Set_Power_Control_3
      (LCD : ST7735R_Device;
-      P1, P2 : Byte);
+      P1, P2 : UInt8);
 
    procedure Set_Power_Control_4
      (LCD : ST7735R_Device;
-      P1, P2 : Byte);
+      P1, P2 : UInt8);
 
    procedure Set_Power_Control_5
      (LCD : ST7735R_Device;
-      P1, P2 : Byte);
+      P1, P2 : UInt8);
 
    procedure Set_Vcom (LCD : ST7735R_Device; VCOMS : UInt6);
 
@@ -162,7 +162,7 @@ package ST7735R is
                    return UInt16;
 
    procedure Write_Raw_Pixels (LCD  : ST7735R_Device;
-                               Data : HAL.Byte_Array);
+                               Data : HAL.UInt8_Array);
    procedure Write_Raw_Pixels (LCD  : ST7735R_Device;
                                Data : HAL.UInt16_Array);
 
@@ -202,7 +202,7 @@ package ST7735R is
 
    overriding
    procedure Set_Background
-     (Display : ST7735R_Device; R, G, B : Byte);
+     (Display : ST7735R_Device; R, G, B : UInt8);
 
    overriding
    procedure Initialize_Layer

--- a/components/src/screen/ili9341/ili9341.adb
+++ b/components/src/screen/ili9341/ili9341.adb
@@ -42,7 +42,6 @@
 ------------------------------------------------------------------------------
 
 with Ada.Unchecked_Conversion;
-with Interfaces;   use Interfaces;
 
 with ILI9341_Regs; use ILI9341_Regs;
 
@@ -106,15 +105,15 @@ package body ILI9341 is
       Y     : Height;
       Color : Colors)
    is
-      Color_High_Byte : constant Byte :=
-        Byte (Shift_Right (As_UInt16 (Color), 8));
-      Color_Low_Byte  : constant Byte :=
-        Byte (As_UInt16 (Color) and 16#FF#);
+      Color_High_UInt8 : constant UInt8 :=
+        UInt8 (Shift_Right (As_UInt16 (Color), 8));
+      Color_Low_UInt8  : constant UInt8 :=
+        UInt8 (As_UInt16 (Color) and 16#FF#);
    begin
       This.Set_Cursor_Position (X, Y, X, Y);
       This.Send_Command (ILI9341_GRAM);
-      This.Send_Data (Color_High_Byte);
-      This.Send_Data (Color_Low_Byte);
+      This.Send_Data (Color_High_UInt8);
+      This.Send_Data (Color_Low_UInt8);
    end Set_Pixel;
 
    ----------
@@ -122,10 +121,10 @@ package body ILI9341 is
    ----------
 
    procedure Fill (This : in out ILI9341_Device; Color : Colors) is
-      Color_High_Byte : constant Byte :=
-        Byte (Shift_Right (As_UInt16 (Color), 8));
-      Color_Low_Byte  : constant Byte :=
-        Byte (As_UInt16 (Color) and 16#FF#);
+      Color_High_UInt8 : constant UInt8 :=
+        UInt8 (Shift_Right (As_UInt16 (Color), 8));
+      Color_Low_UInt8  : constant UInt8 :=
+        UInt8 (As_UInt16 (Color) and 16#FF#);
    begin
       This.Set_Cursor_Position (X1 => 0,
                                 Y1 => 0,
@@ -134,8 +133,8 @@ package body ILI9341 is
 
       This.Send_Command (ILI9341_GRAM);
       for N in 1 .. (Device_Width * Device_Height) loop
-         This.Send_Data (Color_High_Byte);
-         This.Send_Data (Color_Low_Byte);
+         This.Send_Data (Color_High_UInt8);
+         This.Send_Data (Color_Low_UInt8);
       end loop;
    end Fill;
 
@@ -196,15 +195,15 @@ package body ILI9341 is
       X2   : Width;
       Y2   : Height)
    is
-      X1_High : constant Byte := Byte (Shift_Right (UInt16 (X1), 8));
-      X1_Low  : constant Byte := Byte (UInt16 (X1) and 16#FF#);
-      X2_High : constant Byte := Byte (Shift_Right (UInt16 (X2), 8));
-      X2_Low  : constant Byte := Byte (UInt16 (X2) and 16#FF#);
+      X1_High : constant UInt8 := UInt8 (Shift_Right (UInt16 (X1), 8));
+      X1_Low  : constant UInt8 := UInt8 (UInt16 (X1) and 16#FF#);
+      X2_High : constant UInt8 := UInt8 (Shift_Right (UInt16 (X2), 8));
+      X2_Low  : constant UInt8 := UInt8 (UInt16 (X2) and 16#FF#);
 
-      Y1_High : constant Byte := Byte (Shift_Right (UInt16 (Y1), 8));
-      Y1_Low  : constant Byte := Byte (UInt16 (Y1) and 16#FF#);
-      Y2_High : constant Byte := Byte (Shift_Right (UInt16 (Y2), 8));
-      Y2_Low  : constant Byte := Byte (UInt16 (Y2) and 16#FF#);
+      Y1_High : constant UInt8 := UInt8 (Shift_Right (UInt16 (Y1), 8));
+      Y1_Low  : constant UInt8 := UInt8 (UInt16 (Y1) and 16#FF#);
+      Y2_High : constant UInt8 := UInt8 (Shift_Right (UInt16 (Y2), 8));
+      Y2_Low  : constant UInt8 := UInt8 (UInt16 (Y2) and 16#FF#);
    begin
       This.Send_Command (ILI9341_COLUMN_ADDR);
       This.Send_Data (X1_High);
@@ -241,7 +240,7 @@ package body ILI9341 is
    -- Send_Data --
    ---------------
 
-   procedure Send_Data (This : in out ILI9341_Device; Data : Byte) is
+   procedure Send_Data (This : in out ILI9341_Device; Data : UInt8) is
       Status : SPI_Status;
    begin
       This.WRX.Set;
@@ -257,7 +256,7 @@ package body ILI9341 is
    -- Send_Command --
    ------------------
 
-   procedure Send_Command (This : in out ILI9341_Device; Cmd : Byte) is
+   procedure Send_Command (This : in out ILI9341_Device; Cmd : UInt8) is
       Status : SPI_Status;
    begin
       This.WRX.Clear;

--- a/components/src/screen/ili9341/ili9341.ads
+++ b/components/src/screen/ili9341/ili9341.ads
@@ -70,9 +70,9 @@ package ILI9341 is
    --  Initializes the device. Afterward, the device is also enabled so there
    --  is no immediate need to call Enable_Display.
 
-   procedure Send_Command (This : in out ILI9341_Device; Cmd : Byte);
+   procedure Send_Command (This : in out ILI9341_Device; Cmd : UInt8);
 
-   procedure Send_Data (This : in out ILI9341_Device; Data : Byte);
+   procedure Send_Data (This : in out ILI9341_Device; Data : UInt8);
 
    Device_Width  : constant := 240;
    Device_Height : constant := 320;

--- a/components/src/screen/otm8009a/otm8009a.adb
+++ b/components/src/screen/otm8009a/otm8009a.adb
@@ -38,13 +38,13 @@ package body OTM8009A is
    -----------
 
    procedure Write (This    : in out OTM8009A_Device;
-                    Address : Unsigned_16;
+                    Address : UInt16;
                     Data    : DSI_Data)
    is
-      MSB, LSB : Byte;
+      MSB, LSB : UInt8;
    begin
-      MSB := Byte (Shift_Right (Address and 16#FF00#, 8));
-      LSB := Byte (Address and 16#FF#);
+      MSB := UInt8 (Shift_Right (Address and 16#FF00#, 8));
+      LSB := UInt8 (Address and 16#FF#);
       if LSB /= This.Current_Shift then
          This.DSI_IO_WriteCmd ((ADDR_SHIFT_CMD, LSB));
          This.Current_Shift := LSB;
@@ -57,7 +57,7 @@ package body OTM8009A is
    -----------
 
    procedure Write (This   : in out OTM8009A_Device;
-                    S_Addr : Byte;
+                    S_Addr : UInt8;
                     Data   : DSI_Data)
    is
    begin

--- a/components/src/screen/otm8009a/otm8009a.ads
+++ b/components/src/screen/otm8009a/otm8009a.ads
@@ -29,9 +29,8 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Interfaces; use Interfaces;
-with HAL;        use HAL;
-with HAL.DSI;    use HAL.DSI;
+with HAL;      use HAL;
+with HAL.DSI;  use HAL.DSI;
 with HAL.Time;
 
 package OTM8009A is
@@ -104,18 +103,18 @@ private
       Channel_ID : DSI_Virtual_Channel_ID;
       Time       : not null HAL.Time.Any_Delays)
    is tagged limited record
-      Current_Shift : Byte := 0;
+      Current_Shift : UInt8 := 0;
    end record;
 
    procedure DSI_IO_WriteCmd (This : in out OTM8009A_Device;
                               Data : HAL.DSI.DSI_Data);
 
    procedure Write (This    : in out OTM8009A_Device;
-                    Address : Unsigned_16;
+                    Address : UInt16;
                     Data    : HAL.DSI.DSI_Data);
 
    procedure Write (This   : in out OTM8009A_Device;
-                    S_Addr : Byte;
+                    S_Addr : UInt8;
                     Data   : HAL.DSI.DSI_Data);
 
 end OTM8009A;

--- a/components/src/touch_panel/ft5336/ft5336.adb
+++ b/components/src/touch_panel/ft5336/ft5336.adb
@@ -30,7 +30,6 @@
 ------------------------------------------------------------------------------
 
 with Ada.Unchecked_Conversion;
-with Interfaces;  use Interfaces;
 
 package body FT5336 is
 
@@ -42,73 +41,73 @@ package body FT5336 is
    ------------------------------------------------------------
 
    --  Current mode register of the FT5336 (R/W)
-   FT5336_DEV_MODE_REG                 : constant Unsigned_8 := 16#00#;
+   FT5336_DEV_MODE_REG                 : constant UInt8 := 16#00#;
 
    --  Possible values of FT5336_DEV_MODE_REG
-   FT5336_DEV_MODE_WORKING             : constant Unsigned_8 := 16#00#;
-   FT5336_DEV_MODE_FACTORY             : constant Unsigned_8 := 16#04#;
+   FT5336_DEV_MODE_WORKING             : constant UInt8 := 16#00#;
+   FT5336_DEV_MODE_FACTORY             : constant UInt8 := 16#04#;
 
-   FT5336_DEV_MODE_MASK                : constant Unsigned_8 := 16#07#;
-   FT5336_DEV_MODE_SHIFT               : constant Unsigned_8 := 16#04#;
+   FT5336_DEV_MODE_MASK                : constant UInt8 := 16#07#;
+   FT5336_DEV_MODE_SHIFT               : constant UInt8 := 16#04#;
 
    --  Gesture ID register
-   FT5336_GEST_ID_REG                  : constant Unsigned_8 := 16#01#;
+   FT5336_GEST_ID_REG                  : constant UInt8 := 16#01#;
 
    --  Possible values of FT5336_GEST_ID_REG
-   FT5336_GEST_ID_NO_GESTURE           : constant Unsigned_8 := 16#00#;
-   FT5336_GEST_ID_MOVE_UP              : constant Unsigned_8 := 16#10#;
-   FT5336_GEST_ID_MOVE_RIGHT           : constant Unsigned_8 := 16#14#;
-   FT5336_GEST_ID_MOVE_DOWN            : constant Unsigned_8 := 16#18#;
-   FT5336_GEST_ID_MOVE_LEFT            : constant Unsigned_8 := 16#1C#;
-   FT5336_GEST_ID_SINGLE_CLICK         : constant Unsigned_8 := 16#20#;
-   FT5336_GEST_ID_DOUBLE_CLICK         : constant Unsigned_8 := 16#22#;
-   FT5336_GEST_ID_ROTATE_CLOCKWISE     : constant Unsigned_8 := 16#28#;
-   FT5336_GEST_ID_ROTATE_C_CLOCKWISE   : constant Unsigned_8 := 16#29#;
-   FT5336_GEST_ID_ZOOM_IN              : constant Unsigned_8 := 16#40#;
-   FT5336_GEST_ID_ZOOM_OUT             : constant Unsigned_8 := 16#49#;
+   FT5336_GEST_ID_NO_GESTURE           : constant UInt8 := 16#00#;
+   FT5336_GEST_ID_MOVE_UP              : constant UInt8 := 16#10#;
+   FT5336_GEST_ID_MOVE_RIGHT           : constant UInt8 := 16#14#;
+   FT5336_GEST_ID_MOVE_DOWN            : constant UInt8 := 16#18#;
+   FT5336_GEST_ID_MOVE_LEFT            : constant UInt8 := 16#1C#;
+   FT5336_GEST_ID_SINGLE_CLICK         : constant UInt8 := 16#20#;
+   FT5336_GEST_ID_DOUBLE_CLICK         : constant UInt8 := 16#22#;
+   FT5336_GEST_ID_ROTATE_CLOCKWISE     : constant UInt8 := 16#28#;
+   FT5336_GEST_ID_ROTATE_C_CLOCKWISE   : constant UInt8 := 16#29#;
+   FT5336_GEST_ID_ZOOM_IN              : constant UInt8 := 16#40#;
+   FT5336_GEST_ID_ZOOM_OUT             : constant UInt8 := 16#49#;
 
    --  Touch Data Status register : gives number of active touch points (0..5)
-   FT5336_TD_STAT_REG                  : constant Unsigned_8 := 16#02#;
+   FT5336_TD_STAT_REG                  : constant UInt8 := 16#02#;
 
    --  Values related to FT5336_TD_STAT_REG
-   FT5336_TD_STAT_MASK                 : constant Unsigned_8 := 16#0F#;
-   FT5336_TD_STAT_SHIFT                : constant Unsigned_8 := 16#00#;
+   FT5336_TD_STAT_MASK                 : constant UInt8 := 16#0F#;
+   FT5336_TD_STAT_SHIFT                : constant UInt8 := 16#00#;
 
    --  Values Pn_XH and Pn_YH related
-   FT5336_TOUCH_EVT_FLAG_PRESS_DOWN    : constant Unsigned_8 := 16#00#;
-   FT5336_TOUCH_EVT_FLAG_LIFT_UP       : constant Unsigned_8 := 16#01#;
-   FT5336_TOUCH_EVT_FLAG_CONTACT       : constant Unsigned_8 := 16#02#;
-   FT5336_TOUCH_EVT_FLAG_NO_EVENT      : constant Unsigned_8 := 16#03#;
+   FT5336_TOUCH_EVT_FLAG_PRESS_DOWN    : constant UInt8 := 16#00#;
+   FT5336_TOUCH_EVT_FLAG_LIFT_UP       : constant UInt8 := 16#01#;
+   FT5336_TOUCH_EVT_FLAG_CONTACT       : constant UInt8 := 16#02#;
+   FT5336_TOUCH_EVT_FLAG_NO_EVENT      : constant UInt8 := 16#03#;
 
-   FT5336_TOUCH_EVT_FLAG_SHIFT         : constant Unsigned_8 := 16#06#;
-   FT5336_TOUCH_EVT_FLAG_MASK          : constant Unsigned_8 := 2#1100_0000#;
+   FT5336_TOUCH_EVT_FLAG_SHIFT         : constant UInt8 := 16#06#;
+   FT5336_TOUCH_EVT_FLAG_MASK          : constant UInt8 := 2#1100_0000#;
 
-   FT5336_TOUCH_POS_MSB_MASK           : constant Unsigned_8 := 16#0F#;
-   FT5336_TOUCH_POS_MSB_SHIFT          : constant Unsigned_8 := 16#00#;
+   FT5336_TOUCH_POS_MSB_MASK           : constant UInt8 := 16#0F#;
+   FT5336_TOUCH_POS_MSB_SHIFT          : constant UInt8 := 16#00#;
 
    --  Values Pn_XL and Pn_YL related
-   FT5336_TOUCH_POS_LSB_MASK           : constant Unsigned_8 := 16#FF#;
-   FT5336_TOUCH_POS_LSB_SHIFT          : constant Unsigned_8 := 16#00#;
+   FT5336_TOUCH_POS_LSB_MASK           : constant UInt8 := 16#FF#;
+   FT5336_TOUCH_POS_LSB_SHIFT          : constant UInt8 := 16#00#;
 
 
    --  Values Pn_WEIGHT related
-   FT5336_TOUCH_WEIGHT_MASK            : constant Unsigned_8 := 16#FF#;
-   FT5336_TOUCH_WEIGHT_SHIFT           : constant Unsigned_8 := 16#00#;
+   FT5336_TOUCH_WEIGHT_MASK            : constant UInt8 := 16#FF#;
+   FT5336_TOUCH_WEIGHT_SHIFT           : constant UInt8 := 16#00#;
 
 
    --  Values related to FT5336_Pn_MISC_REG
-   FT5336_TOUCH_AREA_MASK              : constant Unsigned_8 := 2#0100_0000#;
-   FT5336_TOUCH_AREA_SHIFT             : constant Unsigned_8 := 16#04#;
+   FT5336_TOUCH_AREA_MASK              : constant UInt8 := 2#0100_0000#;
+   FT5336_TOUCH_AREA_SHIFT             : constant UInt8 := 16#04#;
 
    type FT5336_Pressure_Registers is record
-      XH_Reg     : Unsigned_8;
-      XL_Reg     : Unsigned_8;
-      YH_Reg     : Unsigned_8;
-      YL_Reg     : Unsigned_8;
+      XH_Reg     : UInt8;
+      XL_Reg     : UInt8;
+      YH_Reg     : UInt8;
+      YL_Reg     : UInt8;
       --  Touch Pressure register value (R)
-      Weight_Reg : Unsigned_8;
+      Weight_Reg : UInt8;
       --  Touch area register
-      Misc_Reg   : Unsigned_8;
+      Misc_Reg   : UInt8;
    end record;
 
    FT5336_Px_Regs                : constant array (Positive range <>)
@@ -175,90 +174,90 @@ package body FT5336 is
                                              Misc_Reg   => 16#3E#));
 
    --  Threshold for touch detection
-   FT5336_TH_GROUP_REG                 : constant Unsigned_8 := 16#80#;
+   FT5336_TH_GROUP_REG                 : constant UInt8 := 16#80#;
 
    --  Values FT5336_TH_GROUP_REG : threshold related
-   FT5336_THRESHOLD_MASK               : constant Unsigned_8 := 16#FF#;
-   FT5336_THRESHOLD_SHIFT              : constant Unsigned_8 := 16#00#;
+   FT5336_THRESHOLD_MASK               : constant UInt8 := 16#FF#;
+   FT5336_THRESHOLD_SHIFT              : constant UInt8 := 16#00#;
 
    --  Filter function coefficients
-   FT5336_TH_DIFF_REG                  : constant Unsigned_8 := 16#85#;
+   FT5336_TH_DIFF_REG                  : constant UInt8 := 16#85#;
 
    --  Control register
-   FT5336_CTRL_REG                     : constant Unsigned_8 := 16#86#;
+   FT5336_CTRL_REG                     : constant UInt8 := 16#86#;
 
    --  Values related to FT5336_CTRL_REG
 
    --  Will keep the Active mode when there is no touching
-   FT5336_CTRL_KEEP_ACTIVE_MODE        : constant Unsigned_8 := 16#00#;
+   FT5336_CTRL_KEEP_ACTIVE_MODE        : constant UInt8 := 16#00#;
 
    --  Switching from Active mode to Monitor mode automatically when there
    --  is no touching
-   FT5336_CTRL_KEEP_AUTO_SWITCH_MONITOR_MODE : constant Unsigned_8 := 16#01#;
+   FT5336_CTRL_KEEP_AUTO_SWITCH_MONITOR_MODE : constant UInt8 := 16#01#;
 
    --  The time period of switching from Active mode to Monitor mode when
    --  there is no touching
-   FT5336_TIMEENTERMONITOR_REG               : constant Unsigned_8 := 16#87#;
+   FT5336_TIMEENTERMONITOR_REG               : constant UInt8 := 16#87#;
 
    --  Report rate in Active mode
-   FT5336_PERIODACTIVE_REG             : constant Unsigned_8 := 16#88#;
+   FT5336_PERIODACTIVE_REG             : constant UInt8 := 16#88#;
 
    --  Report rate in Monitor mode
-   FT5336_PERIODMONITOR_REG            : constant Unsigned_8 := 16#89#;
+   FT5336_PERIODMONITOR_REG            : constant UInt8 := 16#89#;
 
    --  The value of the minimum allowed angle while Rotating gesture mode
-   FT5336_RADIAN_VALUE_REG             : constant Unsigned_8 := 16#91#;
+   FT5336_RADIAN_VALUE_REG             : constant UInt8 := 16#91#;
 
    --  Maximum offset while Moving Left and Moving Right gesture
-   FT5336_OFFSET_LEFT_RIGHT_REG        : constant Unsigned_8 := 16#92#;
+   FT5336_OFFSET_LEFT_RIGHT_REG        : constant UInt8 := 16#92#;
 
    --  Maximum offset while Moving Up and Moving Down gesture
-   FT5336_OFFSET_UP_DOWN_REG           : constant Unsigned_8 := 16#93#;
+   FT5336_OFFSET_UP_DOWN_REG           : constant UInt8 := 16#93#;
 
    --  Minimum distance while Moving Left and Moving Right gesture
-   FT5336_DISTANCE_LEFT_RIGHT_REG      : constant Unsigned_8 := 16#94#;
+   FT5336_DISTANCE_LEFT_RIGHT_REG      : constant UInt8 := 16#94#;
 
    --  Minimum distance while Moving Up and Moving Down gesture
-   FT5336_DISTANCE_UP_DOWN_REG         : constant Unsigned_8 := 16#95#;
+   FT5336_DISTANCE_UP_DOWN_REG         : constant UInt8 := 16#95#;
 
    --  Maximum distance while Zoom In and Zoom Out gesture
-   FT5336_DISTANCE_ZOOM_REG            : constant Unsigned_8 := 16#96#;
+   FT5336_DISTANCE_ZOOM_REG            : constant UInt8 := 16#96#;
 
    --  High 8-bit of LIB Version info
-   FT5336_LIB_VER_H_REG                : constant Unsigned_8 := 16#A1#;
+   FT5336_LIB_VER_H_REG                : constant UInt8 := 16#A1#;
 
    --  Low 8-bit of LIB Version info
-   FT5336_LIB_VER_L_REG                : constant Unsigned_8 := 16#A2#;
+   FT5336_LIB_VER_L_REG                : constant UInt8 := 16#A2#;
 
    --  Chip Selecting
-   FT5336_CIPHER_REG                   : constant Unsigned_8 := 16#A3#;
+   FT5336_CIPHER_REG                   : constant UInt8 := 16#A3#;
 
    --  Interrupt mode register (used when in interrupt mode)
-   FT5336_GMODE_REG                    : constant Unsigned_8 := 16#A4#;
+   FT5336_GMODE_REG                    : constant UInt8 := 16#A4#;
 
-   FT5336_G_MODE_INTERRUPT_MASK        : constant Unsigned_8 := 16#03#;
+   FT5336_G_MODE_INTERRUPT_MASK        : constant UInt8 := 16#03#;
 
    --  Possible values of FT5336_GMODE_REG
-   FT5336_G_MODE_INTERRUPT_POLLING     : constant Unsigned_8 := 16#00#;
-   FT5336_G_MODE_INTERRUPT_TRIGGER     : constant Unsigned_8 := 16#01#;
+   FT5336_G_MODE_INTERRUPT_POLLING     : constant UInt8 := 16#00#;
+   FT5336_G_MODE_INTERRUPT_TRIGGER     : constant UInt8 := 16#01#;
 
    --  Current power mode the FT5336 system is in (R)
-   FT5336_PWR_MODE_REG                 : constant Unsigned_8 := 16#A5#;
+   FT5336_PWR_MODE_REG                 : constant UInt8 := 16#A5#;
 
    --  FT5336 firmware version
-   FT5336_FIRMID_REG                   : constant Unsigned_8 := 16#A6#;
+   FT5336_FIRMID_REG                   : constant UInt8 := 16#A6#;
 
    --  FT5336 Chip identification register
-   FT5336_CHIP_ID_REG                  : constant Unsigned_8 := 16#A8#;
+   FT5336_CHIP_ID_REG                  : constant UInt8 := 16#A8#;
 
    --   Possible values of FT5336_CHIP_ID_REG
-   FT5336_ID_VALUE                     : constant Unsigned_8 := 16#51#;
+   FT5336_ID_VALUE                     : constant UInt8 := 16#51#;
 
    --  Release code version
-   FT5336_RELEASE_CODE_ID_REG          : constant Unsigned_8 := 16#AF#;
+   FT5336_RELEASE_CODE_ID_REG          : constant UInt8 := 16#AF#;
 
    --  Current operating mode the FT5336 system is in (R)
-   FT5336_STATE_REG                    : constant Unsigned_8 := 16#BC#;
+   FT5336_STATE_REG                    : constant UInt8 := 16#BC#;
 
    pragma Warnings (On, "* is not referenced");
 
@@ -267,9 +266,9 @@ package body FT5336 is
    --------------
 
    function I2C_Read (This   : in out FT5336_Device;
-                      Reg    : Byte;
+                      Reg    : UInt8;
                       Status : out Boolean)
-                      return Byte
+                      return UInt8
    is
       Ret        : I2C_Data (1 .. 1);
       Tmp_Status : I2C_Status;
@@ -291,8 +290,8 @@ package body FT5336 is
    ---------------
 
    procedure I2C_Write (This   : in out FT5336_Device;
-                        Reg    : Byte;
-                        Data   : Byte;
+                        Reg    : UInt8;
+                        Data   : UInt8;
                         Status : out Boolean)
    is
       Tmp_Status : I2C_Status;
@@ -312,7 +311,7 @@ package body FT5336 is
 
    function Check_Id (This : in out FT5336_Device) return Boolean
    is
-      Id     : Unsigned_8;
+      Id     : UInt8;
       Status : Boolean;
 
    begin
@@ -338,7 +337,7 @@ package body FT5336 is
    procedure TP_Set_Use_Interrupts (This    : in out FT5336_Device;
                                     Enabled : Boolean)
    is
-      Reg_Value : Unsigned_8 := 0;
+      Reg_Value : UInt8 := 0;
       Status    : Boolean with Unreferenced;
    begin
       if Enabled then
@@ -375,7 +374,7 @@ package body FT5336 is
                                  return Touch_Identifier
    is
       Status   : Boolean;
-      Nb_Touch : Unsigned_8 := 0;
+      Nb_Touch : UInt8 := 0;
    begin
       Nb_Touch := This.I2C_Read (FT5336_TD_STAT_REG, Status);
 
@@ -403,7 +402,7 @@ package body FT5336 is
                              return TP_Touch_State
    is
       type UInt16_HL_Type is record
-         High, Low : Unsigned_8;
+         High, Low : UInt8;
       end record with Size => 16;
       for UInt16_HL_Type use record
          High at 1 range 0 .. 7;
@@ -411,7 +410,7 @@ package body FT5336 is
       end record;
 
       function To_UInt16 is
-        new Ada.Unchecked_Conversion (UInt16_HL_Type, Unsigned_16);
+        new Ada.Unchecked_Conversion (UInt16_HL_Type, UInt16);
 
       Ret    : TP_Touch_State;
       Regs   : FT5336_Pressure_Registers;

--- a/components/src/touch_panel/ft5336/ft5336.ads
+++ b/components/src/touch_panel/ft5336/ft5336.ads
@@ -87,13 +87,13 @@ private
    end record;
 
    function I2C_Read (This   : in out FT5336_Device;
-                      Reg    : Byte;
+                      Reg    : UInt8;
                       Status : out Boolean)
-                      return Byte;
+                      return UInt8;
 
    procedure I2C_Write (This   : in out FT5336_Device;
-                        Reg    : Byte;
-                        Data   : Byte;
+                        Reg    : UInt8;
+                        Data   : UInt8;
                         Status : out Boolean);
 
 end FT5336;

--- a/components/src/touch_panel/ft6x06/ft6x06.adb
+++ b/components/src/touch_panel/ft6x06/ft6x06.adb
@@ -42,7 +42,7 @@ package body FT6x06 is
    --------------
 
    function Check_Id (This : in out FT6x06_Device) return Boolean is
-      Id     : Byte;
+      Id     : UInt8;
       Status : Boolean;
    begin
       for J in 1 .. 3 loop
@@ -68,7 +68,7 @@ package body FT6x06 is
      (This    : in out FT6x06_Device;
       Enabled : Boolean)
    is
-      Reg_Value : Byte := 0;
+      Reg_Value : UInt8 := 0;
       Status    : Boolean with Unreferenced;
    begin
       if Enabled then
@@ -105,7 +105,7 @@ package body FT6x06 is
                                  return Touch_Identifier
    is
       Status   : Boolean;
-      Nb_Touch : Unsigned_8 := 0;
+      Nb_Touch : UInt8 := 0;
    begin
       Nb_Touch := This.I2C_Read (FT6206_TD_STAT_REG, Status);
 
@@ -136,7 +136,7 @@ package body FT6x06 is
                              return HAL.Touch_Panel.TP_Touch_State
    is
       type UInt16_HL_Type is record
-         High, Low : Byte;
+         High, Low : UInt8;
       end record with Size => 16;
       for UInt16_HL_Type use record
          High at 1 range 0 .. 7;
@@ -255,9 +255,9 @@ package body FT6x06 is
    --------------
 
    function I2C_Read (This   : in out FT6x06_Device;
-                      Reg    : Byte;
+                      Reg    : UInt8;
                       Status : out Boolean)
-                      return Byte
+                      return UInt8
    is
       Ret        : I2C_Data (1 .. 1);
       Tmp_Status : I2C_Status;
@@ -279,8 +279,8 @@ package body FT6x06 is
    ---------------
 
    procedure I2C_Write (This   : in out FT6x06_Device;
-                        Reg    : Byte;
-                        Data   : Byte;
+                        Reg    : UInt8;
+                        Data   : UInt8;
                         Status : out Boolean)
    is
       Tmp_Status : I2C_Status;

--- a/components/src/touch_panel/ft6x06/ft6x06.ads
+++ b/components/src/touch_panel/ft6x06/ft6x06.ads
@@ -18,7 +18,7 @@
 --   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
 --   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
 --   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
---   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --UInt8
 --   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
 --   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
 --   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
@@ -32,9 +32,8 @@
 --  Driver package for the FT6x06 touch screen panel
 --  Based on the ft6x06 driver from MCD Application Team
 
-with Interfaces; use Interfaces;
-with HAL;        use HAL;
-with HAL.I2C;    use HAL.I2C;
+with HAL;             use HAL;
+with HAL.I2C;         use HAL.I2C;
 with HAL.Touch_Panel;
 
 package FT6x06 is
@@ -88,81 +87,81 @@ private
    end record;
 
    function I2C_Read (This   : in out FT6x06_Device;
-                      Reg    : Byte;
+                      Reg    : UInt8;
                       Status : out Boolean)
-                      return Byte;
+                      return UInt8;
 
    procedure I2C_Write (This   : in out FT6x06_Device;
-                        Reg    : Byte;
-                        Data   : Byte;
+                        Reg    : UInt8;
+                        Data   : UInt8;
                         Status : out Boolean);
    ------------------------------------------------------------
    -- Definitions for FT6206 I2C register addresses on 8 bit --
    ------------------------------------------------------------
 
    --  Current mode register of the FT6206 (R/W)
-   FT6206_DEV_MODE_REG                 : constant Unsigned_8 := 16#00#;
+   FT6206_DEV_MODE_REG                 : constant UInt8 := 16#00#;
 
    --  Possible values of FT6206_DEV_MODE_REG
-   FT6206_DEV_MODE_WORKING             : constant Unsigned_8 := 16#00#;
-   FT6206_DEV_MODE_FACTORY             : constant Unsigned_8 := 16#04#;
+   FT6206_DEV_MODE_WORKING             : constant UInt8 := 16#00#;
+   FT6206_DEV_MODE_FACTORY             : constant UInt8 := 16#04#;
 
-   FT6206_DEV_MODE_MASK                : constant Unsigned_8 := 16#07#;
-   FT6206_DEV_MODE_SHIFT               : constant Unsigned_8 := 16#04#;
+   FT6206_DEV_MODE_MASK                : constant UInt8 := 16#07#;
+   FT6206_DEV_MODE_SHIFT               : constant UInt8 := 16#04#;
 
    --  Gesture ID register
-   FT6206_GEST_ID_REG                  : constant Unsigned_8 := 16#01#;
+   FT6206_GEST_ID_REG                  : constant UInt8 := 16#01#;
 
    --  Possible values of FT6206_GEST_ID_REG
-   FT6206_GEST_ID_NO_GESTURE           : constant Unsigned_8 := 16#00#;
-   FT6206_GEST_ID_MOVE_UP              : constant Unsigned_8 := 16#10#;
-   FT6206_GEST_ID_MOVE_RIGHT           : constant Unsigned_8 := 16#14#;
-   FT6206_GEST_ID_MOVE_DOWN            : constant Unsigned_8 := 16#18#;
-   FT6206_GEST_ID_MOVE_LEFT            : constant Unsigned_8 := 16#1C#;
-   FT6206_GEST_ID_ZOOM_IN              : constant Unsigned_8 := 16#40#;
-   FT6206_GEST_ID_ZOOM_OUT             : constant Unsigned_8 := 16#49#;
+   FT6206_GEST_ID_NO_GESTURE           : constant UInt8 := 16#00#;
+   FT6206_GEST_ID_MOVE_UP              : constant UInt8 := 16#10#;
+   FT6206_GEST_ID_MOVE_RIGHT           : constant UInt8 := 16#14#;
+   FT6206_GEST_ID_MOVE_DOWN            : constant UInt8 := 16#18#;
+   FT6206_GEST_ID_MOVE_LEFT            : constant UInt8 := 16#1C#;
+   FT6206_GEST_ID_ZOOM_IN              : constant UInt8 := 16#40#;
+   FT6206_GEST_ID_ZOOM_OUT             : constant UInt8 := 16#49#;
 
    --  Touch Data Status register : gives number of active touch points (0..5)
-   FT6206_TD_STAT_REG                  : constant Unsigned_8 := 16#02#;
+   FT6206_TD_STAT_REG                  : constant UInt8 := 16#02#;
 
    --  Values related to FT6206_TD_STAT_REG
-   FT6206_TD_STAT_MASK                 : constant Unsigned_8 := 16#0F#;
-   FT6206_TD_STAT_SHIFT                : constant Unsigned_8 := 16#00#;
+   FT6206_TD_STAT_MASK                 : constant UInt8 := 16#0F#;
+   FT6206_TD_STAT_SHIFT                : constant UInt8 := 16#00#;
 
    --  Values Pn_XH and Pn_YH related
-   FT6206_TOUCH_EVT_FLAG_PRESS_DOWN    : constant Unsigned_8 := 16#00#;
-   FT6206_TOUCH_EVT_FLAG_LIFT_UP       : constant Unsigned_8 := 16#01#;
-   FT6206_TOUCH_EVT_FLAG_CONTACT       : constant Unsigned_8 := 16#02#;
-   FT6206_TOUCH_EVT_FLAG_NO_EVENT      : constant Unsigned_8 := 16#03#;
+   FT6206_TOUCH_EVT_FLAG_PRESS_DOWN    : constant UInt8 := 16#00#;
+   FT6206_TOUCH_EVT_FLAG_LIFT_UP       : constant UInt8 := 16#01#;
+   FT6206_TOUCH_EVT_FLAG_CONTACT       : constant UInt8 := 16#02#;
+   FT6206_TOUCH_EVT_FLAG_NO_EVENT      : constant UInt8 := 16#03#;
 
-   FT6206_TOUCH_EVT_FLAG_SHIFT         : constant Unsigned_8 := 16#06#;
-   FT6206_TOUCH_EVT_FLAG_MASK          : constant Unsigned_8 := 2#1100_0000#;
+   FT6206_TOUCH_EVT_FLAG_SHIFT         : constant UInt8 := 16#06#;
+   FT6206_TOUCH_EVT_FLAG_MASK          : constant UInt8 := 2#1100_0000#;
 
-   FT6206_TOUCH_POS_MSB_MASK           : constant Unsigned_8 := 16#0F#;
-   FT6206_TOUCH_POS_MSB_SHIFT          : constant Unsigned_8 := 16#00#;
+   FT6206_TOUCH_POS_MSB_MASK           : constant UInt8 := 16#0F#;
+   FT6206_TOUCH_POS_MSB_SHIFT          : constant UInt8 := 16#00#;
 
    --  Values Pn_XL and Pn_YL related
-   FT6206_TOUCH_POS_LSB_MASK           : constant Unsigned_8 := 16#FF#;
-   FT6206_TOUCH_POS_LSB_SHIFT          : constant Unsigned_8 := 16#00#;
+   FT6206_TOUCH_POS_LSB_MASK           : constant UInt8 := 16#FF#;
+   FT6206_TOUCH_POS_LSB_SHIFT          : constant UInt8 := 16#00#;
 
    --  Values Pn_WEIGHT related
-   FT6206_TOUCH_WEIGHT_MASK            : constant Unsigned_8 := 16#FF#;
-   FT6206_TOUCH_WEIGHT_SHIFT           : constant Unsigned_8 := 16#00#;
+   FT6206_TOUCH_WEIGHT_MASK            : constant UInt8 := 16#FF#;
+   FT6206_TOUCH_WEIGHT_SHIFT           : constant UInt8 := 16#00#;
 
 
    --  Values related to FT6206_Pn_MISC_REG
-   FT6206_TOUCH_AREA_MASK              : constant Unsigned_8 := 2#0100_0000#;
-   FT6206_TOUCH_AREA_SHIFT             : constant Unsigned_8 := 16#04#;
+   FT6206_TOUCH_AREA_MASK              : constant UInt8 := 2#0100_0000#;
+   FT6206_TOUCH_AREA_SHIFT             : constant UInt8 := 16#04#;
 
    type FT6206_Pressure_Registers is record
-      XH_Reg     : Unsigned_8;
-      XL_Reg     : Unsigned_8;
-      YH_Reg     : Unsigned_8;
-      YL_Reg     : Unsigned_8;
+      XH_Reg     : UInt8;
+      XL_Reg     : UInt8;
+      YH_Reg     : UInt8;
+      YL_Reg     : UInt8;
       --  Touch Pressure register value (R)
-      Weight_Reg : Unsigned_8;
+      Weight_Reg : UInt8;
       --  Touch area register
-      Misc_Reg   : Unsigned_8;
+      Misc_Reg   : UInt8;
    end record;
 
    FT6206_Px_Regs                : constant array (Positive range <>)
@@ -181,89 +180,89 @@ private
                                              Misc_Reg   => 16#0E#));
 
    --  Threshold for touch detection
-   FT6206_TH_GROUP_REG                 : constant Unsigned_8 := 16#80#;
+   FT6206_TH_GROUP_REG                 : constant UInt8 := 16#80#;
 
    --  Values FT6206_TH_GROUP_REG : threshold related
-   FT6206_THRESHOLD_MASK               : constant Unsigned_8 := 16#FF#;
-   FT6206_THRESHOLD_SHIFT              : constant Unsigned_8 := 16#00#;
+   FT6206_THRESHOLD_MASK               : constant UInt8 := 16#FF#;
+   FT6206_THRESHOLD_SHIFT              : constant UInt8 := 16#00#;
 
    --  Filter function coefficients
-   FT6206_TH_DIFF_REG                  : constant Unsigned_8 := 16#85#;
+   FT6206_TH_DIFF_REG                  : constant UInt8 := 16#85#;
 
    --  Control register
-   FT6206_CTRL_REG                     : constant Unsigned_8 := 16#86#;
+   FT6206_CTRL_REG                     : constant UInt8 := 16#86#;
 
    --  Values related to FT6206_CTRL_REG
 
    --  Will keep the Active mode when there is no touching
-   FT6206_CTRL_KEEP_ACTIVE_MODE        : constant Unsigned_8 := 16#00#;
+   FT6206_CTRL_KEEP_ACTIVE_MODE        : constant UInt8 := 16#00#;
 
    --  Switching from Active mode to Monitor mode automatically when there
    --  is no touching
-   FT6206_CTRL_KEEP_AUTO_SWITCH_MONITOR_MODE : constant Unsigned_8 := 16#01#;
+   FT6206_CTRL_KEEP_AUTO_SWITCH_MONITOR_MODE : constant UInt8 := 16#01#;
 
    --  The time period of switching from Active mode to Monitor mode when
    --  there is no touching
-   FT6206_TIMEENTERMONITOR_REG               : constant Unsigned_8 := 16#87#;
+   FT6206_TIMEENTERMONITOR_REG               : constant UInt8 := 16#87#;
 
    --  Report rate in Active mode
-   FT6206_PERIODACTIVE_REG             : constant Unsigned_8 := 16#88#;
+   FT6206_PERIODACTIVE_REG             : constant UInt8 := 16#88#;
 
    --  Report rate in Monitor mode
-   FT6206_PERIODMONITOR_REG            : constant Unsigned_8 := 16#89#;
+   FT6206_PERIODMONITOR_REG            : constant UInt8 := 16#89#;
 
    --  The value of the minimum allowed angle while Rotating gesture mode
-   FT6206_RADIAN_VALUE_REG             : constant Unsigned_8 := 16#91#;
+   FT6206_RADIAN_VALUE_REG             : constant UInt8 := 16#91#;
 
    --  Maximum offset while Moving Left and Moving Right gesture
-   FT6206_OFFSET_LEFT_RIGHT_REG        : constant Unsigned_8 := 16#92#;
+   FT6206_OFFSET_LEFT_RIGHT_REG        : constant UInt8 := 16#92#;
 
    --  Maximum offset while Moving Up and Moving Down gesture
-   FT6206_OFFSET_UP_DOWN_REG           : constant Unsigned_8 := 16#93#;
+   FT6206_OFFSET_UP_DOWN_REG           : constant UInt8 := 16#93#;
 
    --  Minimum distance while Moving Left and Moving Right gesture
-   FT6206_DISTANCE_LEFT_RIGHT_REG      : constant Unsigned_8 := 16#94#;
+   FT6206_DISTANCE_LEFT_RIGHT_REG      : constant UInt8 := 16#94#;
 
    --  Minimum distance while Moving Up and Moving Down gesture
-   FT6206_DISTANCE_UP_DOWN_REG         : constant Unsigned_8 := 16#95#;
+   FT6206_DISTANCE_UP_DOWN_REG         : constant UInt8 := 16#95#;
 
    --  Maximum distance while Zoom In and Zoom Out gesture
-   FT6206_DISTANCE_ZOOM_REG            : constant Unsigned_8 := 16#96#;
+   FT6206_DISTANCE_ZOOM_REG            : constant UInt8 := 16#96#;
 
    --  High 8-bit of LIB Version info
-   FT6206_LIB_VER_H_REG                : constant Unsigned_8 := 16#A1#;
+   FT6206_LIB_VER_H_REG                : constant UInt8 := 16#A1#;
 
    --  Low 8-bit of LIB Version info
-   FT6206_LIB_VER_L_REG                : constant Unsigned_8 := 16#A2#;
+   FT6206_LIB_VER_L_REG                : constant UInt8 := 16#A2#;
 
    --  Chip Selecting
-   FT6206_CIPHER_REG                   : constant Unsigned_8 := 16#A3#;
+   FT6206_CIPHER_REG                   : constant UInt8 := 16#A3#;
 
    --  Interrupt mode register (used when in interrupt mode)
-   FT6206_GMODE_REG                    : constant Unsigned_8 := 16#A4#;
+   FT6206_GMODE_REG                    : constant UInt8 := 16#A4#;
 
-   FT6206_G_MODE_INTERRUPT_MASK        : constant Unsigned_8 := 16#03#;
+   FT6206_G_MODE_INTERRUPT_MASK        : constant UInt8 := 16#03#;
 
    --  Possible values of FT6206_GMODE_REG
-   FT6206_G_MODE_INTERRUPT_POLLING     : constant Unsigned_8 := 16#00#;
-   FT6206_G_MODE_INTERRUPT_TRIGGER     : constant Unsigned_8 := 16#01#;
+   FT6206_G_MODE_INTERRUPT_POLLING     : constant UInt8 := 16#00#;
+   FT6206_G_MODE_INTERRUPT_TRIGGER     : constant UInt8 := 16#01#;
 
    --  Current power mode the FT6206 system is in (R)
-   FT6206_PWR_MODE_REG                 : constant Unsigned_8 := 16#A5#;
+   FT6206_PWR_MODE_REG                 : constant UInt8 := 16#A5#;
 
    --  FT6206 firmware version
-   FT6206_FIRMID_REG                   : constant Unsigned_8 := 16#A6#;
+   FT6206_FIRMID_REG                   : constant UInt8 := 16#A6#;
 
    --  FT6206 Chip identification register
-   FT6206_CHIP_ID_REG                  : constant Unsigned_8 := 16#A8#;
+   FT6206_CHIP_ID_REG                  : constant UInt8 := 16#A8#;
 
    --   Possible values of FT6206_CHIP_ID_REG
-   FT6206_ID_VALUE                     : constant Unsigned_8 := 16#11#;
+   FT6206_ID_VALUE                     : constant UInt8 := 16#11#;
 
    --  Release code version
-   FT6206_RELEASE_CODE_ID_REG          : constant Unsigned_8 := 16#AF#;
+   FT6206_RELEASE_CODE_ID_REG          : constant UInt8 := 16#AF#;
 
    --  Current operating mode the FT6206 system is in (R)
-   FT6206_STATE_REG                    : constant Unsigned_8 := 16#BC#;
+   FT6206_STATE_REG                    : constant UInt8 := 16#BC#;
 
 end FT6x06;

--- a/components/src/touch_panel/stmpe811/stmpe811.adb
+++ b/components/src/touch_panel/stmpe811/stmpe811.adb
@@ -41,78 +41,76 @@
 --   COPYRIGHT(c) 2014 STMicroelectronics                                   --
 ------------------------------------------------------------------------------
 
-with Interfaces; use Interfaces;
-
 package body STMPE811 is
 
    pragma Warnings (Off, "constant * is not referenced");
    --  Control Registers
-   IOE_REG_SYS_CTRL1    : constant Byte := 16#03#;
-   IOE_REG_SYS_CTRL2    : constant Byte := 16#04#;
-   IOE_REG_SPI_CFG      : constant Byte := 16#08#;
+   IOE_REG_SYS_CTRL1    : constant UInt8 := 16#03#;
+   IOE_REG_SYS_CTRL2    : constant UInt8 := 16#04#;
+   IOE_REG_SPI_CFG      : constant UInt8 := 16#08#;
 
    --  Touch Panel Registers
-   IOE_REG_TSC_CTRL     : constant Byte := 16#40#;
-   IOE_REG_TSC_CFG      : constant Byte := 16#41#;
-   IOE_REG_WDM_TR_X     : constant Byte := 16#42#;
-   IOE_REG_WDM_TR_Y     : constant Byte := 16#44#;
-   IOE_REG_WDM_BL_X     : constant Byte := 16#46#;
-   IOE_REG_WDM_BL_Y     : constant Byte := 16#48#;
-   IOE_REG_FIFO_TH      : constant Byte := 16#4A#;
-   IOE_REG_FIFO_STA     : constant Byte := 16#4B#;
-   IOE_REG_FIFO_SIZE    : constant Byte := 16#4C#;
-   IOE_REG_TSC_DATA_X   : constant Byte := 16#4D#;
-   IOE_REG_TSC_DATA_Y   : constant Byte := 16#4F#;
-   IOE_REG_TSC_DATA_Z   : constant Byte := 16#51#;
-   IOE_REG_TSC_DATA_XYZ : constant Byte := 16#52#;
-   IOE_REG_TSC_FRACT_Z  : constant Byte := 16#56#;
-   IOE_REG_TSC_DATA     : constant Byte := 16#57#;
-   IOE_REG_TSC_I_DRIVE  : constant Byte := 16#58#;
-   IOE_REG_TSC_SHIELD   : constant Byte := 16#59#;
+   IOE_REG_TSC_CTRL     : constant UInt8 := 16#40#;
+   IOE_REG_TSC_CFG      : constant UInt8 := 16#41#;
+   IOE_REG_WDM_TR_X     : constant UInt8 := 16#42#;
+   IOE_REG_WDM_TR_Y     : constant UInt8 := 16#44#;
+   IOE_REG_WDM_BL_X     : constant UInt8 := 16#46#;
+   IOE_REG_WDM_BL_Y     : constant UInt8 := 16#48#;
+   IOE_REG_FIFO_TH      : constant UInt8 := 16#4A#;
+   IOE_REG_FIFO_STA     : constant UInt8 := 16#4B#;
+   IOE_REG_FIFO_SIZE    : constant UInt8 := 16#4C#;
+   IOE_REG_TSC_DATA_X   : constant UInt8 := 16#4D#;
+   IOE_REG_TSC_DATA_Y   : constant UInt8 := 16#4F#;
+   IOE_REG_TSC_DATA_Z   : constant UInt8 := 16#51#;
+   IOE_REG_TSC_DATA_XYZ : constant UInt8 := 16#52#;
+   IOE_REG_TSC_FRACT_Z  : constant UInt8 := 16#56#;
+   IOE_REG_TSC_DATA     : constant UInt8 := 16#57#;
+   IOE_REG_TSC_I_DRIVE  : constant UInt8 := 16#58#;
+   IOE_REG_TSC_SHIELD   : constant UInt8 := 16#59#;
 
    --  IOE GPIO Registers
-   IOE_REG_GPIO_SET_PIN : constant Byte := 16#10#;
-   IOE_REG_GPIO_CLR_PIN : constant Byte := 16#11#;
-   IOE_REG_GPIO_MP_STA  : constant Byte := 16#12#;
-   IOE_REG_GPIO_DIR     : constant Byte := 16#13#;
-   IOE_REG_GPIO_ED      : constant Byte := 16#14#;
-   IOE_REG_GPIO_RE      : constant Byte := 16#15#;
-   IOE_REG_GPIO_FE      : constant Byte := 16#16#;
-   IOE_REG_GPIO_AF      : constant Byte := 16#17#;
+   IOE_REG_GPIO_SET_PIN : constant UInt8 := 16#10#;
+   IOE_REG_GPIO_CLR_PIN : constant UInt8 := 16#11#;
+   IOE_REG_GPIO_MP_STA  : constant UInt8 := 16#12#;
+   IOE_REG_GPIO_DIR     : constant UInt8 := 16#13#;
+   IOE_REG_GPIO_ED      : constant UInt8 := 16#14#;
+   IOE_REG_GPIO_RE      : constant UInt8 := 16#15#;
+   IOE_REG_GPIO_FE      : constant UInt8 := 16#16#;
+   IOE_REG_GPIO_AF      : constant UInt8 := 16#17#;
 
    --  IOE Functions
-   IOE_ADC_FCT          : constant Byte := 16#01#;
-   IOE_TSC_FCT          : constant Byte := 16#02#;
-   IOE_IO_FCT           : constant Byte := 16#04#;
+   IOE_ADC_FCT          : constant UInt8 := 16#01#;
+   IOE_TSC_FCT          : constant UInt8 := 16#02#;
+   IOE_IO_FCT           : constant UInt8 := 16#04#;
 
    --  ADC Registers
-   IOE_REG_ADC_INT_EN   : constant Byte := 16#0E#;
-   IOE_REG_ADC_INT_STA  : constant Byte := 16#0F#;
-   IOE_REG_ADC_CTRL1    : constant Byte := 16#20#;
-   IOE_REG_ADC_CTRL2    : constant Byte := 16#21#;
-   IOE_REG_ADC_CAPT     : constant Byte := 16#22#;
-   IOE_REG_ADC_DATA_CH0 : constant Byte := 16#30#;
-   IOE_REG_ADC_DATA_CH1 : constant Byte := 16#32#;
-   IOE_REG_ADC_DATA_CH2 : constant Byte := 16#34#;
-   IOE_REG_ADC_DATA_CH3 : constant Byte := 16#36#;
-   IOE_REG_ADC_DATA_CH4 : constant Byte := 16#38#;
-   IOE_REG_ADC_DATA_CH5 : constant Byte := 16#3A#;
-   IOE_REG_ADC_DATA_CH6 : constant Byte := 16#3B#;
-   IOE_REG_ADC_DATA_CH7 : constant Byte := 16#3C#;
+   IOE_REG_ADC_INT_EN   : constant UInt8 := 16#0E#;
+   IOE_REG_ADC_INT_STA  : constant UInt8 := 16#0F#;
+   IOE_REG_ADC_CTRL1    : constant UInt8 := 16#20#;
+   IOE_REG_ADC_CTRL2    : constant UInt8 := 16#21#;
+   IOE_REG_ADC_CAPT     : constant UInt8 := 16#22#;
+   IOE_REG_ADC_DATA_CH0 : constant UInt8 := 16#30#;
+   IOE_REG_ADC_DATA_CH1 : constant UInt8 := 16#32#;
+   IOE_REG_ADC_DATA_CH2 : constant UInt8 := 16#34#;
+   IOE_REG_ADC_DATA_CH3 : constant UInt8 := 16#36#;
+   IOE_REG_ADC_DATA_CH4 : constant UInt8 := 16#38#;
+   IOE_REG_ADC_DATA_CH5 : constant UInt8 := 16#3A#;
+   IOE_REG_ADC_DATA_CH6 : constant UInt8 := 16#3B#;
+   IOE_REG_ADC_DATA_CH7 : constant UInt8 := 16#3C#;
 
    --  Interrupt Control Registers
-   IOE_REG_INT_CTRL     : constant Byte := 16#09#;
-   IOE_REG_INT_EN       : constant Byte := 16#0A#;
-   IOE_REG_INT_STA      : constant Byte := 16#0B#;
-   IOE_REG_GPIO_INT_EN  : constant Byte := 16#0C#;
-   IOE_REG_GPIO_INT_STA : constant Byte := 16#0D#;
+   IOE_REG_INT_CTRL     : constant UInt8 := 16#09#;
+   IOE_REG_INT_EN       : constant UInt8 := 16#0A#;
+   IOE_REG_INT_STA      : constant UInt8 := 16#0B#;
+   IOE_REG_GPIO_INT_EN  : constant UInt8 := 16#0C#;
+   IOE_REG_GPIO_INT_STA : constant UInt8 := 16#0D#;
 
    --  touch Panel Pins
-   TOUCH_YD             : constant Byte := 16#02#;
-   TOUCH_XD             : constant Byte := 16#04#;
-   TOUCH_YU             : constant Byte := 16#08#;
-   TOUCH_XU             : constant Byte := 16#10#;
-   TOUCH_IO_ALL         : constant Byte :=
+   TOUCH_YD             : constant UInt8 := 16#02#;
+   TOUCH_XD             : constant UInt8 := 16#04#;
+   TOUCH_YU             : constant UInt8 := 16#08#;
+   TOUCH_XU             : constant UInt8 := 16#10#;
+   TOUCH_IO_ALL         : constant UInt8 :=
      TOUCH_YD or TOUCH_XD or TOUCH_YU or TOUCH_XU;
    pragma Warnings (On, "constant * is not referenced");
 
@@ -121,7 +119,7 @@ package body STMPE811 is
    ---------------
 
    function Read_Data (This      : in out STMPE811_Device;
-                       Data_Addr : Byte;
+                       Data_Addr : UInt8;
                        Length    : Natural) return TSC_Data
    is
       Data   : TSC_Data (1 .. Length);
@@ -145,7 +143,7 @@ package body STMPE811 is
    -------------------
 
    function Read_Register (This     : STMPE811_Device;
-                           Reg_Addr : Byte) return Byte
+                           Reg_Addr : UInt8) return UInt8
    is
       Data : TSC_Data (1 .. 1);
       Status : I2C_Status;
@@ -169,8 +167,8 @@ package body STMPE811 is
    --------------------
 
    procedure Write_Register (This     : in out STMPE811_Device;
-                             Reg_Addr : Byte;
-                             Data     : Byte) is
+                             Reg_Addr : UInt8;
+                             Data     : UInt8) is
       Status : I2C_Status;
 
    begin
@@ -204,10 +202,10 @@ package body STMPE811 is
    --------------------------
 
    procedure IOE_Function_Command (This : in out STMPE811_Device;
-                                   Func : Byte;
+                                   Func : UInt8;
                                    Enabled : Boolean)
    is
-      Reg : Byte := This.Read_Register (IOE_REG_SYS_CTRL2);
+      Reg : UInt8 := This.Read_Register (IOE_REG_SYS_CTRL2);
    begin
       --  CTRL2 functions are disabled when corresponding bit is set
 
@@ -225,9 +223,9 @@ package body STMPE811 is
    -------------------
 
    procedure IOE_AF_Config (This      : in out STMPE811_Device;
-                            Pin       : Byte;
+                            Pin       : UInt8;
                             Enabled   : Boolean) is
-      Reg : Byte := This.Read_Register (IOE_REG_GPIO_AF);
+      Reg : UInt8 := This.Read_Register (IOE_REG_GPIO_AF);
    begin
       if Enabled then
          Reg := Reg or Pin;
@@ -318,7 +316,7 @@ package body STMPE811 is
    function Active_Touch_Points (This : in out STMPE811_Device)
                                  return Touch_Identifier
    is
-      Val : constant Byte := This.Read_Register (IOE_REG_TSC_CTRL) and 16#80#;
+      Val : constant UInt8 := This.Read_Register (IOE_REG_TSC_CTRL) and 16#80#;
    begin
       if Val = 0 then
          This.Write_Register (IOE_REG_FIFO_STA, 16#01#);

--- a/components/src/touch_panel/stmpe811/stmpe811.ads
+++ b/components/src/touch_panel/stmpe811/stmpe811.ads
@@ -83,19 +83,19 @@ private
    subtype TSC_Data is I2C_Data;
 
    function Read_Data (This      : in out STMPE811_Device;
-                       Data_Addr : Byte;
+                       Data_Addr : UInt8;
                        Length    : Natural) return TSC_Data;
    function Read_Register (This     : STMPE811_Device;
-                           Reg_Addr : Byte) return Byte;
+                           Reg_Addr : UInt8) return UInt8;
    procedure Write_Register (This     : in out STMPE811_Device;
-                             Reg_Addr : Byte;
-                             Data     : Byte);
+                             Reg_Addr : UInt8;
+                             Data     : UInt8);
    procedure IOE_Reset (This : in out STMPE811_Device);
    procedure IOE_Function_Command (This : in out STMPE811_Device;
-                                   Func : Byte;
+                                   Func : UInt8;
                                    Enabled : Boolean);
    procedure IOE_AF_Config (This      : in out STMPE811_Device;
-                            Pin       : Byte;
+                            Pin       : UInt8;
                             Enabled   : Boolean);
    function Get_IOE_ID (This : in out STMPE811_Device) return UInt16;
 

--- a/examples/accelerometer/src/main.adb
+++ b/examples/accelerometer/src/main.adb
@@ -45,7 +45,6 @@ with Simple_Synthesizer;
 with CS43L22;
 
 procedure Main is
-   use type Byte;
 
    Values : LIS3DSH.Axes_Accelerations;
 

--- a/examples/common/gui/bitmapped_drawing.adb
+++ b/examples/common/gui/bitmapped_drawing.adb
@@ -29,7 +29,6 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with HAL;                     use HAL;
 with Bitmap_Color_Conversion; use Bitmap_Color_Conversion;
 
 package body Bitmapped_Drawing is
@@ -43,8 +42,8 @@ package body Bitmapped_Drawing is
       Start      : Point;
       Char       : Character;
       Font       : BMP_Font;
-      Foreground : Unsigned_32;
-      Background : Unsigned_32)
+      Foreground : UInt32;
+      Background : UInt32)
    is
    begin
       for H in 0 .. Char_Height (Font) - 1 loop
@@ -73,9 +72,9 @@ package body Bitmapped_Drawing is
       Background : Bitmap_Color)
    is
       Count : Natural := 0;
-      FG    : constant Unsigned_32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
+      FG    : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
                                                             Foreground);
-      BG    : constant Unsigned_32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
+      BG    : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
                                                             Background);
    begin
       for C of Msg loop
@@ -161,7 +160,7 @@ package body Bitmapped_Drawing is
                   Hershey_Fonts.Strlen (Msg, Font, Area.Height);
       Ratio   : Float;
       Current : Point := (0, 0);
-      Prev    : Unsigned_32;
+      Prev    : UInt32;
       FG      : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
                                                        Foreground);
       Blk     : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
@@ -216,8 +215,8 @@ package body Bitmapped_Drawing is
 
             for X in Area.Position.X + 1 .. Area.Position.X + Area.Width loop
                declare
-                  Col : constant Unsigned_32 := Buffer.Pixel ((X, Y));
-                  Top : constant Unsigned_32 := Buffer.Pixel ((X, Y - 1));
+                  Col : constant UInt32 := Buffer.Pixel ((X, Y));
+                  Top : constant UInt32 := Buffer.Pixel ((X, Y - 1));
                begin
 
                   if Prev /= FG

--- a/examples/common/gui/bitmapped_drawing.ads
+++ b/examples/common/gui/bitmapped_drawing.ads
@@ -32,9 +32,9 @@
 --  This package provides routines for drawing shapes, characters, and strings
 --  on a bit-mapped device or graphical buffer.
 
-with Interfaces;    use Interfaces;
 with BMP_Fonts;     use BMP_Fonts;
 with Hershey_Fonts; use Hershey_Fonts;
+with HAL;           use HAL;
 with HAL.Bitmap;    use HAL.Bitmap;
 
 package Bitmapped_Drawing is
@@ -44,8 +44,8 @@ package Bitmapped_Drawing is
       Start      : Point;
       Char       : Character;
       Font       : BMP_Font;
-      Foreground : Unsigned_32;
-      Background : Unsigned_32);
+      Foreground : UInt32;
+      Background : UInt32);
 
    procedure Draw_String
      (Buffer     : in out Bitmap_Buffer'Class;

--- a/examples/common/gui/bmp_fonts.adb
+++ b/examples/common/gui/bmp_fonts.adb
@@ -3477,7 +3477,7 @@ package body BMP_Fonts is
       16#0000#,
       16#0000#);
 
-   BMP_Font8x8 : constant array (0 .. 767) of Byte :=
+   BMP_Font8x8 : constant array (0 .. 767) of UInt8 :=
      (16#00#,
       16#00#,
       16#00#,

--- a/examples/common/gui/hershey_fonts-futural.ads
+++ b/examples/common/gui/hershey_fonts-futural.ads
@@ -58,7 +58,7 @@
 --     format *EXCEPT* the format distributed by the U.S. NTIS (which
 --     organization holds the rights to the distribution and use of the font
 --     data in that particular format). Not that anybody would really *want*
---     to use their format... each point is described in eight bytes as
+--     to use their format... each point is described in eight UInt8s as
 --     "xxx yyy:", where xxx and yyy are the coordinate values as ASCII
 --     numbers.
 --

--- a/examples/common/gui/hershey_fonts.adb
+++ b/examples/common/gui/hershey_fonts.adb
@@ -139,13 +139,13 @@ package body Hershey_Fonts is
       Fnt_Idx     : Natural;
       Fnt_Y_Min   : Integer_8 := Integer_8'Last;
 
-      function To_Byte (S : String) return Natural;
+      function To_UInt8 (S : String) return Natural;
 
       -------------
-      -- To_Byte --
+      -- To_UInt8 --
       -------------
 
-      function To_Byte (S : String) return Natural
+      function To_UInt8 (S : String) return Natural
       is
          Ret : Natural := 0;
       begin
@@ -155,7 +155,7 @@ package body Hershey_Fonts is
             end if;
          end loop;
          return Ret;
-      end To_Byte;
+      end To_UInt8;
 
    begin
       Fnt_Idx := Fnt'First;
@@ -165,7 +165,7 @@ package body Hershey_Fonts is
          Fnt_Idx := Fnt_Idx + 5;
 
          declare
-            Size  : constant Natural := To_Byte (Fnt (Fnt_Idx .. Fnt_Idx + 2));
+            Size  : constant Natural := To_UInt8 (Fnt (Fnt_Idx .. Fnt_Idx + 2));
             G     : Glyph;
             CStr  : String (1 .. 2);
             C     : Coord;
@@ -198,7 +198,7 @@ package body Hershey_Fonts is
                      --  First coordinate tells the left and right borders of
                      --  the glyph.
                      Left := C.X;
-                     G.Width := Unsigned_8 (C.Y - C.X + 1);
+                     G.Width := UInt8 (C.Y - C.X + 1);
                   else
                      C.X := C.X - Left;
                      XMin := Integer_8'Min (XMin, C.X);
@@ -216,7 +216,7 @@ package body Hershey_Fonts is
             if G.Vertices = 0 then
                G.Height := 0;
             else
-               G.Height := Unsigned_8 (YMax - YMin);
+               G.Height := UInt8 (YMax - YMin);
                Fnt_Y_Min := Integer_8'Min (YMin, Fnt_Y_Min);
             end if;
 
@@ -238,8 +238,8 @@ package body Hershey_Fonts is
                end if;
             end loop;
 
-            Ret.Baseline := Unsigned_8 (-Fnt_Y_Min);
-            Ret.Font_Height := Unsigned_8'Max (Ret.Font_Height, G.Height);
+            Ret.Baseline := UInt8 (-Fnt_Y_Min);
+            Ret.Font_Height := UInt8'Max (Ret.Font_Height, G.Height);
          end;
       end loop;
    end Read;

--- a/examples/common/gui/hershey_fonts.ads
+++ b/examples/common/gui/hershey_fonts.ads
@@ -32,6 +32,7 @@
 --  This package handles the Hershey font format.
 
 with Interfaces; use Interfaces;
+with HAL;        use HAL;
 
 package Hershey_Fonts is
 
@@ -75,8 +76,8 @@ private
 
    type Glyph is record
       Vertices : Natural;
-      Width    : Unsigned_8;
-      Height   : Unsigned_8;
+      Width    : UInt8;
+      Height   : UInt8;
       Coords   : Coord_Array (1 .. 120);
    end record with Pack;
 
@@ -87,8 +88,8 @@ private
    type Hershey_Font is record
       Number_Of_Glyphs : Glyph_Index;
       Glyphs           : Glyph_Array;
-      Font_Height      : Unsigned_8;
-      Baseline         : Unsigned_8;
+      Font_Height      : UInt8;
+      Baseline         : UInt8;
    end record;
 
 end Hershey_Fonts;

--- a/examples/stm32_dma2d/src/dma2d.adb
+++ b/examples/stm32_dma2d/src/dma2d.adb
@@ -29,17 +29,16 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Last_Chance_Handler;  pragma Unreferenced (Last_Chance_Handler);
+with Last_Chance_Handler; pragma Unreferenced (Last_Chance_Handler);
 --  The "last chance handler" is the user-defined routine that is called when
 --  an exception is propagated. We need it in the executable, therefore it
 --  must be somewhere in the closure of the context clauses.
 
-with STM32.Board;           use STM32.Board;
-with STM32.DMA2D;           use STM32.DMA2D;
-with STM32.DMA2D_Bitmap;    use STM32.DMA2D_Bitmap;
-with HAL;                   use HAL;
-with Interfaces;            use Interfaces;
-with HAL.Bitmap;            use HAL.Bitmap;
+with STM32.Board;         use STM32.Board;
+with STM32.DMA2D;         use STM32.DMA2D;
+with STM32.DMA2D_Bitmap;  use STM32.DMA2D_Bitmap;
+with HAL;                 use HAL;
+with HAL.Bitmap;          use HAL.Bitmap;
 
 procedure Dma2d
 is
@@ -155,7 +154,7 @@ begin
 
       --  Fill L4 CLUT
       for Index in UInt4 loop
-         L4_CLUT (Index) := (255, 0, 0, Byte (Index) * 16);
+         L4_CLUT (Index) := (255, 0, 0, UInt8 (Index) * 16);
       end loop;
 
       --  Fill L4 bitmap

--- a/hal/src/hal-bitmap.ads
+++ b/hal/src/hal-bitmap.ads
@@ -79,10 +79,10 @@ package HAL.Bitmap is
    end record;
 
    type Bitmap_Color is record
-      Alpha : Byte;
-      Red   : Byte;
-      Green : Byte;
-      Blue  : Byte;
+      Alpha : UInt8;
+      Red   : UInt8;
+      Green : UInt8;
+      Blue  : UInt8;
    end record with Size => 32;
 
    for Bitmap_Color use record

--- a/hal/src/hal-block_drivers.ads
+++ b/hal/src/hal-block_drivers.ads
@@ -29,24 +29,22 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Interfaces; use Interfaces;
-
 package HAL.Block_Drivers is
 
    type Block_Driver is limited interface;
    type Any_Block_Driver is access all Block_Driver'Class;
 
-   subtype Block is Byte_Array;
+   subtype Block is UInt8_Array;
 
    function Read
      (This         : in out Block_Driver;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : out Block)
       return Boolean is abstract;
 
    function Write
      (This         : in out Block_Driver;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : Block)
       return Boolean is abstract;
 

--- a/hal/src/hal-dsi.ads
+++ b/hal/src/hal-dsi.ads
@@ -35,7 +35,7 @@ package HAL.DSI is
 
    subtype DSI_Virtual_Channel_ID is UInt2;
 
-   type DSI_Data is array (Positive range <>) of Byte;
+   type DSI_Data is array (Positive range <>) of UInt8;
 
    type DSI_Pkt_Data_Type is
      (DCS_Short_Pkt_Write_P0, --  DCS Short write, no parameter
@@ -64,14 +64,14 @@ package HAL.DSI is
      (Port       : in out DSI_Port;
       Channel_ID : DSI_Virtual_Channel_ID;
       Mode       : DSI_Short_Write_Packet_Data_Type;
-      Param1     : Byte;
-      Param2     : Byte) is abstract;
+      Param1     : UInt8;
+      Param2     : UInt8) is abstract;
 
    procedure DSI_Long_Write
      (Port       : in out DSI_Port;
       Channel_Id : DSI_Virtual_Channel_ID;
       Mode       : DSI_Long_Write_Packet_Data_Type;
-      Param1     : Byte;
+      Param1     : UInt8;
       Parameters : DSI_Data) is abstract;
 
 end HAL.DSI;

--- a/hal/src/hal-filesystem.ads
+++ b/hal/src/hal-filesystem.ads
@@ -117,7 +117,7 @@ package HAL.Filesystem is
                            Length : IO_Count)
                            return Status_Kind is abstract;
    --  Assuming Path designates a regular file, set its size to be Length. This
-   --  operation preserves the first Length bytes and leaves the other with
+   --  operation preserves the first Length UInt8s and leaves the other with
    --  undefined values.
 
    function Open (This   : in out FS_Driver;
@@ -149,21 +149,21 @@ package HAL.Filesystem is
    ------------------
 
    function Read (This : in out File_Handle;
-                  Data : out Byte_Array)
+                  Data : out UInt8_Array)
                   return Status_Kind is abstract;
-   --  Read the next Data'Length bytes in This and put to in Data. If there
-   --  isn't enough byte to read to fill Data, return Input_Output_Error.
+   --  Read the next Data'Length UInt8s in This and put to in Data. If there
+   --  isn't enough UInt8 to read to fill Data, return Input_Output_Error.
 
    function Write (This : in out File_Handle;
-                   Data : Byte_Array)
+                   Data : UInt8_Array)
                    return Status_Kind is abstract;
-   --  Write bytes in Data to This. This overrides the next Data'Length bytes in
+   --  Write UInt8s in Data to This. This overrides the next Data'Length UInt8s in
    --  this file, if they exist, it extends the file otherwise.
 
    function Seek (This   : in out File_Handle;
                   Offset : IO_Count)
                   return Status_Kind is abstract;
-   --  Set the read/write cursor of This to point to its byte at the absolute
+   --  Set the read/write cursor of This to point to its UInt8 at the absolute
    --  Offset.
    --
    --  ??? What should happen if this offset is beyond the end of the file?

--- a/hal/src/hal-framebuffer.ads
+++ b/hal/src/hal-framebuffer.ads
@@ -78,7 +78,7 @@ package HAL.Framebuffer is
    --  hardware orientation change.
 
    procedure Set_Background
-     (This : Frame_Buffer_Display; R, G, B : Byte) is abstract;
+     (This : Frame_Buffer_Display; R, G, B : UInt8) is abstract;
 
    procedure Initialize_Layer
      (This   : in out Frame_Buffer_Display;

--- a/hal/src/hal-i2c.ads
+++ b/hal/src/hal-i2c.ads
@@ -37,7 +37,7 @@ package HAL.I2C is
       Err_Timeout,
       Busy);
 
-   subtype I2C_Data is Byte_Array;
+   subtype I2C_Data is UInt8_Array;
 
    type I2C_Memory_Address_Size is
      (Memory_Size_8b,

--- a/hal/src/hal-spi.ads
+++ b/hal/src/hal-spi.ads
@@ -41,7 +41,7 @@ package HAL.SPI is
      (Data_Size_8b,
       Data_Size_16b);
 
-   type SPI_Data_8b is array (Natural range <>) of Byte;
+   type SPI_Data_8b is array (Natural range <>) of UInt8;
 
    type SPI_Data_16b is array (Natural range <>) of UInt16;
 

--- a/hal/src/hal-uart.ads
+++ b/hal/src/hal-uart.ads
@@ -41,7 +41,7 @@ package HAL.UART is
      (Data_Size_8b,
       Data_Size_9b);
 
-   type UART_Data_8b is array (Natural range <>) of Byte;
+   type UART_Data_8b is array (Natural range <>) of UInt8;
 
    type UART_Data_9b is array (Natural range <>) of UInt9;
 

--- a/hal/src/hal.ads
+++ b/hal/src/hal.ads
@@ -34,7 +34,7 @@ with Interfaces;
 package HAL is
    pragma Pure;
 
-   type UInt1 is mod 2**1
+   type Bit is mod 2**1
      with Size => 1;
    type UInt2 is mod 2**2
      with Size => 2;

--- a/hal/src/hal.ads
+++ b/hal/src/hal.ads
@@ -34,7 +34,7 @@ with Interfaces;
 package HAL is
    pragma Pure;
 
-   type Bit is mod 2**1
+   type UInt1 is mod 2**1
      with Size => 1;
    type UInt2 is mod 2**2
      with Size => 2;
@@ -50,8 +50,7 @@ package HAL is
      with Size => 7;
    type UInt9 is mod 2**9
      with Size => 9;
-   subtype UInt8 is Interfaces.Unsigned_8;
-   subtype Byte is Interfaces.Unsigned_8;
+   type UInt8 is new Interfaces.Unsigned_8;
    type UInt10 is mod 2**10
      with Size => 10;
    type UInt11 is mod 2**11
@@ -64,7 +63,7 @@ package HAL is
      with Size => 14;
    type UInt15 is mod 2**15
      with Size => 15;
-   subtype UInt16 is Interfaces.Unsigned_16;
+   type UInt16 is new Interfaces.Unsigned_16;
    type UInt17 is mod 2**17
      with Size => 17;
    type UInt18 is mod 2**18
@@ -95,7 +94,7 @@ package HAL is
      with Size => 30;
    type UInt31 is mod 2**31
      with Size => 31;
-   subtype UInt32 is Interfaces.Unsigned_32;
+   type UInt32 is new Interfaces.Unsigned_32;
    type UInt33 is mod 2**33
      with Size => 33;
    type UInt34 is mod 2**34
@@ -158,9 +157,9 @@ package HAL is
      with Size => 62;
    type UInt63 is mod 2**63
      with Size => 63;
-   subtype UInt64 is Interfaces.Unsigned_64;
+   type UInt64 is new Interfaces.Unsigned_64;
 
-   type Byte_Array is array (Natural range <>) of Byte;
+   type UInt8_Array is array (Natural range <>) of UInt8;
    type UInt16_Array is array (Natural range <>) of UInt16;
    type Word_Array is array (Natural range <>) of UInt32;
 

--- a/middleware/src/BLE/bluetooth_low_energy-beacon.adb
+++ b/middleware/src/BLE/bluetooth_low_energy-beacon.adb
@@ -43,15 +43,15 @@ package body Bluetooth_Low_Energy.Beacon is
       --  MAC
       Push (Pck, (16#FE#, 16#CA#, 16#EF#, 16#BE#, 16#AD#, 16#DE#));
       --  Flag length
-      Push (Pck, Byte (2));
+      Push (Pck, UInt8 (2));
       --  Flag type
-      Push (Pck, Byte (1));
+      Push (Pck, UInt8 (1));
       --  Flag Content
-      Push (Pck, Byte (6));
+      Push (Pck, UInt8 (6));
       --  Data length
-      Push (Pck, Byte (16#1A#));
+      Push (Pck, UInt8 (16#1A#));
       --  Data type
-      Push (Pck, Byte (16#FF#));
+      Push (Pck, UInt8 (16#FF#));
       --  Data header
       Push (Pck, (16#4C#, 16#00#, 16#02#, 16#15#));
       --  UUID

--- a/middleware/src/BLE/bluetooth_low_energy-beacon.ads
+++ b/middleware/src/BLE/bluetooth_low_energy-beacon.ads
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 with Bluetooth_Low_Energy.Packets; use Bluetooth_Low_Energy.Packets;
+with Interfaces;                   use Interfaces;
 
 package Bluetooth_Low_Energy.Beacon is
 

--- a/middleware/src/BLE/bluetooth_low_energy-packets.adb
+++ b/middleware/src/BLE/bluetooth_low_energy-packets.adb
@@ -33,8 +33,8 @@ with Ada.Unchecked_Conversion;
 
 package body Bluetooth_Low_Energy.Packets is
 
-   function As_Unsigned_8 is new Ada.Unchecked_Conversion (Integer_8,
-                                                           Unsigned_8);
+   function As_UInt8 is new Ada.Unchecked_Conversion (Interfaces.Integer_8,
+                                                      UInt8);
    -----------------
    -- Get_Address --
    -----------------
@@ -49,7 +49,7 @@ package body Bluetooth_Low_Energy.Packets is
    ----------------
 
    procedure Set_Header (This   : in out BLE_Packet;
-                         Header : Unsigned_8)
+                         Header : UInt8)
    is
    begin
       This.Header := Header;
@@ -61,7 +61,7 @@ package body Bluetooth_Low_Energy.Packets is
 
    procedure Push
      (This : in out BLE_Packet;
-      Data : Byte)
+      Data : UInt8)
    is
       Next_Index : constant Integer :=
         This.Data'First + Integer (This.Packet_Length);
@@ -77,10 +77,10 @@ package body Bluetooth_Low_Energy.Packets is
    ----------
 
    procedure Push (This : in out BLE_Packet;
-                        Data : Integer_8)
+                   Data : Interfaces.Integer_8)
    is
    begin
-      Push (This, As_Unsigned_8 (Data));
+      Push (This, As_UInt8 (Data));
    end Push;
 
    ----------
@@ -91,7 +91,7 @@ package body Bluetooth_Low_Energy.Packets is
      (This : in out BLE_Packet;
       Data : UInt16)
    is
-      type As_Array is array (1 .. 2) of Byte with Pack, Size => 16;
+      type As_Array is array (1 .. 2) of UInt8 with Pack, Size => 16;
 
       Data_As_Array : As_Array;
       for Data_As_Array'Address use Data'Address;
@@ -108,7 +108,7 @@ package body Bluetooth_Low_Energy.Packets is
      (This : in out BLE_Packet;
       Data : UInt32)
    is
-      type As_Array is array (1 .. 4) of Byte with Pack, Size => 32;
+      type As_Array is array (1 .. 4) of UInt8 with Pack, Size => 32;
 
       Data_As_Array : As_Array;
       for Data_As_Array'Address use Data'Address;
@@ -125,7 +125,7 @@ package body Bluetooth_Low_Energy.Packets is
 
    procedure Push
      (This : in out BLE_Packet;
-      Data : Byte_Array)
+      Data : UInt8_Array)
    is
    begin
       for Elt of Data loop
@@ -147,8 +147,8 @@ package body Bluetooth_Low_Energy.Packets is
             Push (This, UUID.UUID_16);
          when UUID_32bits =>
             Push (This, UUID.UUID_32);
-         when UUID_16bytes =>
-            Push (This, UUID.UUID_16_Bytes);
+         when UUID_16UInt8s =>
+            Push (This, UUID.UUID_16_UInt8s);
       end case;
    end Push_UUID;
 

--- a/middleware/src/BLE/bluetooth_low_energy-packets.ads
+++ b/middleware/src/BLE/bluetooth_low_energy-packets.ads
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 with System;
+with Interfaces;
 
 package Bluetooth_Low_Energy.Packets is
 
@@ -39,22 +40,22 @@ package Bluetooth_Low_Energy.Packets is
    --  Return memory address of the radio data to be transmitted
 
    procedure Set_Header (This   : in out BLE_Packet;
-                         Header : Unsigned_8);
+                         Header : UInt8);
 
    procedure Push (This : in out BLE_Packet;
-                   Data : Unsigned_8);
+                   Data : UInt8);
 
    procedure Push (This : in out BLE_Packet;
-                   Data : Integer_8);
+                   Data : Interfaces.Integer_8);
 
    procedure Push (This : in out BLE_Packet;
-                   Data : Unsigned_16);
+                   Data : UInt16);
 
    procedure Push (This : in out BLE_Packet;
-                   Data : Unsigned_32);
+                   Data : UInt32);
 
    procedure Push (This : in out BLE_Packet;
-                   Data : Byte_Array);
+                   Data : UInt8_Array);
 
    procedure Push_UUID (This : in out BLE_Packet;
                         UUID : BLE_UUID);
@@ -67,12 +68,12 @@ private
    --  Maximum size of BLE payload (without header, MIC or CRC)
 
    type BLE_Data is array (1 .. BLE_PACKET_MAX_PAYLOAD + BLE_PACKET_MIC_SIZE)
-     of Byte with Pack;
+     of UInt8 with Pack;
    --  BLE Payload plus optional MIC field
 
    type BLE_Packet is record
-      Header        : Byte;
-      Packet_Length : Byte := 0;
+      Header        : UInt8;
+      Packet_Length : UInt8 := 0;
       Data          : BLE_Data;
    end record with Pack;
 

--- a/middleware/src/BLE/bluetooth_low_energy.adb
+++ b/middleware/src/BLE/bluetooth_low_energy.adb
@@ -24,10 +24,10 @@ package body Bluetooth_Low_Energy is
    -- Make_UUID --
    ---------------
 
-   function Make_UUID (UUID : BLE_16bytes_UUID) return BLE_UUID is
+   function Make_UUID (UUID : BLE_16UInt8s_UUID) return BLE_UUID is
    begin
-      return (Kind          => UUID_16bytes,
-              UUID_16_Bytes => UUID);
+      return (Kind          => UUID_16UInt8s,
+              UUID_16_UInt8s => UUID);
    end Make_UUID;
 
 end Bluetooth_Low_Energy;

--- a/middleware/src/BLE/bluetooth_low_energy.ads
+++ b/middleware/src/BLE/bluetooth_low_energy.ads
@@ -30,7 +30,6 @@
 ------------------------------------------------------------------------------
 
 with HAL;        use HAL;
-with Interfaces; use Interfaces;
 
 package Bluetooth_Low_Energy is
 
@@ -58,23 +57,23 @@ package Bluetooth_Low_Energy is
    -- UUID --
    ----------
 
-   type BLE_UUID_Kind is (UUID_16bits, UUID_32bits, UUID_16bytes);
+   type BLE_UUID_Kind is (UUID_16bits, UUID_32bits, UUID_16UInt8s);
 
-   subtype BLE_16bytes_UUID is Byte_Array (1 .. 16);
+   subtype BLE_16UInt8s_UUID is UInt8_Array (1 .. 16);
 
    type BLE_UUID (Kind : BLE_UUID_Kind) is record
       case Kind is
          when UUID_16bits =>
-            UUID_16 : Unsigned_16;
+            UUID_16 : UInt16;
          when UUID_32bits =>
-            UUID_32 : Unsigned_32;
-         when UUID_16bytes =>
-            UUID_16_Bytes : BLE_16bytes_UUID;
+            UUID_32 : UInt32;
+         when UUID_16UInt8s =>
+            UUID_16_UInt8s : BLE_16UInt8s_UUID;
       end case;
    end record;
 
-   function Make_UUID (UUID : Unsigned_16) return BLE_UUID;
-   function Make_UUID (UUID : Unsigned_32) return BLE_UUID;
-   function Make_UUID (UUID : BLE_16bytes_UUID) return BLE_UUID;
+   function Make_UUID (UUID : UInt16) return BLE_UUID;
+   function Make_UUID (UUID : UInt32) return BLE_UUID;
+   function Make_UUID (UUID : BLE_16UInt8s_UUID) return BLE_UUID;
 
 end Bluetooth_Low_Energy;

--- a/middleware/src/bitmap/bitmap_color_conversion.adb
+++ b/middleware/src/bitmap/bitmap_color_conversion.adb
@@ -29,8 +29,6 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Interfaces; use Interfaces;
-
 package body Bitmap_Color_Conversion is
 
    --------------------------
@@ -43,17 +41,17 @@ package body Bitmap_Color_Conversion is
    is
       Ret : UInt32 := 0;
 
-      procedure Add_Byte
-        (Value : Byte; Pos : Natural; Size : Positive) with Inline;
+      procedure Add_UInt8
+        (Value : UInt8; Pos : Natural; Size : Positive) with Inline;
 
-      function Luminance return Byte;
+      function Luminance return UInt8;
 
       --------------
-      -- Add_Byte --
+      -- Add_UInt8 --
       --------------
 
-      procedure Add_Byte
-        (Value : Byte; Pos : Natural; Size : Positive)
+      procedure Add_UInt8
+        (Value : UInt8; Pos : Natural; Size : Positive)
       is
          Val : constant UInt32 :=
                  Shift_Left
@@ -63,16 +61,16 @@ package body Bitmap_Color_Conversion is
                     Pos);
       begin
          Ret := Ret or Val;
-      end Add_Byte;
+      end Add_UInt8;
 
       ---------------
       -- Luminance --
       ---------------
 
-      function Luminance return Byte
+      function Luminance return UInt8
       is
       begin
-         return Byte
+         return UInt8
            (Shift_Right
               (UInt32 (Col.Red) * 3 + UInt32 (Col.Blue) + UInt32 (Col.Green) * 4,
                3));
@@ -81,52 +79,52 @@ package body Bitmap_Color_Conversion is
    begin
       case Mode is
          when ARGB_8888 =>
-            Add_Byte (Col.Alpha, 24, 8);
-            Add_Byte (Col.Red,   16, 8);
-            Add_Byte (Col.Green,  8, 8);
-            Add_Byte (Col.Blue,   0, 8);
+            Add_UInt8 (Col.Alpha, 24, 8);
+            Add_UInt8 (Col.Red,   16, 8);
+            Add_UInt8 (Col.Green,  8, 8);
+            Add_UInt8 (Col.Blue,   0, 8);
 
          when RGB_888 =>
-            Add_Byte (Col.Red,   16, 8);
-            Add_Byte (Col.Green,  8, 8);
-            Add_Byte (Col.Blue,   0, 8);
+            Add_UInt8 (Col.Red,   16, 8);
+            Add_UInt8 (Col.Green,  8, 8);
+            Add_UInt8 (Col.Blue,   0, 8);
 
          when RGB_565 =>
-            Add_Byte (Col.Red,   11, 5);
-            Add_Byte (Col.Green,  5, 6);
-            Add_Byte (Col.Blue,   0, 5);
+            Add_UInt8 (Col.Red,   11, 5);
+            Add_UInt8 (Col.Green,  5, 6);
+            Add_UInt8 (Col.Blue,   0, 5);
 
          when ARGB_1555 =>
-            Add_Byte (Col.Alpha, 15, 1);
-            Add_Byte (Col.Red,   10, 5);
-            Add_Byte (Col.Green,  5, 5);
-            Add_Byte (Col.Blue,   0, 5);
+            Add_UInt8 (Col.Alpha, 15, 1);
+            Add_UInt8 (Col.Red,   10, 5);
+            Add_UInt8 (Col.Green,  5, 5);
+            Add_UInt8 (Col.Blue,   0, 5);
 
          when ARGB_4444 =>
-            Add_Byte (Col.Alpha, 12, 4);
-            Add_Byte (Col.Red,    8, 4);
-            Add_Byte (Col.Green,  4, 4);
-            Add_Byte (Col.Blue,   0, 4);
+            Add_UInt8 (Col.Alpha, 12, 4);
+            Add_UInt8 (Col.Red,    8, 4);
+            Add_UInt8 (Col.Green,  4, 4);
+            Add_UInt8 (Col.Blue,   0, 4);
 
          when L_8 =>
-            Add_Byte (Luminance, 0, 8);
+            Add_UInt8 (Luminance, 0, 8);
 
          when AL_44 =>
-            Add_Byte (Col.Alpha, 4, 4);
-            Add_Byte (Luminance, 0, 4);
+            Add_UInt8 (Col.Alpha, 4, 4);
+            Add_UInt8 (Luminance, 0, 4);
 
          when AL_88 =>
-            Add_Byte (Col.Alpha, 8, 8);
-            Add_Byte (Luminance, 0, 8);
+            Add_UInt8 (Col.Alpha, 8, 8);
+            Add_UInt8 (Luminance, 0, 8);
 
          when L_4 =>
-            Add_Byte (Luminance, 0, 4);
+            Add_UInt8 (Luminance, 0, 4);
 
          when A_8 =>
-            Add_Byte (Col.Alpha, 0, 8);
+            Add_UInt8 (Col.Alpha, 0, 8);
 
          when A_4 =>
-            Add_Byte (Col.Alpha, 0, 4);
+            Add_UInt8 (Col.Alpha, 0, 4);
       end case;
 
       return Ret;
@@ -141,20 +139,20 @@ package body Bitmap_Color_Conversion is
       return Bitmap_Color
    is
 
-      function Get_Byte
-        (Pos : Natural; Size : Positive) return Byte with Inline;
+      function Get_UInt8
+        (Pos : Natural; Size : Positive) return UInt8 with Inline;
 
       --------------
-      -- Get_Byte --
+      -- Get_UInt8 --
       --------------
 
-      function Get_Byte
-        (Pos : Natural; Size : Positive) return Byte
+      function Get_UInt8
+        (Pos : Natural; Size : Positive) return UInt8
       is
-         Ret : Byte;
+         Ret : UInt8;
          Mask : constant UInt32 := Shift_Left (2 ** Size - 1, Pos);
       begin
-         Ret := Byte (Shift_Right (Col and Mask, Pos));
+         Ret := UInt8 (Shift_Right (Col and Mask, Pos));
 
          if Size = 8 then
             return Ret;
@@ -167,73 +165,73 @@ package body Bitmap_Color_Conversion is
          else
             raise Constraint_Error with "Unsupported color component size";
          end if;
-      end Get_Byte;
+      end Get_UInt8;
 
-      A, R, G, B : Byte;
+      A, R, G, B : UInt8;
    begin
       case Mode is
          when ARGB_8888 =>
-            A := Get_Byte (24, 8);
-            R := Get_Byte (16, 8);
-            G := Get_Byte (8, 8);
-            B := Get_Byte (0, 8);
+            A := Get_UInt8 (24, 8);
+            R := Get_UInt8 (16, 8);
+            G := Get_UInt8 (8, 8);
+            B := Get_UInt8 (0, 8);
 
          when RGB_888 =>
             A := 255;
-            R := Get_Byte (16, 8);
-            G := Get_Byte (8, 8);
-            B := Get_Byte (0, 8);
+            R := Get_UInt8 (16, 8);
+            G := Get_UInt8 (8, 8);
+            B := Get_UInt8 (0, 8);
 
          when RGB_565 =>
             A := 255;
-            R := Get_Byte (11, 5);
-            G := Get_Byte (5, 6);
-            B := Get_Byte (0, 5);
+            R := Get_UInt8 (11, 5);
+            G := Get_UInt8 (5, 6);
+            B := Get_UInt8 (0, 5);
 
          when ARGB_1555 =>
-            A := Get_Byte (15, 1);
-            R := Get_Byte (10, 5);
-            G := Get_Byte (5, 5);
-            B := Get_Byte (0, 5);
+            A := Get_UInt8 (15, 1);
+            R := Get_UInt8 (10, 5);
+            G := Get_UInt8 (5, 5);
+            B := Get_UInt8 (0, 5);
 
          when ARGB_4444 =>
-            A := Get_Byte (12, 4);
-            R := Get_Byte (8, 4);
-            G := Get_Byte (4, 4);
-            B := Get_Byte (0, 4);
+            A := Get_UInt8 (12, 4);
+            R := Get_UInt8 (8, 4);
+            G := Get_UInt8 (4, 4);
+            B := Get_UInt8 (0, 4);
 
          when L_8 =>
             A := 255;
-            R := Get_Byte (0, 8);
+            R := Get_UInt8 (0, 8);
             G := R;
             B := R;
 
          when AL_44 =>
-            A := Get_Byte (4, 4);
-            R := Get_Byte (0, 4);
+            A := Get_UInt8 (4, 4);
+            R := Get_UInt8 (0, 4);
             G := R;
             B := R;
 
          when AL_88 =>
-            A := Get_Byte (8, 8);
-            R := Get_Byte (0, 8);
+            A := Get_UInt8 (8, 8);
+            R := Get_UInt8 (0, 8);
             G := R;
             B := R;
 
          when L_4 =>
             A := 255;
-            R := Get_Byte (0, 4);
+            R := Get_UInt8 (0, 4);
             G := R;
             B := R;
 
          when A_8 =>
-            A := Get_Byte (0, 8);
+            A := Get_UInt8 (0, 8);
             R := 255;
             G := 255;
             B := 255;
 
          when A_4 =>
-            A := Get_Byte (0, 4);
+            A := Get_UInt8 (0, 4);
             R := 255;
             G := 255;
             B := 255;

--- a/middleware/src/bitmap/bitmap_file_output.adb
+++ b/middleware/src/bitmap/bitmap_file_output.adb
@@ -37,7 +37,7 @@ package body Bitmap_File_Output is
    type Header (As_Array : Boolean := True) is record
       case As_Array is
          when True =>
-            Arr : Byte_Array (1 .. 14);
+            Arr : UInt8_Array (1 .. 14);
          when False =>
             Signature : Integer_16;
             Size      : Integer_32; --  File size
@@ -50,7 +50,7 @@ package body Bitmap_File_Output is
    type Info (As_Array : Boolean := True) is record
       case As_Array is
          when True =>
-            Arr : Byte_Array (1 .. 40);
+            Arr : UInt8_Array (1 .. 40);
          when False =>
             Struct_Size   : Integer_32;
             Width         : Integer_32; -- Image width in pixels
@@ -58,7 +58,7 @@ package body Bitmap_File_Output is
             Planes        : Integer_16;
             Pixel_Size    : Integer_16; -- Bits per pixel
             Compression   : Integer_32; -- Zero means no compression
-            Image_Size    : Integer_32; -- Size of the image data in bytes
+            Image_Size    : Integer_32; -- Size of the image data in UInt8s
             PPMX          : Integer_32; -- Pixels per meter in x led
             PPMY          : Integer_32; -- Pixels per meter in y led
             Palette_Size  : Integer_32; -- Number of colors
@@ -81,8 +81,8 @@ package body Bitmap_File_Output is
       Data_Size   : constant Integer_32 := (Row_Size + Row_Padding) * Integer_32 (Bitmap.Height);
 
       RGB_Pix : Bitmap_Color;
-      Pix_Out : Byte_Array (1 .. 3);
-      Padding : constant Byte_Array (1 .. Integer (Row_Padding)) := (others => 0);
+      Pix_Out : UInt8_Array (1 .. 3);
+      Padding : constant UInt8_Array (1 .. Integer (Row_Padding)) := (others => 0);
    begin
       Hdr.Signature := 16#4D42#;
       Hdr.Size      := (Data_Size + 54) / 4;

--- a/middleware/src/bitmap/memory_mapped_bitmap.adb
+++ b/middleware/src/bitmap/memory_mapped_bitmap.adb
@@ -30,7 +30,6 @@
 ------------------------------------------------------------------------------
 
 with System.Storage_Elements; use System.Storage_Elements;
-with Interfaces;              use Interfaces;
 with Bitmap_Color_Conversion; use Bitmap_Color_Conversion;
 
 package body Memory_Mapped_Bitmap is
@@ -117,20 +116,20 @@ package body Memory_Mapped_Bitmap is
 
          when RGB_888 =>
             declare
-               Pixel_B : aliased Byte
+               Pixel_B : aliased UInt8
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset * 3);
-               Pixel_G : aliased Byte
+               Pixel_G : aliased UInt8
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset * 3 + 1);
-               Pixel_R : aliased Byte
+               Pixel_R : aliased UInt8
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset * 3 + 2);
-               R       : constant Byte :=
-                           Byte (Shift_Right (Value and 16#FF0000#, 16));
-               G       : constant Byte :=
-                           Byte (Shift_Right (Value and 16#FF00#, 8));
-               B       : constant Byte := Byte (Value and 16#FF#);
+               R       : constant UInt8 :=
+                           UInt8 (Shift_Right (Value and 16#FF0000#, 16));
+               G       : constant UInt8 :=
+                           UInt8 (Shift_Right (Value and 16#FF00#, 8));
+               B       : constant UInt8 := UInt8 (Value and 16#FF#);
             begin
                Pixel_B := B;
                Pixel_G := G;
@@ -148,25 +147,25 @@ package body Memory_Mapped_Bitmap is
 
          when L_8 | AL_44 | A_8 =>
             declare
-               Pixel : aliased Byte
+               Pixel : aliased UInt8
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset);
             begin
-               Pixel := Byte (Value and 16#FF#);
+               Pixel := UInt8 (Value and 16#FF#);
             end;
 
          when L_4 | A_4 =>
             declare
-               Pixel : aliased Byte
+               Pixel : aliased UInt8
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset / 2);
             begin
                if Offset mod 2 = 0 then
                   Pixel :=
                     (Pixel and 16#0F#) or
-                    Shift_Left (Byte (Value and 16#0F#), 4);
+                    Shift_Left (UInt8 (Value and 16#0F#), 4);
                else
-                  Pixel := (Pixel and 16#F0#) or Byte (Value and 16#0F#);
+                  Pixel := (Pixel and 16#F0#) or UInt8 (Value and 16#0F#);
                end if;
             end;
 
@@ -208,10 +207,10 @@ package body Memory_Mapped_Bitmap is
          RG := FgG * FgA / RA + BgG * BgA * (1.0 - FgA) / RA;
          RB := FgB * FgA / RA + BgB * BgA * (1.0 - FgA) / RA;
 
-         Col := (Alpha => Byte (RA * 255.0),
-                 Red   => Byte (RR * 255.0),
-                 Green => Byte (RG * 255.0),
-                 Blue  => Byte (RB * 255.0));
+         Col := (Alpha => UInt8 (RA * 255.0),
+                 Red   => UInt8 (RR * 255.0),
+                 Green => UInt8 (RG * 255.0),
+                 Blue  => UInt8 (RB * 255.0));
          Set_Pixel (Bitmap_Buffer'Class (Buffer), Pt, Col);
       end if;
    end Set_Pixel_Blend;
@@ -268,13 +267,13 @@ package body Memory_Mapped_Bitmap is
 
          when RGB_888 =>
             declare
-               Pixel_B : aliased Byte
+               Pixel_B : aliased UInt8
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset * 3);
-               Pixel_G : aliased Byte
+               Pixel_G : aliased UInt8
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset * 3 + 1);
-               Pixel_R : aliased Byte
+               Pixel_R : aliased UInt8
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset * 3 + 2);
             begin
@@ -293,7 +292,7 @@ package body Memory_Mapped_Bitmap is
 
          when L_8 | AL_44 | A_8 =>
             declare
-               Pixel : aliased Byte
+               Pixel : aliased UInt8
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset);
             begin
@@ -302,7 +301,7 @@ package body Memory_Mapped_Bitmap is
 
          when L_4 | A_4 =>
             declare
-               Pixel : aliased Byte
+               Pixel : aliased UInt8
                  with Import,
                       Address => Buffer.Addr + Storage_Offset (Offset / 2);
             begin

--- a/middleware/src/bitmap/soft_drawing_bitmap.adb
+++ b/middleware/src/bitmap/soft_drawing_bitmap.adb
@@ -61,12 +61,11 @@ package body Soft_Drawing_Bitmap is
       begin
          if Thickness /= 1 then
             if not Fast then
-               Fill_Circle (Buffer,
-                            Color  => Color,
-                            Center => P,
-                            Radius => Thickness / 2);
+               Dispatch (Buffer). Fill_Circle (Color  => Color,
+                                               Center => P,
+                                               Radius => Thickness / 2);
             else
-               Buffer.Fill_Rect
+               Dispatch (Buffer).Fill_Rect
                  (Color,
                   ((P.X - (Thickness / 2), P.Y - (Thickness / 2)),
                    Thickness,
@@ -124,7 +123,7 @@ package body Soft_Drawing_Bitmap is
       Col : constant UInt32 :=
         Bitmap_Color_To_Word (Dispatch (Buffer).Color_Mode, Color);
    begin
-      Draw_Line (Buffer, Col, Start, Stop, Thickness, Fast);
+      Dispatch (Buffer).Draw_Line (Col, Start, Stop, Thickness, Fast);
    end Draw_Line;
 
    ----------
@@ -368,22 +367,22 @@ package body Soft_Drawing_Bitmap is
       Y0 := Area.Position.Y;
       X1 := Area.Position.X + Area.Width - 1;
       Y1 := Area.Position.Y + Area.Height - 1;
-      Buffer.Fill_Rect
+      Dispatch (Buffer).Fill_Rect
         (Color,
          (Position => (X0 - Thickness / 2, Y0),
           Width    => Thickness,
           Height   => Area.Height + Thickness / 2));
-      Buffer.Fill_Rect
+      Dispatch (Buffer).Fill_Rect
         (Color,
          (Position => (X1 - Thickness / 2, Y0),
           Width    => Thickness,
           Height   => Area.Height + Thickness / 2));
-      Buffer.Fill_Rect
+      Dispatch (Buffer).Fill_Rect
         (Color,
          (Position => (X0, Y0 - Thickness / 2),
           Width    => Area.Width + Thickness / 2,
           Height   => Thickness));
-      Buffer.Fill_Rect
+      Dispatch (Buffer).Fill_Rect
         (Color,
          (Position => (X0, Y1 - Thickness / 2),
           Width    => Area. Width + Thickness / 2,
@@ -421,7 +420,7 @@ package body Soft_Drawing_Bitmap is
       procedure Draw_Point (X, Y : Natural) is
       begin
          if Thickness /= 1 then
-            Buffer.Fill_Rect
+            Dispatch (Buffer).Fill_Rect
               (Color,
                (Position => (X - (Thickness / 2), Y - (Thickness / 2)),
                 Width    => Thickness,
@@ -437,22 +436,22 @@ package body Soft_Drawing_Bitmap is
          return;
       end if;
 
-      Buffer.Fill_Rect
+      Dispatch (Buffer).Fill_Rect
         (Color,
          (Position => (Area.Position.X - Thickness / 2, Area.Position.Y + Radius),
           Width    => Thickness,
           Height   => Area.Height - 2 * Radius));
-      Buffer.Fill_Rect
+      Dispatch (Buffer).Fill_Rect
         (Color,
          (Position => (Area.Position.X + Area.Width - Thickness / 2 - 1, Area.Position.Y + Radius),
           Width    => Thickness,
           Height   => Area.Height - 2 * Radius));
-      Buffer.Fill_Rect
+      Dispatch (Buffer).Fill_Rect
         (Color,
          (Position => (Area.Position.X + Radius, Area.Position.Y - Thickness / 2),
           Width    => Area.Width - 2 * Radius,
           Height   => Thickness));
-      Buffer.Fill_Rect
+      Dispatch (Buffer).Fill_Rect
         (Color,
          (Position => (Area.Position.X + Radius, Area.Position.Y + Area.Height - Thickness / 2 - 1),
           Width    => Area.Width - 2 * Radius,
@@ -503,11 +502,11 @@ package body Soft_Drawing_Bitmap is
 
    begin
       if Radius = 0 then
-         Buffer.Fill_Rect (Col, Area'Update (Position => (X0, Y0)));
+         Dispatch (Buffer).Fill_Rect (Col, Area'Update (Position => (X0, Y0)));
          return;
       end if;
 
-      Buffer.Fill_Rect
+      Dispatch (Buffer).Fill_Rect
         (Col,
          (Position => (Area.Position.X, Center_Top),
           Width    => Area.Width,
@@ -524,19 +523,19 @@ package body Soft_Drawing_Bitmap is
          ddF_X := ddF_X + 2;
          F := F + ddF_X + 1;
 
-         Buffer.Draw_Horizontal_Line
+         Dispatch (Buffer).Draw_Horizontal_Line
            (Col,
             (Center_Lft - X0, Center_Bot + Y0),
             Area.Width - 2 * Radius + 2 * X0);
-         Buffer.Draw_Horizontal_Line
+         Dispatch (Buffer).Draw_Horizontal_Line
            (Col,
             (Center_Lft - X0, Center_Top - Y0),
             Area.Width - 2 * Radius + 2 * X0);
-         Buffer.Draw_Horizontal_Line
+         Dispatch (Buffer).Draw_Horizontal_Line
            (Col,
             (Center_Lft - Y0, Center_Bot + X0),
             Area.Width - 2 * Radius + 2 * Y0);
-         Buffer.Draw_Horizontal_Line
+         Dispatch (Buffer).Draw_Horizontal_Line
            (Col,
             (Center_Lft - Y0, Center_Top - X0),
             Area.Width - 2 * Radius + 2 * Y0);
@@ -556,7 +555,7 @@ package body Soft_Drawing_Bitmap is
    is
    begin
       Draw_Circle
-        (Buffer,
+        (Dispatch (Buffer),
          Bitmap_Color_To_Word (Dispatch (Buffer).Color_Mode, Color),
          Center,
          Radius);
@@ -619,7 +618,7 @@ package body Soft_Drawing_Bitmap is
       U32_Color : constant UInt32 :=
         Bitmap_Color_To_Word (Dispatch (Buffer).Color_Mode, Color);
    begin
-      Fill_Circle (Buffer, U32_Color, Center, Radius);
+      Dispatch (Buffer).Fill_Circle (U32_Color, Center, Radius);
    end Fill_Circle;
 
    -----------------
@@ -674,7 +673,7 @@ package body Soft_Drawing_Bitmap is
             return;
          end if;
 
-         Buffer.Fill_Rect (Color, ((X1, Y), W1, 1));
+         Dispatch (Buffer).Fill_Rect (Color, ((X1, Y), W1, 1));
       end Draw_Horizontal_Line;
 
       ------------------------
@@ -711,7 +710,7 @@ package body Soft_Drawing_Bitmap is
             return;
          end if;
 
-         Buffer.Fill_Rect (Color, ((X, Y1), 1, H1));
+         Dispatch (Buffer).Fill_Rect (Color, ((X, Y1), 1, H1));
       end Draw_Vertical_Line;
 
       F     : Integer := 1 - Radius;
@@ -780,8 +779,8 @@ package body Soft_Drawing_Bitmap is
          end;
       end loop;
       for I in Points'First .. Points'Last - 1 loop
-         Draw_Line (Buffer, Color, Points (I), Points (I + 1),
-                    Thickness => Thickness);
+         Dispatch (Buffer).Draw_Line (Color, Points (I), Points (I + 1),
+                                      Thickness => Thickness);
       end loop;
    end Cubic_Bezier;
 

--- a/middleware/src/filesystems/partitions.ads
+++ b/middleware/src/filesystems/partitions.ads
@@ -31,11 +31,10 @@
 
 with HAL; use HAL;
 with HAL.Block_Drivers; use HAL.Block_Drivers;
-with Interfaces; use Interfaces;
 
 package Partitions is
 
-   type Partition_Kind is new Unsigned_8;
+   type Partition_Kind is new UInt8;
 
    Empty_Partition       : constant Partition_Kind := 16#00#;
    Fat12_Parition        : constant Partition_Kind := 16#01#;
@@ -50,21 +49,21 @@ package Partitions is
    Linux_Swap_Partition  : constant Partition_Kind := 16#82#;
    Linux_Partition       : constant Partition_Kind := 16#83#;
 
-   subtype Logical_Block_Address is Unsigned_32;
+   subtype Logical_Block_Address is UInt32;
 
    type CHS_Address is record
       C : UInt10;
-      H : Byte;
+      H : UInt8;
       S : UInt6;
    end record with Pack, Size => 24;
 
    type Partition_Entry is record
-      Status            : Byte;
+      Status            : UInt8;
       First_Sector_CHS  : CHS_Address;
       Kind              : Partition_Kind;
       Last_Sector_CHS   : CHS_Address;
       First_Sector_LBA  : Logical_Block_Address;
-      Number_Of_Sectors : Unsigned_32;
+      Number_Of_Sectors : UInt32;
    end record with Pack, Size => 16 * 8;
 
    type Status_Code is (Status_Ok, Disk_Error, Invalid_Parition);

--- a/middleware/src/utils/file_block_drivers.adb
+++ b/middleware/src/utils/file_block_drivers.adb
@@ -38,7 +38,7 @@ package body File_Block_Drivers is
    overriding
    function Read
      (This         : in out File_Block_Driver;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : out Block)
       return Boolean
    is
@@ -58,7 +58,7 @@ package body File_Block_Drivers is
    overriding
    function Write
      (This         : in out File_Block_Driver;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : Block)
       return Boolean
    is

--- a/middleware/src/utils/file_block_drivers.ads
+++ b/middleware/src/utils/file_block_drivers.ads
@@ -33,7 +33,7 @@
 
 with HAL.Block_Drivers; use HAL.Block_Drivers;
 with HAL.Filesystem;    use HAL.Filesystem;
-with Interfaces;        use Interfaces;
+with HAL;               use HAL;
 
 package File_Block_Drivers is
 
@@ -42,14 +42,14 @@ package File_Block_Drivers is
    overriding
    function Read
      (This         : in out File_Block_Driver;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : out Block)
       return Boolean;
 
    overriding
    function Write
      (This         : in out File_Block_Driver;
-      Block_Number : Unsigned_32;
+      Block_Number : UInt32;
       Data         : Block)
       return Boolean;
 

--- a/testsuite/tests/virtual_file_system/src/helpers.adb
+++ b/testsuite/tests/virtual_file_system/src/helpers.adb
@@ -50,12 +50,12 @@ package body Helpers is
    -- Read_File --
    ---------------
 
-   function Read_File (File : in out File_Handle'Class) return Byte_Array is
-      type Byte_Array_Access is access Byte_Array;
+   function Read_File (File : in out File_Handle'Class) return UInt8_Array is
+      type UInt8_Array_Access is access UInt8_Array;
       procedure Destroy is new Ada.Unchecked_Deallocation
-        (Byte_Array, Byte_Array_Access);
+        (UInt8_Array, UInt8_Array_Access);
 
-      Buffer : Byte_Array_Access := new Byte_Array (1 .. 1024);
+      Buffer : UInt8_Array_Access := new UInt8_Array (1 .. 1024);
       Last   : Natural := 0;
    begin
       loop
@@ -63,8 +63,8 @@ package body Helpers is
 
          if Last >= Buffer'Last then
             declare
-               New_Buffer : constant Byte_Array_Access :=
-                 new Byte_Array (1 .. 2 * Buffer'Length);
+               New_Buffer : constant UInt8_Array_Access :=
+                 new UInt8_Array (1 .. 2 * Buffer'Length);
             begin
                New_Buffer (1 .. Buffer'Length) := Buffer.all;
                Destroy (Buffer);
@@ -87,7 +87,7 @@ package body Helpers is
       end loop;
 
       declare
-         Result : constant Byte_Array := Buffer (1 .. Last);
+         Result : constant UInt8_Array := Buffer (1 .. Last);
       begin
          Destroy (Buffer);
          return Result;
@@ -98,12 +98,11 @@ package body Helpers is
    -- Quote_Bytes --
    -----------------
 
-   function Quote_Bytes (Bytes : Byte_Array) return String is
+   function Quote_Bytes (Bytes : UInt8_Array) return String is
       use Ada.Strings.Unbounded;
-      use type HAL.Byte;
       Result : Unbounded_String;
 
-      Hex_Digits : constant array (Byte range 0 .. 15) of Character :=
+      Hex_Digits : constant array (UInt8 range 0 .. 15) of Character :=
         "0123456789abcdef";
    begin
       for B of Bytes loop
@@ -153,7 +152,7 @@ package body Helpers is
                   begin
                      Test (FS.Open (Name, Read_Only, File));
                      declare
-                        Content : constant Byte_Array := Read_File (File.all);
+                        Content : constant UInt8_Array := Read_File (File.all);
                      begin
                         Put_Line ("  Contents: " & Quote_Bytes (Content));
                      end;

--- a/testsuite/tests/virtual_file_system/src/helpers.ads
+++ b/testsuite/tests/virtual_file_system/src/helpers.ads
@@ -19,11 +19,11 @@ package Helpers is
    --  Create a native FS driver rooted at Root_Dir, in the Material_Name
    --  material directory.
 
-   function Read_File (File : in out File_Handle'Class) return Byte_Array;
+   function Read_File (File : in out File_Handle'Class) return UInt8_Array;
    --  Read the whole content of File and return it. Raise a Program_Error if
    --  anything goes wrong.
 
-   function Quote_Bytes (Bytes : Byte_Array) return String;
+   function Quote_Bytes (Bytes : UInt8_Array) return String;
    --  Return a human-readable representation of Bytes, considered as ASCII
 
    procedure Dump (FS : in out FS_Driver'Class; Dir : Pathname);


### PR DESCRIPTION
As discussed in #141.

This remove the dependency on the Interfaces package which simplify the
use of HAL types.

Also remove Byte and Bit subtype.