### PR TITLE
Update some demos' readme files

### DIFF
--- a/arch/ARM/STM32/driver_demos/demo_L3GD20_dataready_int/readme.md
+++ b/arch/ARM/STM32/driver_demos/demo_L3GD20_dataready_int/readme.md
@@ -10,5 +10,5 @@ not moving, due to noise.
 
 This program demonstrates use of interrupts rather than polling.
 
-Note that you will need to set the RTS scenaqrio variable to "ravenscar-full"
+Note that you will need to set the RTS scenario variable to "ravenscar-full"
 because the demo code uses the floating point image attribute.

--- a/arch/ARM/STM32/driver_demos/demo_L3GD20_dataready_int/readme.md
+++ b/arch/ARM/STM32/driver_demos/demo_L3GD20_dataready_int/readme.md
@@ -9,3 +9,6 @@ movement. Note that the values are not constant, even when the board is
 not moving, due to noise.
 
 This program demonstrates use of interrupts rather than polling.
+
+Note that you will need to set the RTS scenaqrio variable to "ravenscar-full"
+because the demo code uses the floating point image attribute.

--- a/arch/ARM/STM32/driver_demos/demo_L3GD20_fifo_int/readme.md
+++ b/arch/ARM/STM32/driver_demos/demo_L3GD20_fifo_int/readme.md
@@ -14,3 +14,6 @@ each axis value and scale by the selected sensitivity. The adjusted and
 scaled values are displayed on each iteration. The stable bias offsets
 are also displayed, initially (not iteratively since they are not
 recomputed).
+
+Note that you will need to set the RTS scenaqrio variable to "ravenscar-full"
+because the demo code uses the floating point image attribute.

--- a/arch/ARM/STM32/driver_demos/demo_L3GD20_fifo_int/readme.md
+++ b/arch/ARM/STM32/driver_demos/demo_L3GD20_fifo_int/readme.md
@@ -15,5 +15,5 @@ scaled values are displayed on each iteration. The stable bias offsets
 are also displayed, initially (not iteratively since they are not
 recomputed).
 
-Note that you will need to set the RTS scenaqrio variable to "ravenscar-full"
+Note that you will need to set the RTS scenario variable to "ravenscar-full"
 because the demo code uses the floating point image attribute.

--- a/arch/ARM/STM32/driver_demos/demo_L3GD20_polling/readme.md
+++ b/arch/ARM/STM32/driver_demos/demo_L3GD20_polling/readme.md
@@ -9,4 +9,5 @@ not moving, due to noise.
 
 Polling is used to determine when gyro data are available.
 
-
+Note that you will need to set the RTS scenaqrio variable to "ravenscar-full"
+because the demo code uses the floating point image attribute.

--- a/arch/ARM/STM32/driver_demos/demo_L3GD20_polling/readme.md
+++ b/arch/ARM/STM32/driver_demos/demo_L3GD20_polling/readme.md
@@ -9,5 +9,5 @@ not moving, due to noise.
 
 Polling is used to determine when gyro data are available.
 
-Note that you will need to set the RTS scenaqrio variable to "ravenscar-full"
+Note that you will need to set the RTS scenario variable to "ravenscar-full"
 because the demo code uses the floating point image attribute.


### PR DESCRIPTION
To say that the ravenscar-full runtime is required for the demo (only) and to set the scenario accordingly.