### PR TITLE
 STM32F4.I2C: Fix master transmit

### DIFF
--- a/arch/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
+++ b/arch/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
@@ -691,13 +691,14 @@ package body STM32.I2C is
          This.Periph.DR.DR := Data (Idx);
          Idx := Idx + 1;
 
-         if Idx <= Data'Last then
-            Wait_Flag (This, UInt8_Transfer_Finished, True, Timeout, Status);
-
-            if Status = HAL.I2C.Ok then
-               This.Periph.DR.DR := Data (Idx);
-               Idx := Idx + 1;
-            end if;
+         if Flag_Status (This, Byte_Transfer_Finished)
+           and then
+            Idx <= Data'Last
+           and then
+            Status = HAL.I2C.Ok
+         then
+            This.Periph.DR.DR := Data (Idx);
+            Idx := Idx + 1;
          end if;
       end loop;
 
@@ -941,17 +942,14 @@ package body STM32.I2C is
          This.Periph.DR.DR := Data (Idx);
          Idx := Idx + 1;
 
-         if Idx <= Data'Last then
-            Wait_Flag (This,
-                       UInt8_Transfer_Finished,
-                       True,
-                       Timeout,
-                       Status);
-
-            if Status = HAL.I2C.Ok then
-               This.Periph.DR.DR := Data (Idx);
-               Idx := Idx + 1;
-            end if;
+         if Flag_Status (This, Byte_Transfer_Finished)
+           and then
+            Idx <= Data'Last
+           and then
+            Status = HAL.I2C.Ok
+         then
+            This.Periph.DR.DR := Data (Idx);
+            Idx := Idx + 1;
          end if;
       end loop;
 

--- a/arch/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
+++ b/arch/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
@@ -51,7 +51,7 @@ package body STM32.I2C is
    type I2C_Status_Flag is
      (Start_Bit,
       Address_Sent,
-      UInt8_Transfer_Finished,
+      Byte_Transfer_Finished,
       Address_Sent_10bit,
       Stop_Detection,
       Rx_Data_Register_Not_Empty,
@@ -242,7 +242,7 @@ package body STM32.I2C is
             return This.Periph.SR1.SB;
          when Address_Sent =>
             return This.Periph.SR1.ADDR;
-         when UInt8_Transfer_Finished =>
+         when Byte_Transfer_Finished =>
             return This.Periph.SR1.BTF;
          when Address_Sent_10bit =>
             return This.Periph.SR1.ADD10;
@@ -759,11 +759,13 @@ package body STM32.I2C is
       end if;
 
       if Data'Length = 1 then
+         --  Disable acknowledge
          This.Periph.CR1.ACK := False;
          Clear_Address_Sent_Status (This);
          This.Periph.CR1.STOP := True;
 
       elsif Data'Length = 2 then
+         --  Disable acknowledge
          This.Periph.CR1.ACK := False;
          This.Periph.CR1.POS := True;
          Clear_Address_Sent_Status (This);
@@ -791,11 +793,11 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
          elsif Idx + 1 = Data'Last then
-            --  Two UInt8s to read
+            --  Two bytes to read
             This.Periph.CR1.ACK := False;
 
             Wait_Flag (This,
-                       UInt8_Transfer_Finished,
+                       Byte_Transfer_Finished,
                        False,
                        Timeout,
                        Status);
@@ -812,9 +814,9 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
          elsif Idx + 2 = Data'Last then
-            --  Three UInt8s to read
+            --  Three bytes to read
             Wait_Flag (This,
-                       UInt8_Transfer_Finished,
+                       Byte_Transfer_Finished,
                        False,
                        Timeout,
                        Status);
@@ -829,7 +831,7 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
             Wait_Flag (This,
-                       UInt8_Transfer_Finished,
+                       Byte_Transfer_Finished,
                        False,
                        Timeout,
                        Status);
@@ -846,7 +848,7 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
          else
-            --  One UInt8 to read
+            --  One byte to read
             Wait_Flag
               (This,
                Rx_Data_Register_Not_Empty,
@@ -861,7 +863,7 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
             Wait_Flag (This,
-                       UInt8_Transfer_Finished,
+                       Byte_Transfer_Finished,
                        False,
                        Timeout,
                        Status);
@@ -1035,7 +1037,7 @@ package body STM32.I2C is
 
       while Idx <= Data'Last loop
          if Idx = Data'Last then
-            --  One UInt8 to read
+            --  One byte to read
             Wait_Flag
               (This, Rx_Data_Register_Not_Empty, False, Timeout, Status);
             if Status /= HAL.I2C.Ok then
@@ -1046,10 +1048,10 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
          elsif Idx + 1 = Data'Last then
-            --  Two UInt8s to read
+            --  Two bytes to read
             This.Periph.CR1.ACK := False;
 
-            Wait_Flag (This, UInt8_Transfer_Finished, False, Timeout, Status);
+            Wait_Flag (This, Byte_Transfer_Finished, False, Timeout, Status);
             if Status /= HAL.I2C.Ok then
                return;
             end if;
@@ -1063,8 +1065,8 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
          elsif Idx + 2 = Data'Last then
-            --  Three UInt8s to read
-            Wait_Flag (This, UInt8_Transfer_Finished, False, Timeout, Status);
+            --  Three bytes to read
+            Wait_Flag (This, Byte_Transfer_Finished, False, Timeout, Status);
             if Status /= HAL.I2C.Ok then
                return;
             end if;
@@ -1075,7 +1077,7 @@ package body STM32.I2C is
             Data (Idx) := This.Periph.DR.DR;
             Idx := Idx + 1;
 
-            Wait_Flag (This, UInt8_Transfer_Finished, False, Timeout, Status);
+            Wait_Flag (This, Byte_Transfer_Finished, False, Timeout, Status);
             if Status /= HAL.I2C.Ok then
                return;
             end if;
@@ -1089,7 +1091,7 @@ package body STM32.I2C is
             Idx := Idx + 1;
 
          else
-            --  One UInt8 to read
+            --  One byte to read
             Wait_Flag
               (This, Rx_Data_Register_Not_Empty, False, Timeout, Status);
             if Status /= HAL.I2C.Ok then
@@ -1099,7 +1101,7 @@ package body STM32.I2C is
             Data (Idx) := This.Periph.DR.DR;
             Idx := Idx + 1;
 
-            Wait_Flag (This, UInt8_Transfer_Finished, False, Timeout, Status);
+            Wait_Flag (This, Byte_Transfer_Finished, False, Timeout, Status);
 
             if Status = HAL.I2C.Ok then
                Data (Idx) := This.Periph.DR.DR;


### PR DESCRIPTION
Looks like this code was badly copied from the reference drivers. We are
not supposed to wait for BTF to be set, but just check it once. Note
that when reading the documentation, the behavior of this BTF flag is
still not clear to me. I think I spotted this error by reducing the
speed on an I2C port for an experiment. The result was that one out of
two bytes was dropped.