### PR TITLE
Add Transmit_Receive to HAL.SPI SPI_Port interface

### DIFF
--- a/arch/ARM/STM32/drivers/stm32-spi.adb
+++ b/arch/ARM/STM32/drivers/stm32-spi.adb
@@ -921,6 +921,7 @@ package body STM32.SPI is
    -- Transfer --
    --------------
 
+   overriding
    procedure Transfer
      (This      : in out SPI_Port;
       Data_Out  :        HAL.SPI.SPI_Data_8b;
@@ -930,8 +931,8 @@ package body STM32.SPI is
    is
       pragma Unreferenced (Timeout);
    begin
-      Send_Receive_8bit_Mode(This, UInt8_Buffer (Data_Out), UInt8_Buffer (Data_In), Data_Out'Length);
-      Status := HAL.SPI.OK;
+      Send_Receive_8bit_Mode (This, UInt8_Buffer (Data_Out), UInt8_Buffer (Data_In), Data_Out'Length);
+      Status := HAL.SPI.Ok;
    end Transfer;
 
    ------------------------

--- a/arch/ARM/STM32/drivers/stm32-spi.adb
+++ b/arch/ARM/STM32/drivers/stm32-spi.adb
@@ -917,6 +917,23 @@ package body STM32.SPI is
       end if;
    end Send_8bit_Mode;
 
+   --------------
+   -- Transfer --
+   --------------
+
+   procedure Transfer
+     (This      : in out SPI_Port;
+      Data_Out  :        HAL.SPI.SPI_Data_8b;
+      Data_In   :    out HAL.SPI.SPI_Data_8b;
+      Status    :    out HAL.SPI.SPI_Status;
+      Timeout   :        Natural := 1000)
+   is
+      pragma Unreferenced (Timeout);
+   begin
+      Send_Receive_8bit_Mode(This, UInt8_Buffer (Data_Out), UInt8_Buffer (Data_In), Data_Out'Length);
+      Status := HAL.SPI.OK;
+   end Transfer;
+
    ------------------------
    -- Receive_16bit_Mode --
    ------------------------

--- a/arch/ARM/STM32/drivers/stm32-spi.ads
+++ b/arch/ARM/STM32/drivers/stm32-spi.ads
@@ -192,13 +192,20 @@ package STM32.SPI is
      (This     : in out SPI_Port;
       Incoming : out UInt8);
 
+   overriding
+   procedure Transfer
+     (This      : in out SPI_Port;
+      Data_Out  :        HAL.SPI.SPI_Data_8b;
+      Data_In   :    out HAL.SPI.SPI_Data_8b;
+      Status    :    out HAL.SPI.SPI_Status;
+      Timeout   :        Natural := 1000);
+
    procedure Transmit_Receive
      (This      : in out SPI_Port;
       Outgoing  : UInt8_Buffer;
       Incoming  : out UInt8_Buffer;
       Size      : Positive);
 
-   overriding
    procedure Transmit_Receive
      (This      : in out SPI_Port;
       Outgoing  : UInt8;

--- a/arch/ARM/STM32/drivers/stm32-spi.ads
+++ b/arch/ARM/STM32/drivers/stm32-spi.ads
@@ -198,6 +198,7 @@ package STM32.SPI is
       Incoming  : out UInt8_Buffer;
       Size      : Positive);
 
+   overriding
    procedure Transmit_Receive
      (This      : in out SPI_Port;
       Outgoing  : UInt8;

--- a/components/src/network/bluenrg-ms/bluenrg_ms.adb
+++ b/components/src/network/bluenrg-ms/bluenrg_ms.adb
@@ -22,8 +22,6 @@
 --                                                                        --
 ----------------------------------------------------------------------------
 with Bluetooth.HCI;  use Bluetooth.HCI;
-with HAL.Time;
-with Ravenscar_Time;
 
 package body BlueNRG_MS is
 
@@ -691,12 +689,11 @@ package body BlueNRG_MS is
    procedure Reset
      (Device : in out BlueNRG_MS_Device)
    is
-      HAL_Time  : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
    begin
       Device.Reset_Pin.all.Clear;
-      HAL_Time.all.Delay_Milliseconds (Reset_Duration);
+      Device.Time.Delay_Milliseconds (Reset_Duration);
       Device.Reset_Pin.all.Set;
-      HAL_Time.all.Delay_Milliseconds (Reset_Duration);
+      Device.Time.Delay_Milliseconds (Reset_Duration);
    end Reset;
 
    ------------------
@@ -709,7 +706,6 @@ package body BlueNRG_MS is
       Parameters :        UInt8_Array)
       return Boolean
    is
-      HAL_Time  : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
       Try_Count : Natural := 0;
    begin
       loop
@@ -721,7 +717,7 @@ package body BlueNRG_MS is
          if Try_Count = Maximum_Command_Retries then
             return False;
          end if;
-         HAL_Time.all.Delay_Microseconds (Wait_For_Wakeup_Duration);
+         Device.Time.Delay_Microseconds (Wait_For_Wakeup_Duration);
       end loop;
       return True;
    end Send_Command;
@@ -735,7 +731,6 @@ package body BlueNRG_MS is
       Command    :        OpCode)
       return Boolean
    is
-      HAL_Time  : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
       Try_Count : Natural := 0;
    begin
       loop
@@ -746,7 +741,7 @@ package body BlueNRG_MS is
          if Try_Count = Maximum_Command_Retries then
             return False;
          end if;
-         HAL_Time.all.Delay_Microseconds (Wait_For_Wakeup_Duration);
+         Device.Time.Delay_Microseconds (Wait_For_Wakeup_Duration);
       end loop;
       return True;
    end Send_Command;
@@ -761,7 +756,6 @@ package body BlueNRG_MS is
       Parameters :        UInt8_Array)
       return UInt8_Array
    is
-      HAL_Time   : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
       Try_Count  : Natural := 0;
       Null_Array : UInt8_Array (1 .. 0);
    begin
@@ -775,7 +769,7 @@ package body BlueNRG_MS is
          if Try_Count = Maximum_Command_Retries then
             return Null_Array;
          end if;
-         HAL_Time.all.Delay_Microseconds (Wait_For_Wakeup_Duration);
+         Device.Time.Delay_Microseconds (Wait_For_Wakeup_Duration);
       end loop;
 
       Try_Count := 0;
@@ -793,7 +787,7 @@ package body BlueNRG_MS is
             end if;
          end;
          exit when Try_Count = Maximum_Response_Retries;
-         HAL_Time.all.Delay_Microseconds (Response_Delay_Duration);
+         Device.Time.Delay_Microseconds (Response_Delay_Duration);
          Try_Count := Try_Count + 1;
       end loop;
 
@@ -809,7 +803,6 @@ package body BlueNRG_MS is
       Command    :        OpCode)
       return UInt8_Array
    is
-      HAL_Time   : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
       Try_Count  : Natural := 0;
       Null_Array : UInt8_Array (1 .. 0);
    begin
@@ -822,7 +815,7 @@ package body BlueNRG_MS is
          if Try_Count = Maximum_Command_Retries then
             return Null_Array;
          end if;
-         HAL_Time.all.Delay_Microseconds (Wait_For_Wakeup_Duration);
+         Device.Time.Delay_Microseconds (Wait_For_Wakeup_Duration);
       end loop;
 
       Try_Count := 0;
@@ -840,7 +833,7 @@ package body BlueNRG_MS is
             end if;
          end;
          exit when Try_Count = Maximum_Response_Retries;
-         HAL_Time.all.Delay_Microseconds (Response_Delay_Duration);
+         Device.Time.Delay_Microseconds (Response_Delay_Duration);
          Try_Count := Try_Count + 1;
       end loop;
 

--- a/components/src/network/bluenrg-ms/bluenrg_ms.adb
+++ b/components/src/network/bluenrg-ms/bluenrg_ms.adb
@@ -41,14 +41,14 @@ package body BlueNRG_MS is
      (Device                  : in out BlueNRG_MS_Device;
       Role                    :        Device_Role;
       Enable_Privacy          :        Boolean;
-      Device_Name_Length      :        Byte;
-      Status                  :    out Byte;
+      Device_Name_Length      :        UInt8;
+      Status                  :    out UInt8;
       Service_Handle          :    out Handle;
       Device_Name_Char_Handle :    out Handle;
       Appearance_Char_Handle  :    out Handle)
       return Boolean
    is
-      Privacy : Byte;
+      Privacy : UInt8;
       Command : constant OpCode := ACI_GAP_Init;
    begin
       if Enable_Privacy then
@@ -58,11 +58,11 @@ package body BlueNRG_MS is
       end if;
       declare
          Parameters : constant
-                      Byte_Array := Byte_Array'(Role'Enum_Rep &
+                      UInt8_Array := UInt8_Array'(Role'Enum_Rep &
                                                 Privacy &
                                                 Device_Name_Length);
          Response   : constant
-                      Byte_Array := Send_Command
+                      UInt8_Array := Send_Command
                                       (Device,
                                        Command,
                                        Parameters);
@@ -88,21 +88,21 @@ package body BlueNRG_MS is
      (Device                  : in out BlueNRG_MS_Device;
       MITM_Required           :        Boolean;
       OOB_Enabled             :        Boolean;
-      OOB_Data                :        Byte_Array;
-      Min_Encryption_Key_Size :        Byte;
-      Max_Encryption_Key_Size :        Byte;
+      OOB_Data                :        UInt8_Array;
+      Min_Encryption_Key_Size :        UInt8;
+      Max_Encryption_Key_Size :        UInt8;
       Use_Fixed_Pin           :        Boolean;
       Pin                     :        Unsigned_32;
       Bonding_Required        :        Boolean;
-      Status                  :    out Byte)
+      Status                  :    out UInt8)
       return Boolean
    is
       Command       : constant OpCode := ACI_GAP_Set_Auth_Requirement;
-      MITM_Mode     : Byte := 0;
-      OOB_Enable    : Byte := 0;
-      Bonding_Mode  : Byte := 0;
-      Fixed_Pin     : Byte := 0;
-      Pin_Parameter : Byte_Array (1 .. 4);
+      MITM_Mode     : UInt8 := 0;
+      OOB_Enable    : UInt8 := 0;
+      Bonding_Mode  : UInt8 := 0;
+      Fixed_Pin     : UInt8 := 0;
+      Pin_Parameter : UInt8_Array (1 .. 4);
    begin
 
       if MITM_Required then
@@ -121,14 +121,14 @@ package body BlueNRG_MS is
          Bonding_Mode := 1;
       end if;
 
-      Pin_Parameter (1) := Byte (Pin and 16#FF#);
-      Pin_Parameter (2) := Byte (Shift_Right (Pin,  8) and 16#FF#);
-      Pin_Parameter (3) := Byte (Shift_Right (Pin, 16) and 16#FF#);
-      Pin_Parameter (4) := Byte (Shift_Right (Pin, 24) and 16#FF#);
+      Pin_Parameter (1) := UInt8 (Pin and 16#FF#);
+      Pin_Parameter (2) := UInt8 (Shift_Right (Pin,  8) and 16#FF#);
+      Pin_Parameter (3) := UInt8 (Shift_Right (Pin, 16) and 16#FF#);
+      Pin_Parameter (4) := UInt8 (Shift_Right (Pin, 24) and 16#FF#);
 
       declare
          Parameters : constant
-                      Byte_Array := Byte_Array'(MITM_Mode &
+                      UInt8_Array := UInt8_Array'(MITM_Mode &
                                                 OOB_Enable &
                                                 OOB_Data &
                                                 Min_Encryption_Key_Size &
@@ -137,7 +137,7 @@ package body BlueNRG_MS is
                                                 Pin_Parameter &
                                                 Bonding_Mode);
          Response   : constant
-                      Byte_Array := Send_Command
+                      UInt8_Array := Send_Command
                                       (Device,
                                        Command,
                                        Parameters);
@@ -159,20 +159,20 @@ package body BlueNRG_MS is
    function GAP_Set_Discoverable
      (Device                   : in out BlueNRG_MS_Device;
       Advertising_Event        :        Advertising_Event_Type;
-      Advertising_Interval_Min :        Unsigned_16;
-      Advertising_Interval_Max :        Unsigned_16;
+      Advertising_Interval_Min :        UInt16;
+      Advertising_Interval_Max :        UInt16;
       BT_Address_Type          :        Address_Type;
       Filter_Policy            :        Filter_Policy_Type;
       Local_Name_Type          :        Name_Type;
       Local_Name               :        String;
-      Service_UUID_List        :        Byte_Array;
-      Slave_Conn_Interval_Min  :        Unsigned_16;
-      Slave_Conn_Interval_Max  :        Unsigned_16;
-      Status                   :    out Byte)
+      Service_UUID_List        :        UInt8_Array;
+      Slave_Conn_Interval_Min  :        UInt16;
+      Slave_Conn_Interval_Max  :        UInt16;
+      Status                   :    out UInt8)
       return Boolean
    is
-      Advertising_Event_Byte : constant Byte := Advertising_Event'Enum_Rep;
-      Name_Length            : Byte;
+      Advertising_Event_UInt8 : constant UInt8 := Advertising_Event'Enum_Rep;
+      Name_Length            : UInt8;
       Command                : constant OpCode := ACI_GAP_Set_Discoverable;
    begin
 
@@ -185,20 +185,20 @@ package body BlueNRG_MS is
 
       declare
          Parameters : constant
-                      Byte_Array := Byte_Array'(Advertising_Event_Byte &
-                                                To_Byte_Array (Advertising_Interval_Min) &
-                                                To_Byte_Array (Advertising_Interval_Max) &
+                      UInt8_Array := UInt8_Array'(Advertising_Event_UInt8 &
+                                                To_UInt8_Array (Advertising_Interval_Min) &
+                                                To_UInt8_Array (Advertising_Interval_Max) &
                                                 BT_Address_Type'Enum_Rep &
                                                 Filter_Policy'Enum_Rep &
                                                 Name_Length &
                                                 Local_Name_Type'Enum_Rep &
-                                                To_Byte_Array (Local_Name) &
-                                                Byte (Service_UUID_List'Length) &
+                                                To_UInt8_Array (Local_Name) &
+                                                UInt8 (Service_UUID_List'Length) &
                                                 Service_UUID_List &
-                                                To_Byte_Array (Slave_Conn_Interval_Min) &
-                                                To_Byte_Array (Slave_Conn_Interval_Max));
+                                                To_UInt8_Array (Slave_Conn_Interval_Min) &
+                                                To_UInt8_Array (Slave_Conn_Interval_Max));
          Response   : constant
-                      Byte_Array := Send_Command (Device, Command, Parameters);
+                      UInt8_Array := Send_Command (Device, Command, Parameters);
       begin
          if Response'Length = 7 then
             Status := Response (7);
@@ -216,13 +216,13 @@ package body BlueNRG_MS is
 
    function GAP_Slave_Security_Request
      (Device           : in out BlueNRG_MS_Device;
-      Conn_Handle      :        Byte_Array;
+      Conn_Handle      :        UInt8_Array;
       Bonding_Required :        Boolean;
       MITM_Required    :        Boolean)
       return Boolean
    is
-      Bonding : Byte            := 0;
-      MITM    : Byte            := 0;
+      Bonding : UInt8            := 0;
+      MITM    : UInt8            := 0;
       Command : constant OpCode := ACI_GAP_Slave_Security_request;
    begin
 
@@ -236,11 +236,11 @@ package body BlueNRG_MS is
 
       declare
          Parameters : constant
-                      Byte_Array := Byte_Array'(Conn_Handle &
+                      UInt8_Array := UInt8_Array'(Conn_Handle &
                                                 Bonding &
                                                 MITM);
          Response   : constant
-                      Byte_Array := Send_Command (Device, Command, Parameters);
+                      UInt8_Array := Send_Command (Device, Command, Parameters);
       begin
          if Response'Length = 4 then
             if Response (4) = 0 then
@@ -261,17 +261,17 @@ package body BlueNRG_MS is
      (Device                : in out BlueNRG_MS_Device;
       Service               :        Handle;
       UUID                  :        UUID_16;
-      Max_Value_Length      :        Byte;
-      Properties            :        Byte;
-      Security              :        Byte;
-      Event_Mask            :        Byte;
-      Encryption_Key_Size   :        Byte;
+      Max_Value_Length      :        UInt8;
+      Properties            :        UInt8;
+      Security              :        UInt8;
+      Event_Mask            :        UInt8;
+      Encryption_Key_Size   :        UInt8;
       Value_Is_Fixed_Length :        Boolean;
-      Status                :    out Byte;
+      Status                :    out UInt8;
       Char_Handle           :    out Handle)
       return Boolean
    is
-      Is_Variable : Byte;
+      Is_Variable : UInt8;
       Command     : constant OpCode := ACI_GATT_Add_Char;
    begin
 
@@ -282,17 +282,17 @@ package body BlueNRG_MS is
       end if;
 
       declare
-         Parameters : constant Byte_Array :=
-                                  Byte_Array'(Service &
+         Parameters : constant UInt8_Array :=
+                                  UInt8_Array'(Service &
                                               16#01# &
-                                              Byte_Array (UUID) &
+                                              UInt8_Array (UUID) &
                                               Max_Value_Length &
                                               Properties &
                                               Security &
                                               Event_Mask &
                                               Encryption_Key_Size &
                                               Is_Variable);
-         Response   : constant Byte_Array := Send_Command (Device, Command, Parameters);
+         Response   : constant UInt8_Array := Send_Command (Device, Command, Parameters);
       begin
          if Response'Length = 9 then
             Status      := Response (7);
@@ -313,17 +313,17 @@ package body BlueNRG_MS is
      (Device                : in out BlueNRG_MS_Device;
       Service               :        Handle;
       UUID                  :        UUID_128;
-      Max_Value_Length      :        Byte;
-      Properties            :        Byte;
-      Security              :        Byte;
-      Event_Mask            :        Byte;
-      Encryption_Key_Size   :        Byte;
+      Max_Value_Length      :        UInt8;
+      Properties            :        UInt8;
+      Security              :        UInt8;
+      Event_Mask            :        UInt8;
+      Encryption_Key_Size   :        UInt8;
       Value_Is_Fixed_Length :        Boolean;
-      Status                :    out Byte;
+      Status                :    out UInt8;
       Char_Handle           :    out Handle)
       return Boolean
    is
-      Is_Variable : Byte;
+      Is_Variable : UInt8;
       Command     : constant OpCode := ACI_GATT_Add_Char;
    begin
 
@@ -334,17 +334,17 @@ package body BlueNRG_MS is
       end if;
 
       declare
-         Parameters : constant Byte_Array :=
-                                 Byte_Array'(Service &
+         Parameters : constant UInt8_Array :=
+                                 UInt8_Array'(Service &
                                              16#02# &
-                                             Byte_Array (UUID) &
+                                             UInt8_Array (UUID) &
                                              Max_Value_Length &
                                              Properties &
                                              Security &
                                              Event_Mask &
                                              Encryption_Key_Size &
                                              Is_Variable);
-         Response   : constant Byte_Array := Send_Command (Device, Command, Parameters);
+         Response   : constant UInt8_Array := Send_Command (Device, Command, Parameters);
       begin
          if Response'Length = 9 then
             Status      := Response (7);
@@ -365,20 +365,20 @@ package body BlueNRG_MS is
       (Device                : in out BlueNRG_MS_Device;
        UUID                  :        UUID_16;
        Service               :        Service_Type;
-       Max_Attribute_Records :        Byte;
-       Status                :    out Byte;
+       Max_Attribute_Records :        UInt8;
+       Status                :    out UInt8;
        Service_Handle        :    out Handle)
        return Boolean
    is
       Command : constant OpCode := ACI_GATT_Add_Serv;
    begin
       declare
-         Parameters : constant Byte_Array :=
-                                 Byte_Array'(16#01# &
-                                             Byte_Array (UUID) &
+         Parameters : constant UInt8_Array :=
+                                 UInt8_Array'(16#01# &
+                                             UInt8_Array (UUID) &
                                              Service'Enum_Rep &
                                              Max_Attribute_Records);
-         Response   : constant Byte_Array := Send_Command (Device, Command, Parameters);
+         Response   : constant UInt8_Array := Send_Command (Device, Command, Parameters);
       begin
          if Response'Length = 9 then
             Status         := Response (7);
@@ -399,20 +399,20 @@ package body BlueNRG_MS is
       (Device                : in out BlueNRG_MS_Device;
        UUID                  :        UUID_128;
        Service               :        Service_Type;
-       Max_Attribute_Records :        Byte;
-       Status                :    out Byte;
+       Max_Attribute_Records :        UInt8;
+       Status                :    out UInt8;
        Service_Handle        :    out Handle)
        return Boolean
    is
       Command : constant OpCode := ACI_GATT_Add_Serv;
    begin
       declare
-         Parameters : constant Byte_Array :=
-                                 Byte_Array'(16#02# &
-                                             Byte_Array (UUID) &
+         Parameters : constant UInt8_Array :=
+                                 UInt8_Array'(16#02# &
+                                             UInt8_Array (UUID) &
                                              Service'Enum_Rep &
                                              Max_Attribute_Records);
-         Response   : constant Byte_Array := Send_Command (Device, Command, Parameters);
+         Response   : constant UInt8_Array := Send_Command (Device, Command, Parameters);
       begin
          if Response'Length = 9 then
             Status         := Response (7);
@@ -431,13 +431,13 @@ package body BlueNRG_MS is
 
    function GATT_Init
      (Device : in out BlueNRG_MS_Device;
-      Status :    out Byte)
+      Status :    out UInt8)
       return Boolean
    is
       Command : constant OpCode := ACI_GATT_Init;
    begin
       declare
-         Response : constant Byte_Array := Send_Command (Device, Command);
+         Response : constant UInt8_Array := Send_Command (Device, Command);
       begin
          if Response'Length = 7 then
             Status := Response (7);
@@ -460,21 +460,21 @@ package body BlueNRG_MS is
      (Device            : in out BlueNRG_MS_Device;
       Service_Handle    :        Handle;
       Char_Handle       :        Handle;
-      Offset            :        Byte;
-      Char_Value        :        Byte_Array;
-      Status            :    out Byte)
+      Offset            :        UInt8;
+      Char_Value        :        UInt8_Array;
+      Status            :    out UInt8)
       return Boolean
    is
       Command : constant OpCode := ACI_GATT_Update_Char_Value;
    begin
       declare
-         Parameters : constant Byte_Array :=
-                                 Byte_Array'(Service_Handle &
+         Parameters : constant UInt8_Array :=
+                                 UInt8_Array'(Service_Handle &
                                              Char_Handle &
                                              Offset &
-                                             Byte (Char_Value'Length) &
+                                             UInt8 (Char_Value'Length) &
                                              Char_Value);
-         Response   : constant Byte_Array := Send_Command (Device, Command, Parameters);
+         Response   : constant UInt8_Array := Send_Command (Device, Command, Parameters);
       begin
          if Response'Length = 7 then
             Status := Response (7);
@@ -492,28 +492,28 @@ package body BlueNRG_MS is
 
    function Get_BlueNRG_Version
      (Device             : in out BlueNRG_MS_Device;
-      HCI_Version        :    out Unsigned_8;
-      HCI_Revision       :    out Unsigned_16;
-      LMP_PAL_Version    :    out Unsigned_8;
-      Mfr_Name           :    out Unsigned_16;
-      LMP_PAL_Subversion :    out Unsigned_16;
-      Status             :    out Byte)
+      HCI_Version        :    out UInt8;
+      HCI_Revision       :    out UInt16;
+      LMP_PAL_Version    :    out UInt8;
+      Mfr_Name           :    out UInt16;
+      LMP_PAL_Subversion :    out UInt16;
+      Status             :    out UInt8)
       return Boolean
    is
       Command : constant OpCode := HCI_Read_Local_Version_Information;
    begin
       declare
