### PR TITLE
Various tentative fixes to the LTDC and DSI drivers (stm32):

### DIFF
--- a/arch/ARM/STM32/drivers/dsi/stm32-dsi.adb
+++ b/arch/ARM/STM32/drivers/dsi/stm32-dsi.adb
@@ -171,9 +171,7 @@ package body STM32.DSI is
       --  => UIX4 = 4_000 * IDF * ODV / (PLLNDIV * HSE_MHz)
       declare
          HSE_MHz          : constant UInt32 := HSE_Clock / 1_000_000;
-         IDF              : constant UInt32 :=
-                              (if PLL_IN_Div > 0
-                               then UInt32 (PLL_IN_Div) else 1);
+         IDF              : constant UInt32 := UInt32 (PLL_IN_Div);
          ODF              : constant UInt32 :=
                               Shift_Left
                                 (1, DSI_PLL_ODF'Enum_Rep (PLL_OUT_Div));
@@ -284,7 +282,7 @@ package body STM32.DSI is
          This.Periph.DSI_LCOLCR.LPE := Loosely_Packed;
       end if;
 
-      --  Set the Horizontal Synchronization Active (HSA) in lane UInt8 clock
+      --  Set the Horizontal Synchronization Active (HSA) in lane byte clock
       --  cycles
       This.Periph.DSI_VHSACR.HSA := HSync_Active_Duration;
       --  Set the Horizontal Back Porch
@@ -344,7 +342,6 @@ package body STM32.DSI is
    begin
       --  Select the command mode by setting CMDM and DSIM bits
       This.Periph.DSI_MCR.CMDM := True;
-      This.Periph.DSI_WCFGR.DSIM := False;
       This.Periph.DSI_WCFGR.DSIM := True;
 
       --  Select the virtual channel for the LTDC interface traffic

--- a/arch/ARM/STM32/drivers/dsi/stm32-dsi.ads
+++ b/arch/ARM/STM32/drivers/dsi/stm32-dsi.ads
@@ -51,7 +51,7 @@ package STM32.DSI is
    --  Values 2#10# and 2#11# are reserved
 
    subtype DSI_PLLN_Div is UInt7 range 10 .. 125;
-   subtype DSI_PLL_IDF is UInt4 range 0 .. 7;
+   subtype DSI_PLL_IDF is UInt4 range 1 .. 7;
    PLL_IN_DIV1 : constant DSI_PLL_IDF := 1;
    PLL_IN_DIV2 : constant DSI_PLL_IDF := 2;
    PLL_IN_DIV3 : constant DSI_PLL_IDF := 3;

--- a/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.ads
+++ b/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.ads
@@ -60,7 +60,7 @@ package STM32.LTDC is
       Pixel_Fmt_AL88) --  8-bit Alpha, 8-bit Luniunance
      with Size => 3;
 
-   function UInt8s_Per_Pixel (Fmt : Pixel_Format) return Natural
+   function Bytes_Per_Pixel (Fmt : Pixel_Format) return Natural
      with Inline;
 
    subtype Frame_Buffer_Access is System.Address;
@@ -111,7 +111,7 @@ package STM32.LTDC is
 
 private
 
-   function UInt8s_Per_Pixel (Fmt : Pixel_Format) return Natural
+   function Bytes_Per_Pixel (Fmt : Pixel_Format) return Natural
    is (case Fmt is
           when Pixel_Fmt_ARGB8888 => 4,
           when Pixel_Fmt_RGB888 => 3,

--- a/boards/stm32f469_discovery/src/framebuffer_otm8009a.adb
+++ b/boards/stm32f469_discovery/src/framebuffer_otm8009a.adb
@@ -143,18 +143,18 @@ package body Framebuffer_OTM8009A is
       Enable_Clock (LCD_XRES);
       Configure_IO (LCD_XRES,
                     (Mode        => Mode_Out,
-                     Output_Type => Open_Drain,
+                     Output_Type => Push_Pull,
                      Speed       => Speed_50MHz,
-                     Resistors   => Floating));
+                     Resistors   => Pull_Up));
 
       --  Activate XRES active low
       Clear (LCD_XRES);
 
-      delay until Clock + Microseconds (20);
+      delay until Clock + Milliseconds (20);
 
       Set (LCD_XRES);
 
-      delay until Clock + Microseconds (10);
+      delay until Clock + Milliseconds (10);
    end LCD_Reset;
 
    ----------------

--- a/boards/stm32f769_discovery/src/framebuffer_otm8009a.adb
+++ b/boards/stm32f769_discovery/src/framebuffer_otm8009a.adb
@@ -145,18 +145,18 @@ package body Framebuffer_OTM8009A is
       Enable_Clock (DSI_RESET);
       Configure_IO (DSI_RESET,
                     (Mode        => Mode_Out,
-                     Output_Type => Open_Drain,
+                     Output_Type => Push_Pull,
                      Speed       => Speed_50MHz,
-                     Resistors   => Floating));
+                     Resistors   => Pull_Up));
 
       --  Activate XRES active low
       Clear (DSI_RESET);
 
-      delay until Clock + Milliseconds (1);
+      delay until Clock + Milliseconds (20);
 
       Set (DSI_RESET);
 
-      delay until Clock + Milliseconds (1);
+      delay until Clock + Milliseconds (10);
    end LCD_Reset;
 
    ----------------


### PR DESCRIPTION
* ltdc: make sure to explicitely disable the layers during init, and force
  a hardware reset of the peripheral. Also improve a bit the readability
  of the timing settings.
* dsi: do not allow an input division factor of zero, not allowed by the
  hardware.
* framebuffer_otm8009a: fix timings during the LCD reset.