### PR TITLE
Allow composition using PWM type by removing timer discriminant.

### DIFF
--- a/arch/ARM/STM32/driver_demos/demo_LIS3DSH_pwm/src/demo_lis3dsh_pwm.adb
+++ b/arch/ARM/STM32/driver_demos/demo_LIS3DSH_pwm/src/demo_lis3dsh_pwm.adb
@@ -171,34 +171,34 @@ procedure Demo_LIS3DSH_PWM is
    begin
       Configure_PWM_Timer (PWM_Output_Timer'Access, PWM_Frequency);
 
-      Attach_PWM_Channel
-        (PWM_Output_Green,
-         Channel => Channel_1,
-         Point   => Green_LED,
-         PWM_AF  => PWM_Output_AF);
+      PWM_Output_Green.Attach_PWM_Channel
+        (Generator => PWM_Output_Timer'Access,
+         Channel   => Channel_1,
+         Point     => Green_LED,
+         PWM_AF    => PWM_Output_AF);
 
-      Attach_PWM_Channel
-        (PWM_Output_Orange,
-         Channel => Channel_2,
-         Point   => Orange_LED,
-         PWM_AF  => PWM_Output_AF);
+      PWM_Output_Orange.Attach_PWM_Channel
+        (Generator => PWM_Output_Timer'Access,
+         Channel   => Channel_2,
+         Point     => Orange_LED,
+         PWM_AF    => PWM_Output_AF);
 
-      Attach_PWM_Channel
-        (PWM_Output_Red,
-         Channel => Channel_3,
-         Point   => Red_LED,
-         PWM_AF  => PWM_Output_AF);
+      PWM_Output_Red.Attach_PWM_Channel
+        (Generator => PWM_Output_Timer'Access,
+         Channel   => Channel_3,
+         Point     => Red_LED,
+         PWM_AF    => PWM_Output_AF);
 
-      Attach_PWM_Channel
-        (PWM_Output_Blue,
-         Channel => Channel_4,
-         Point   => Blue_LED,
-         PWM_AF  => PWM_Output_AF);
+      PWM_Output_Blue.Attach_PWM_Channel
+        (Generator => PWM_Output_Timer'Access,
+         Channel   => Channel_4,
+         Point     => Blue_LED,
+         PWM_AF    => PWM_Output_AF);
 
-      Enable_Output (PWM_Output_Green);
-      Enable_Output (PWM_Output_Orange);
-      Enable_Output (PWM_Output_Red);
-      Enable_Output (PWM_Output_Blue);
+      PWM_Output_Green.Enable_Output;
+      PWM_Output_Orange.Enable_Output;
+      PWM_Output_Red.Enable_Output;
+      PWM_Output_Blue.Enable_Output;
    end Initialize_PWM_Outputs;
 
 begin

--- a/arch/ARM/STM32/driver_demos/demo_LIS3DSH_pwm/src/demo_pwm_settings.ads
+++ b/arch/ARM/STM32/driver_demos/demo_LIS3DSH_pwm/src/demo_pwm_settings.ads
@@ -36,11 +36,13 @@ with STM32.PWM;       use STM32.PWM;
 package Demo_PWM_Settings is
 
    PWM_Output_Timer : Timer renames Timer_4;
+   --  This timer is shared among the four PWM objects. Timer 4 is used because
+   --  it is tied to the four LEDs on the STM32F4 Disco board.
 
-   PWM_Output_Green  : aliased PWM_Modulator (PWM_Output_Timer'Access);
-   PWM_Output_Orange : aliased PWM_Modulator (PWM_Output_Timer'Access);
-   PWM_Output_Red    : aliased PWM_Modulator (PWM_Output_Timer'Access);
-   PWM_Output_Blue   : aliased PWM_Modulator (PWM_Output_Timer'Access);
+   PWM_Output_Green  : PWM_Modulator;
+   PWM_Output_Orange : PWM_Modulator;
+   PWM_Output_Red    : PWM_Modulator;
+   PWM_Output_Blue   : PWM_Modulator;
 
    PWM_Output_AF : constant STM32.GPIO_Alternate_Function := GPIO_AF_2_TIM4;
 

--- a/arch/ARM/STM32/driver_demos/demo_adc_timer_dma/src/demo_adc_timer_dma.adb
+++ b/arch/ARM/STM32/driver_demos/demo_adc_timer_dma/src/demo_adc_timer_dma.adb
@@ -50,7 +50,7 @@ procedure Demo_ADC_Timer_DMA is
 
    Selected_Timer : Timer renames Timer_1;
 
-   Triggering_Signal : PWM_Modulator (Selected_Timer'Access);
+   Triggering_Signal : PWM_Modulator;
    --  the PWM modulator used to generate the square wave that triggers the ADC
    --  conversions
 
@@ -149,15 +149,15 @@ procedure Demo_ADC_Timer_DMA is
       --  note that the output pin is not used since we are reading the
       --  internal VBat channel, which is ADC1_IN18
    begin
-      Configure_PWM_Timer (Triggering_Signal.Generator, Frequency);
+      Configure_PWM_Timer (Selected_Timer'Access, Frequency);
 
-      Attach_PWM_Channel
-        (Triggering_Signal,
+      Triggering_Signal.Attach_PWM_Channel
+        (Selected_Timer'Access,
          Output_Channel,
          Output_Pin,
          Timer_AF);
 
-      Set_Duty_Cycle (Triggering_Signal, Value => 10);
+      Triggering_Signal.Set_Duty_Cycle (Value => 10);
       --  An arbitrary percentage, but determines the number of rising/falling
       --  transitions
    end Configure_Timer;
@@ -215,7 +215,7 @@ begin
       Data_Count  => 1);  -- ie, 1 halfword
 
    Enable (VBat.ADC.all);
-   Enable_Output (Triggering_Signal);
+   Triggering_Signal.Enable_Output;
 
    loop
       Print (0, 24, Voltage, "mv");

--- a/arch/ARM/STM32/driver_demos/demo_adc_timer_triggered/src/demo_adc_timer_triggered.adb
+++ b/arch/ARM/STM32/driver_demos/demo_adc_timer_triggered/src/demo_adc_timer_triggered.adb
@@ -53,7 +53,7 @@ procedure Demo_ADC_Timer_Triggered is
 
    Selected_Timer : Timer renames Timer_1;
 
-   Triggering_Signal : PWM_Modulator (Selected_Timer'Access);
+   Triggering_Signal : PWM_Modulator;
    --  the PWM modulator used to generate the square wave that triggers the ADC
    --  conversions
 
@@ -131,15 +131,15 @@ procedure Demo_ADC_Timer_Triggered is
       --  note that the output pin is not used since we are reading the
       --  internal VBat channel, which is ADC1_IN18
    begin
-      Configure_PWM_Timer (Triggering_Signal.Generator, Frequency);
+      Configure_PWM_Timer (Selected_Timer'Access, Frequency);
 
-      Attach_PWM_Channel
-        (Triggering_Signal,
+      Triggering_Signal.Attach_PWM_Channel
+        (Selected_Timer'Access,
          Output_Channel,
          Output_Pin,
          Timer_AF);
 
-      Set_Duty_Cycle (Triggering_Signal, Value => 10);
+      Triggering_Signal.Set_Duty_Cycle (Value => 10);
       --  An arbitrary percentage, but determines the number of rising/falling
       --  transitions
    end Configure_Timer;
@@ -161,7 +161,7 @@ begin
    Configure_Timer;
 
    Enable (VBat.ADC.all);
-   Enable_Output (Triggering_Signal);
+   Triggering_Signal.Enable_Output;
 
    loop
       Print (0, 24, VBat_Reader.Voltage, "mv");

--- a/arch/ARM/STM32/driver_demos/demo_timer_pwm/src/demo_pwm_adt.adb
+++ b/arch/ARM/STM32/driver_demos/demo_timer_pwm/src/demo_pwm_adt.adb
@@ -82,7 +82,7 @@ procedure Demo_PWM_ADT is  -- demo the higher-level PWM abstract data type
 
    Requested_Frequency : constant Hertz := 30_000;  -- arbitrary
 
-   Power_Control : PWM_Modulator (Selected_Timer'Access);
+   Power_Control : PWM_Modulator;
 
    procedure Configure_LEDs;
    --  initialize all of the LEDs to be in the AF mode
@@ -141,15 +141,15 @@ procedure Demo_PWM_ADT is  -- demo the higher-level PWM abstract data type
 begin
    Configure_LEDs;
 
-   Configure_PWM_Timer (Power_Control.Generator, Requested_Frequency);
+   Configure_PWM_Timer (Selected_Timer'Access, Requested_Frequency);
 
-   Attach_PWM_Channel
-     (Power_Control,
+   Power_Control.Attach_PWM_Channel
+     (Selected_Timer'Access,
       Output_Channel,
       LED_For (Output_Channel),
       Timer_AF);
 
-   Enable_Output (Power_Control);
+   Power_Control.Enable_Output;
 
    declare
       Arg       : Long_Float := 0.0;

--- a/arch/ARM/STM32/drivers/stm32-pwm.adb
+++ b/arch/ARM/STM32/drivers/stm32-pwm.adb
@@ -154,14 +154,16 @@ package body STM32.PWM is
    ------------------------
 
    procedure Attach_PWM_Channel
-     (This     : in out PWM_Modulator;
-      Channel  : Timer_Channel;
-      Point    : GPIO_Point;
-      PWM_AF   : GPIO_Alternate_Function;
-      Polarity : Timer_Output_Compare_Polarity := High)
+     (This      : in out PWM_Modulator;
+      Generator : not null access Timer;
+      Channel   : Timer_Channel;
+      Point     : GPIO_Point;
+      PWM_AF    : GPIO_Alternate_Function;
+      Polarity  : Timer_Output_Compare_Polarity := High)
    is
    begin
       This.Channel := Channel;
+      This.Generator := Generator;
 
       Enable_Clock (Point);
 
@@ -186,6 +188,7 @@ package body STM32.PWM is
 
    procedure Attach_PWM_Channel
      (This                     : in out PWM_Modulator;
+      Generator                : not null access Timer;
       Channel                  : Timer_Channel;
       Point                    : GPIO_Point;
       Complementary_Point      : GPIO_Point;
@@ -197,6 +200,7 @@ package body STM32.PWM is
    is
    begin
       This.Channel := Channel;
+      This.Generator := Generator;
 
       Enable_Clock (Point);
       Enable_Clock (Complementary_Point);

--- a/boards/OpenMV2/src/openmv-sensor.adb
+++ b/boards/OpenMV2/src/openmv-sensor.adb
@@ -47,7 +47,7 @@ package body OpenMV.Sensor is
    REG_PID : constant := 16#0A#;
    --  REG_VER : constant := 16#0B#;
 
-   CLK_PWM_Mod    : PWM_Modulator (SENSOR_CLK_TIM'Access);
+   CLK_PWM_Mod    : PWM_Modulator;
    Camera_PID     : HAL.UInt8 := 0;
    Camera_2640    : OV2640_Camera (Sensor_I2C'Access);
    Camera_7725    : OV7725_Camera (Sensor_I2C'Access);
@@ -99,14 +99,15 @@ package body OpenMV.Sensor is
       begin
          Configure_PWM_Timer (SENSOR_CLK_TIM'Access, SENSOR_CLK_FREQ);
 
-         Attach_PWM_Channel (This    => CLK_PWM_Mod,
-                             Channel => SENSOR_CLK_CHAN,
-                             Point   => SENSOR_CLK_IO,
-                             PWM_AF  => SENSOR_CLK_AF);
+         CLK_PWM_Mod.Attach_PWM_Channel
+          (Generator => SENSOR_CLK_TIM'Access,
+           Channel   => SENSOR_CLK_CHAN,
+           Point     => SENSOR_CLK_IO,
+           PWM_AF    => SENSOR_CLK_AF);
 
-         Set_Duty_Cycle (CLK_PWM_Mod, Value => 50);
+         CLK_PWM_Mod.Set_Duty_Cycle (Value => 50);
 
-         Enable_Output (CLK_PWM_Mod);
+         CLK_PWM_Mod.Enable_Output;
       end Initialize_Clock;
 
       -----------------------


### PR DESCRIPTION
Also make the PWM type tagged, since it is not a direct driver (it is a higher-level wrapper).

The issue with composition is that, for example, an enclosing record type cannot simply declare a component of the PWM type because the discriminant (timer) constraint is required at that point, and it might not be known there. That forces the component to be an access to the PWM type, thus requiring dynamic allocation or a fix timer object, or a timer discriminant on the enclosing type -- both of which are  problematic).