### PR TITLE
Micro:Bit: Switch README instructions to DAPLink + pyOCD instead or Jlink

### DIFF
--- a/examples/MicroBit/microbit_example.gpr
+++ b/examples/MicroBit/microbit_example.gpr
@@ -19,7 +19,7 @@ project MicroBit_Example is
   end Linker;
 
   package Ide is
-     for Program_Host use ":2331";
+     for Program_Host use ":1234";
      for Communication_Protocol use "remote";
   end Ide;
 


### PR DESCRIPTION
Works out of the box. No need to flash a new probe firmware to the board.