### PR TITLE
README.md: fix various Markdown details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 [![Build Status](https://travis-ci.org/AdaCore/Ada_Drivers_Library.svg?branch=master)](https://travis-ci.org/AdaCore/Ada_Drivers_Library)
 [![Build status](https://ci.appveyor.com/api/projects/status/dvay075xkwxgppwm?svg=true)](https://ci.appveyor.com/project/AdaCore/ada-drivers-library)
 
-# Warning!
+## Warning!
 
-This repository uses git submodule, please clone with the --recursive option:
+This repository uses git submodule, please clone with the `--recursive` option:
 
 ```shell
 git clone --recursive https://github.com/AdaCore/Ada_Drivers_Library.git
 ```
 
-1. Introduction
----------------
+# 1. Introduction
 
 This repository contains Ada source code and complete sample GNAT projects for
 selected bare-board platforms supported by GNAT.  Initially the repository
@@ -19,18 +18,16 @@ to be a location for both AdaCore and the community in general to contribute
 support for additional processors, platforms, and vendors.
 
 
-2. License
-----------
+# 2. License
 
 All files are provided under a 3-clause Berkeley Software Distribution (BSD)
 license. As such, and within the conditions required by the license, the files
 are available both for proprietary ("commercial") and non-proprietary use.
 
-For details, see the "LICENSE" file in the root directory.
+For details, see the `LICENSE` file in the root directory.
 
 
-3. Requirements
----------------
+# 3. Requirements
 
 The software is written in Ada 2012 and uses, for example, preconditions,
 postconditions, and the high-level iterator form of for-loops.
@@ -38,19 +35,18 @@ postconditions, and the high-level iterator form of for-loops.
 In addition, a GNAT implementation-defined pragma is used extensively. This
 pragma makes it possible to avoid explicit temporary copies when assigning
 components of types representing hardware registers requiring full word or full
-half-word accesses. The pragma is named Volatile_Full_Access. Those persons
+half-word accesses. The pragma is named `Volatile_Full_Access`. Those persons
 wishing to submit additions to the library should see the GNAT Reference Manual
 for details.
 
 Therefore, building with the sources requires a compiler supporting both Ada
-2012 and the GNAT-defined pragma Volatile_Full_Access. The "GNAT GPL 2016"
+2012 and the GNAT-defined pragma `Volatile_Full_Access`. The "GNAT GPL 2016"
 compiler for ARM ELF is one such compiler [(Download it
 here)](http://libre.adacore.com/download/configurations). A recent GNAT Pro
 compiler for that target will also suffice.
 
 
-4. Content
-----------
+# 4. Content
 
 Initial provision is for the hardware in the STM32F4 family of 32-bit MCUs, as
 defined in the "RM0090 Reference Manual" (Doc ID 018909 Rev 6, Feb 2014) by
@@ -71,8 +67,7 @@ Not all devices defined by the Reference Manual are supported, and not all those
 supported are complete. We encourage contributions of corrections, enhancements,
 and new drivers.
 
-5. Roadmap
-----------
+# 5. Roadmap
 
 Here is a list of projects that we are either dreaming about or already working
 on. If you are interested by one of those, please contact us on the projects's
@@ -86,8 +81,7 @@ GitHub page.
  * Bluetooth Low Energy stack
  * USB stack
 
-6. Project using the Ada_Drivers_Library
-----------------------------------------
+# 6. Project using the Ada_Drivers_Library
 
  * [Certyflie: Ada/SPARK flight controller for the Crazyflie 2.0](https://github.com/AdaCore/Certyflie)
  * [ACNC: A Gcode interpreter and CNC controller](https://github.com/Fabien-Chouteau/ACNC)


### PR DESCRIPTION
In particular, make sure titles are parsed as such and tag as code the
pragma, command-line option and file names.