### PR TITLE
Common_Config: Treat warnings as errors

### DIFF
--- a/boards/common_config.gpr
+++ b/boards/common_config.gpr
@@ -19,8 +19,8 @@ abstract project Common_Config is
               ("-g", "-O0", "-gnata", "-fcallgraph-info=su");
       end case;
       for Default_Switches ("ada") use Compiler'Default_Switches ("Ada") &
-        ("-gnatwa", "-gnatQ", "-gnatw.X", "-gnaty", "-gnatyO", "-gnatyM120",
-         "-ffunction-sections", "-fdata-sections");
+        ("-gnatwa", "-gnatwe", "-gnatQ", "-gnatw.X", "-gnaty", "-gnatyO",
+         "-gnatyM120", "-ffunction-sections", "-fdata-sections");
    end Compiler;
 
    package Builder is


### PR DESCRIPTION
I thought this was already enabled since the beginning...

It's even more important now that we have continuous builders.

Note that the entire code base is already compiling without warnings.