### PR TITLE
 STM32.SPI: Useless assignments

### DIFF
--- a/arch/ARM/STM32/drivers/stm32-spi.adb
+++ b/arch/ARM/STM32/drivers/stm32-spi.adb
@@ -735,7 +735,6 @@ package body STM32.SPI is
 
          As_Half_Word_Pointer (Incoming (Incoming_Index)'Address).all :=
            This.Periph.DR.DR;
-         Incoming_Index := Incoming_Index + 2;
 
          return;
       end if;
@@ -775,7 +774,6 @@ package body STM32.SPI is
 
          As_Half_Word_Pointer (Incoming (Incoming_Index)'Address).all :=
            This.Periph.DR.DR;
-         Incoming_Index := Incoming_Index + 2;
       end if;
    end Send_Receive_16bit_Mode;
 
@@ -848,7 +846,6 @@ package body STM32.SPI is
          end loop;
 
          Incoming (Incoming_Index) := Data (This);
-         Incoming_Index := Incoming_Index + 1;
       end if;
    end Send_Receive_8bit_Mode;
 

--- a/boards/stm32f469_discovery/src/audio.adb
+++ b/boards/stm32f469_discovery/src/audio.adb
@@ -33,7 +33,6 @@
 ------------------------------------------------------------------------------
 
 with Ada.Real_Time;        use Ada.Real_Time;
-with Interfaces;           use Interfaces;
 
 with HAL;                  use HAL;
 with STM32;                use STM32;


### PR DESCRIPTION
This was detected by a tool. The code is a little bit strange with this
As_Half_Word_Pointer conversion, but I think it's OK to remove the
assignments.

