### PR TITLE
scripts/install_deps: Don't fail when the repository is already cloned

### DIFF
--- a/scripts/install_optional_deps.py
+++ b/scripts/install_optional_deps.py
@@ -71,7 +71,10 @@ def main(args):
         if args.pattern and not any(pat in repo for pat in args.pattern):
             continue
 
-        ret = git_clone (repo, dest, recursive)
+        if not os.path.exists(ROOT_DIR + dest):
+            ret = git_clone (repo, dest, recursive)
+        else:
+            print "%s already cloned" % dest
 
         if ret:
             at_least_one_error = True


### PR DESCRIPTION
This failure report is not necessary and just makes scripting more difficult.