### PR TITLE
Fix for mem addr 16b TxE wait issue

### DIFF
--- a/arch/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
+++ b/arch/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
@@ -561,6 +561,14 @@ package body STM32.I2C is
 
             This.Periph.DR.DR := UInt8 (Mem_Addr and 16#FF#);
       end case;
+
+      --  Wait until TXE flag is set
+      Wait_Flag (This, Tx_Data_Register_Empty, False, Timeout, Status);
+
+      if Status /= HAL.I2C.Ok then
+         return;
+      end if;
+
    end Mem_Request_Write;
 
    ----------------------
@@ -617,6 +625,13 @@ package body STM32.I2C is
 
             This.Periph.DR.DR := UInt8 (Mem_Addr and 16#FF#);
       end case;
+
+      --  Wait until TXE flag is set
+      Wait_Flag (This, Tx_Data_Register_Empty, False, Timeout, Status);
+
+      if Status /= HAL.I2C.Ok then
+         return;
+      end if;
 
       --  We now need to reset and send the slave address in read mode
       This.Periph.CR1.START := True;

--- a/arch/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
+++ b/arch/ARM/STM32/drivers/i2c_stm32f4/stm32-i2c.adb
@@ -565,10 +565,6 @@ package body STM32.I2C is
       --  Wait until TXE flag is set
       Wait_Flag (This, Tx_Data_Register_Empty, False, Timeout, Status);
 
-      if Status /= HAL.I2C.Ok then
-         return;
-      end if;
-
    end Mem_Request_Write;
 
    ----------------------


### PR DESCRIPTION
Tested with 8b BNO055 part to verify 8b not busted.

Original issue was with 16b mem addr, the read/write cmd following the write of the mem addr LSB would step on the LSB of the addr. Interestingly the MSB to LSB TxE wait is basically a nop as the part immediately reports TxE and latches the LSB, the next write to the bus though... that one needs a wait as that is where the TxE hold will wait.