-         Response : constant Byte_Array := Send_Command (Device, Command);
+         Response : constant UInt8_Array := Send_Command (Device, Command);
       begin
          if Response'Length = 15 then
             Status := Response (7);
             HCI_Version        := Response (8);
-            HCI_Revision       := Unsigned_16 (Response (9) +
+            HCI_Revision       := UInt16 (Response (9) +
                                                Response (10) * 16#FF#);
             LMP_PAL_Version    := Response (11);
-            Mfr_Name           := Unsigned_16 (Response (12) +
+            Mfr_Name           := UInt16 (Response (12) +
                                                Response (13) * 16#FF#);
-            LMP_PAL_Subversion := Unsigned_16 (Response (14) +
+            LMP_PAL_Subversion := UInt16 (Response (14) +
                                                Response (15) * 16#FF#);
             return True;
          else
@@ -522,7 +522,7 @@ package body BlueNRG_MS is
             LMP_PAL_Version    := 0;
             Mfr_Name           := 0;
             LMP_PAL_Subversion := 0;
-            Status := 0;
+            Status             := 0;
             return False;
          end if;
       end;
@@ -536,23 +536,23 @@ package body BlueNRG_MS is
      (Device            : in out BlueNRG_MS_Device;
       Enable_High_Power :        Boolean;
       Level             :        Power_Level;
-      Status            :    out Byte)
+      Status            :    out UInt8)
       return Boolean
    is
-      High_Power_Byte  : Byte;
-      Power_Level_Byte : constant Byte := Byte (Level);
+      High_Power_UInt8  : UInt8;
+      Power_Level_UInt8 : constant UInt8 := UInt8 (Level);
       Command          : constant OpCode := ACI_HAL_Set_Tx_Power_Level;
    begin
       if Enable_High_Power then
-         High_Power_Byte := 1;
+         High_Power_UInt8 := 1;
       else
-         High_Power_Byte := 0;
+         High_Power_UInt8 := 0;
       end if;
 
       declare
-         Parameters : constant Byte_Array := Byte_Array'(High_Power_Byte &
-                                                         Power_Level_Byte);
-         Response   : constant Byte_Array := Send_Command (Device, Command, Parameters);
+         Parameters : constant UInt8_Array := UInt8_Array'(High_Power_UInt8 &
+                                                         Power_Level_UInt8);
+         Response   : constant UInt8_Array := Send_Command (Device, Command, Parameters);
       begin
          if Response'Length = 7 then
             Status := Response (7);
@@ -570,12 +570,12 @@ package body BlueNRG_MS is
 
    function HAL_Write_Config_Data
      (Device : in out BlueNRG_MS_Device;
-      Offset :        Byte;
-      Value  :        Byte_Array;
-      Status :    out Byte)
+      Offset :        UInt8;
+      Value  :        UInt8_Array;
+      Status :    out UInt8)
       return Boolean
    is
-      Parameters : Byte_Array (1 .. Value'Length + 2);
+      Parameters : UInt8_Array (1 .. Value'Length + 2);
       Command    : constant OpCode := ACI_HAL_Write_Config_Data;
    begin
       Parameters (1)                    := Offset;
@@ -583,7 +583,7 @@ package body BlueNRG_MS is
       Parameters (3 .. Parameters'Last) := Value;
 
       declare
-         Response : constant Byte_Array := Send_Command (Device, Command, Parameters);
+         Response : constant UInt8_Array := Send_Command (Device, Command, Parameters);
       begin
          if Response'Length = 7 then
             Status := Response (7);
@@ -601,12 +601,12 @@ package body BlueNRG_MS is
 
    function Read
      (Device : in out BlueNRG_MS_Device)
-      return Byte_Array
+      return UInt8_Array
    is
       Operation        : constant SPI_Data_8b (1 .. 1) := (1 => Read_Operation);
       Empty            : constant SPI_Data_8b (1 .. 4) := (others => 16#00#);
-      No_Data          : Byte_Array (1 .. 0);
-      Read_Buffer_Size : Byte;
+      No_Data          : UInt8_Array (1 .. 0);
+      Read_Buffer_Size : UInt8;
       Ready            : SPI_Data_8b (1 .. 1);
       SPI_Response     : SPI_Data_8b (1 .. 4);
       Transfer_Status  : SPI_Status;
@@ -628,7 +628,7 @@ package body BlueNRG_MS is
       end if;
 
       declare
-         Data  : Byte_Array  (1 .. Integer (Read_Buffer_Size));
+         Data  : UInt8_Array  (1 .. Integer (Read_Buffer_Size));
          Zeros : constant SPI_Data_8b (1 .. Integer (Read_Buffer_Size)) := (others => 16#00#);
       begin
          Device.SPI_Port.all.Transfer (Zeros, SPI_Data_8b (Data), Transfer_Status);
@@ -644,12 +644,12 @@ package body BlueNRG_MS is
    function Read
      (Device : in out BlueNRG_MS_Device;
       Count  : in out Natural)
-      return Byte_Array
+      return UInt8_Array
    is
       Operation        : constant SPI_Data_8b (1 .. 1) := (1 => Read_Operation);
       Empty            : constant SPI_Data_8b (1 .. 4) := (others => 16#00#);
-      No_Data          : Byte_Array (1 .. 0);
-      Read_Buffer_Size : Byte;
+      No_Data          : UInt8_Array (1 .. 0);
+      Read_Buffer_Size : UInt8;
       Ready            : SPI_Data_8b (1 .. 1);
       SPI_Response     : SPI_Data_8b (1 .. 4);
       Transfer_Status  : SPI_Status;
@@ -675,7 +675,7 @@ package body BlueNRG_MS is
       end if;
 
       declare
-         Data  : Byte_Array  (1 .. Integer (Count));
+         Data  : UInt8_Array  (1 .. Integer (Count));
          Zeros : constant SPI_Data_8b (1 .. Integer (Count)) := (others => 16#00#);
       begin
          Device.SPI_Port.all.Transfer (Zeros, SPI_Data_8b (Data), Transfer_Status);
@@ -706,7 +706,7 @@ package body BlueNRG_MS is
    function Send_Command
      (Device     : in out BlueNRG_MS_Device;
       Command    :        OpCode;
-      Parameters :        Byte_Array)
+      Parameters :        UInt8_Array)
       return Boolean
    is
       HAL_Time  : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
@@ -758,12 +758,12 @@ package body BlueNRG_MS is
    function Send_Command
      (Device     : in out BlueNRG_MS_Device;
       Command    :        OpCode;
-      Parameters :        Byte_Array)
-      return Byte_Array
+      Parameters :        UInt8_Array)
+      return UInt8_Array
    is
       HAL_Time   : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
       Try_Count  : Natural := 0;
-      Null_Array : Byte_Array (1 .. 0);
+      Null_Array : UInt8_Array (1 .. 0);
    begin
       -- Send Command --
       loop
@@ -782,7 +782,7 @@ package body BlueNRG_MS is
 
       loop
          declare
-            Response : constant Byte_Array := Device.Read;
+            Response : constant UInt8_Array := Device.Read;
          begin
             if Response'Length >= 7 then
                if Response (1) = Event_Packet_Type and then
@@ -807,11 +807,11 @@ package body BlueNRG_MS is
    function Send_Command
      (Device     : in out BlueNRG_MS_Device;
       Command    :        OpCode)
-      return Byte_Array
+      return UInt8_Array
    is
       HAL_Time   : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
       Try_Count  : Natural := 0;
-      Null_Array : Byte_Array (1 .. 0);
+      Null_Array : UInt8_Array (1 .. 0);
    begin
       -- Send Command --
       loop
@@ -829,7 +829,7 @@ package body BlueNRG_MS is
 
       loop
          declare
-            Response : constant Byte_Array := Device.Read;
+            Response : constant UInt8_Array := Device.Read;
          begin
             if Response'Length >= 7 then
                if Response (1) = Event_Packet_Type and then
@@ -854,7 +854,7 @@ package body BlueNRG_MS is
    function Set_Bluetooth_Public_Address
      (Device            : in out BlueNRG_MS_Device;
       Bluetooth_Address :        Address;
-      Status            :    out Byte)
+      Status            :    out UInt8)
       return Boolean
    is
    begin
@@ -866,41 +866,41 @@ package body BlueNRG_MS is
    end Set_Bluetooth_Public_Address;
 
    -------------------
-   -- To_Byte_Array --
+   -- To_UInt8_Array --
    -------------------
 
-   function To_Byte_Array
-     (Input : Unsigned_16)
-      return Byte_Array
+   function To_UInt8_Array
+     (Input : UInt16)
+      return UInt8_Array
    is
-      No_Output : Byte_Array (1 .. 0);
-      First     : Byte;
-      Second    : Byte;
+      No_Output : UInt8_Array (1 .. 0);
+      First     : UInt8;
+      Second    : UInt8;
    begin
-      First  := Byte (Input and 16#00FF#);
-      Second := Byte (Shift_Right (Input, 8));
-      return Byte_Array'(Second, First);
+      First  := UInt8 (Input and 16#00FF#);
+      Second := UInt8 (Shift_Right (Input, 8));
+      return UInt8_Array'(Second, First);
    exception
       when Constraint_Error =>
          return No_Output;
-   end To_Byte_Array;
+   end To_UInt8_Array;
 
    -------------------
-   -- To_Byte_Array --
+   -- To_UInt8_Array --
    -------------------
 
-   function To_Byte_Array
+   function To_UInt8_Array
      (Input : String)
-      return Byte_Array
+      return UInt8_Array
    is
-      No_Output    : Byte_Array (1 .. 0);
+      No_Output    : UInt8_Array (1 .. 0);
       Output_Index : Natural := 1;
    begin
       declare
-         Output : Byte_Array (1 .. Input'Length);
+         Output : UInt8_Array (1 .. Input'Length);
       begin
          for Input_Index in Integer range Input'Range loop
-            Output (Output_Index) := Byte (Character'Pos (Input (Input_Index)));
+            Output (Output_Index) := UInt8 (Character'Pos (Input (Input_Index)));
             Output_Index := Output_Index + 1;
          end loop;
          return Output;
@@ -908,7 +908,7 @@ package body BlueNRG_MS is
    exception
       when Constraint_Error =>
          return No_Output;
-   end To_Byte_Array;
+   end To_UInt8_Array;
 
    -----------
    -- Write --
@@ -916,12 +916,12 @@ package body BlueNRG_MS is
 
    function Write
      (Device : in out BlueNRG_MS_Device;
-      Data   :        Byte_Array)
+      Data   :        UInt8_Array)
       return Boolean
    is
       Operation         : constant SPI_Data_8b (1 .. 1) := (1 => Write_Operation);
       Empty             : constant SPI_Data_8b (1 .. 4) := (others => 16#00#);
-      Write_Buffer_Size : Byte;
+      Write_Buffer_Size : UInt8;
       Ready             : SPI_Data_8b (1 .. 1);
       SPI_Response      : SPI_Data_8b (1 .. 4);
       Transfer_Status   : SPI_Status;
@@ -933,11 +933,6 @@ package body BlueNRG_MS is
          Device.Chip_Select_Pin.all.Set;
          return False;
       end if;
-
---      Device.SPI_Port.all.Transmit_Receive (16#00#, Write_Buffer_Size);
---      Device.SPI_Port.all.Transmit_Receive (16#00#, Dummy);
---      Device.SPI_Port.all.Transmit_Receive (16#00#, Dummy);
---      Device.SPI_Port.all.Transmit_Receive (16#00#, Dummy);
 
       Device.SPI_Port.all.Transfer (Empty, SPI_Response, Transfer_Status);
       Write_Buffer_Size := SPI_Response (1);
@@ -952,10 +947,6 @@ package body BlueNRG_MS is
       begin
          Device.SPI_Port.all.Transfer (SPI_Data_8b (Data), Not_Used, Transfer_Status);
       end;
-
---      for Index in Integer range Data'First .. Data'Last loop
---         Device.SPI_Port.all.Transmit_Receive (Data (Index), Dummy);
---      end loop;
 
       Device.Chip_Select_Pin.all.Set;
 

--- a/components/src/network/bluenrg-ms/bluenrg_ms.adb
+++ b/components/src/network/bluenrg-ms/bluenrg_ms.adb
@@ -1,0 +1,965 @@
+----------------------------------------------------------------------------
+--                                                                        --
+--  BlueNRG-MS                                                            --
+--                                                                        --
+--  Copyright (C) 2017, John Leimon                                       --
+--                                                                        --
+-- Permission to use, copy, modify, and/or distribute                     --
+-- this software for any purpose with or without fee                      --
+-- is hereby granted, provided that the above copyright                   --
+-- notice and this permission notice appear in all copies.                --
+--                                                                        --
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR                        --
+-- DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE                  --
+-- INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY                    --
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE                    --
+-- FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL                    --
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS                  --
+-- OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF                       --
+-- CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING                 --
+-- OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF                 --
+-- THIS SOFTWARE.                                                         --
+--                                                                        --
+----------------------------------------------------------------------------
+with Bluetooth.HCI;  use Bluetooth.HCI;
+with HAL.Time;
+with Ravenscar_Time;
+
+package body BlueNRG_MS is
+
+   Reset_Duration           : constant := 10; -- Milliseconds
+   Wait_For_Wakeup_Duration : constant := 50; -- Microseconds
+   Response_Delay_Duration  : constant := 10; -- Microseconds
+   Maximum_Response_Retries : constant := 10;
+   Maximum_Command_Retries  : constant := 10;
+
+   --------------
+   -- GAP_Init --
+   --------------
+
+   function GAP_Init
+     (Device                  : in out BlueNRG_MS_Device;
+      Role                    :        Device_Role;
+      Enable_Privacy          :        Boolean;
+      Device_Name_Length      :        Byte;
+      Status                  :    out Byte;
+      Service_Handle          :    out Handle;
+      Device_Name_Char_Handle :    out Handle;
+      Appearance_Char_Handle  :    out Handle)
+      return Boolean
+   is
+      Privacy : Byte;
+      Command : constant OpCode := ACI_GAP_Init;
+   begin
+      if Enable_Privacy then
+         Privacy := 1;
+      else
+         Privacy := 0;
+      end if;
+      declare
+         Parameters : constant
+                      Byte_Array := Byte_Array'(Role'Enum_Rep &
+                                                Privacy &
+                                                Device_Name_Length);
+         Response   : constant
+                      Byte_Array := Send_Command
+                                      (Device,
+                                       Command,
+                                       Parameters);
+      begin
+         if Response'Length = 13 then
+            Status                  := Response (7);
+            Service_Handle          := Response (8 .. 9);
+            Device_Name_Char_Handle := Response (10 .. 11);
+            Appearance_Char_Handle  := Response (12 .. 13);
+            return True;
+         else
+            Status := 0;
+            return False;
+         end if;
+      end;
+   end GAP_Init;
+
+   ------------------------------
+   -- GAP_Set_Auth_Requirement --
+   ------------------------------
+
+   function GAP_Set_Auth_Requirement
+     (Device                  : in out BlueNRG_MS_Device;
+      MITM_Required           :        Boolean;
+      OOB_Enabled             :        Boolean;
+      OOB_Data                :        Byte_Array;
+      Min_Encryption_Key_Size :        Byte;
+      Max_Encryption_Key_Size :        Byte;
+      Use_Fixed_Pin           :        Boolean;
+      Pin                     :        Unsigned_32;
+      Bonding_Required        :        Boolean;
+      Status                  :    out Byte)
+      return Boolean
+   is
+      Command       : constant OpCode := ACI_GAP_Set_Auth_Requirement;
+      MITM_Mode     : Byte := 0;
+      OOB_Enable    : Byte := 0;
+      Bonding_Mode  : Byte := 0;
+      Fixed_Pin     : Byte := 0;
+      Pin_Parameter : Byte_Array (1 .. 4);
+   begin
+
+      if MITM_Required then
+         MITM_Mode := 1;
+      end if;
+
+      if OOB_Enabled then
+         OOB_Enable := 1;
+      end if;
+
+      if Use_Fixed_Pin = False then
+         Fixed_Pin := 1;
+      end if;
+
+      if Bonding_Required then
+         Bonding_Mode := 1;
+      end if;
+
+      Pin_Parameter (1) := Byte (Pin and 16#FF#);
+      Pin_Parameter (2) := Byte (Shift_Right (Pin,  8) and 16#FF#);
+      Pin_Parameter (3) := Byte (Shift_Right (Pin, 16) and 16#FF#);
+      Pin_Parameter (4) := Byte (Shift_Right (Pin, 24) and 16#FF#);
+
+      declare
+         Parameters : constant
+                      Byte_Array := Byte_Array'(MITM_Mode &
+                                                OOB_Enable &
+                                                OOB_Data &
+                                                Min_Encryption_Key_Size &
+                                                Max_Encryption_Key_Size &
+                                                Fixed_Pin &
+                                                Pin_Parameter &
+                                                Bonding_Mode);
+         Response   : constant
+                      Byte_Array := Send_Command
+                                      (Device,
+                                       Command,
+                                       Parameters);
+      begin
+         if Response'Length = 7 then
+            Status := Response (7);
+            return True;
+         else
+            Status := 0;
+            return False;
+         end if;
+      end;
+   end GAP_Set_Auth_Requirement;
+
+   --------------------------
+   -- GAP_Set_Discoverable --
+   --------------------------
+
+   function GAP_Set_Discoverable
+     (Device                   : in out BlueNRG_MS_Device;
+      Advertising_Event        :        Advertising_Event_Type;
+      Advertising_Interval_Min :        Unsigned_16;
+      Advertising_Interval_Max :        Unsigned_16;
+      BT_Address_Type          :        Address_Type;
+      Filter_Policy            :        Filter_Policy_Type;
+      Local_Name_Type          :        Name_Type;
+      Local_Name               :        String;
+      Service_UUID_List        :        Byte_Array;
+      Slave_Conn_Interval_Min  :        Unsigned_16;
+      Slave_Conn_Interval_Max  :        Unsigned_16;
+      Status                   :    out Byte)
+      return Boolean
+   is
+      Advertising_Event_Byte : constant Byte := Advertising_Event'Enum_Rep;
+      Name_Length            : Byte;
+      Command                : constant OpCode := ACI_GAP_Set_Discoverable;
+   begin
+
+      if Local_Name'Length = 0 then
+         Name_Length := 0;
+      else
+         -- Add one byte for the AD type --
+         Name_Length := Local_Name'Length + 1;
+      end if;
+
+      declare
+         Parameters : constant
+                      Byte_Array := Byte_Array'(Advertising_Event_Byte &
+                                                To_Byte_Array (Advertising_Interval_Min) &
+                                                To_Byte_Array (Advertising_Interval_Max) &
+                                                BT_Address_Type'Enum_Rep &
+                                                Filter_Policy'Enum_Rep &
+                                                Name_Length &
+                                                Local_Name_Type'Enum_Rep &
+                                                To_Byte_Array (Local_Name) &
+                                                Byte (Service_UUID_List'Length) &
+                                                Service_UUID_List &
+                                                To_Byte_Array (Slave_Conn_Interval_Min) &
+                                                To_Byte_Array (Slave_Conn_Interval_Max));
+         Response   : constant
+                      Byte_Array := Send_Command (Device, Command, Parameters);
+      begin
+         if Response'Length = 7 then
+            Status := Response (7);
+            return True;
+         else
+            Status := 0;
+            return False;
+         end if;
+      end;
+   end GAP_Set_Discoverable;
+
+   --------------------------------
+   -- GAP_Slave_Security_Request --
+   --------------------------------
+
+   function GAP_Slave_Security_Request
+     (Device           : in out BlueNRG_MS_Device;
+      Conn_Handle      :        Byte_Array;
+      Bonding_Required :        Boolean;
+      MITM_Required    :        Boolean)
+      return Boolean
+   is
+      Bonding : Byte            := 0;
+      MITM    : Byte            := 0;
+      Command : constant OpCode := ACI_GAP_Slave_Security_request;
+   begin
+
+      if Bonding_Required then
+         Bonding := 1;
+      end if;
+
+      if MITM_Required then
+         MITM := 1;
+      end if;
+
+      declare
+         Parameters : constant
+                      Byte_Array := Byte_Array'(Conn_Handle &
+                                                Bonding &
+                                                MITM);
+         Response   : constant
+                      Byte_Array := Send_Command (Device, Command, Parameters);
+      begin
+         if Response'Length = 4 then
+            if Response (4) = 0 then
+               return True;
+            end if;
+            return False;
+         else
+            return False;
+         end if;
+      end;
+   end GAP_Slave_Security_Request;
+
+   -----------------------------
+   -- GATT_Add_Characteristic --
+   -----------------------------
+
+   function GATT_Add_Characteristic
+     (Device                : in out BlueNRG_MS_Device;
+      Service               :        Handle;
+      UUID                  :        UUID_16;
+      Max_Value_Length      :        Byte;
+      Properties            :        Byte;
+      Security              :        Byte;
+      Event_Mask            :        Byte;
+      Encryption_Key_Size   :        Byte;
+      Value_Is_Fixed_Length :        Boolean;
+      Status                :    out Byte;
+      Char_Handle           :    out Handle)
+      return Boolean
+   is
+      Is_Variable : Byte;
+      Command     : constant OpCode := ACI_GATT_Add_Char;
+   begin
+
+      if Value_Is_Fixed_Length then
+         Is_Variable := 0;
+      else
+         Is_Variable := 1;
+      end if;
+
+      declare
+         Parameters : constant Byte_Array :=
+                                  Byte_Array'(Service &
+                                              16#01# &
+                                              Byte_Array (UUID) &
+                                              Max_Value_Length &
+                                              Properties &
+                                              Security &
+                                              Event_Mask &
+                                              Encryption_Key_Size &
+                                              Is_Variable);
+         Response   : constant Byte_Array := Send_Command (Device, Command, Parameters);
+      begin
+         if Response'Length = 9 then
+            Status      := Response (7);
+            Char_Handle := Response (8 .. 9);
+            return True;
+         else
+            Status := 0;
+            return False;
+         end if;
+      end;
+   end GATT_Add_Characteristic;
+
+   -----------------------------
+   -- GATT_Add_Characteristic --
+   -----------------------------
+
+   function GATT_Add_Characteristic
+     (Device                : in out BlueNRG_MS_Device;
+      Service               :        Handle;
+      UUID                  :        UUID_128;
+      Max_Value_Length      :        Byte;
+      Properties            :        Byte;
+      Security              :        Byte;
+      Event_Mask            :        Byte;
+      Encryption_Key_Size   :        Byte;
+      Value_Is_Fixed_Length :        Boolean;
+      Status                :    out Byte;
+      Char_Handle           :    out Handle)
+      return Boolean
+   is
+      Is_Variable : Byte;
+      Command     : constant OpCode := ACI_GATT_Add_Char;
+   begin
+
+      if Value_Is_Fixed_Length then
+         Is_Variable := 0;
+      else
+         Is_Variable := 1;
+      end if;
+
+      declare
+         Parameters : constant Byte_Array :=
+                                 Byte_Array'(Service &
+                                             16#02# &
+                                             Byte_Array (UUID) &
+                                             Max_Value_Length &
+                                             Properties &
+                                             Security &
+                                             Event_Mask &
+                                             Encryption_Key_Size &
+                                             Is_Variable);
+         Response   : constant Byte_Array := Send_Command (Device, Command, Parameters);
+      begin
+         if Response'Length = 9 then
+            Status      := Response (7);
+            Char_Handle := Response (8 .. 9);
+            return True;
+         else
+            Status := 0;
+            return False;
+         end if;
+      end;
+   end GATT_Add_Characteristic;
+
+   ----------------------
+   -- GATT_Add_Service --
+   ----------------------
+
+   function GATT_Add_Service
+      (Device                : in out BlueNRG_MS_Device;
+       UUID                  :        UUID_16;
+       Service               :        Service_Type;
+       Max_Attribute_Records :        Byte;
+       Status                :    out Byte;
+       Service_Handle        :    out Handle)
+       return Boolean
+   is
+      Command : constant OpCode := ACI_GATT_Add_Serv;
+   begin
+      declare
+         Parameters : constant Byte_Array :=
+                                 Byte_Array'(16#01# &
+                                             Byte_Array (UUID) &
+                                             Service'Enum_Rep &
+                                             Max_Attribute_Records);
+         Response   : constant Byte_Array := Send_Command (Device, Command, Parameters);
+      begin
+         if Response'Length = 9 then
+            Status         := Response (7);
+            Service_Handle := Response (8 .. 9);
+            return True;
+         else
+            Status := 0;
+            return False;
+         end if;
+      end;
+   end GATT_Add_Service;
+
+   ----------------------
+   -- GATT_Add_Service --
+   ----------------------
+
+   function GATT_Add_Service
+      (Device                : in out BlueNRG_MS_Device;
+       UUID                  :        UUID_128;
+       Service               :        Service_Type;
+       Max_Attribute_Records :        Byte;
+       Status                :    out Byte;
+       Service_Handle        :    out Handle)
+       return Boolean
+   is
+      Command : constant OpCode := ACI_GATT_Add_Serv;
+   begin
+      declare
+         Parameters : constant Byte_Array :=
+                                 Byte_Array'(16#02# &
+                                             Byte_Array (UUID) &
+                                             Service'Enum_Rep &
+                                             Max_Attribute_Records);
+         Response   : constant Byte_Array := Send_Command (Device, Command, Parameters);
+      begin
+         if Response'Length = 9 then
+            Status         := Response (7);
+            Service_Handle := Response (8 .. 9);
+            return True;
+         else
+            Status := 0;
+            return False;
+         end if;
+      end;
+   end GATT_Add_Service;
+
+   ---------------
+   -- GATT_Init --
+   ---------------
+
+   function GATT_Init
+     (Device : in out BlueNRG_MS_Device;
+      Status :    out Byte)
+      return Boolean
+   is
+      Command : constant OpCode := ACI_GATT_Init;
+   begin
+      declare
+         Response : constant Byte_Array := Send_Command (Device, Command);
+      begin
+         if Response'Length = 7 then
+            Status := Response (7);
+            return True;
+         else
+            Status := 0;
+            return False;
+         end if;
+      end;
+   exception
+      when Constraint_Error =>
+         return False;
+   end GATT_Init;
+
+   -------------------------------------
+   -- GATT_Update_Characteristic_Value --
+   -------------------------------------
+
+   function GATT_Update_Characteristic_Value
+     (Device            : in out BlueNRG_MS_Device;
+      Service_Handle    :        Handle;
+      Char_Handle       :        Handle;
+      Offset            :        Byte;
+      Char_Value        :        Byte_Array;
+      Status            :    out Byte)
+      return Boolean
+   is
+      Command : constant OpCode := ACI_GATT_Update_Char_Value;
+   begin
+      declare
+         Parameters : constant Byte_Array :=
+                                 Byte_Array'(Service_Handle &
+                                             Char_Handle &
+                                             Offset &
+                                             Byte (Char_Value'Length) &
+                                             Char_Value);
+         Response   : constant Byte_Array := Send_Command (Device, Command, Parameters);
+      begin
+         if Response'Length = 7 then
+            Status := Response (7);
+            return True;
+         else
+            Status := 0;
+            return False;
+         end if;
+      end;
+   end GATT_Update_Characteristic_Value;
+
+   -------------------------
+   -- Get_BlueNRG_Verison --
+   -------------------------
+
+   function Get_BlueNRG_Version
+     (Device             : in out BlueNRG_MS_Device;
+      HCI_Version        :    out Unsigned_8;
+      HCI_Revision       :    out Unsigned_16;
+      LMP_PAL_Version    :    out Unsigned_8;
+      Mfr_Name           :    out Unsigned_16;
+      LMP_PAL_Subversion :    out Unsigned_16;
+      Status             :    out Byte)
+      return Boolean
+   is
+      Command : constant OpCode := HCI_Read_Local_Version_Information;
+   begin
+      declare
+         Response : constant Byte_Array := Send_Command (Device, Command);
+      begin
+         if Response'Length = 15 then
+            Status := Response (7);
+            HCI_Version        := Response (8);
+            HCI_Revision       := Unsigned_16 (Response (9) +
+                                               Response (10) * 16#FF#);
+            LMP_PAL_Version    := Response (11);
+            Mfr_Name           := Unsigned_16 (Response (12) +
+                                               Response (13) * 16#FF#);
+            LMP_PAL_Subversion := Unsigned_16 (Response (14) +
+                                               Response (15) * 16#FF#);
+            return True;
+         else
+            HCI_Version        := 0;
+            HCI_Revision       := 0;
+            LMP_PAL_Version    := 0;
+            Mfr_Name           := 0;
+            LMP_PAL_Subversion := 0;
+            Status := 0;
+            return False;
+         end if;
+      end;
+   end Get_BlueNRG_Version;
+
+   ----------------------------
+   -- HAL_Set_TX_Power_Level --
+   ----------------------------
+
+   function HAL_Set_TX_Power_Level
+     (Device            : in out BlueNRG_MS_Device;
+      Enable_High_Power :        Boolean;
+      Level             :        Power_Level;
+      Status            :    out Byte)
+      return Boolean
+   is
+      High_Power_Byte  : Byte;
+      Power_Level_Byte : constant Byte := Byte (Level);
+      Command          : constant OpCode := ACI_HAL_Set_Tx_Power_Level;
+   begin
+      if Enable_High_Power then
+         High_Power_Byte := 1;
+      else
+         High_Power_Byte := 0;
+      end if;
+
+      declare
+         Parameters : constant Byte_Array := Byte_Array'(High_Power_Byte &
+                                                         Power_Level_Byte);
+         Response   : constant Byte_Array := Send_Command (Device, Command, Parameters);
+      begin
+         if Response'Length = 7 then
+            Status := Response (7);
+            return True;
+         else
+            Status := 0;
+            return False;
+         end if;
+      end;
+   end HAL_Set_TX_Power_Level;
+
+   ---------------------------
+   -- HAL_Write_Config_Data --
+   ---------------------------
+
+   function HAL_Write_Config_Data
+     (Device : in out BlueNRG_MS_Device;
+      Offset :        Byte;
+      Value  :        Byte_Array;
+      Status :    out Byte)
+      return Boolean
+   is
+      Parameters : Byte_Array (1 .. Value'Length + 2);
+      Command    : constant OpCode := ACI_HAL_Write_Config_Data;
+   begin
+      Parameters (1)                    := Offset;
+      Parameters (2)                    := Value'Length;
+      Parameters (3 .. Parameters'Last) := Value;
+
+      declare
+         Response : constant Byte_Array := Send_Command (Device, Command, Parameters);
+      begin
+         if Response'Length = 7 then
+            Status := Response (7);
+            return True;
+         else
+            Status := 0;
+            return False;
+         end if;
+      end;
+   end HAL_Write_Config_Data;
+
+   ----------
+   -- Read --
+   ----------
+
+   function Read
+     (Device : in out BlueNRG_MS_Device)
+      return Byte_Array
+   is
+      Operation        : constant SPI_Data_8b (1 .. 1) := (1 => Read_Operation);
+      Empty            : constant SPI_Data_8b (1 .. 4) := (others => 16#00#);
+      No_Data          : Byte_Array (1 .. 0);
+      Read_Buffer_Size : Byte;
+      Ready            : SPI_Data_8b (1 .. 1);
+      SPI_Response     : SPI_Data_8b (1 .. 4);
+      Transfer_Status  : SPI_Status;
+   begin
+      Device.Chip_Select_Pin.all.Clear;
+      Device.SPI_Port.all.Transfer (Operation, Ready, Transfer_Status);
+
+      if Ready (1) /= Device_Ready then
+         Device.Chip_Select_Pin.all.Set;
+         return No_Data;
+      end if;
+
+      Device.SPI_Port.all.Transfer (Empty, SPI_Response, Transfer_Status);
+      Read_Buffer_Size := SPI_Response (3);
+
+      if Read_Buffer_Size = 0 then
+         Device.Chip_Select_Pin.all.Set;
+         return No_Data;
+      end if;
+
+      declare
+         Data  : Byte_Array  (1 .. Integer (Read_Buffer_Size));
+         Zeros : constant SPI_Data_8b (1 .. Integer (Read_Buffer_Size)) := (others => 16#00#);
+      begin
+         Device.SPI_Port.all.Transfer (Zeros, SPI_Data_8b (Data), Transfer_Status);
+         Device.Chip_Select_Pin.all.Set;
+         return Data;
+      end;
+   end Read;
+
+   ----------
+   -- Read --
+   ----------
+
+   function Read
+     (Device : in out BlueNRG_MS_Device;
+      Count  : in out Natural)
+      return Byte_Array
+   is
+      Operation        : constant SPI_Data_8b (1 .. 1) := (1 => Read_Operation);
+      Empty            : constant SPI_Data_8b (1 .. 4) := (others => 16#00#);
+      No_Data          : Byte_Array (1 .. 0);
+      Read_Buffer_Size : Byte;
+      Ready            : SPI_Data_8b (1 .. 1);
+      SPI_Response     : SPI_Data_8b (1 .. 4);
+      Transfer_Status  : SPI_Status;
+   begin
+      Device.Chip_Select_Pin.all.Clear;
+      Device.SPI_Port.all.Transfer (Operation, Ready, Transfer_Status);
+
+      if Ready (1) /= Device_Ready then
+         Device.Chip_Select_Pin.all.Set;
+         return No_Data;
+      end if;
+
+      Device.SPI_Port.all.Transfer (Empty, SPI_Response, Transfer_Status);
+      Read_Buffer_Size := SPI_Response (3);
+
+      if Read_Buffer_Size = 0 then
+         Device.Chip_Select_Pin.all.Set;
+         return No_Data;
+      end if;
+
+      if Count > Natural (Read_Buffer_Size) then
+         Count := Natural (Read_Buffer_Size);
+      end if;
+
+      declare
+         Data  : Byte_Array  (1 .. Integer (Count));
+         Zeros : constant SPI_Data_8b (1 .. Integer (Count)) := (others => 16#00#);
+      begin
+         Device.SPI_Port.all.Transfer (Zeros, SPI_Data_8b (Data), Transfer_Status);
+         Device.Chip_Select_Pin.all.Set;
+         return Data;
+      end;
+   end Read;
+
+   -----------
+   -- Reset --
+   -----------
+
+   procedure Reset
+     (Device : in out BlueNRG_MS_Device)
+   is
+      HAL_Time  : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
+   begin
+      Device.Reset_Pin.all.Clear;
+      HAL_Time.all.Delay_Milliseconds (Reset_Duration);
+      Device.Reset_Pin.all.Set;
+      HAL_Time.all.Delay_Milliseconds (Reset_Duration);
+   end Reset;
+
+   ------------------
+   -- Send_Command --
+   ------------------
+
+   function Send_Command
+     (Device     : in out BlueNRG_MS_Device;
+      Command    :        OpCode;
+      Parameters :        Byte_Array)
+      return Boolean
+   is
+      HAL_Time  : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
+      Try_Count : Natural := 0;
+   begin
+      loop
+         Try_Count := Try_Count + 1;
+         exit when Device.Write (Command_Packet_Type &
+                                 Command &
+                                 Parameters'Length &
+                                 Parameters);
+         if Try_Count = Maximum_Command_Retries then
+            return False;
+         end if;
+         HAL_Time.all.Delay_Microseconds (Wait_For_Wakeup_Duration);
+      end loop;
+      return True;
+   end Send_Command;
+
+   ------------------
+   -- Send_Command --
+   ------------------
+
+   function Send_Command
+     (Device     : in out BlueNRG_MS_Device;
+      Command    :        OpCode)
+      return Boolean
+   is
+      HAL_Time  : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
+      Try_Count : Natural := 0;
+   begin
+      loop
+         Try_Count := Try_Count + 1;
+         exit when Device.Write (Command_Packet_Type &
+                                 Command &
+                                 16#00#);
+         if Try_Count = Maximum_Command_Retries then
+            return False;
+         end if;
+         HAL_Time.all.Delay_Microseconds (Wait_For_Wakeup_Duration);
+      end loop;
+      return True;
+   end Send_Command;
+
+   ------------------
+   -- Send_Command --
+   ------------------
+
+   function Send_Command
+     (Device     : in out BlueNRG_MS_Device;
+      Command    :        OpCode;
+      Parameters :        Byte_Array)
+      return Byte_Array
+   is
+      HAL_Time   : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
+      Try_Count  : Natural := 0;
+      Null_Array : Byte_Array (1 .. 0);
+   begin
+      -- Send Command --
+      loop
+         Try_Count := Try_Count + 1;
+         exit when Device.Write (Command_Packet_Type &
+                                 Command &
+                                 Parameters'Length &
+                                 Parameters);
+         if Try_Count = Maximum_Command_Retries then
+            return Null_Array;
+         end if;
+         HAL_Time.all.Delay_Microseconds (Wait_For_Wakeup_Duration);
+      end loop;
+
+      Try_Count := 0;
+
+      loop
+         declare
+            Response : constant Byte_Array := Device.Read;
+         begin
+            if Response'Length >= 7 then
+               if Response (1) = Event_Packet_Type and then
+                  Response (5 .. 6) = Command
+               then
+                  return Response;
+               end if;
+            end if;
+         end;
+         exit when Try_Count = Maximum_Response_Retries;
+         HAL_Time.all.Delay_Microseconds (Response_Delay_Duration);
+         Try_Count := Try_Count + 1;
+      end loop;
+
+      return Null_Array;
+   end Send_Command;
+
+   ------------------
+   -- Send_Command --
+   ------------------
+
+   function Send_Command
+     (Device     : in out BlueNRG_MS_Device;
+      Command    :        OpCode)
+      return Byte_Array
+   is
+      HAL_Time   : constant HAL.Time.Any_Delays := Ravenscar_Time.Delays;
+      Try_Count  : Natural := 0;
+      Null_Array : Byte_Array (1 .. 0);
+   begin
+      -- Send Command --
+      loop
+         Try_Count := Try_Count + 1;
+         exit when Device.Write (Command_Packet_Type &
+                                 Command &
+                                 16#00#);
+         if Try_Count = Maximum_Command_Retries then
+            return Null_Array;
+         end if;
+         HAL_Time.all.Delay_Microseconds (Wait_For_Wakeup_Duration);
+      end loop;
+
+      Try_Count := 0;
+
+      loop
+         declare
+            Response : constant Byte_Array := Device.Read;
+         begin
+            if Response'Length >= 7 then
+               if Response (1) = Event_Packet_Type and then
+                  Response (5 .. 6) = Command
+               then
+                  return Response;
+               end if;
+            end if;
+         end;
+         exit when Try_Count = Maximum_Response_Retries;
+         HAL_Time.all.Delay_Microseconds (Response_Delay_Duration);
+         Try_Count := Try_Count + 1;
+      end loop;
+
+      return Null_Array;
+   end Send_Command;
+
+   ----------------------------------
+   -- Set_Bluetooth_Public_Address --
+   ----------------------------------
+
+   function Set_Bluetooth_Public_Address
+     (Device            : in out BlueNRG_MS_Device;
+      Bluetooth_Address :        Address;
+      Status            :    out Byte)
+      return Boolean
+   is
+   begin
+      return HAL_Write_Config_Data
+               (Device => Device,
+                Offset => Config_Data_Public_Address_Offset,
+                Value  => Bluetooth_Address,
+                Status => Status);
+   end Set_Bluetooth_Public_Address;
+
+   -------------------
+   -- To_Byte_Array --
+   -------------------
+
+   function To_Byte_Array
+     (Input : Unsigned_16)
+      return Byte_Array
+   is
+      No_Output : Byte_Array (1 .. 0);
+      First     : Byte;
+      Second    : Byte;
+   begin
+      First  := Byte (Input and 16#00FF#);
+      Second := Byte (Shift_Right (Input, 8));
+      return Byte_Array'(Second, First);
+   exception
+      when Constraint_Error =>
+         return No_Output;
+   end To_Byte_Array;
+
+   -------------------
+   -- To_Byte_Array --
+   -------------------
+
+   function To_Byte_Array
+     (Input : String)
+      return Byte_Array
+   is
+      No_Output    : Byte_Array (1 .. 0);
+      Output_Index : Natural := 1;
+   begin
+      declare
+         Output : Byte_Array (1 .. Input'Length);
+      begin
+         for Input_Index in Integer range Input'Range loop
+            Output (Output_Index) := Byte (Character'Pos (Input (Input_Index)));
+            Output_Index := Output_Index + 1;
+         end loop;
+         return Output;
+      end;
+   exception
+      when Constraint_Error =>
+         return No_Output;
+   end To_Byte_Array;
+
+   -----------
+   -- Write --
+   -----------
+
+   function Write
+     (Device : in out BlueNRG_MS_Device;
+      Data   :        Byte_Array)
+      return Boolean
+   is
+      Operation         : constant SPI_Data_8b (1 .. 1) := (1 => Write_Operation);
+      Empty             : constant SPI_Data_8b (1 .. 4) := (others => 16#00#);
+      Write_Buffer_Size : Byte;
+      Ready             : SPI_Data_8b (1 .. 1);
+      SPI_Response      : SPI_Data_8b (1 .. 4);
+      Transfer_Status   : SPI_Status;
+   begin
+      Device.Chip_Select_Pin.all.Clear;
+      Device.SPI_Port.all.Transfer (Operation, Ready, Transfer_Status);
+
+      if Ready (1) /= Device_Ready then
+         Device.Chip_Select_Pin.all.Set;
+         return False;
+      end if;
+
+--      Device.SPI_Port.all.Transmit_Receive (16#00#, Write_Buffer_Size);
+--      Device.SPI_Port.all.Transmit_Receive (16#00#, Dummy);
+--      Device.SPI_Port.all.Transmit_Receive (16#00#, Dummy);
+--      Device.SPI_Port.all.Transmit_Receive (16#00#, Dummy);
+
+      Device.SPI_Port.all.Transfer (Empty, SPI_Response, Transfer_Status);
+      Write_Buffer_Size := SPI_Response (1);
+
+      if Write_Buffer_Size < Data'Length then
+         Device.Chip_Select_Pin.all.Set;
+         return False;
+      end if;
+
+      declare
+         Not_Used : SPI_Data_8b (Data'Range);
+      begin
+         Device.SPI_Port.all.Transfer (SPI_Data_8b (Data), Not_Used, Transfer_Status);
+      end;
+
+--      for Index in Integer range Data'First .. Data'Last loop
+--         Device.SPI_Port.all.Transmit_Receive (Data (Index), Dummy);
+--      end loop;
+
+      Device.Chip_Select_Pin.all.Set;
+
+      return True;
+   end Write;
+
+end BlueNRG_MS;

--- a/components/src/network/bluenrg-ms/bluenrg_ms.ads
+++ b/components/src/network/bluenrg-ms/bluenrg_ms.ads
@@ -25,6 +25,7 @@ with Bluetooth;     use Bluetooth;
 with HAL;           use HAL;
 with HAL.GPIO;      use HAL.GPIO;
 with HAL.SPI;       use HAL.SPI;
+with HAL.Time;
 with Interfaces;    use Interfaces;
 
 package BlueNRG_MS is
@@ -33,6 +34,7 @@ package BlueNRG_MS is
       SPI_Port        : not null Any_SPI_Port;
       Chip_Select_Pin : not null Any_GPIO_Point;
       Reset_Pin       : not null Any_GPIO_Point;
+      Time            : not null HAL.Time.Any_Delays;
    end record;
 
    subtype Power_Level is Integer range 0 .. 7;

--- a/components/src/network/bluenrg-ms/bluenrg_ms.ads
+++ b/components/src/network/bluenrg-ms/bluenrg_ms.ads
@@ -1,0 +1,670 @@
+----------------------------------------------------------------------------
+--                                                                        --
+--  BlueNRG-MS Specification                                              --
+--                                                                        --
+--  Copyright (C) 2017, John Leimon                                       --
+--                                                                        --
+-- Permission to use, copy, modify, and/or distribute                     --
+-- this software for any purpose with or without fee                      --
+-- is hereby granted, provided that the above copyright                   --
+-- notice and this permission notice appear in all copies.                --
+--                                                                        --
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR                        --
+-- DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE                  --
+-- INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY                    --
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE                    --
+-- FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL                    --
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS                  --
+-- OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF                       --
+-- CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING                 --
+-- OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF                 --
+-- THIS SOFTWARE.                                                         --
+--                                                                        --
+----------------------------------------------------------------------------
+with Bluetooth;     use Bluetooth;
+with HAL;           use HAL;
+with HAL.GPIO;      use HAL.GPIO;
+with HAL.SPI;       use HAL.SPI;
+with Interfaces;    use Interfaces;
+
+package BlueNRG_MS is
+
+   type BlueNRG_MS_Device is tagged limited record
+      SPI_Port        : not null Any_SPI_Port;
+      Chip_Select_Pin : not null Any_GPIO_Point;
+      Reset_Pin       : not null Any_GPIO_Point;
+   end record;
+
+   subtype Power_Level is Integer range 0 .. 7;
+
+   Config_Data_Public_Address_Offset     : constant Byte         := 16#00#;
+   -- Bluetooth public address --
+
+   Config_Data_Div_Offset                : constant Byte         := 16#06#;
+   -- DIV used to derive CSRK --
+
+   Config_Data_ER_Offset                 : constant Byte         := 16#08#;
+   -- Encryption root key used to derive LTK and CSRK --
+
+   Config_Data_IR_Offset                 : constant Byte         := 16#18#;
+   -- Identity root key used to derive LTK and CSRK --
+
+   Config_Data_LL_Without_Host           : constant Byte         := 16#2C#;
+   -- Switch on/off Link Layer only mode. Set to 1 to disable Host. --
+
+   No_Properties                         : constant Byte         := 16#00#;
+   Broadcast_Property                    : constant Byte         := 16#01#;
+   Read_Property                         : constant Byte         := 16#02#;
+   Write_Without_Response_Property       : constant Byte         := 16#04#;
+   Write_Property                        : constant Byte         := 16#08#;
+   Notify_Property                       : constant Byte         := 16#10#;
+   Indicate_Property                     : constant Byte         := 16#20#;
+   Authenticated_Signed_Writes_Property  : constant Byte         := 16#40#;
+
+   Dont_Notify_Events_Mask               : constant Byte         := 16#00#;
+   Server_Write_Attribute_Mask           : constant Byte         := 16#01#;
+   Intimate_And_Write_For_Appl_Auth_Mask : constant Byte         := 16#02#;
+   Intimate_Appl_When_Read_And_Wait_Mask : constant Byte         := 16#04#;
+
+   type Device_Role is
+      (Peripheral,
+       Broadcaster,
+       Central,
+       Observer);
+
+   for Device_Role use
+      (Peripheral  => 16#01#,
+       Broadcaster => 16#02#,
+       Central     => 16#04#,
+       Observer    => 16#08#);
+
+   ---------------------------------------------------------------------
+   -- The SPI frame header of the master on the MOSI line is composed --
+   -- of 1 control byte and 4 dummy bytes (0x00)                      --
+   ---------------------------------------------------------------------
+   SPI_Frame_Header_Size : constant := 5;
+
+   HCI_Disconnect                                 : constant OpCode := (16#06#, 16#04#);
+   HCI_Read_Remote_Version_Information            : constant OpCode := (16#1D#, 16#04#);
+   HCI_Set_Event_Mask                             : constant OpCode := (16#01#, 16#0C#);
+   HCI_Reset                                      : constant OpCode := (16#03#, 16#0C#);
+   HCI_Read_Transmit_Power_Level                  : constant OpCode := (16#2D#, 16#0C#);
+   HCI_Read_Local_Version_Information             : constant OpCode := (16#01#, 16#10#);
+   HCI_Read_Local_Supported_Commands              : constant OpCode := (16#02#, 16#10#);
+   HCI_Read_Local_Supported_Features              : constant OpCode := (16#03#, 16#10#);
+   HCI_Read_BD_ADDR                               : constant OpCode := (16#09#, 16#10#);
+   HCI_Read_RSSI                                  : constant OpCode := (16#05#, 16#14#);
+   HCI_LE_Set_Event_Mask                          : constant OpCode := (16#01#, 16#20#);
+   HCI_LE_Read_Buffer_Size                        : constant OpCode := (16#02#, 16#20#);
+   HCI_LE_Read_Local_Supported_Feature            : constant OpCode := (16#03#, 16#20#);
+   HCI_LE_Set_Random_Address                      : constant OpCode := (16#05#, 16#20#);
+   HCI_LE_Set_Advertizing_Parameters              : constant OpCode := (16#06#, 16#20#);
+   HCI_LE_Read_Advertizing_Channel_Tx_Power       : constant OpCode := (16#07#, 16#20#);
+   HCI_LE_Set_Advertizing_Data                    : constant OpCode := (16#08#, 16#20#);
+   HCI_LE_Set_Scan_Resp_Data                      : constant OpCode := (16#09#, 16#20#);
+   HCI_LE_Set_Advertize_Enable                    : constant OpCode := (16#0A#, 16#20#);
+   HCI_LE_Set_Scan_Parameters                     : constant OpCode := (16#0B#, 16#20#);
+   HCI_LE_Set_Scan_Enable                         : constant OpCode := (16#0C#, 16#20#);
+   HCI_LE_Create_Connection                       : constant OpCode := (16#0D#, 16#20#);
+   HCI_LE_Create_Connection_Cancel                : constant OpCode := (16#0E#, 16#20#);
+   HCI_LE_Read_White_List_Size                    : constant OpCode := (16#0F#, 16#20#);
+   HCI_LE_Clear_While_List                        : constant OpCode := (16#10#, 16#20#);
+   HCI_LE_Add_Device_To_While_List                : constant OpCode := (16#11#, 16#20#);
+   HCI_LE_Remove_Device_From_While_List           : constant OpCode := (16#12#, 16#20#);
+   HCI_LE_Connection_Update                       : constant OpCode := (16#13#, 16#20#);
+   HCI_LE_Set_Host_Channel_Classification         : constant OpCode := (16#14#, 16#20#);
+   HCI_LE_Read_Channel_Map                        : constant OpCode := (16#15#, 16#20#);
+   HCI_LE_Read_Remote_Used_Features               : constant OpCode := (16#16#, 16#20#);
+   HCI_LE_Encrypt                                 : constant OpCode := (16#17#, 16#20#);
+   HCI_LE_Rand                                    : constant OpCode := (16#18#, 16#20#);
+   HCI_LE_Start_Encryption                        : constant OpCode := (16#19#, 16#20#);
+   HCI_LE_Long_Term_Key_Request_Reply             : constant OpCode := (16#1A#, 16#20#);
+   HCI_LE_Long_Term_Key_Requested_Negative_Reply  : constant OpCode := (16#1B#, 16#20#);
+   HCI_LE_Read_Supported_States                   : constant OpCode := (16#1C#, 16#20#);
+   HCI_LE_Receiver_Test                           : constant OpCode := (16#1D#, 16#20#);
+   HCI_LE_Transmitter_Test                        : constant OpCode := (16#1E#, 16#20#);
+   HCI_LE_Test_End                                : constant OpCode := (16#1F#, 16#20#);
+   ACI_HAL_Get_Fw_Build_Number                    : constant OpCode := (16#00#, 16#FC#);
+   ACI_HAL_Write_Config_Data                      : constant OpCode := (16#0C#, 16#FC#);
+   ACI_HAL_Read_Config_Data                       : constant OpCode := (16#0D#, 16#FC#);
+   ACI_HAL_Set_Tx_Power_Level                     : constant OpCode := (16#0F#, 16#FC#);
+   ACI_HAL_Device_Standby                         : constant OpCode := (16#13#, 16#FC#);
+   ACI_HAL_LE_Tx_Test_Packet_Number               : constant OpCode := (16#14#, 16#FC#);
+   ACI_HAL_Tone_Start                             : constant OpCode := (16#15#, 16#FC#);
+   ACI_HAL_Tone_Stop                              : constant OpCode := (16#16#, 16#FC#);
+   ACI_HAL_Get_Link_Status                        : constant OpCode := (16#17#, 16#FC#);
+   ACI_Updater_Start                              : constant OpCode := (16#20#, 16#FC#);
+   ACI_Updater_Reboot                             : constant OpCode := (16#21#, 16#FC#);
+   ACI_Get_Updater_Version                        : constant OpCode := (16#22#, 16#FC#);
+   ACI_Get_Updater_Buffer_Size                    : constant OpCode := (16#23#, 16#FC#);
+   ACI_Erase_Blue_Flag                            : constant OpCode := (16#24#, 16#FC#);
+   ACI_Reset_Blue_Flag                            : constant OpCode := (16#25#, 16#FC#);
+   ACI_Updater_Erase_Sector                       : constant OpCode := (16#26#, 16#FC#);
+   ACI_Updater_Program_Data_Block                 : constant OpCode := (16#27#, 16#FC#);
+   ACI_Updater_Read_Data_Block                    : constant OpCode := (16#28#, 16#FC#);
+   ACI_Updater_Calc_CRC                           : constant OpCode := (16#29#, 16#FC#);
+   ACI_Updater_HW_Version                         : constant OpCode := (16#2A#, 16#FC#);
+   ACI_GAP_Set_Non_Discoverable                   : constant OpCode := (16#81#, 16#FC#);
+   ACI_GAP_Set_Limited_Discoverable               : constant OpCode := (16#82#, 16#FC#);
+   ACI_GAP_Set_Discoverable                       : constant OpCode := (16#83#, 16#FC#);
+   ACI_GAP_Set_Direct_Connectable                 : constant OpCode := (16#84#, 16#FC#);
+   ACI_GAP_Set_IO_Capability                      : constant OpCode := (16#85#, 16#FC#);
+   ACI_GAP_Set_Auth_Requirement                   : constant OpCode := (16#86#, 16#FC#);
+   ACI_GAP_Set_Author_Requirement                 : constant OpCode := (16#87#, 16#FC#);
+   ACI_GAP_Pass_Key_Response                      : constant OpCode := (16#88#, 16#FC#);
+   ACI_GAP_Authorization_Response                 : constant OpCode := (16#89#, 16#FC#);
+   ACI_GAP_Init                                   : constant OpCode := (16#8A#, 16#FC#);
+   ACI_GAP_Set_Non_Connectable                    : constant OpCode := (16#8B#, 16#FC#);
+   ACI_GAP_Set_Undirected_Connectable             : constant OpCode := (16#8C#, 16#FC#);
+   ACI_GAP_Slave_Security_request                 : constant OpCode := (16#8D#, 16#FC#);
+   ACI_GAP_Update_Adv_Data                        : constant OpCode := (16#8E#, 16#FC#);
+   ACI_GAP_Delete_AD_Type                         : constant OpCode := (16#8F#, 16#FC#);
+   ACI_GAP_Get_Security_Level                     : constant OpCode := (16#90#, 16#FC#);
+   ACI_GAP_Set_Event_Mask                         : constant OpCode := (16#91#, 16#FC#);
+   ACI_GAP_Configure_WhiteList                    : constant OpCode := (16#92#, 16#FC#);
+   ACI_GAP_Terminate                              : constant OpCode := (16#93#, 16#FC#);
+   ACI_GAP_Clear_Security_Database                : constant OpCode := (16#94#, 16#FC#);
+   ACI_GAP_Allow_Rebond                           : constant OpCode := (16#95#, 16#FC#);
+   ACI_GAP_Start_Limited_Discovery_Proc           : constant OpCode := (16#96#, 16#FC#);
+   ACI_GAP_Start_General_Discovery_Proc           : constant OpCode := (16#97#, 16#FC#);
+   ACI_GAP_Start_Name_Discovery_Proc              : constant OpCode := (16#98#, 16#FC#);
+   ACI_GAP_Start_Auto_Conn_Establishment          : constant OpCode := (16#99#, 16#FC#);
+   ACI_GAP_Start_General_Conn_Establishment       : constant OpCode := (16#9A#, 16#FC#);
+   ACI_GAP_Start_Selective_Conn_Establishment     : constant OpCode := (16#9B#, 16#FC#);
+   ACI_GAP_Create_Connection                      : constant OpCode := (16#9C#, 16#FC#);
+   ACI_GAP_Terminate_Gap_Procedure                : constant OpCode := (16#9D#, 16#FC#);
+   ACI_GAP_Start_Connection_Update                : constant OpCode := (16#9E#, 16#FC#);
+   ACI_GAP_Send_Pairing_Request                   : constant OpCode := (16#9F#, 16#FC#);
+   ACI_GAP_Resolve_Private_Address                : constant OpCode := (16#A0#, 16#FC#);
+   ACI_GAP_Get_Bonded_Devices                     : constant OpCode := (16#A3#, 16#FC#);
+   ACI_HAL_Get_Anchor_Period                      : constant OpCode := (16#F8#, 16#FC#);
+   ACI_GATT_Init                                  : constant OpCode := (16#01#, 16#FD#);
+   ACI_GATT_Add_Serv                              : constant OpCode := (16#02#, 16#FD#);
+   ACI_GATT_Include_Service                       : constant OpCode := (16#03#, 16#FD#);
+   ACI_GATT_Add_Char                              : constant OpCode := (16#04#, 16#FD#);
+   ACI_GATT_Add_Char_Desc                         : constant OpCode := (16#05#, 16#FD#);
+   ACI_GATT_Update_Char_Value                     : constant OpCode := (16#06#, 16#FD#);
+   ACI_GATT_Del_Char                              : constant OpCode := (16#07#, 16#FD#);
+   ACI_GATT_Del_Service                           : constant OpCode := (16#08#, 16#FD#);
+   ACI_GATT_Del_Include_Service                   : constant OpCode := (16#09#, 16#FD#);
+   ACI_GATT_Set_Event_Mask                        : constant OpCode := (16#0A#, 16#FD#);
+   ACI_GATT_Exchange_configuration                : constant OpCode := (16#0B#, 16#FD#);
+   ACI_ATT_Find_Information_Req                   : constant OpCode := (16#0C#, 16#FD#);
+   ACI_ATT_Find_By_Type_Value_Req                 : constant OpCode := (16#0D#, 16#FD#);
+   ACI_ATT_Read_By_Type_Req                       : constant OpCode := (16#0E#, 16#FD#);
+   ACI_ATT_Read_By_Group_Type_Req                 : constant OpCode := (16#0F#, 16#FD#);
+   ACI_ATT_Prepare_Write_Req                      : constant OpCode := (16#10#, 16#FD#);
+   ACI_ATT_Execute_Write_Req                      : constant OpCode := (16#11#, 16#FD#);
+   ACI_GATT_Disc_All_Prim_Services                : constant OpCode := (16#12#, 16#FD#);
+   ACI_GATT_Disc_Prim_Service_By_UUID             : constant OpCode := (16#13#, 16#FD#);
+   ACI_GATT_Find_Included_Services                : constant OpCode := (16#14#, 16#FD#);
+   ACI_GATT_Disc_All_Charac_Of_Serv               : constant OpCode := (16#15#, 16#FD#);
+   ACI_GATT_Disc_Charac_By_UUID                   : constant OpCode := (16#16#, 16#FD#);
+   ACI_GATT_Disc_All_Charac_Descriptors           : constant OpCode := (16#17#, 16#FD#);
+   ACI_GATT_Read_Charac_Val                       : constant OpCode := (16#18#, 16#FD#);
+   ACI_GATT_Read_Charac_Using_UUID                : constant OpCode := (16#19#, 16#FD#);
+   ACI_GATT_Read_Long_Charac_Val                  : constant OpCode := (16#1A#, 16#FD#);
+   ACI_GATT_Read_Multiple_Charac_Val              : constant OpCode := (16#1B#, 16#FD#);
+   ACI_GATT_Write_Charac_Value                    : constant OpCode := (16#1C#, 16#FD#);
+   ACI_GATT_Write_Long_Charac_Val                 : constant OpCode := (16#1D#, 16#FD#);
+   ACI_GATT_Write_Charac_Reliable                 : constant OpCode := (16#1E#, 16#FD#);
+   ACI_GATT_Write_Long_Charac_Desc                : constant OpCode := (16#1F#, 16#FD#);
+   ACI_GATT_Read_Long_Charac_Desc                 : constant OpCode := (16#20#, 16#FD#);
+   ACI_GATT_Write_Charac_Descriptor               : constant OpCode := (16#21#, 16#FD#);
+   ACI_GATT_Read_Charac_Desc                      : constant OpCode := (16#22#, 16#FD#);
+   ACI_GATT_Write_Without_Response                : constant OpCode := (16#23#, 16#FD#);
+   ACI_GATT_Signed_Write_Without_Resp             : constant OpCode := (16#24#, 16#FD#);
+   ACI_GATT_Confirm_Indication                    : constant OpCode := (16#25#, 16#FD#);
+   ACI_GATT_Write_Response                        : constant OpCode := (16#26#, 16#FD#);
+   ACI_GATT_Allow_Read                            : constant OpCode := (16#27#, 16#FD#);
+   ACI_GATT_Set_Security_Permission               : constant OpCode := (16#28#, 16#FD#);
+   ACI_GATT_Set_Desc_Value                        : constant OpCode := (16#29#, 16#FD#);
+   ACI_GATT_Read_Handle_Value                     : constant OpCode := (16#2A#, 16#FD#);
+   ACI_GATT_Read_Handle_Value_Offset              : constant OpCode := (16#2B#, 16#FD#);
+   ACI_GATT_Update_Char_Value_Ext                 : constant OpCode := (16#2C#, 16#FD#);
+   ACI_L2CAP_Connection_Parameter_Update_Request  : constant OpCode := (16#81#, 16#FD#);
+   ACI_L2CAP_Connection_Parameter_Update_Response : constant OpCode := (16#82#, 16#FD#);
+
+   type LE_Event is
+     (Event_LE_Conn_Complete,
+      Event_LE_Advertising_Report,
+      Event_LE_Conn_Update_Complete,
+      Event_LE_Read_Remote_Used_Features_Complete,
+      Event_LE_LTK_Request);
+
+   for LE_Event use
+     (Event_LE_Conn_Complete                      => 16#01#,
+      Event_LE_Advertising_Report                 => 16#02#,
+      Event_LE_Conn_Update_Complete               => 16#03#,
+      Event_LE_Read_Remote_Used_Features_Complete => 16#04#,
+      Event_LE_LTK_Request                        => 16#05#);
+
+   type Vendor_Specific_Event is
+     (Event_Blue_Initialized,
+      Event_Blue_Lost_Events,
+      Event_Fault_Data_Event,
+      Event_Blue_Gap_Limited_Discoverable,
+      Event_Blue_Gap_Pairing_Cmplt,
+      Event_Blue_Gap_Pass_Key_Request,
+      Event_Blue_Gap_Authorization_Request,
+      Event_Blue_Gap_Slave_Security_Initiated,
+      Event_Blue_Gap_Bond_Lost,
+      Event_Blue_Gap_Procedure_Complete,
+      Event_Blue_Gap_Addr_Not_Resolved,
+      Event_Blue_L2CAP_Conn_Upd_Resp,
+      Event_Blue_L2CAP_Procedure_Timeout,
+      Event_Blue_L2CAP_Conn_Upd_Req,
+      Event_Blue_Gatt_Attribute_modified,
+      Event_Blue_Gatt_Procedure_Timeout,
+      Event_Blue_Att_Exchange_MTU_Resp,
+      Event_Blue_Att_Find_Information_Resp,
+      Event_Blue_Att_Find_By_Type_Value_Resp,
+      Event_Blue_Att_Read_By_Type_Resp,
+      Event_Blue_Att_Read_Resp,
+      Event_Blue_Att_Read_Blob_Resp,
+      Event_Blue_Att_Read_Multiple_Resp,
+      Event_Blue_Att_Read_By_Group_Type_Resp,
+      Event_Blue_Att_Prepare_Write_Resp,
+      Event_Blue_Att_Exec_Write_Resp,
+      Event_Blue_Gatt_Indication,
+      Event_Blue_Gatt_notification,
+      Event_Blue_Gatt_Procedure_Complete,
+      Event_Blue_Gatt_Error_Resp,
+      Event_Blue_Gatt_Disc_Read_Charac_By_UUID_Resp,
+      Event_Blue_Gatt_Write_Permit_req,
+      Event_Blue_Gatt_Read_Permit_Req,
+      Event_Blue_Gatt_Read_Multi_Permit_Req,
+      Event_Blue_Gatt_Tx_Pool_Available,
+      Event_Blue_Gatt_Server_Confirmation);
+
+   for Vendor_Specific_Event use
+     (Event_Blue_Initialized                        => 16#0001#,
+      Event_Blue_Lost_Events                        => 16#0002#,
+      Event_Fault_Data_Event                        => 16#0003#,
+      Event_Blue_Gap_Limited_Discoverable           => 16#0400#,
+      Event_Blue_Gap_Pairing_Cmplt                  => 16#0401#,
+      Event_Blue_Gap_Pass_Key_Request               => 16#0402#,
+      Event_Blue_Gap_Authorization_Request          => 16#0403#,
+      Event_Blue_Gap_Slave_Security_Initiated       => 16#0404#,
+      Event_Blue_Gap_Bond_Lost                      => 16#0405#,
+      Event_Blue_Gap_Procedure_Complete             => 16#0407#,
+      Event_Blue_Gap_Addr_Not_Resolved              => 16#0408#,
+      Event_Blue_L2CAP_Conn_Upd_Resp                => 16#0800#,
+      Event_Blue_L2CAP_Procedure_Timeout            => 16#0801#,
+      Event_Blue_L2CAP_Conn_Upd_Req                 => 16#0802#,
+      Event_Blue_Gatt_Attribute_modified            => 16#0C01#,
+      Event_Blue_Gatt_Procedure_Timeout             => 16#0C02#,
+      Event_Blue_Att_Exchange_MTU_Resp              => 16#0C03#,
+      Event_Blue_Att_Find_Information_Resp          => 16#0C04#,
+      Event_Blue_Att_Find_By_Type_Value_Resp        => 16#0C05#,
+      Event_Blue_Att_Read_By_Type_Resp              => 16#0C06#,
+      Event_Blue_Att_Read_Resp                      => 16#0C07#,
+      Event_Blue_Att_Read_Blob_Resp                 => 16#0C08#,
+      Event_Blue_Att_Read_Multiple_Resp             => 16#0C09#,
+      Event_Blue_Att_Read_By_Group_Type_Resp        => 16#0C0A#,
+      Event_Blue_Att_Prepare_Write_Resp             => 16#0C0C#,
+      Event_Blue_Att_Exec_Write_Resp                => 16#0C0D#,
+      Event_Blue_Gatt_Indication                    => 16#0C0E#,
+      Event_Blue_Gatt_notification                  => 16#0C0F#,
+      Event_Blue_Gatt_Procedure_Complete            => 16#0C10#,
+      Event_Blue_Gatt_Error_Resp                    => 16#0C11#,
+      Event_Blue_Gatt_Disc_Read_Charac_By_UUID_Resp => 16#0C12#,
+      Event_Blue_Gatt_Write_Permit_req              => 16#0C13#,
+      Event_Blue_Gatt_Read_Permit_Req               => 16#0C14#,
+      Event_Blue_Gatt_Read_Multi_Permit_Req         => 16#0C15#,
+      Event_Blue_Gatt_Tx_Pool_Available             => 16#0C16#,
+      Event_Blue_Gatt_Server_Confirmation           => 16#0C17#);
+   -- Vendor Specific Event Codes (ECODE) --
+
+   type HCI_Sub_Event is
+     (Event_LE_Conn_Complete,
+      Event_LE_Advertising_Report,
+      Event_LE_Conn_Update_Complete,
+      Event_LE_Read_Remote_Used_Features_Complete,
+      Event_LE_LTK_Request);
+
+   for HCI_Sub_Event use
+     (Event_LE_Conn_Complete                       => 16#01#,
+      Event_LE_Advertising_Report                  => 16#02#,
+      Event_LE_Conn_Update_Complete                => 16#03#,
+      Event_LE_Read_Remote_Used_Features_Complete  => 16#04#,
+      Event_LE_LTK_Request                         => 16#05#);
+
+   type Advertising_Event_Type is
+     (Connectable_Unidirected,
+      Scannable_Unidirected,
+      Non_Connectable_Unidirected);
+
+   for Advertising_Event_Type use
+     (Connectable_Unidirected     => 16#00#,
+      Scannable_Unidirected       => 16#02#,
+      Non_Connectable_Unidirected => 16#03#);
+
+   type Filter_Policy_Type is
+     (Scan_From_Any_Connect_From_Any,
+      Scan_From_Whitelist_Connect_From_Any,
+      Scan_From_Any_Connect_From_Whitelist,
+      Scan_From_Whitelist_Connect_From_Whitelist);
+
+   for Filter_Policy_Type use
+     (Scan_From_Any_Connect_From_Any             => 16#00#,
+      Scan_From_Whitelist_Connect_From_Any       => 16#01#,
+      Scan_From_Any_Connect_From_Whitelist       => 16#02#,
+      Scan_From_Whitelist_Connect_From_Whitelist => 16#03#);
+
+   type Address_Type is
+     (Public,
+      Random);
+
+   for Address_Type use
+     (Public => 16#00#,
+      Random => 16#01#);
+
+   type Name_Type is
+     (Shortened_Local_Name,
+      Complete_Local_Name);
+
+   for Name_Type use
+     (Shortened_Local_Name => 16#08#,
+      Complete_Local_Name  => 16#09#);
+
+   type GATT_Add_Service_Status is
+     (Success,
+      Out_Of_Memory,
+      Error,
+      Invalid_Parameter,
+      Out_Of_Handle,
+      Insufficient_Resources);
+
+   for GATT_Add_Service_Status use
+     (Success                => 16#00#,
+      Out_Of_Memory          => 16#1F#,
+      Error                  => 16#47#,
+      Invalid_Parameter      => 16#61#,
+      Out_Of_Handle          => 16#62#,
+      Insufficient_Resources => 16#64#);
+
+   function GAP_Init
+     (Device                  : in out BlueNRG_MS_Device;
+      Role                    :        Device_Role;
+      Enable_Privacy          :        Boolean;
+      Device_Name_Length      :        Byte;
+      Status                  :    out Byte;
+      Service_Handle          :    out Handle;
+      Device_Name_Char_Handle :    out Handle;
+      Appearance_Char_Handle  :    out Handle)
+      return Boolean;
+   -- Register the GAP service with the GATT. The device name characteristic and appearance
+   -- characteristic are added by default and the handles of these characteristics are returned in
+   -- the event data. The role parameter can be a bitwise OR of any of the values mentioned
+   -- below.
+   -- Returns: True when command is sent successfully
+
+   function GAP_Set_Auth_Requirement
+     (Device                  : in out BlueNRG_MS_Device;
+      MITM_Required           :        Boolean;
+      OOB_Enabled             :        Boolean;
+      OOB_Data                :        Byte_Array;
+      Min_Encryption_Key_Size :        Byte;
+      Max_Encryption_Key_Size :        Byte;
+      Use_Fixed_Pin           :        Boolean;
+      Pin                     :        Unsigned_32;
+      Bonding_Required        :        Boolean;
+      Status                  :    out Byte)
+      return Boolean
+      with Pre => OOB_Data'Length = 16 and
+                  Pin <= 999999 and
+                  Pin >= 0;
+   -- Set the authentication requirements for the device. If the OOB_Enable is set to 0, the
+   -- following 16 octets of OOB_Data will be ignored on reception. This command has to be
+   -- given only when the device is not in a connected state.
+   -- Returns: True when command is sent successfully
+
+   function GAP_Set_Discoverable
+     (Device                   : in out BlueNRG_MS_Device;
+      Advertising_Event        :        Advertising_Event_Type;
+      Advertising_Interval_Min :        Unsigned_16;
+      Advertising_Interval_Max :        Unsigned_16;
+      BT_Address_Type          :        Address_Type;
+      Filter_Policy            :        Filter_Policy_Type;
+      Local_Name_Type          :        Name_Type;
+      Local_Name               :        String;
+      Service_UUID_List        :        Byte_Array;
+      Slave_Conn_Interval_Min  :        Unsigned_16;
+      Slave_Conn_Interval_Max  :        Unsigned_16;
+      Status                   :    out Byte)
+      return Boolean
+      with Pre => Service_UUID_List'Length < 256 and
+                  Local_Name'Length < 256;
+   -- Set the device in general discoverable mode (as defined in GAP specification volume 3,
+   -- section 9.2.4). The device will be discoverable until the host issues the
+   -- Aci_Gap_Set_Non_Discoverable command. The Adv_Interval_Min and Adv_Interval_Max
+   -- parameters are optional. If both are set to 0, the GAP uses the default values for adv
+   -- intervals for general discoverable mode.
+   -- Returns: True when command is sent successfully
+
+   function GAP_Slave_Security_Request
+     (Device           : in out BlueNRG_MS_Device;
+      Conn_Handle      :        Byte_Array;
+      Bonding_Required :        Boolean;
+      MITM_Required    :        Boolean)
+      return Boolean
+      with Pre => Conn_Handle'Length = 2;
+   -- This command has to be issued to notify the master of the security requirements of the
+   -- slave.
+   -- Returns: True when command is sent successfully
+
+   function GATT_Add_Characteristic
+     (Device                : in out BlueNRG_MS_Device;
+      Service               :        Handle;
+      UUID                  :        UUID_16;
+      Max_Value_Length      :        Byte;
+      Properties            :        Byte;
+      Security              :        Byte;
+      Event_Mask            :        Byte;
+      Encryption_Key_Size   :        Byte;
+      Value_Is_Fixed_Length :        Boolean;
+      Status                :    out Byte;
+      Char_Handle           :    out Handle)
+      return Boolean;
+   -- Add a characteristic to a service
+   -- Returns: True when command is sent successfully
+
+   function GATT_Add_Characteristic
+     (Device                : in out BlueNRG_MS_Device;
+      Service               :        Handle;
+      UUID                  :        UUID_128;
+      Max_Value_Length      :        Byte;
+      Properties            :        Byte;
+      Security              :        Byte;
+      Event_Mask            :        Byte;
+      Encryption_Key_Size   :        Byte;
+      Value_Is_Fixed_Length :        Boolean;
+      Status                :    out Byte;
+      Char_Handle           :    out Handle)
+      return Boolean;
+   -- Add a characteristic to a service
+   -- Returns: True when command is sent successfully
+
+   function GATT_Add_Service
+      (Device                : in out BlueNRG_MS_Device;
+       UUID                  :        UUID_16;
+       Service               :        Service_Type;
+       Max_Attribute_Records :        Byte;
+       Status                :    out Byte;
+       Service_Handle        :    out Handle)
+       return Boolean;
+   -- Add a service to GATT Server. When a service is created in the server, the host needs to
+   -- reserve the handle ranges for this service using Max_Attribute_Records parameter. This
+   -- parameter specifies the maximum number of attribute records that can be added to this
+   -- service (including the service attribute, include attribute, characteristic attribute,
+   -- characteristic value attribute and characteristic descriptor attribute). Handle of the created
+   -- service is returned in command complete event.
+   -- Returns: True when command is sent successfully
+
+   function GATT_Add_Service
+      (Device                : in out BlueNRG_MS_Device;
+       UUID                  :        UUID_128;
+       Service               :        Service_Type;
+       Max_Attribute_Records :        Byte;
+       Status                :    out Byte;
+       Service_Handle        :    out Handle)
+       return Boolean;
+   -- Add a service to GATT Server. When a service is created in the server, the host needs to
+   -- reserve the handle ranges for this service using Max_Attribute_Records parameter. This
+   -- parameter specifies the maximum number of attribute records that can be added to this
+   -- service (including the service attribute, include attribute, characteristic attribute,
+   -- characteristic value attribute and characteristic descriptor attribute). Handle of the created
+   -- service is returned in command complete event.
+   -- Returns: True when command is sent successfully
+
+   function GATT_Init
+     (Device : in out BlueNRG_MS_Device;
+      Status :    out Byte)
+      return Boolean;
+   -- Initialize the GATT server on the slave device. Initialize all the pools and active nodes. Also
+   -- it adds GATT service with service changed characteristic. Until this command is issued the
+   -- GATT channel will not process any commands even if the connection is opened. This
+   -- command has to be given before using any of the GAP features.
+   -- Returns: True when command is sent successfully
+
+   function GATT_Update_Characteristic_Value
+     (Device            : in out BlueNRG_MS_Device;
+      Service_Handle    :        Handle;
+      Char_Handle       :        Handle;
+      Offset            :        Byte;
+      Char_Value        :        Byte_Array;
+      Status            :    out Byte)
+      return Boolean
+      with Pre => Char_Value'Length < 256;
+   -- Update a characteristic value in a service
+   -- Returns: True when command is sent successfully
+
+   function Get_BlueNRG_Version
+     (Device             : in out BlueNRG_MS_Device;
+      HCI_Version        :    out Unsigned_8;
+      HCI_Revision       :    out Unsigned_16;
+      LMP_PAL_Version    :    out Unsigned_8;
+      Mfr_Name           :    out Unsigned_16;
+      LMP_PAL_Subversion :    out Unsigned_16;
+      Status             :    out Byte)
+      return Boolean;
+   -- Returns true when the command is sent successfully
+
+   function HAL_Set_TX_Power_Level
+     (Device            : in out BlueNRG_MS_Device;
+      Enable_High_Power :        Boolean;
+      Level             :        Power_Level;
+      Status            :    out Byte)
+      return Boolean;
+   -- This command sets the TX power level of the BlueNRG-MS. By controlling the
+   -- EN_HIGH_POWER and the PA_LEVEL, the combination of the 2 determines the output
+   -- power level (dBm). See the table below.
+   -- When the system starts up or reboots, the default TX power level will be used, which is the
+   -- maximum value of 8 dBm. Once this command is given, the output power will be changed
+   -- instantly, regardless if there is Bluetooth communication going on or not. For example, for
+   -- debugging purpose, the BlueNRG-MS can be set to advertise all the time. And use this
+   -- command to observe the signal strength changing.
+   -- Returns: True when command is sent successfully
+
+   -- EN_HIGH_POWER | PA_LEVEL TX | Power Level (dBm)
+   --        0      |    0        |   -18
+   --        0      |    1        |   -14.7
+   --        0      |    2        |   -11.4
+   --        0      |    3        |   -8.1
+   --        0      |    4        |   -4.9
+   --        0      |    5        |   -1.6
+   --        0      |    6        |    1.7
+   --        0      |    7        |    5.0
+   --        1      |    0        |   -15
+   --        1      |    1        |   -11.7
+   --        1      |    2        |   -8.4
+   --        1      |    3        |   -5.1
+   --        1      |    4        |   -2.1
+   --        1      |    5        |    1.4
+   --        1      |    6        |    4.7
+   --        1      |    7        |    8.0 (default)
+
+   function HAL_Write_Config_Data
+     (Device : in out BlueNRG_MS_Device;
+      Offset :        Byte;
+      Value  :        Byte_Array;
+      Status :    out Byte)
+      return Boolean;
+   -- This command writes a value to a low level configure data structure.
+   -- It is useful to setup directly some low level parameters for the
+   -- system in the runtime.
+   -- Returns true when the command is sent successfully
+
+   procedure Reset
+     (Device : in out BlueNRG_MS_Device);
+   -- Activates reset line of device to perform a hard reset
+
+   function Set_Bluetooth_Public_Address
+     (Device            : in out BlueNRG_MS_Device;
+      Bluetooth_Address :        Address;
+      Status            :    out Byte)
+      return Boolean;
+   -- Writes to the Bluetooth Public Address segment in the
+   -- device config data.
+   -- Returns true when command is sent successfully
+
+private
+
+   function Read
+     (Device : in out BlueNRG_MS_Device)
+      return Byte_Array;
+   -- Reads all bytes that are available in the read buffer
+
+   function Read
+      (Device : in out BlueNRG_MS_Device;
+       Count  : in out Natural)
+       return Byte_Array;
+   -- Reads a maximum of Count bytes from the read buffer
+
+   function Send_Command
+     (Device     : in out BlueNRG_MS_Device;
+      Command    :        OpCode;
+      Parameters :        Byte_Array)
+      return Boolean
+      with Pre => Parameters'Length < 256;
+   -- Returns true when command is sent successfully
+
+   function Send_Command
+     (Device     : in out BlueNRG_MS_Device;
+      Command    :        OpCode)
+      return Boolean;
+   -- Returns true when command is sent successfully
+
+   function Send_Command
+     (Device     : in out BlueNRG_MS_Device;
+      Command    :        OpCode;
+      Parameters :        Byte_Array)
+      return Byte_Array
+      with Pre => Parameters'Length < 256;
+   -- Returns the HID event response from the BlueNRG
+   -- or an empty array if a timeout condition occured.
+
+   function Send_Command
+     (Device     : in out BlueNRG_MS_Device;
+      Command    :        OpCode)
+      return Byte_Array;
+   -- Returns the HID event response from the BlueNRG
+   -- or an empty array if a timeout condition occured.
+
+   function To_Byte_Array
+     (Input : Unsigned_16)
+      return Byte_Array;
+   -- Convert a Unsigned_16 to Bluetooth byte order
+
+   function To_Byte_Array
+     (Input : String)
+      return Byte_Array;
+
+   function Write
+     (Device : in out BlueNRG_MS_Device;
+      Data   :        Byte_Array)
+      return Boolean;
+   -- Returns true if data was successfully written
+
+end BlueNRG_MS;

--- a/components/src/network/bluenrg-ms/bluenrg_ms.ads
+++ b/components/src/network/bluenrg-ms/bluenrg_ms.ads
@@ -37,34 +37,34 @@ package BlueNRG_MS is
 
    subtype Power_Level is Integer range 0 .. 7;
 
-   Config_Data_Public_Address_Offset     : constant Byte         := 16#00#;
+   Config_Data_Public_Address_Offset     : constant UInt8         := 16#00#;
    -- Bluetooth public address --
 
-   Config_Data_Div_Offset                : constant Byte         := 16#06#;
+   Config_Data_Div_Offset                : constant UInt8         := 16#06#;
    -- DIV used to derive CSRK --
 
-   Config_Data_ER_Offset                 : constant Byte         := 16#08#;
+   Config_Data_ER_Offset                 : constant UInt8         := 16#08#;
    -- Encryption root key used to derive LTK and CSRK --
 
-   Config_Data_IR_Offset                 : constant Byte         := 16#18#;
+   Config_Data_IR_Offset                 : constant UInt8         := 16#18#;
    -- Identity root key used to derive LTK and CSRK --
 
-   Config_Data_LL_Without_Host           : constant Byte         := 16#2C#;
+   Config_Data_LL_Without_Host           : constant UInt8         := 16#2C#;
    -- Switch on/off Link Layer only mode. Set to 1 to disable Host. --
 
-   No_Properties                         : constant Byte         := 16#00#;
-   Broadcast_Property                    : constant Byte         := 16#01#;
-   Read_Property                         : constant Byte         := 16#02#;
-   Write_Without_Response_Property       : constant Byte         := 16#04#;
-   Write_Property                        : constant Byte         := 16#08#;
-   Notify_Property                       : constant Byte         := 16#10#;
-   Indicate_Property                     : constant Byte         := 16#20#;
-   Authenticated_Signed_Writes_Property  : constant Byte         := 16#40#;
+   No_Properties                         : constant UInt8         := 16#00#;
+   Broadcast_Property                    : constant UInt8         := 16#01#;
+   Read_Property                         : constant UInt8         := 16#02#;
+   Write_Without_Response_Property       : constant UInt8         := 16#04#;
+   Write_Property                        : constant UInt8         := 16#08#;
+   Notify_Property                       : constant UInt8         := 16#10#;
+   Indicate_Property                     : constant UInt8         := 16#20#;
+   Authenticated_Signed_Writes_Property  : constant UInt8         := 16#40#;
 
-   Dont_Notify_Events_Mask               : constant Byte         := 16#00#;
-   Server_Write_Attribute_Mask           : constant Byte         := 16#01#;
-   Intimate_And_Write_For_Appl_Auth_Mask : constant Byte         := 16#02#;
-   Intimate_Appl_When_Read_And_Wait_Mask : constant Byte         := 16#04#;
+   Dont_Notify_Events_Mask               : constant UInt8         := 16#00#;
+   Server_Write_Attribute_Mask           : constant UInt8         := 16#01#;
+   Intimate_And_Write_For_Appl_Auth_Mask : constant UInt8         := 16#02#;
+   Intimate_Appl_When_Read_And_Wait_Mask : constant UInt8         := 16#04#;
 
    type Device_Role is
       (Peripheral,
@@ -388,283 +388,283 @@ package BlueNRG_MS is
      (Device                  : in out BlueNRG_MS_Device;
       Role                    :        Device_Role;
       Enable_Privacy          :        Boolean;
-      Device_Name_Length      :        Byte;
-      Status                  :    out Byte;
+      Device_Name_Length      :        UInt8;
+      Status                  :    out UInt8;
       Service_Handle          :    out Handle;
       Device_Name_Char_Handle :    out Handle;
       Appearance_Char_Handle  :    out Handle)
       return Boolean;
-   -- Register the GAP service with the GATT. The device name characteristic and appearance
-   -- characteristic are added by default and the handles of these characteristics are returned in
-   -- the event data. The role parameter can be a bitwise OR of any of the values mentioned
-   -- below.
-   -- Returns: True when command is sent successfully
+   --  Register the GAP service with the GATT. The device name characteristic and appearance
+   --  characteristic are added by default and the handles of these characteristics are returned in
+   --  the event data. The role parameter can be a bitwise OR of any of the values mentioned
+   --  below.
+   --  Returns: True when command is sent successfully
 
    function GAP_Set_Auth_Requirement
      (Device                  : in out BlueNRG_MS_Device;
       MITM_Required           :        Boolean;
       OOB_Enabled             :        Boolean;
-      OOB_Data                :        Byte_Array;
-      Min_Encryption_Key_Size :        Byte;
-      Max_Encryption_Key_Size :        Byte;
+      OOB_Data                :        UInt8_Array;
+      Min_Encryption_Key_Size :        UInt8;
+      Max_Encryption_Key_Size :        UInt8;
       Use_Fixed_Pin           :        Boolean;
       Pin                     :        Unsigned_32;
       Bonding_Required        :        Boolean;
-      Status                  :    out Byte)
+      Status                  :    out UInt8)
       return Boolean
       with Pre => OOB_Data'Length = 16 and
                   Pin <= 999999 and
                   Pin >= 0;
-   -- Set the authentication requirements for the device. If the OOB_Enable is set to 0, the
-   -- following 16 octets of OOB_Data will be ignored on reception. This command has to be
-   -- given only when the device is not in a connected state.
-   -- Returns: True when command is sent successfully
+   --  Set the authentication requirements for the device. If the OOB_Enable is set to 0, the
+   --  following 16 octets of OOB_Data will be ignored on reception. This command has to be
+   --  given only when the device is not in a connected state.
+   --  Returns: True when command is sent successfully
 
    function GAP_Set_Discoverable
      (Device                   : in out BlueNRG_MS_Device;
       Advertising_Event        :        Advertising_Event_Type;
-      Advertising_Interval_Min :        Unsigned_16;
-      Advertising_Interval_Max :        Unsigned_16;
+      Advertising_Interval_Min :        UInt16;
+      Advertising_Interval_Max :        UInt16;
       BT_Address_Type          :        Address_Type;
       Filter_Policy            :        Filter_Policy_Type;
       Local_Name_Type          :        Name_Type;
       Local_Name               :        String;
-      Service_UUID_List        :        Byte_Array;
-      Slave_Conn_Interval_Min  :        Unsigned_16;
-      Slave_Conn_Interval_Max  :        Unsigned_16;
-      Status                   :    out Byte)
+      Service_UUID_List        :        UInt8_Array;
+      Slave_Conn_Interval_Min  :        UInt16;
+      Slave_Conn_Interval_Max  :        UInt16;
+      Status                   :    out UInt8)
       return Boolean
       with Pre => Service_UUID_List'Length < 256 and
                   Local_Name'Length < 256;
-   -- Set the device in general discoverable mode (as defined in GAP specification volume 3,
-   -- section 9.2.4). The device will be discoverable until the host issues the
-   -- Aci_Gap_Set_Non_Discoverable command. The Adv_Interval_Min and Adv_Interval_Max
-   -- parameters are optional. If both are set to 0, the GAP uses the default values for adv
-   -- intervals for general discoverable mode.
-   -- Returns: True when command is sent successfully
+   --  Set the device in general discoverable mode (as defined in GAP specification volume 3,
+   --  section 9.2.4). The device will be discoverable until the host issues the
+   --  Aci_Gap_Set_Non_Discoverable command. The Adv_Interval_Min and Adv_Interval_Max
+   --  parameters are optional. If both are set to 0, the GAP uses the default values for adv
+   --  intervals for general discoverable mode.
+   --  Returns: True when command is sent successfully
 
    function GAP_Slave_Security_Request
      (Device           : in out BlueNRG_MS_Device;
-      Conn_Handle      :        Byte_Array;
+      Conn_Handle      :        UInt8_Array;
       Bonding_Required :        Boolean;
       MITM_Required    :        Boolean)
       return Boolean
       with Pre => Conn_Handle'Length = 2;
-   -- This command has to be issued to notify the master of the security requirements of the
-   -- slave.
-   -- Returns: True when command is sent successfully
+   --  This command has to be issued to notify the master of the security requirements of the
+   --  slave.
+   --  Returns: True when command is sent successfully
 
    function GATT_Add_Characteristic
      (Device                : in out BlueNRG_MS_Device;
       Service               :        Handle;
       UUID                  :        UUID_16;
-      Max_Value_Length      :        Byte;
-      Properties            :        Byte;
-      Security              :        Byte;
-      Event_Mask            :        Byte;
-      Encryption_Key_Size   :        Byte;
+      Max_Value_Length      :        UInt8;
+      Properties            :        UInt8;
+      Security              :        UInt8;
+      Event_Mask            :        UInt8;
+      Encryption_Key_Size   :        UInt8;
       Value_Is_Fixed_Length :        Boolean;
-      Status                :    out Byte;
+      Status                :    out UInt8;
       Char_Handle           :    out Handle)
       return Boolean;
-   -- Add a characteristic to a service
-   -- Returns: True when command is sent successfully
+   --  Add a characteristic to a service
+   --  Returns: True when command is sent successfully
 
    function GATT_Add_Characteristic
      (Device                : in out BlueNRG_MS_Device;
       Service               :        Handle;
       UUID                  :        UUID_128;
-      Max_Value_Length      :        Byte;
-      Properties            :        Byte;
-      Security              :        Byte;
-      Event_Mask            :        Byte;
-      Encryption_Key_Size   :        Byte;
+      Max_Value_Length      :        UInt8;
+      Properties            :        UInt8;
+      Security              :        UInt8;
+      Event_Mask            :        UInt8;
+      Encryption_Key_Size   :        UInt8;
       Value_Is_Fixed_Length :        Boolean;
-      Status                :    out Byte;
+      Status                :    out UInt8;
       Char_Handle           :    out Handle)
       return Boolean;
-   -- Add a characteristic to a service
-   -- Returns: True when command is sent successfully
+   --  Add a characteristic to a service
+   --  Returns: True when command is sent successfully
 
    function GATT_Add_Service
       (Device                : in out BlueNRG_MS_Device;
        UUID                  :        UUID_16;
        Service               :        Service_Type;
-       Max_Attribute_Records :        Byte;
-       Status                :    out Byte;
+       Max_Attribute_Records :        UInt8;
+       Status                :    out UInt8;
        Service_Handle        :    out Handle)
        return Boolean;
-   -- Add a service to GATT Server. When a service is created in the server, the host needs to
-   -- reserve the handle ranges for this service using Max_Attribute_Records parameter. This
-   -- parameter specifies the maximum number of attribute records that can be added to this
-   -- service (including the service attribute, include attribute, characteristic attribute,
-   -- characteristic value attribute and characteristic descriptor attribute). Handle of the created
-   -- service is returned in command complete event.
-   -- Returns: True when command is sent successfully
+   --  Add a service to GATT Server. When a service is created in the server, the host needs to
+   --  reserve the handle ranges for this service using Max_Attribute_Records parameter. This
+   --  parameter specifies the maximum number of attribute records that can be added to this
+   --  service (including the service attribute, include attribute, characteristic attribute,
+   --  characteristic value attribute and characteristic descriptor attribute). Handle of the created
+   --  service is returned in command complete event.
+   --  Returns: True when command is sent successfully
 
    function GATT_Add_Service
       (Device                : in out BlueNRG_MS_Device;
        UUID                  :        UUID_128;
        Service               :        Service_Type;
-       Max_Attribute_Records :        Byte;
-       Status                :    out Byte;
+       Max_Attribute_Records :        UInt8;
+       Status                :    out UInt8;
        Service_Handle        :    out Handle)
        return Boolean;
-   -- Add a service to GATT Server. When a service is created in the server, the host needs to
-   -- reserve the handle ranges for this service using Max_Attribute_Records parameter. This
-   -- parameter specifies the maximum number of attribute records that can be added to this
-   -- service (including the service attribute, include attribute, characteristic attribute,
-   -- characteristic value attribute and characteristic descriptor attribute). Handle of the created
-   -- service is returned in command complete event.
-   -- Returns: True when command is sent successfully
+   --  Add a service to GATT Server. When a service is created in the server, the host needs to
+   --  reserve the handle ranges for this service using Max_Attribute_Records parameter. This
+   --  parameter specifies the maximum number of attribute records that can be added to this
+   --  service (including the service attribute, include attribute, characteristic attribute,
+   --  characteristic value attribute and characteristic descriptor attribute). Handle of the created
+   --  service is returned in command complete event.
+   --  Returns: True when command is sent successfully
 
    function GATT_Init
      (Device : in out BlueNRG_MS_Device;
-      Status :    out Byte)
+      Status :    out UInt8)
       return Boolean;
-   -- Initialize the GATT server on the slave device. Initialize all the pools and active nodes. Also
-   -- it adds GATT service with service changed characteristic. Until this command is issued the
-   -- GATT channel will not process any commands even if the connection is opened. This
-   -- command has to be given before using any of the GAP features.
-   -- Returns: True when command is sent successfully
+   --  Initialize the GATT server on the slave device. Initialize all the pools and active nodes. Also
+   --  it adds GATT service with service changed characteristic. Until this command is issued the
+   --  GATT channel will not process any commands even if the connection is opened. This
+   --  command has to be given before using any of the GAP features.
+   --  Returns: True when command is sent successfully
 
    function GATT_Update_Characteristic_Value
      (Device            : in out BlueNRG_MS_Device;
       Service_Handle    :        Handle;
       Char_Handle       :        Handle;
-      Offset            :        Byte;
-      Char_Value        :        Byte_Array;
-      Status            :    out Byte)
+      Offset            :        UInt8;
+      Char_Value        :        UInt8_Array;
+      Status            :    out UInt8)
       return Boolean
       with Pre => Char_Value'Length < 256;
-   -- Update a characteristic value in a service
-   -- Returns: True when command is sent successfully
+   --  Update a characteristic value in a service
+   --  Returns: True when command is sent successfully
 
    function Get_BlueNRG_Version
      (Device             : in out BlueNRG_MS_Device;
-      HCI_Version        :    out Unsigned_8;
-      HCI_Revision       :    out Unsigned_16;
-      LMP_PAL_Version    :    out Unsigned_8;
-      Mfr_Name           :    out Unsigned_16;
-      LMP_PAL_Subversion :    out Unsigned_16;
-      Status             :    out Byte)
+      HCI_Version        :    out UInt8;
+      HCI_Revision       :    out UInt16;
+      LMP_PAL_Version    :    out UInt8;
+      Mfr_Name           :    out UInt16;
+      LMP_PAL_Subversion :    out UInt16;
+      Status             :    out UInt8)
       return Boolean;
-   -- Returns true when the command is sent successfully
+   --  Returns true when the command is sent successfully
 
    function HAL_Set_TX_Power_Level
      (Device            : in out BlueNRG_MS_Device;
       Enable_High_Power :        Boolean;
       Level             :        Power_Level;
-      Status            :    out Byte)
+      Status            :    out UInt8)
       return Boolean;
-   -- This command sets the TX power level of the BlueNRG-MS. By controlling the
-   -- EN_HIGH_POWER and the PA_LEVEL, the combination of the 2 determines the output
-   -- power level (dBm). See the table below.
-   -- When the system starts up or reboots, the default TX power level will be used, which is the
-   -- maximum value of 8 dBm. Once this command is given, the output power will be changed
-   -- instantly, regardless if there is Bluetooth communication going on or not. For example, for
-   -- debugging purpose, the BlueNRG-MS can be set to advertise all the time. And use this
-   -- command to observe the signal strength changing.
-   -- Returns: True when command is sent successfully
+   --  This command sets the TX power level of the BlueNRG-MS. By controlling the
+   --  EN_HIGH_POWER and the PA_LEVEL, the combination of the 2 determines the output
+   --  power level (dBm). See the table below.
+   --  When the system starts up or reboots, the default TX power level will be used, which is the
+   --  maximum value of 8 dBm. Once this command is given, the output power will be changed
+   --  instantly, regardless if there is Bluetooth communication going on or not. For example, for
+   --  debugging purpose, the BlueNRG-MS can be set to advertise all the time. And use this
+   --  command to observe the signal strength changing.
+   --  Returns: True when command is sent successfully
 
-   -- EN_HIGH_POWER | PA_LEVEL TX | Power Level (dBm)
-   --        0      |    0        |   -18
-   --        0      |    1        |   -14.7
-   --        0      |    2        |   -11.4
-   --        0      |    3        |   -8.1
-   --        0      |    4        |   -4.9
-   --        0      |    5        |   -1.6
-   --        0      |    6        |    1.7
-   --        0      |    7        |    5.0
-   --        1      |    0        |   -15
-   --        1      |    1        |   -11.7
-   --        1      |    2        |   -8.4
-   --        1      |    3        |   -5.1
-   --        1      |    4        |   -2.1
-   --        1      |    5        |    1.4
-   --        1      |    6        |    4.7
-   --        1      |    7        |    8.0 (default)
+   --  EN_HIGH_POWER | PA_LEVEL TX | Power Level (dBm)
+   --         0      |    0        |   -18
+   --         0      |    1        |   -14.7
+   --         0      |    2        |   -11.4
+   --         0      |    3        |   -8.1
+   --         0      |    4        |   -4.9
+   --         0      |    5        |   -1.6
+   --         0      |    6        |    1.7
+   --         0      |    7        |    5.0
+   --         1      |    0        |   -15
+   --         1      |    1        |   -11.7
+   --         1      |    2        |   -8.4
+   --         1      |    3        |   -5.1
+   --         1      |    4        |   -2.1
+   --         1      |    5        |    1.4
+   --         1      |    6        |    4.7
+   --         1      |    7        |    8.0 (default)
 
    function HAL_Write_Config_Data
      (Device : in out BlueNRG_MS_Device;
-      Offset :        Byte;
-      Value  :        Byte_Array;
-      Status :    out Byte)
+      Offset :        UInt8;
+      Value  :        UInt8_Array;
+      Status :    out UInt8)
       return Boolean;
-   -- This command writes a value to a low level configure data structure.
-   -- It is useful to setup directly some low level parameters for the
-   -- system in the runtime.
-   -- Returns true when the command is sent successfully
+   --  This command writes a value to a low level configure data structure.
+   --  It is useful to setup directly some low level parameters for the
+   --  system in the runtime.
+   --  Returns true when the command is sent successfully
 
    procedure Reset
      (Device : in out BlueNRG_MS_Device);
-   -- Activates reset line of device to perform a hard reset
+   --  Activates reset line of device to perform a hard reset
 
    function Set_Bluetooth_Public_Address
      (Device            : in out BlueNRG_MS_Device;
       Bluetooth_Address :        Address;
-      Status            :    out Byte)
+      Status            :    out UInt8)
       return Boolean;
-   -- Writes to the Bluetooth Public Address segment in the
-   -- device config data.
-   -- Returns true when command is sent successfully
+   --  Writes to the Bluetooth Public Address segment in the
+   --  device config data.
+   --  Returns true when command is sent successfully
 
 private
 
    function Read
      (Device : in out BlueNRG_MS_Device)
-      return Byte_Array;
-   -- Reads all bytes that are available in the read buffer
+      return UInt8_Array;
+   --  Reads all bytes that are available in the read buffer
 
    function Read
       (Device : in out BlueNRG_MS_Device;
        Count  : in out Natural)
-       return Byte_Array;
-   -- Reads a maximum of Count bytes from the read buffer
+       return UInt8_Array;
+   --  Reads a maximum of Count bytes from the read buffer
 
    function Send_Command
      (Device     : in out BlueNRG_MS_Device;
       Command    :        OpCode;
-      Parameters :        Byte_Array)
+      Parameters :        UInt8_Array)
       return Boolean
       with Pre => Parameters'Length < 256;
-   -- Returns true when command is sent successfully
+   --  Returns true when command is sent successfully
 
    function Send_Command
      (Device     : in out BlueNRG_MS_Device;
       Command    :        OpCode)
       return Boolean;
-   -- Returns true when command is sent successfully
+   --  Returns true when command is sent successfully
 
    function Send_Command
      (Device     : in out BlueNRG_MS_Device;
       Command    :        OpCode;
-      Parameters :        Byte_Array)
-      return Byte_Array
+      Parameters :        UInt8_Array)
+      return UInt8_Array
       with Pre => Parameters'Length < 256;
-   -- Returns the HID event response from the BlueNRG
-   -- or an empty array if a timeout condition occured.
+   --  Returns the HID event response from the BlueNRG
+   --  or an empty array if a timeout condition occured.
 
    function Send_Command
      (Device     : in out BlueNRG_MS_Device;
       Command    :        OpCode)
-      return Byte_Array;
-   -- Returns the HID event response from the BlueNRG
-   -- or an empty array if a timeout condition occured.
+      return UInt8_Array;
+   --  Returns the HID event response from the BlueNRG
+   --  or an empty array if a timeout condition occured.
 
-   function To_Byte_Array
-     (Input : Unsigned_16)
-      return Byte_Array;
-   -- Convert a Unsigned_16 to Bluetooth byte order
+   function To_UInt8_Array
+     (Input : UInt16)
+      return UInt8_Array;
+   --  Convert a UInt16 to Bluetooth byte order
 
-   function To_Byte_Array
+   function To_UInt8_Array
      (Input : String)
-      return Byte_Array;
+      return UInt8_Array;
 
    function Write
      (Device : in out BlueNRG_MS_Device;
-      Data   :        Byte_Array)
+      Data   :        UInt8_Array)
       return Boolean;
-   -- Returns true if data was successfully written
+   --  Returns true if data was successfully written
 
 end BlueNRG_MS;

--- a/components/src/network/bluenrg-ms/bluenrg_ms_debug.adb
+++ b/components/src/network/bluenrg-ms/bluenrg_ms_debug.adb
@@ -22,12 +22,11 @@
 --                                                                        --
 ----------------------------------------------------------------------------
 with Bluetooth_Debug;
-with Interfaces;      use Interfaces;
 
 package body BlueNRG_MS_Debug is
-   
-   LF   : constant Character := Character'Val(16#0A#);
-   CR   : constant Character := Character'Val(16#0D#);
+
+   LF   : constant Character := Character'Val (16#0A#);
+   CR   : constant Character := Character'Val (16#0D#);
    CRLF : constant String    := CR & LF;
 
    ------------
@@ -35,7 +34,7 @@ package body BlueNRG_MS_Debug is
    ------------
 
    function To_Hex
-     (Input : Byte)
+     (Input : UInt8)
       return String
    is
       Output : String (1 .. 2);
@@ -43,87 +42,87 @@ package body BlueNRG_MS_Debug is
 
       case Input and 16#0F# is
          when 16#00# =>
-            Output(2) := '0';
+            Output (2) := '0';
          when 16#01# =>
-            Output(2) := '1';
+            Output (2) := '1';
          when 16#02# =>
-            Output(2) := '2';
+            Output (2) := '2';
          when 16#03# =>
-            Output(2) := '3';
+            Output (2) := '3';
          when 16#04# =>
-            Output(2) := '4';
+            Output (2) := '4';
          when 16#05# =>
-            Output(2) := '5';
+            Output (2) := '5';
          when 16#06# =>
-            Output(2) := '6';
+            Output (2) := '6';
          when 16#07# =>
-            Output(2) := '7';
+            Output (2) := '7';
          when 16#08# =>
-            Output(2) := '8';
+            Output (2) := '8';
          when 16#09# =>
-            Output(2) := '9';
-         when 16#0A# => 
-            Output(2) := 'A';
+            Output (2) := '9';
+         when 16#0A# =>
+            Output (2) := 'A';
          when 16#0B# =>
-            Output(2) := 'B';
+            Output (2) := 'B';
          when 16#0C# =>
-            Output(2) := 'C';
+            Output (2) := 'C';
          when 16#0D# =>
-            Output(2) := 'D';
+            Output (2) := 'D';
          when 16#0E# =>
-            Output(2) := 'E';
+            Output (2) := 'E';
          when 16#0F# =>
-            Output(2) := 'F';
+            Output (2) := 'F';
          when others =>
-            Output(2) := '?';
+            Output (2) := '?';
       end case;
-      
+
       case Input and 16#F0# is
          when 16#00# =>
-            Output(1) := '0';
+            Output (1) := '0';
          when 16#10# =>
-            Output(1) := '1';
+            Output (1) := '1';
          when 16#20# =>
-            Output(1) := '2';
+            Output (1) := '2';
          when 16#30# =>
-            Output(1) := '3';
+            Output (1) := '3';
          when 16#40# =>
-            Output(1) := '4';
+            Output (1) := '4';
          when 16#50# =>
-            Output(1) := '5';
+            Output (1) := '5';
          when 16#60# =>
-            Output(1) := '6';
+            Output (1) := '6';
          when 16#70# =>
-            Output(1) := '7';
+            Output (1) := '7';
          when 16#80# =>
-            Output(1) := '8';
+            Output (1) := '8';
          when 16#90# =>
-            Output(1) := '9';
-         when 16#A0# => 
-            Output(1) := 'A';
+            Output (1) := '9';
+         when 16#A0# =>
+            Output (1) := 'A';
          when 16#B0# =>
-            Output(1) := 'B';
+            Output (1) := 'B';
          when 16#C0# =>
-            Output(1) := 'C';
+            Output (1) := 'C';
          when 16#D0# =>
-            Output(1) := 'D';
+            Output (1) := 'D';
          when 16#E0# =>
-            Output(1) := 'E';
+            Output (1) := 'E';
          when 16#F0# =>
-            Output(1) := 'F';
+            Output (1) := 'F';
          when others =>
-            Output(1) := '?';
+            Output (1) := '?';
       end case;
 
       return Output;
    end To_Hex;
-   
+
    ------------
    -- To_Hex --
    ------------
-   
+
    function To_Hex
-     (Input : Byte_Array)
+     (Input : UInt8_Array)
       return String
    is
       Output : String (1 .. Input'Length * 3);
@@ -134,8 +133,8 @@ package body BlueNRG_MS_Debug is
       end if;
 
       for I in Integer range Input'Range loop
-         Output(1 + 3 * (I - Input'First) .. 2 + 3 * (I - Input'First)) := To_Hex(Input(I));
-         Output(3 + 3 * (I - Input'First)) := ' ';
+         Output (1 + 3 * (I - Input'First) .. 2 + 3 * (I - Input'First)) := To_Hex (Input (I));
+         Output (3 + 3 * (I - Input'First)) := ' ';
       end loop;
 
       return Output;
@@ -146,7 +145,7 @@ package body BlueNRG_MS_Debug is
    -------------------------
 
    function HCI_Event_To_String
-     (Data : Byte_Array)
+     (Data : UInt8_Array)
       return String
    is
    begin
@@ -154,7 +153,7 @@ package body BlueNRG_MS_Debug is
          return "No Data";
       end if;
 
-      if Data(1) /= 16#04# then
+      if Data (1) /= 16#04# then
          return "Not an Event";
       end if;
 
@@ -162,189 +161,189 @@ package body BlueNRG_MS_Debug is
          return "Not enough data";
       end if;
 
-      if Data(2) /= 16#FF# then
-         return Bluetooth_Debug.HCI_Event_To_String(Data);
+      if Data (2) /= 16#FF# then
+         return Bluetooth_Debug.HCI_Event_To_String (Data);
       end if;
 
-      if Data(5) = 16#08# and
-         Data(4) = 16#00#
+      if Data (5) = 16#08# and
+         Data (4) = 16#00#
       then
          return "Evt_Blue_L2CAP_Conn_Upd_Resp";
       end if;
-      if Data(5) = 16#08# and
-         Data(4) = 16#01#
+      if Data (5) = 16#08# and
+         Data (4) = 16#01#
       then
          return "Evt_Blue_L2CAP_Procedure_Timeout";
       end if;
-      if Data(5) = 16#08# and
-         Data(4) = 16#02#
+      if Data (5) = 16#08# and
+         Data (4) = 16#02#
       then
          return "Evt_Blue_L2CAP_Conn_Upd_Req";
       end if;
-      if Data(5) = 16#04# and
-         Data(4) = 16#00#
+      if Data (5) = 16#04# and
+         Data (4) = 16#00#
       then
          return "Evt_Blue_Gap_Limited_Discoverable";
       end if;
-      if Data(5) = 16#04# and
-         Data(4) = 16#01#
+      if Data (5) = 16#04# and
+         Data (4) = 16#01#
       then
-         return 
+         return
          "Evt_Blue_Gap_Pairing_Cmplt" & CRLF &
-         
-         "Status      : " & 
-        (if    Data(8) = 16#00# then
-            "Success"   
-         elsif Data(8) = 16#01# then
-            "Pairing Timeout"   
-         elsif Data(8) = 16#02# then
+
+         "Status      : " &
+        (if    Data (8) = 16#00# then
+            "Success"
+         elsif Data (8) = 16#01# then
+            "Pairing Timeout"
+         elsif Data (8) = 16#02# then
             "Pairing Failed"
          else
             "Unknown Value");
       end if;
-      if Data(5) = 16#04# and
-         Data(4) = 16#02#
+      if Data (5) = 16#04# and
+         Data (4) = 16#02#
       then
          return "Evt_Blue_Gap_Pass_Key_Request";
       end if;
-      if Data(5) = 16#04# and
-         Data(4) = 16#03#
+      if Data (5) = 16#04# and
+         Data (4) = 16#03#
       then
          return "Evt_Blue_Gap_Authorization_Request";
       end if;
-      if Data(5) = 16#04# and
-         Data(4) = 16#04#
+      if Data (5) = 16#04# and
+         Data (4) = 16#04#
       then
          return "Evt_Blue_Gap_Slave_Security_Initiated";
       end if;
-      if Data(5) = 16#04# and
-         Data(4) = 16#05#
+      if Data (5) = 16#04# and
+         Data (4) = 16#05#
       then
          return "Evt_Blue_Gap_Bond_Lost";
       end if;
-      if Data(5) = 16#04# and
-         Data(4) = 16#07#
+      if Data (5) = 16#04# and
+         Data (4) = 16#07#
       then
          return "Evt_Blue_Gap_Procedure_Complete";
       end if;
-      if Data(5) = 16#04# and
-         Data(4) = 16#08#
+      if Data (5) = 16#04# and
+         Data (4) = 16#08#
       then
          return "Evt_Blue_Gap_Addr_Not_Resolved";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#01#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#01#
       then
-         return 
+         return
          "Evt_Blue_Gatt_Attribute_modified" & CRLF &
-         "Conn_Handle : " & To_Hex(Data(6 .. 7)) & CRLF &
-         "Attr_Handle : " & To_Hex(Data(8 .. 9)) & CRLF &
-         "Data Length : " & Unsigned_8'Image(Data(10)) & CRLF &
-         "Offset      : " & Integer'Image(Integer(Data(11)) + Integer(Data(12)) * 16#FF#) & CRLF &
-         "Value       : " & To_Hex(Data(13 .. Data'Last));
+         "Conn_Handle : " & To_Hex (Data (6 .. 7)) & CRLF &
+         "Attr_Handle : " & To_Hex (Data (8 .. 9)) & CRLF &
+         "Data Length : " & UInt8'Image (Data (10)) & CRLF &
+         "Offset      : " & Integer'Image (Integer (Data (11)) + Integer (Data (12)) * 16#FF#) & CRLF &
+         "Value       : " & To_Hex (Data (13 .. Data'Last));
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#02#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#02#
       then
          return "Evt_Blue_Gatt_Procedure_Timeout";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#03#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#03#
       then
          return "Evt_Blue_Att_Exchange_MTU_Resp";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#04#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#04#
       then
          return "Evt_Blue_Att_Find_Information_Resp";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#05#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#05#
       then
          return "Evt_Blue_Att_Find_By_Type_Value_Resp";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#06#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#06#
       then
          return "Evt_Blue_Att_Read_By_Type_Resp";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#07#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#07#
       then
          return "Evt_Blue_Att_Read_Resp";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#08#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#08#
       then
          return "Evt_Blue_Att_Read_Blob_Resp";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#09#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#09#
       then
          return "Evt_Blue_Att_Read_Multiple_Resp";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#0A#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#0A#
       then
          return "Evt_Blue_Att_Read_By_Group_Type_Resp";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#0C#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#0C#
       then
          return "Evt_Blue_Att_Prepare_Write_Resp";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#0D#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#0D#
       then
          return "Evt_Blue_Att_Exec_Write_Resp";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#0E#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#0E#
       then
          return "Evt_Blue_Gatt_Indication";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#0F#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#0F#
       then
          return "Evt_Blue_Gatt_notification";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#10#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#10#
       then
          return "Evt_Blue_Gatt_Procedure_Complete";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#11#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#11#
       then
          return "Evt_Blue_Gatt_Error_Resp";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#12#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#12#
       then
          return "Evt_Blue_Gatt_Disc_Read_Charac_By_UUID_Resp";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#13#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#13#
       then
          return "Evt_Blue_Gatt_Write_Permit_req";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#14#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#14#
       then
          return "Evt_Blue_Gatt_Read_Permit_Req";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#15#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#15#
       then
          return "Evt_Blue_Gatt_Read_Multi_Permit_Req";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#16#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#16#
       then
          return "Evt_Blue_Gatt_Tx_Pool_Available";
       end if;
-      if Data(5) = 16#0C# and
-         Data(4) = 16#17#
+      if Data (5) = 16#0C# and
+         Data (4) = 16#17#
       then
          return "Evt_Blue_Gatt_Server_Confirmation";
       end if;

--- a/components/src/network/bluenrg-ms/bluenrg_ms_debug.adb
+++ b/components/src/network/bluenrg-ms/bluenrg_ms_debug.adb
@@ -1,0 +1,357 @@
+----------------------------------------------------------------------------
+--                                                                        --
+--  BlueNRG-MS.Debug                                                      --
+--                                                                        --
+--  Copyright (C) 2017, John Leimon                                       --
+--                                                                        --
+-- Permission to use, copy, modify, and/or distribute                     --
+-- this software for any purpose with or without fee                      --
+-- is hereby granted, provided that the above copyright                   --
+-- notice and this permission notice appear in all copies.                --
+--                                                                        --
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR                        --
+-- DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE                  --
+-- INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY                    --
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE                    --
+-- FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL                    --
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS                  --
+-- OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF                       --
+-- CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING                 --
+-- OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF                 --
+-- THIS SOFTWARE.                                                         --
+--                                                                        --
+----------------------------------------------------------------------------
+with Bluetooth_Debug;
+with Interfaces;      use Interfaces;
+
+package body BlueNRG_MS_Debug is
+   
+   LF   : constant Character := Character'Val(16#0A#);
+   CR   : constant Character := Character'Val(16#0D#);
+   CRLF : constant String    := CR & LF;
+
+   ------------
+   -- To_Hex --
+   ------------
+
+   function To_Hex
+     (Input : Byte)
+      return String
+   is
+      Output : String (1 .. 2);
+   begin
+
+      case Input and 16#0F# is
+         when 16#00# =>
+            Output(2) := '0';
+         when 16#01# =>
+            Output(2) := '1';
+         when 16#02# =>
+            Output(2) := '2';
+         when 16#03# =>
+            Output(2) := '3';
+         when 16#04# =>
+            Output(2) := '4';
+         when 16#05# =>
+            Output(2) := '5';
+         when 16#06# =>
+            Output(2) := '6';
+         when 16#07# =>
+            Output(2) := '7';
+         when 16#08# =>
+            Output(2) := '8';
+         when 16#09# =>
+            Output(2) := '9';
+         when 16#0A# => 
+            Output(2) := 'A';
+         when 16#0B# =>
+            Output(2) := 'B';
+         when 16#0C# =>
+            Output(2) := 'C';
+         when 16#0D# =>
+            Output(2) := 'D';
+         when 16#0E# =>
+            Output(2) := 'E';
+         when 16#0F# =>
+            Output(2) := 'F';
+         when others =>
+            Output(2) := '?';
+      end case;
+      
+      case Input and 16#F0# is
+         when 16#00# =>
+            Output(1) := '0';
+         when 16#10# =>
+            Output(1) := '1';
+         when 16#20# =>
+            Output(1) := '2';
+         when 16#30# =>
+            Output(1) := '3';
+         when 16#40# =>
+            Output(1) := '4';
+         when 16#50# =>
+            Output(1) := '5';
+         when 16#60# =>
+            Output(1) := '6';
+         when 16#70# =>
+            Output(1) := '7';
+         when 16#80# =>
+            Output(1) := '8';
+         when 16#90# =>
+            Output(1) := '9';
+         when 16#A0# => 
+            Output(1) := 'A';
+         when 16#B0# =>
+            Output(1) := 'B';
+         when 16#C0# =>
+            Output(1) := 'C';
+         when 16#D0# =>
+            Output(1) := 'D';
+         when 16#E0# =>
+            Output(1) := 'E';
+         when 16#F0# =>
+            Output(1) := 'F';
+         when others =>
+            Output(1) := '?';
+      end case;
+
+      return Output;
+   end To_Hex;
+   
+   ------------
+   -- To_Hex --
+   ------------
+   
+   function To_Hex
+     (Input : Byte_Array)
+      return String
+   is
+      Output : String (1 .. Input'Length * 3);
+   begin
+
+      if Input'Length = 0 then
+         return "";
+      end if;
+
+      for I in Integer range Input'Range loop
+         Output(1 + 3 * (I - Input'First) .. 2 + 3 * (I - Input'First)) := To_Hex(Input(I));
+         Output(3 + 3 * (I - Input'First)) := ' ';
+      end loop;
+
+      return Output;
+   end To_Hex;
+
+   -------------------------
+   -- HCI_Event_To_String --
+   -------------------------
+
+   function HCI_Event_To_String
+     (Data : Byte_Array)
+      return String
+   is
+   begin
+      if Data'Length = 0 then
+         return "No Data";
+      end if;
+
+      if Data(1) /= 16#04# then
+         return "Not an Event";
+      end if;
+
+      if Data'Length < 2 then
+         return "Not enough data";
+      end if;
+
+      if Data(2) /= 16#FF# then
+         return Bluetooth_Debug.HCI_Event_To_String(Data);
+      end if;
+
+      if Data(5) = 16#08# and
+         Data(4) = 16#00#
+      then
+         return "Evt_Blue_L2CAP_Conn_Upd_Resp";
+      end if;
+      if Data(5) = 16#08# and
+         Data(4) = 16#01#
+      then
+         return "Evt_Blue_L2CAP_Procedure_Timeout";
+      end if;
+      if Data(5) = 16#08# and
+         Data(4) = 16#02#
+      then
+         return "Evt_Blue_L2CAP_Conn_Upd_Req";
+      end if;
+      if Data(5) = 16#04# and
+         Data(4) = 16#00#
+      then
+         return "Evt_Blue_Gap_Limited_Discoverable";
+      end if;
+      if Data(5) = 16#04# and
+         Data(4) = 16#01#
+      then
+         return 
+         "Evt_Blue_Gap_Pairing_Cmplt" & CRLF &
+         
+         "Status      : " & 
+        (if    Data(8) = 16#00# then
+            "Success"   
+         elsif Data(8) = 16#01# then
+            "Pairing Timeout"   
+         elsif Data(8) = 16#02# then
+            "Pairing Failed"
+         else
+            "Unknown Value");
+      end if;
+      if Data(5) = 16#04# and
+         Data(4) = 16#02#
+      then
+         return "Evt_Blue_Gap_Pass_Key_Request";
+      end if;
+      if Data(5) = 16#04# and
+         Data(4) = 16#03#
+      then
+         return "Evt_Blue_Gap_Authorization_Request";
+      end if;
+      if Data(5) = 16#04# and
+         Data(4) = 16#04#
+      then
+         return "Evt_Blue_Gap_Slave_Security_Initiated";
+      end if;
+      if Data(5) = 16#04# and
+         Data(4) = 16#05#
+      then
+         return "Evt_Blue_Gap_Bond_Lost";
+      end if;
+      if Data(5) = 16#04# and
+         Data(4) = 16#07#
+      then
+         return "Evt_Blue_Gap_Procedure_Complete";
+      end if;
+      if Data(5) = 16#04# and
+         Data(4) = 16#08#
+      then
+         return "Evt_Blue_Gap_Addr_Not_Resolved";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#01#
+      then
+         return 
+         "Evt_Blue_Gatt_Attribute_modified" & CRLF &
+         "Conn_Handle : " & To_Hex(Data(6 .. 7)) & CRLF &
+         "Attr_Handle : " & To_Hex(Data(8 .. 9)) & CRLF &
+         "Data Length : " & Unsigned_8'Image(Data(10)) & CRLF &
+         "Offset      : " & Integer'Image(Integer(Data(11)) + Integer(Data(12)) * 16#FF#) & CRLF &
+         "Value       : " & To_Hex(Data(13 .. Data'Last));
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#02#
+      then
+         return "Evt_Blue_Gatt_Procedure_Timeout";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#03#
+      then
+         return "Evt_Blue_Att_Exchange_MTU_Resp";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#04#
+      then
+         return "Evt_Blue_Att_Find_Information_Resp";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#05#
+      then
+         return "Evt_Blue_Att_Find_By_Type_Value_Resp";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#06#
+      then
+         return "Evt_Blue_Att_Read_By_Type_Resp";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#07#
+      then
+         return "Evt_Blue_Att_Read_Resp";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#08#
+      then
+         return "Evt_Blue_Att_Read_Blob_Resp";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#09#
+      then
+         return "Evt_Blue_Att_Read_Multiple_Resp";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#0A#
+      then
+         return "Evt_Blue_Att_Read_By_Group_Type_Resp";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#0C#
+      then
+         return "Evt_Blue_Att_Prepare_Write_Resp";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#0D#
+      then
+         return "Evt_Blue_Att_Exec_Write_Resp";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#0E#
+      then
+         return "Evt_Blue_Gatt_Indication";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#0F#
+      then
+         return "Evt_Blue_Gatt_notification";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#10#
+      then
+         return "Evt_Blue_Gatt_Procedure_Complete";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#11#
+      then
+         return "Evt_Blue_Gatt_Error_Resp";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#12#
+      then
+         return "Evt_Blue_Gatt_Disc_Read_Charac_By_UUID_Resp";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#13#
+      then
+         return "Evt_Blue_Gatt_Write_Permit_req";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#14#
+      then
+         return "Evt_Blue_Gatt_Read_Permit_Req";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#15#
+      then
+         return "Evt_Blue_Gatt_Read_Multi_Permit_Req";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#16#
+      then
+         return "Evt_Blue_Gatt_Tx_Pool_Available";
+      end if;
+      if Data(5) = 16#0C# and
+         Data(4) = 16#17#
+      then
+         return "Evt_Blue_Gatt_Server_Confirmation";
+      end if;
+      return "Unknown Event";
+   exception
+      when others =>
+         return "Malformed Packet";
+   end HCI_Event_To_String;
+
+end BlueNRG_MS_Debug;

--- a/components/src/network/bluenrg-ms/bluenrg_ms_debug.ads
+++ b/components/src/network/bluenrg-ms/bluenrg_ms_debug.ads
@@ -26,8 +26,18 @@ with HAL; use HAL;
 package BlueNRG_MS_Debug is
 
    function HCI_Event_To_String
-      (Data : Byte_Array)
+      (Data : UInt8_Array)
        return String;
-   -- Returns a string representing HCI event data
+   --  Returns a string representing HCI event data
+
+private
+
+   function To_Hex
+     (Input : UInt8)
+      return String;
+
+   function To_Hex
+     (Input : UInt8_Array)
+      return String;
 
 end BlueNRG_MS_Debug;

--- a/components/src/network/bluenrg-ms/bluenrg_ms_debug.ads
+++ b/components/src/network/bluenrg-ms/bluenrg_ms_debug.ads
@@ -1,0 +1,33 @@
+----------------------------------------------------------------------------
+--                                                                        --
+--  BlueNRG-MS.Debug Specification                                        --
+--                                                                        --
+--  Copyright (C) 2017, John Leimon                                       --
+--                                                                        --
+-- Permission to use, copy, modify, and/or distribute                     --
+-- this software for any purpose with or without fee                      --
+-- is hereby granted, provided that the above copyright                   --
+-- notice and this permission notice appear in all copies.                --
+--                                                                        --
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR                        --
+-- DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE                  --
+-- INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY                    --
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE                    --
+-- FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL                    --
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS                  --
+-- OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF                       --
+-- CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING                 --
+-- OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF                 --
+-- THIS SOFTWARE.                                                         --
+--                                                                        --
+----------------------------------------------------------------------------
+with HAL; use HAL;
+
+package BlueNRG_MS_Debug is
+
+   function HCI_Event_To_String
+      (Data : Byte_Array)
+       return String;
+   -- Returns a string representing HCI event data
+
+end BlueNRG_MS_Debug;

--- a/components/src/network/bluetooth/bluetooth-hci.adb
+++ b/components/src/network/bluetooth/bluetooth-hci.adb
@@ -21,7 +21,7 @@
 -- THIS SOFTWARE.                                                         --
 --                                                                        --
 ----------------------------------------------------------------------------
-   
+
 package body Bluetooth.HCI is
 
    -----------------------
@@ -30,8 +30,8 @@ package body Bluetooth.HCI is
 
    function Build_HCI_Command
      (Command    : OpCode;
-      Parameters : Byte_Array)
-      return Byte_Array
+      Parameters : UInt8_Array)
+      return UInt8_Array
    is
    begin
       return (Command_Packet_Type &
@@ -46,7 +46,7 @@ package body Bluetooth.HCI is
 
    function Build_HCI_Command
      (Command    : OpCode)
-      return Byte_Array
+      return UInt8_Array
    is
    begin
       return (Command_Packet_Type &

--- a/components/src/network/bluetooth/bluetooth-hci.adb
+++ b/components/src/network/bluetooth/bluetooth-hci.adb
@@ -1,0 +1,57 @@
+----------------------------------------------------------------------------
+--                                                                        --
+--  Bluetooth.HCI                                                         --
+--                                                                        --
+--  Copyright (C) 2017, John Leimon                                       --
+--                                                                        --
+-- Permission to use, copy, modify, and/or distribute                     --
+-- this software for any purpose with or without fee                      --
+-- is hereby granted, provided that the above copyright                   --
+-- notice and this permission notice appear in all copies.                --
+--                                                                        --
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR                        --
+-- DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE                  --
+-- INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY                    --
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE                    --
+-- FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL                    --
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS                  --
+-- OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF                       --
+-- CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING                 --
+-- OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF                 --
+-- THIS SOFTWARE.                                                         --
+--                                                                        --
+----------------------------------------------------------------------------
+   
+package body Bluetooth.HCI is
+
+   -----------------------
+   -- Build_HCI_Command --
+   -----------------------
+
+   function Build_HCI_Command
+     (Command    : OpCode;
+      Parameters : Byte_Array)
+      return Byte_Array
+   is
+   begin
+      return (Command_Packet_Type &
+              Command &
+              Parameters'Length &
+              Parameters);
+   end Build_HCI_Command;
+
+   -----------------------
+   -- Build_HCI_Command --
+   -----------------------
+
+   function Build_HCI_Command
+     (Command    : OpCode)
+      return Byte_Array
+   is
+   begin
+      return (Command_Packet_Type &
+              Command &
+              16#00#);
+   end Build_HCI_Command;
+
+end Bluetooth.HCI;

--- a/components/src/network/bluetooth/bluetooth-hci.ads
+++ b/components/src/network/bluetooth/bluetooth-hci.ads
@@ -1,0 +1,73 @@
+----------------------------------------------------------------------------
+--                                                                        --
+--  Bluetooth.HCI Specification                                           --
+--                                                                        --
+--  Copyright (C) 2017, John Leimon                                       --
+--                                                                        --
+-- Permission to use, copy, modify, and/or distribute                     --
+-- this software for any purpose with or without fee                      --
+-- is hereby granted, provided that the above copyright                   --
+-- notice and this permission notice appear in all copies.                --
+--                                                                        --
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR                        --
+-- DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE                  --
+-- INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY                    --
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE                    --
+-- FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL                    --
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS                  --
+-- OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF                       --
+-- CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING                 --
+-- OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF                 --
+-- THIS SOFTWARE.                                                         --
+--                                                                        --
+----------------------------------------------------------------------------
+with HAL;        use HAL;
+with HAL.GPIO;   use HAL.GPIO;
+with HAL.SPI;    use HAL.SPI;
+with Interfaces; use Interfaces;
+
+package Bluetooth.HCI is
+
+   Command_Packet_Type : constant Byte := 16#01#;
+   Event_Packet_Type   : constant Byte := 16#04#;
+
+   type Event is
+     (Event_Disconn_Complete,
+      Event_Encrypt_Change,
+      Event_Read_Remote_Version_Complete,
+      Event_Cmd_Complete,
+      Event_Cmd_Status,
+      Event_Hardware_Error,
+      Event_Num_Comp_Pkts,
+      Event_Data_Buffer_Overflow,
+      Event_Encryption_Key_Refresh_Complete,
+      Event_LE);
+
+   for Event use
+     (Event_Disconn_Complete                => 16#05#,
+      Event_Encrypt_Change                  => 16#08#,
+      Event_Read_Remote_Version_Complete    => 16#0C#,
+      Event_Cmd_Complete                    => 16#0E#,
+      Event_Cmd_Status                      => 16#0F#,
+      Event_Hardware_Error                  => 16#10#,
+      Event_Num_Comp_Pkts                   => 16#13#,
+      Event_Data_Buffer_Overflow            => 16#1A#,
+      Event_Encryption_Key_Refresh_Complete => 16#30#,
+      Event_LE                              => 16#3E#);
+
+   function Build_HCI_Command
+     (Command    : OpCode;
+      Parameters : Byte_Array)
+      return Byte_Array
+     with
+      Pre => Parameters'Length < 256;
+   -- Returns a Bluetooth HCI packet using the OpCode
+   -- and parameters.
+
+   function Build_HCI_Command
+     (Command    : OpCode)
+      return Byte_Array;
+   -- Returns a Bluetooth HCI packet using the OpCode
+   -- and no parameters.
+
+end Bluetooth.HCI;

--- a/components/src/network/bluetooth/bluetooth-hci.ads
+++ b/components/src/network/bluetooth/bluetooth-hci.ads
@@ -21,15 +21,12 @@
 -- THIS SOFTWARE.                                                         --
 --                                                                        --
 ----------------------------------------------------------------------------
-with HAL;        use HAL;
 with HAL.GPIO;   use HAL.GPIO;
-with HAL.SPI;    use HAL.SPI;
-with Interfaces; use Interfaces;
 
 package Bluetooth.HCI is
 
-   Command_Packet_Type : constant Byte := 16#01#;
-   Event_Packet_Type   : constant Byte := 16#04#;
+   Command_Packet_Type : constant UInt8 := 16#01#;
+   Event_Packet_Type   : constant UInt8 := 16#04#;
 
    type Event is
      (Event_Disconn_Complete,
@@ -57,17 +54,17 @@ package Bluetooth.HCI is
 
    function Build_HCI_Command
      (Command    : OpCode;
-      Parameters : Byte_Array)
-      return Byte_Array
+      Parameters : UInt8_Array)
+      return UInt8_Array
      with
       Pre => Parameters'Length < 256;
-   -- Returns a Bluetooth HCI packet using the OpCode
-   -- and parameters.
+   --  Returns a Bluetooth HCI packet using the OpCode
+   --  and parameters.
 
    function Build_HCI_Command
      (Command    : OpCode)
-      return Byte_Array;
-   -- Returns a Bluetooth HCI packet using the OpCode
-   -- and no parameters.
+      return UInt8_Array;
+   --  Returns a Bluetooth HCI packet using the OpCode
+   --  and no parameters.
 
 end Bluetooth.HCI;

--- a/components/src/network/bluetooth/bluetooth.ads
+++ b/components/src/network/bluetooth/bluetooth.ads
@@ -1,0 +1,47 @@
+----------------------------------------------------------------------------
+--                                                                        --
+--  Bluetooth Specification                                               --
+--                                                                        --
+--  Copyright (C) 2017, John Leimon                                       --
+--                                                                        --
+-- Permission to use, copy, modify, and/or distribute                     --
+-- this software for any purpose with or without fee                      --
+-- is hereby granted, provided that the above copyright                   --
+-- notice and this permission notice appear in all copies.                --
+--                                                                        --
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR                        --
+-- DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE                  --
+-- INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY                    --
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE                    --
+-- FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL                    --
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS                  --
+-- OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF                       --
+-- CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING                 --
+-- OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF                 --
+-- THIS SOFTWARE.                                                         --
+--                                                                        --
+----------------------------------------------------------------------------
+with HAL; use HAL;
+
+package Bluetooth is
+
+   Write_Operation : constant := 16#0A#;
+   Read_Operation  : constant := 16#0B#;
+   Device_Ready    : constant := 16#02#;
+
+   subtype OpCode  is Byte_Array (1 .. 2);
+   subtype Handle  is Byte_Array (1 .. 2);
+   subtype Address is Byte_Array (1 .. 6);
+
+   type UUID_16  is new Byte_Array (1 .. 2);
+   type UUID_128 is new Byte_Array (1 .. 16);
+
+   type Service_Type is
+     (Primary,
+      Secondary);
+
+   for Service_Type use
+     (Primary   => 16#01#,
+      Secondary => 16#02#);
+
+end Bluetooth;

--- a/components/src/network/bluetooth/bluetooth.ads
+++ b/components/src/network/bluetooth/bluetooth.ads
@@ -29,12 +29,12 @@ package Bluetooth is
    Read_Operation  : constant := 16#0B#;
    Device_Ready    : constant := 16#02#;
 
-   subtype OpCode  is Byte_Array (1 .. 2);
-   subtype Handle  is Byte_Array (1 .. 2);
-   subtype Address is Byte_Array (1 .. 6);
+   subtype OpCode  is UInt8_Array (1 .. 2);
+   subtype Handle  is UInt8_Array (1 .. 2);
+   subtype Address is UInt8_Array (1 .. 6);
 
-   type UUID_16  is new Byte_Array (1 .. 2);
-   type UUID_128 is new Byte_Array (1 .. 16);
+   type UUID_16  is new UInt8_Array (1 .. 2);
+   type UUID_128 is new UInt8_Array (1 .. 16);
 
    type Service_Type is
      (Primary,

--- a/components/src/network/bluetooth/bluetooth_debug.adb
+++ b/components/src/network/bluetooth/bluetooth_debug.adb
@@ -1,0 +1,419 @@
+----------------------------------------------------------------------------
+--                                                                        --
+--  Bluetooth.Debug                                                       --
+--                                                                        --
+--  Copyright (C) 2017, John Leimon                                       --
+--                                                                        --
+-- Permission to use, copy, modify, and/or distribute                     --
+-- this software for any purpose with or without fee                      --
+-- is hereby granted, provided that the above copyright                   --
+-- notice and this permission notice appear in all copies.                --
+--                                                                        --
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR                        --
+-- DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE                  --
+-- INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY                    --
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE                    --
+-- FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL                    --
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS                  --
+-- OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF                       --
+-- CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING                 --
+-- OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF                 --
+-- THIS SOFTWARE.                                                         --
+--                                                                        --
+----------------------------------------------------------------------------
+with Interfaces; use Interfaces;
+
+package body Bluetooth_Debug is
+
+   LF   : constant Character := Character'Val(16#0A#);
+   CR   : constant Character := Character'Val(16#0D#);
+   CRLF : constant String    := CR & LF;
+
+   ------------
+   -- To_Hex --
+   ------------
+
+   function To_Hex
+     (Input : Byte)
+      return String
+   is
+      Output : String (1 .. 2);
+   begin
+
+      case Input and 16#0F# is
+         when 16#00# =>
+            Output(2) := '0';
+         when 16#01# =>
+            Output(2) := '1';
+         when 16#02# =>
+            Output(2) := '2';
+         when 16#03# =>
+            Output(2) := '3';
+         when 16#04# =>
+            Output(2) := '4';
+         when 16#05# =>
+            Output(2) := '5';
+         when 16#06# =>
+            Output(2) := '6';
+         when 16#07# =>
+            Output(2) := '7';
+         when 16#08# =>
+            Output(2) := '8';
+         when 16#09# =>
+            Output(2) := '9';
+         when 16#0A# => 
+            Output(2) := 'A';
+         when 16#0B# =>
+            Output(2) := 'B';
+         when 16#0C# =>
+            Output(2) := 'C';
+         when 16#0D# =>
+            Output(2) := 'D';
+         when 16#0E# =>
+            Output(2) := 'E';
+         when 16#0F# =>
+            Output(2) := 'F';
+         when others =>
+            Output(2) := '?';
+      end case;
+      
+      case Input and 16#F0# is
+         when 16#00# =>
+            Output(1) := '0';
+         when 16#10# =>
+            Output(1) := '1';
+         when 16#20# =>
+            Output(1) := '2';
+         when 16#30# =>
+            Output(1) := '3';
+         when 16#40# =>
+            Output(1) := '4';
+         when 16#50# =>
+            Output(1) := '5';
+         when 16#60# =>
+            Output(1) := '6';
+         when 16#70# =>
+            Output(1) := '7';
+         when 16#80# =>
+            Output(1) := '8';
+         when 16#90# =>
+            Output(1) := '9';
+         when 16#A0# => 
+            Output(1) := 'A';
+         when 16#B0# =>
+            Output(1) := 'B';
+         when 16#C0# =>
+            Output(1) := 'C';
+         when 16#D0# =>
+            Output(1) := 'D';
+         when 16#E0# =>
+            Output(1) := 'E';
+         when 16#F0# =>
+            Output(1) := 'F';
+         when others =>
+            Output(1) := '?';
+      end case;
+
+      return Output;
+   end To_Hex;
+   
+   ------------
+   -- To_Hex --
+   ------------
+   
+   function To_Hex
+     (Input : Byte_Array)
+      return String
+   is
+      Output : String (1 .. Input'Length * 3);
+   begin
+
+      if Input'Length = 0 then
+         return "";
+      end if;
+
+      for I in Integer range Input'Range loop
+         Output(1 + 3 * (I - Input'First) .. 2 + 3 * (I - Input'First)) := To_Hex(Input(I));
+         Output(3 + 3 * (I - Input'First)) := ' ';
+      end loop;
+
+      return Output;
+   end To_Hex;
+   
+   --------------------------
+   -- Error_Code_To_String --
+   --------------------------
+
+   function Error_Code_To_String
+     (Code : Byte)
+      return String
+   is
+   begin
+      case Code is
+         when 16#02# =>
+            return "Unknown Connection Identifier";
+         when 16#03# =>
+            return "Hardware Failure";
+         when 16#04# =>
+            return "Page Timeout";
+         when 16#05# =>
+            return "Authentication Failure";
+         when 16#06# =>
+            return "PIN or Key Missing";
+         when 16#07# =>
+            return "Memory Capacity Exceeded";
+         when 16#08# =>
+            return "Connection Timeout";
+         when 16#09# =>
+            return "Connection Limit Exceeded";
+         when 16#0A# =>
+            return "Synchronous Connection Limit To A Device Exceeded";
+         when 16#0B# =>
+            return "Connection Already Exists";
+         when 16#0C# =>
+            return "Command Disallowed";
+         when 16#0D# =>
+            return "Connection Rejected due to Limited Resources";
+         when 16#0E# =>
+            return "Connection Rejected Due To Security Reasons";
+         when 16#0F# =>
+            return "Connection Rejected due to Unacceptable BD_ADDR";
+         when 16#10# =>
+            return "Connection Accept Timeout Exceeded";
+         when 16#11# =>
+            return "Unsupported Feature or Parameter Value";
+         when 16#12# =>
+            return "Invalid HCI Command Parameters";
+         when 16#13# =>
+            return "Remote User Terminated Connection";
+         when 16#14# =>
+            return "Remote Device Terminated Connection due to Low Resources";
+         when 16#15# =>
+            return "Remote Device Terminated Connection due to Power Off";
+         when 16#16# =>
+            return "Connection Terminated By Local Host";
+         when 16#17# =>
+            return "Repeated Attempts";
+         when 16#18# =>
+            return "Pairing Not Allowed";
+         when 16#19# =>
+            return "Unknown LMP PDU";
+         when 16#1A# =>
+            return "Unsupported Remote Feature / Unsupported LMP Feature";
+         when 16#1B# =>
+            return "SCO Offset Rejected";
+         when 16#1C# =>
+            return "SCO Interval Rejected";
+         when 16#1D# =>
+            return "SCO Air Mode Rejected";
+         when 16#1E# =>
+            return "Invalid LMP Parameters / Invalid LL Parameters";
+         when 16#1F# =>
+            return "Unspecified Error";
+         when 16#20# =>
+            return "Unsupported LMP Parameter Value / Unsupported LL Parameter Value";
+         when 16#21# =>
+            return "Role Change Not Allowed";
+         when 16#22# =>
+            return "LMP Response Timeout / LL Response Timeout";
+         when 16#23# =>
+            return "LMP Error Transaction Collision / LL Procedure Collision";
+         when 16#24# =>
+            return "LMP PDU Not Allowed";
+         when 16#25# =>
+            return "Encryption Mode Not Acceptable";
+         when 16#26# =>
+            return "Link Key cannot be Changed";
+         when 16#27# =>
+            return "Requested QoS Not Supported";
+         when 16#28# =>
+            return "Instant Passed";
+         when 16#29# =>
+            return "Pairing With Unit Key Not Supported";
+         when 16#2A# =>
+            return "Different Transaction Collision";
+         when 16#2B# =>
+            return "Reserved for Future Use";
+         when 16#2C# =>
+            return "QoS Unacceptable Parameter";
+         when 16#2D# =>
+            return "QoS Rejected";
+         when 16#2E# =>
+            return "Channel Classification Not Supported";
+         when 16#2F# =>
+            return "Insufficient Security";
+         when 16#30# =>
+            return "Parameter Out Of Mandatory Range";
+         when 16#31# =>
+            return "Reserved for Future Use";
+         when 16#32# =>
+            return "Role Switch Pending";
+         when 16#33# =>
+            return "Reserved for Future Use";
+         when 16#34# =>
+            return "Reserved Slot Violation";
+         when 16#35# =>
+            return "Role Switch Failed";
+         when 16#36# =>
+            return "Extended Inquiry Response Too Large";
+         when 16#37# =>
+            return "Secure Simple Pairing Not Supported By Host";
+         when 16#38# =>
+            return "Host Busy - Pairing";
+         when 16#39# =>
+            return "Connection Rejected due to No Suitable Channel Found";
+         when 16#3A# =>
+            return "Controller Busy";
+         when 16#3B# =>
+            return "Unacceptable Connection Parameters";
+         when 16#3C# =>
+            return "Advertising Timeout";
+         when 16#3D# =>
+            return "Connection Terminated due to MIC Failure";
+         when 16#3E# =>
+            return "Connection Failed to be Established";
+         when 16#3F# =>
+            return "MAC Connection Failed";
+         when 16#40# =>
+            return "Coarse Clock Adjustment Rejected but Will Try to Adjust Using Clock";
+         when 16#41# =>
+            return "Type0 Submap Not Defined";
+         when 16#42# =>
+            return "Unknown Advertising Identifier";
+         when 16#43# =>
+            return "Limit Reached";
+         when 16#44# =>
+            return "Operation Cancelled by Host";
+         when others =>
+            return "Unknown Error Code";
+      end case;
+   end Error_Code_To_String;
+
+   -------------------------
+   -- HCI_Event_To_String --
+   -------------------------
+
+   function HCI_Event_To_String
+     (Data : Byte_Array)
+      return String
+   is
+      --------------------------------------
+      -- LE_Connection_Complete_To_String --
+      --------------------------------------
+     
+      function LE_Connection_Complete_To_String 
+         (Data : Byte_Array)
+          return String
+      is
+      begin
+         return "Event_LE_Conn_Complete " & CRLF &
+
+         "Status      : " &
+         (if Data(5) = 16#00# then
+            "Success"
+         else
+             "Error:" & Error_Code_To_String(Data(5))) & CRLF &
+            
+         "Handle      : " & To_Hex(Data(6 .. 7)) & CRLF &
+         
+         "Role        : " & 
+         (if Data(8) = 16#00# then
+           "Master "
+         else
+           "Slave ") & CRLF &
+           
+         "Address     : " & To_Hex(Data(9 .. 15)) & CRLF &
+
+         "ConnInt     :" & Integer'Image(Integer(Data(16) + Data(17) * 16#FF#)) & CRLF &
+
+         "SuperTimeout:" & Integer'Image(Integer(Data(20) + Data(21) * 16#FF#));
+
+      end LE_Connection_Complete_To_String;
+
+      ---------------------------------------------
+      -- LE_Connection_Update_Complete_To_String --
+      ---------------------------------------------
+
+      function LE_Connection_Update_Complete_To_String
+        (Data : Byte_Array)
+         return String
+      is
+      begin
+         return "LE_Connection_Update_Complete" & CRLF &
+
+         "Status      : " &
+         (if Data(5) = 16#00# then
+             "Success"
+          else
+             "Error: " & Error_Code_To_String(Data(5)));
+
+      end LE_Connection_Update_Complete_To_String;
+
+   begin
+      if Data'Length = 0 then
+         return "No Data";
+      end if;
+
+      if Data(1) /= 16#04# then
+         return "Not an Event";
+      end if;
+
+      if Data'Length < 2 then
+         return "Not enough data";
+      end if;
+
+      case Data(2) is
+         when 16#05# =>
+            return "Event_Disconn_Complete" & CRLF &
+
+           (if Data(4) = 16#00# then
+               "Disconnection Occured"
+            else
+               Error_Code_To_String(Data(4))) & CRLF &
+
+            "Handle      : " & To_Hex(Data(5 .. 6)) & CRLF &
+
+            Error_Code_To_String(Data(7));
+
+         when 16#08# =>
+            return "Event_Encrypt_Change";
+         when 16#0C# =>
+            return "Event_Read_Remote_Version_Complete";
+         when 16#0E# =>
+            return "Event_Cmd_Complete";
+         when 16#0F# =>
+            return "Event_Cmd_Status";
+         when 16#10# =>
+            return "Event_Hardware_Error";
+         when 16#13# =>
+            return "Event_Num_Comp_Pkts";
+         when 16#1A# =>
+            return "Event_Data_Buffer_Overflow";
+         when 16#30# =>
+            return "Event_Encryption_Key_Refresh_Complete";
+         when 16#3E# =>
+            case Data(4) is
+               when 16#01# =>
+                  return LE_Connection_Complete_To_String(Data);
+               when 16#02# =>
+                  return "Event_LE_Advertising_Report";
+               when 16#03# =>
+                  return LE_Connection_Update_Complete_To_String(Data);
+               when 16#04# =>
+                  return "Event_LE_Read_Remote_Used_Features_Complete";
+               when 16#05# =>
+                  return "Event_LE_LTK_Request";
+               when others =>
+                  return "Unknown LE Event";
+            end case;
+         when 16#FF# =>
+            return "Vendor Specific Event";
+         when others =>
+            return "Unknown Event";
+      end case;
+   exception
+      when others =>
+         return "Malformed Packet";
+   end HCI_Event_To_String;
+
+end Bluetooth_Debug;

--- a/components/src/network/bluetooth/bluetooth_debug.adb
+++ b/components/src/network/bluetooth/bluetooth_debug.adb
@@ -21,20 +21,27 @@
 -- THIS SOFTWARE.                                                         --
 --                                                                        --
 ----------------------------------------------------------------------------
-with Interfaces; use Interfaces;
 
 package body Bluetooth_Debug is
 
-   LF   : constant Character := Character'Val(16#0A#);
-   CR   : constant Character := Character'Val(16#0D#);
+   LF   : constant Character := Character'Val (16#0A#);
+   CR   : constant Character := Character'Val (16#0D#);
    CRLF : constant String    := CR & LF;
+
+   function To_Hex
+     (Input : UInt8)
+      return String;
+
+   function To_Hex
+     (Input : UInt8_Array)
+      return String;
 
    ------------
    -- To_Hex --
    ------------
 
    function To_Hex
-     (Input : Byte)
+     (Input : UInt8)
       return String
    is
       Output : String (1 .. 2);
@@ -42,87 +49,87 @@ package body Bluetooth_Debug is
 
       case Input and 16#0F# is
          when 16#00# =>
-            Output(2) := '0';
+            Output (2) := '0';
          when 16#01# =>
-            Output(2) := '1';
+            Output (2) := '1';
          when 16#02# =>
-            Output(2) := '2';
+            Output (2) := '2';
          when 16#03# =>
-            Output(2) := '3';
+            Output (2) := '3';
          when 16#04# =>
-            Output(2) := '4';
+            Output (2) := '4';
          when 16#05# =>
-            Output(2) := '5';
+            Output (2) := '5';
          when 16#06# =>
-            Output(2) := '6';
+            Output (2) := '6';
          when 16#07# =>
-            Output(2) := '7';
+            Output (2) := '7';
          when 16#08# =>
-            Output(2) := '8';
+            Output (2) := '8';
          when 16#09# =>
-            Output(2) := '9';
-         when 16#0A# => 
-            Output(2) := 'A';
+            Output (2) := '9';
+         when 16#0A# =>
+            Output (2) := 'A';
          when 16#0B# =>
-            Output(2) := 'B';
+            Output (2) := 'B';
          when 16#0C# =>
-            Output(2) := 'C';
+            Output (2) := 'C';
          when 16#0D# =>
-            Output(2) := 'D';
+            Output (2) := 'D';
          when 16#0E# =>
-            Output(2) := 'E';
+            Output (2) := 'E';
          when 16#0F# =>
-            Output(2) := 'F';
+            Output (2) := 'F';
          when others =>
-            Output(2) := '?';
+            Output (2) := '?';
       end case;
-      
+
       case Input and 16#F0# is
          when 16#00# =>
-            Output(1) := '0';
+            Output (1) := '0';
          when 16#10# =>
-            Output(1) := '1';
+            Output (1) := '1';
          when 16#20# =>
-            Output(1) := '2';
+            Output (1) := '2';
          when 16#30# =>
-            Output(1) := '3';
+            Output (1) := '3';
          when 16#40# =>
-            Output(1) := '4';
+            Output (1) := '4';
          when 16#50# =>
-            Output(1) := '5';
+            Output (1) := '5';
          when 16#60# =>
-            Output(1) := '6';
+            Output (1) := '6';
          when 16#70# =>
-            Output(1) := '7';
+            Output (1) := '7';
          when 16#80# =>
-            Output(1) := '8';
+            Output (1) := '8';
          when 16#90# =>
-            Output(1) := '9';
-         when 16#A0# => 
-            Output(1) := 'A';
+            Output (1) := '9';
+         when 16#A0# =>
+            Output (1) := 'A';
          when 16#B0# =>
-            Output(1) := 'B';
+            Output (1) := 'B';
          when 16#C0# =>
-            Output(1) := 'C';
+            Output (1) := 'C';
          when 16#D0# =>
-            Output(1) := 'D';
+            Output (1) := 'D';
          when 16#E0# =>
-            Output(1) := 'E';
+            Output (1) := 'E';
          when 16#F0# =>
-            Output(1) := 'F';
+            Output (1) := 'F';
          when others =>
-            Output(1) := '?';
+            Output (1) := '?';
       end case;
 
       return Output;
    end To_Hex;
-   
+
    ------------
    -- To_Hex --
    ------------
-   
+
    function To_Hex
-     (Input : Byte_Array)
+     (Input : UInt8_Array)
       return String
    is
       Output : String (1 .. Input'Length * 3);
@@ -133,19 +140,19 @@ package body Bluetooth_Debug is
       end if;
 
       for I in Integer range Input'Range loop
-         Output(1 + 3 * (I - Input'First) .. 2 + 3 * (I - Input'First)) := To_Hex(Input(I));
-         Output(3 + 3 * (I - Input'First)) := ' ';
+         Output (1 + 3 * (I - Input'First) .. 2 + 3 * (I - Input'First)) := To_Hex (Input (I));
+         Output (3 + 3 * (I - Input'First)) := ' ';
       end loop;
 
       return Output;
    end To_Hex;
-   
+
    --------------------------
    -- Error_Code_To_String --
    --------------------------
 
    function Error_Code_To_String
-     (Code : Byte)
+     (Code : UInt8)
       return String
    is
    begin
@@ -294,39 +301,47 @@ package body Bluetooth_Debug is
    -------------------------
 
    function HCI_Event_To_String
-     (Data : Byte_Array)
+     (Data : UInt8_Array)
       return String
    is
+      function LE_Connection_Complete_To_String
+         (Data : UInt8_Array)
+          return String;
+
+      function LE_Connection_Update_Complete_To_String
+        (Data : UInt8_Array)
+         return String;
+
       --------------------------------------
       -- LE_Connection_Complete_To_String --
       --------------------------------------
-     
-      function LE_Connection_Complete_To_String 
-         (Data : Byte_Array)
+
+      function LE_Connection_Complete_To_String
+         (Data : UInt8_Array)
           return String
       is
       begin
          return "Event_LE_Conn_Complete " & CRLF &
 
          "Status      : " &
-         (if Data(5) = 16#00# then
+         (if Data (5) = 16#00# then
             "Success"
          else
-             "Error:" & Error_Code_To_String(Data(5))) & CRLF &
-            
-         "Handle      : " & To_Hex(Data(6 .. 7)) & CRLF &
-         
-         "Role        : " & 
-         (if Data(8) = 16#00# then
+             "Error:" & Error_Code_To_String (Data (5))) & CRLF &
+
+         "Handle      : " & To_Hex (Data (6 .. 7)) & CRLF &
+
+         "Role        : " &
+         (if Data (8) = 16#00# then
            "Master "
          else
            "Slave ") & CRLF &
-           
-         "Address     : " & To_Hex(Data(9 .. 15)) & CRLF &
 
-         "ConnInt     :" & Integer'Image(Integer(Data(16) + Data(17) * 16#FF#)) & CRLF &
+         "Address     : " & To_Hex (Data (9 .. 15)) & CRLF &
 
-         "SuperTimeout:" & Integer'Image(Integer(Data(20) + Data(21) * 16#FF#));
+         "ConnInt     :" & Integer'Image (Integer (Data (16) + Data (17) * 16#FF#)) & CRLF &
+
+         "SuperTimeout:" & Integer'Image (Integer (Data (20) + Data (21) * 16#FF#));
 
       end LE_Connection_Complete_To_String;
 
@@ -335,17 +350,17 @@ package body Bluetooth_Debug is
       ---------------------------------------------
 
       function LE_Connection_Update_Complete_To_String
-        (Data : Byte_Array)
+        (Data : UInt8_Array)
          return String
       is
       begin
          return "LE_Connection_Update_Complete" & CRLF &
 
          "Status      : " &
-         (if Data(5) = 16#00# then
+         (if Data (5) = 16#00# then
              "Success"
           else
-             "Error: " & Error_Code_To_String(Data(5)));
+             "Error: " & Error_Code_To_String (Data (5)));
 
       end LE_Connection_Update_Complete_To_String;
 
@@ -354,7 +369,7 @@ package body Bluetooth_Debug is
          return "No Data";
       end if;
 
-      if Data(1) /= 16#04# then
+      if Data (1) /= 16#04# then
          return "Not an Event";
       end if;
 
@@ -362,18 +377,18 @@ package body Bluetooth_Debug is
          return "Not enough data";
       end if;
 
-      case Data(2) is
+      case Data (2) is
          when 16#05# =>
             return "Event_Disconn_Complete" & CRLF &
 
-           (if Data(4) = 16#00# then
+           (if Data (4) = 16#00# then
                "Disconnection Occured"
             else
-               Error_Code_To_String(Data(4))) & CRLF &
+               Error_Code_To_String (Data (4))) & CRLF &
 
-            "Handle      : " & To_Hex(Data(5 .. 6)) & CRLF &
+            "Handle      : " & To_Hex (Data (5 .. 6)) & CRLF &
 
-            Error_Code_To_String(Data(7));
+            Error_Code_To_String (Data (7));
 
          when 16#08# =>
             return "Event_Encrypt_Change";
@@ -392,13 +407,13 @@ package body Bluetooth_Debug is
          when 16#30# =>
             return "Event_Encryption_Key_Refresh_Complete";
          when 16#3E# =>
-            case Data(4) is
+            case Data (4) is
                when 16#01# =>
-                  return LE_Connection_Complete_To_String(Data);
+                  return LE_Connection_Complete_To_String (Data);
                when 16#02# =>
                   return "Event_LE_Advertising_Report";
                when 16#03# =>
-                  return LE_Connection_Update_Complete_To_String(Data);
+                  return LE_Connection_Update_Complete_To_String (Data);
                when 16#04# =>
                   return "Event_LE_Read_Remote_Used_Features_Complete";
                when 16#05# =>

--- a/components/src/network/bluetooth/bluetooth_debug.ads
+++ b/components/src/network/bluetooth/bluetooth_debug.ads
@@ -24,14 +24,14 @@
 with HAL; use HAL;
 
 package Bluetooth_Debug is
-   
+
    function Error_Code_To_String
-     (Code : Byte)
+     (Code : UInt8)
       return String;
 
    function HCI_Event_To_String
-      (Data : Byte_Array)
+      (Data : UInt8_Array)
        return String;
-   -- Returns a string representing HCI event data
+   --  Returns a string representing HCI event data
 
 end Bluetooth_Debug;

--- a/components/src/network/bluetooth/bluetooth_debug.ads
+++ b/components/src/network/bluetooth/bluetooth_debug.ads
@@ -1,0 +1,37 @@
+----------------------------------------------------------------------------
+--                                                                        --
+--  Bluetooth.Debug Specification                                         --
+--                                                                        --
+--  Copyright (C) 2017, John Leimon                                       --
+--                                                                        --
+-- Permission to use, copy, modify, and/or distribute                     --
+-- this software for any purpose with or without fee                      --
+-- is hereby granted, provided that the above copyright                   --
+-- notice and this permission notice appear in all copies.                --
+--                                                                        --
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR                        --
+-- DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE                  --
+-- INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY                    --
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE                    --
+-- FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL                    --
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS                  --
+-- OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF                       --
+-- CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING                 --
+-- OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF                 --
+-- THIS SOFTWARE.                                                         --
+--                                                                        --
+----------------------------------------------------------------------------
+with HAL; use HAL;
+
+package Bluetooth_Debug is
+   
+   function Error_Code_To_String
+     (Code : Byte)
+      return String;
+
+   function HCI_Event_To_String
+      (Data : Byte_Array)
+       return String;
+   -- Returns a string representing HCI event data
+
+end Bluetooth_Debug;

--- a/hal/src/hal-spi.ads
+++ b/hal/src/hal-spi.ads
@@ -67,6 +67,16 @@ package HAL.SPI is
      with
        Pre'Class => Data_Size (This) = Data_Size_16b;
 
+   procedure Transfer
+     (This      : in out SPI_Port;
+      Data_Out  :        SPI_Data_8b;
+      Data_In   :    out SPI_Data_8b;
+      Status    :    out SPI_Status;
+      Timeout   :        Natural := 1000) is abstract
+     with
+       Pre'Class => Data_Size (This) = Data_Size_8b and
+                    Data_Out'Length = Data_In'Length;
+
    procedure Receive
      (This    : in out SPI_Port;
       Data    : out SPI_Data_8b;
@@ -82,10 +92,5 @@ package HAL.SPI is
       Timeout : Natural := 1000) is abstract
      with
        Pre'Class => Data_Size (This) = Data_Size_16b;
-
-   procedure Transmit_Receive
-     (This      : in out SPI_Port;
-      Outgoing  : UInt8;
-      Incoming  : out UInt8) is abstract;
 
 end HAL.SPI;

--- a/hal/src/hal-spi.ads
+++ b/hal/src/hal-spi.ads
@@ -83,4 +83,9 @@ package HAL.SPI is
      with
        Pre'Class => Data_Size (This) = Data_Size_16b;
 
+   procedure Transmit_Receive
+     (This      : in out SPI_Port;
+      Outgoing  : UInt8;
+      Incoming  : out UInt8) is abstract;
+
 end HAL.SPI;


### PR DESCRIPTION
Add Transmit_Receive procedure to the SPI_Port interface.

Rationale:
1. Only the STM32-SPI package currently uses this interface, and it already has the Transmit_Receive procedure implemented.
2. The STMicroelectronics BlueNRG-MS component requires a transmit and receive operation to communicate with the component using the SPI interface. See STMicroelectronics UM1865 "BlueNRG-MS Bluetooth LE stack application command interface (ACI)" section 5.2.1. Figure 10 SPI frame header. In this protocol, a 'control' byte is transmitted and a 'ready' byte is received simultaneously.