### PR TITLE
[RFC] STM32 dma services

### DIFF
--- a/arch/ARM/STM32/devices/stm32f42x/stm32-device.adb
+++ b/arch/ARM/STM32/devices/stm32f42x/stm32-device.adb
@@ -436,7 +436,7 @@ package body STM32.Device is
    -- Enable_Clock --
    ------------------
 
-   procedure Enable_Clock (This : SPI_Port) is
+   procedure Enable_Clock (This : SPI_Port'Class) is
    begin
       if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2ENR.SPI1EN := True;
@@ -459,7 +459,7 @@ package body STM32.Device is
    -- Reset --
    -----------
 
-   procedure Reset (This : SPI_Port) is
+   procedure Reset (This : SPI_Port'Class) is
    begin
       if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2RSTR.SPI1RST := True;

--- a/arch/ARM/STM32/devices/stm32f42x/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f42x/stm32-device.ads
@@ -44,17 +44,21 @@
 
 with STM32_SVD;     use STM32_SVD;
 
-with STM32.DMA;     use STM32.DMA;
-with STM32.GPIO;    use STM32.GPIO;
-with STM32.ADC;     use STM32.ADC;
-with STM32.USARTs;  use STM32.USARTs;
-with STM32.SPI;     use STM32.SPI;
-with STM32.I2S;     use STM32.I2S;
-with STM32.I2C;     use STM32.I2C;
-with STM32.Timers;  use STM32.Timers;
-with STM32.DAC;     use STM32.DAC;
-with STM32.RTC;     use STM32.RTC;
-with STM32.CRC;     use STM32.CRC;
+with Ada.Interrupts.Names;
+
+with STM32.DMA;            use STM32.DMA;
+with STM32.DMA.Interrupts; use STM32.DMA.Interrupts;
+with STM32.GPIO;           use STM32.GPIO;
+with STM32.ADC;            use STM32.ADC;
+with STM32.USARTs;         use STM32.USARTs;
+with STM32.SPI;            use STM32.SPI;
+with STM32.SPI.DMA;        use STM32.SPI.DMA;
+with STM32.I2S;            use STM32.I2S;
+with STM32.I2C;            use STM32.I2C;
+with STM32.Timers;         use STM32.Timers;
+with STM32.DAC;            use STM32.DAC;
+with STM32.RTC;            use STM32.RTC;
+with STM32.CRC;            use STM32.CRC;
 
 package STM32.Device is
    pragma Elaborate_Body;
@@ -373,6 +377,40 @@ package STM32.Device is
 
    procedure Enable_Clock (This : aliased in out DMA_Controller);
    procedure Reset (This : aliased in out DMA_Controller);
+
+   DMA1_Stream0 : aliased DMA_Interrupt_Controller
+     (DMA_1'Access, Stream_0, Ada.Interrupts.Names.DMA1_Stream0_Interrupt);
+   DMA1_Stream1 : aliased DMA_Interrupt_Controller
+     (DMA_1'Access, Stream_1, Ada.Interrupts.Names.DMA1_Stream1_Interrupt);
+   DMA1_Stream2 : aliased DMA_Interrupt_Controller
+     (DMA_1'Access, Stream_2, Ada.Interrupts.Names.DMA1_Stream2_Interrupt);
+   DMA1_Stream3 : aliased DMA_Interrupt_Controller
+     (DMA_1'Access, Stream_3, Ada.Interrupts.Names.DMA1_Stream3_Interrupt);
+   DMA1_Stream4 : aliased DMA_Interrupt_Controller
+     (DMA_1'Access, Stream_4, Ada.Interrupts.Names.DMA1_Stream4_Interrupt);
+   DMA1_Stream5 : aliased DMA_Interrupt_Controller
+     (DMA_1'Access, Stream_5, Ada.Interrupts.Names.DMA1_Stream5_Interrupt);
+   DMA1_Stream6 : aliased DMA_Interrupt_Controller
+     (DMA_1'Access, Stream_6, Ada.Interrupts.Names.DMA1_Stream6_Interrupt);
+   DMA1_Stream7 : aliased DMA_Interrupt_Controller
+     (DMA_1'Access, Stream_7, Ada.Interrupts.Names.DMA1_Stream7_Interrupt);
+
+   DMA2_Stream0 : aliased DMA_Interrupt_Controller
+     (DMA_2'Access, Stream_0, Ada.Interrupts.Names.DMA2_Stream0_Interrupt);
+   DMA2_Stream1 : aliased DMA_Interrupt_Controller
+     (DMA_2'Access, Stream_1, Ada.Interrupts.Names.DMA2_Stream1_Interrupt);
+   DMA2_Stream2 : aliased DMA_Interrupt_Controller
+     (DMA_2'Access, Stream_2, Ada.Interrupts.Names.DMA2_Stream2_Interrupt);
+   DMA2_Stream3 : aliased DMA_Interrupt_Controller
+     (DMA_2'Access, Stream_3, Ada.Interrupts.Names.DMA2_Stream3_Interrupt);
+   DMA2_Stream4 : aliased DMA_Interrupt_Controller
+     (DMA_2'Access, Stream_4, Ada.Interrupts.Names.DMA2_Stream4_Interrupt);
+   DMA2_Stream5 : aliased DMA_Interrupt_Controller
+     (DMA_2'Access, Stream_5, Ada.Interrupts.Names.DMA2_Stream5_Interrupt);
+   DMA2_Stream6 : aliased DMA_Interrupt_Controller
+     (DMA_2'Access, Stream_6, Ada.Interrupts.Names.DMA2_Stream6_Interrupt);
+   DMA2_Stream7 : aliased DMA_Interrupt_Controller
+     (DMA_2'Access, Stream_7, Ada.Interrupts.Names.DMA2_Stream7_Interrupt);
 
    Internal_I2C_Port_1 : aliased Internal_I2C_Port with Import, Volatile, Address => I2C1_Base;
    Internal_I2C_Port_2 : aliased Internal_I2C_Port with Import, Volatile, Address => I2C2_Base;

--- a/arch/ARM/STM32/devices/stm32f42x/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f42x/stm32-device.ads
@@ -444,8 +444,15 @@ package STM32.Device is
    SPI_5 : aliased SPI_Port (Internal_SPI_5'Access);
    SPI_6 : aliased SPI_Port (Internal_SPI_6'Access);
 
-   procedure Enable_Clock (This : SPI_Port);
-   procedure Reset (This : SPI_Port);
+   SPI_1_DMA : aliased SPI_Port_DMA (Internal_SPI_1'Access);
+   SPI_2_DMA : aliased SPI_Port_DMA (Internal_SPI_2'Access);
+   SPI_3_DMA : aliased SPI_Port_DMA (Internal_SPI_3'Access);
+   SPI_4_DMA : aliased SPI_Port_DMA (Internal_SPI_4'Access);
+   SPI_5_DMA : aliased SPI_Port_DMA (Internal_SPI_5'Access);
+   SPI_6_DMA : aliased SPI_Port_DMA (Internal_SPI_6'Access);
+
+   procedure Enable_Clock (This : SPI_Port'Class);
+   procedure Reset (This : SPI_Port'Class);
 
    Internal_I2S_1 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI1_Base;
    Internal_I2S_2 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI2_Base;

--- a/arch/ARM/STM32/drivers/dma/stm32-dma-interrupts.adb
+++ b/arch/ARM/STM32/drivers/dma/stm32-dma-interrupts.adb
@@ -1,0 +1,117 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2016, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+package body STM32.DMA.Interrupts is
+
+   protected body DMA_Interrupt_Controller is
+
+      --------------------
+      -- Start_Transfer --
+      --------------------
+
+      procedure Start_Transfer (Source      : Address;
+                                Destination : Address;
+                                Data_Count  : UInt16)
+      is
+      begin
+         No_Transfer_In_Progess := False;
+
+         Clear_All_Status (Controller.all, Stream);
+
+         Start_Transfer_with_Interrupts (This               => Controller.all,
+                                         Stream             => Stream,
+                                         Source             => Source,
+                                         Destination        => Destination,
+                                         Data_Count         => Data_Count);
+      end Start_Transfer;
+
+      --------------------
+      -- Abort_Transfer --
+      --------------------
+
+      procedure Abort_Transfer (Result : out DMA_Error_Code) is
+      begin
+         Abort_Transfer (This   => Controller.all,
+                         Stream => Stream,
+                         Result => Result);
+         No_Transfer_In_Progess := Result = DMA_No_Error;
+      end Abort_Transfer;
+
+      -------------------------
+      -- Wait_For_Completion --
+      -------------------------
+
+      entry Wait_For_Completion (Status : out DMA_Error_Code)
+        when No_Transfer_In_Progess
+      is
+      begin
+         Status := Last_Status;
+      end Wait_For_Completion;
+
+      -----------------------
+      -- Interrupt_Handler --
+      -----------------------
+
+      procedure Interrupt_Handler is
+      begin
+         for Flag in DMA_Status_Flag loop
+            if Status (Controller.all, Stream, Flag) then
+               case Flag is
+                  when FIFO_Error_Indicated =>
+                     Last_Status := DMA_FIFO_Error;
+                     if not Enabled (Controller.all, Stream) then
+                        --  If the stream was disabled by hardware, the transfer
+                        --  is stopped. Otherwise we can ignore the even.
+                        No_Transfer_In_Progess := True;
+                     end if;
+                  when Direct_Mode_Error_Indicated =>
+                     Last_Status := DMA_Direct_Mode_Error;
+                     if not Enabled (Controller.all, Stream) then
+                        --  If the stream was disabled by hardware, the transfer
+                        --  is stopped. Otherwise we can ignore the even.
+                        No_Transfer_In_Progess := True;
+                     end if;
+                  when Transfer_Error_Indicated =>
+                     Last_Status := DMA_Transfer_Error;
+                     No_Transfer_In_Progess := True;
+                  when Half_Transfer_Complete_Indicated =>
+                     null;
+                  when Transfer_Complete_Indicated =>
+                     Last_Status := DMA_No_Error;
+                     No_Transfer_In_Progess := True;
+               end case;
+               Clear_Status (Controller.all, Stream, Flag);
+            end if;
+         end loop;
+      end Interrupt_Handler;
+   end DMA_Interrupt_Controller;
+
+end STM32.DMA.Interrupts;

--- a/arch/ARM/STM32/drivers/dma/stm32-dma-interrupts.ads
+++ b/arch/ARM/STM32/drivers/dma/stm32-dma-interrupts.ads
@@ -56,6 +56,6 @@ package STM32.DMA.Interrupts is
       Last_Status            : DMA_Error_Code := DMA_No_Error;
    end DMA_Interrupt_Controller;
 
-   type DMA_Interrupt_Controller_Ref is access all DMA_Interrupt_Controller;
+   type Any_DMA_Interrupt_Controller is access all DMA_Interrupt_Controller;
 
 end STM32.DMA.Interrupts;

--- a/arch/ARM/STM32/drivers/dma/stm32-dma-interrupts.ads
+++ b/arch/ARM/STM32/drivers/dma/stm32-dma-interrupts.ads
@@ -1,0 +1,61 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2016, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Interrupts;
+
+package STM32.DMA.Interrupts is
+
+   protected type DMA_Interrupt_Controller
+     (Controller : not null access DMA_Controller;
+      Stream     : DMA_Stream_Selector;
+      ID         : Ada.Interrupts.Interrupt_ID)
+   is
+
+      procedure Start_Transfer (Source      : Address;
+                                Destination : Address;
+                                Data_Count  : UInt16);
+
+      procedure Abort_Transfer (Result : out DMA_Error_Code);
+
+      entry Wait_For_Completion (Status : out DMA_Error_Code);
+
+   private
+
+      procedure Interrupt_Handler;
+      pragma Attach_Handler (Interrupt_Handler, ID);
+
+      No_Transfer_In_Progess : Boolean := True;
+      Last_Status            : DMA_Error_Code := DMA_No_Error;
+   end DMA_Interrupt_Controller;
+
+   type DMA_Interrupt_Controller_Ref is access all DMA_Interrupt_Controller;
+
+end STM32.DMA.Interrupts;

--- a/arch/ARM/STM32/drivers/stm32-spi-dma.adb
+++ b/arch/ARM/STM32/drivers/stm32-spi-dma.adb
@@ -1,0 +1,183 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2016, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with STM32.DMA; use STM32.DMA;
+with HAL.SPI;
+
+package body STM32.SPI.DMA is
+
+   procedure Transmit_Common
+     (This        : in out SPI_Port_DMA;
+      Source      : System.Address;
+      Data_Count  : UInt16;
+      Status      : out HAL.SPI.SPI_Status;
+      Timeout     : Natural := 1000);
+
+   ---------------------
+   -- Transmit_Common --
+   ---------------------
+
+   procedure Transmit_Common
+     (This        : in out SPI_Port_DMA;
+      Source      : System.Address;
+      Data_Count  : UInt16;
+      Status      : out HAL.SPI.SPI_Status;
+      Timeout     : Natural := 1000)
+   is
+      pragma Unreferenced (Timeout);
+      DMA_Status : DMA_Error_Code;
+   begin
+      if not Compatible_Alignments (This.TX_DMA.Controller.all,
+                                    This.TX_DMA.Stream,
+                                    Source,
+                                    This.Data_Register_Address)
+      then
+         raise Program_Error with "Incompatible alignments";
+      end if;
+
+      --  Enable TX DMA
+      This.Periph.CR2.TXDMAEN := True;
+
+      This.TX_DMA.Start_Transfer (Source      => Source,
+                                  Destination => This.Data_Register_Address,
+                                  Data_Count  => Data_Count);
+
+      This.TX_DMA.Wait_For_Completion (DMA_Status);
+
+      if DMA_Status = DMA_No_Error then
+         Status := HAL.SPI.Ok;
+      else
+         Status := HAL.SPI.Err_Error;
+      end if;
+   end Transmit_Common;
+
+
+   ------------------------
+   -- Set_TX_DMA_Handler --
+   ------------------------
+
+   procedure Set_TX_DMA_Handler
+     (This : in out SPI_Port_DMA;
+      DMA  : DMA_Interrupt_Controller_Ref)
+   is
+   begin
+      This.TX_DMA := DMA;
+   end Set_TX_DMA_Handler;
+
+   ---------------
+   -- Configure --
+   ---------------
+
+   overriding procedure Configure
+     (This : in out SPI_Port_DMA;
+      Conf : SPI_Configuration)
+   is
+   begin
+      Configure (Parent (This), Conf);
+   end Configure;
+
+   --------------
+   -- Transmit --
+   --------------
+
+   overriding procedure Transmit
+     (This   : in out SPI_Port_DMA;
+      Data   : HAL.SPI.SPI_Data_8b;
+      Status : out HAL.SPI.SPI_Status;
+      Timeout : Natural := 1000)
+   is
+   begin
+      if This.TX_DMA = null or else Data'Length < Polling_Threshold then
+         --  Fallback to polling implementation
+         Transmit (Parent (This), Data, Status, Timeout);
+      else
+         Transmit_Common (This,
+                          Data (Data'First)'Address,
+                          Data'Length,
+                          Status,
+                          Timeout);
+      end if;
+   end Transmit;
+
+   --------------
+   -- Transmit --
+   --------------
+
+   overriding procedure Transmit
+     (This   : in out SPI_Port_DMA;
+      Data   : HAL.SPI.SPI_Data_16b;
+      Status : out HAL.SPI.SPI_Status;
+      Timeout : Natural := 1000)
+   is
+   begin
+      if This.TX_DMA = null or else Data'Length < Polling_Threshold then
+         --  Fallback to polling implementation
+         Transmit (Parent (This), Data, Status, Timeout);
+      else
+         Transmit_Common (This,
+                          Data (Data'First)'Address,
+                          Data'Length,
+                          Status,
+                          Timeout);
+      end if;
+   end Transmit;
+
+   -------------
+   -- Receive --
+   -------------
+
+   overriding procedure Receive
+     (This    : in out SPI_Port_DMA;
+      Data    : out HAL.SPI.SPI_Data_8b;
+      Status  : out HAL.SPI.SPI_Status;
+      Timeout : Natural := 1000)
+   is
+   begin
+      --  Not implemented, fallback to polling implementation
+      Receive (Parent (This), Data, Status, Timeout);
+   end Receive;
+
+   -------------
+   -- Receive --
+   -------------
+
+   overriding procedure Receive
+     (This    : in out SPI_Port_DMA;
+      Data    : out HAL.SPI.SPI_Data_16b;
+      Status  : out HAL.SPI.SPI_Status;
+      Timeout : Natural := 1000)
+   is
+   begin
+      --  Not implemented, fallback to polling implementation
+      Receive (Parent (This), Data, Status, Timeout);
+   end Receive;
+
+end STM32.SPI.DMA;

--- a/arch/ARM/STM32/drivers/stm32-spi-dma.adb
+++ b/arch/ARM/STM32/drivers/stm32-spi-dma.adb
@@ -86,7 +86,7 @@ package body STM32.SPI.DMA is
 
    procedure Set_TX_DMA_Handler
      (This : in out SPI_Port_DMA;
-      DMA  : DMA_Interrupt_Controller_Ref)
+      DMA  : Any_DMA_Interrupt_Controller)
    is
    begin
       This.TX_DMA := DMA;

--- a/arch/ARM/STM32/drivers/stm32-spi-dma.ads
+++ b/arch/ARM/STM32/drivers/stm32-spi-dma.ads
@@ -1,0 +1,84 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2016, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with STM32.DMA.Interrupts; use STM32.DMA.Interrupts;
+
+package STM32.SPI.DMA is
+
+   subtype Parent is SPI_Port;
+   type SPI_Port_DMA is limited new Parent with private;
+
+   procedure Set_TX_DMA_Handler (This : in out SPI_Port_DMA;
+                                 DMA  : DMA_Interrupt_Controller_Ref);
+
+   overriding
+   procedure Configure (This : in out SPI_Port_DMA;
+                        Conf : SPI_Configuration);
+
+   overriding
+   procedure Transmit
+     (This   : in out SPI_Port_DMA;
+      Data   : HAL.SPI.SPI_Data_8b;
+      Status : out HAL.SPI.SPI_Status;
+      Timeout : Natural := 1000);
+
+   overriding
+   procedure Transmit
+     (This   : in out SPI_Port_DMA;
+      Data   : HAL.SPI.SPI_Data_16b;
+      Status : out HAL.SPI.SPI_Status;
+      Timeout : Natural := 1000);
+
+   overriding
+   procedure Receive
+     (This    : in out SPI_Port_DMA;
+      Data    : out HAL.SPI.SPI_Data_8b;
+      Status  : out HAL.SPI.SPI_Status;
+      Timeout : Natural := 1000);
+
+   overriding
+   procedure Receive
+     (This    : in out SPI_Port_DMA;
+      Data    : out HAL.SPI.SPI_Data_16b;
+      Status  : out HAL.SPI.SPI_Status;
+      Timeout : Natural := 1000);
+
+private
+
+   type SPI_Port_DMA is limited new Parent with record
+      TX_DMA : DMA_Interrupt_Controller_Ref := null;
+   end record;
+
+   Polling_Threshold : constant := 5;
+   --  Bellow a certain amount of data polling is faster and more efficient
+   --  than DMA. This value arbitrary fixed, it could be user defined at some
+   --  point.
+end STM32.SPI.DMA;

--- a/arch/ARM/STM32/drivers/stm32-spi-dma.ads
+++ b/arch/ARM/STM32/drivers/stm32-spi-dma.ads
@@ -37,7 +37,7 @@ package STM32.SPI.DMA is
    type SPI_Port_DMA is limited new Parent with private;
 
    procedure Set_TX_DMA_Handler (This : in out SPI_Port_DMA;
-                                 DMA  : DMA_Interrupt_Controller_Ref);
+                                 DMA  : Any_DMA_Interrupt_Controller);
 
    overriding
    procedure Configure (This : in out SPI_Port_DMA;
@@ -74,7 +74,7 @@ package STM32.SPI.DMA is
 private
 
    type SPI_Port_DMA is limited new Parent with record
-      TX_DMA : DMA_Interrupt_Controller_Ref := null;
+      TX_DMA : Any_DMA_Interrupt_Controller := null;
    end record;
 
    Polling_Threshold : constant := 5;

--- a/arch/ARM/STM32/drivers/stm32-spi.adb
+++ b/arch/ARM/STM32/drivers/stm32-spi.adb
@@ -40,7 +40,6 @@
 ------------------------------------------------------------------------------
 
 with Ada.Unchecked_Conversion;
-with System;
 
 with STM32_SVD.SPI; use STM32_SVD.SPI;
 
@@ -699,6 +698,18 @@ package body STM32.SPI is
          Reset_CRC (This);
       end if;
    end Transmit_Receive;
+
+   ---------------------------
+   -- Data_Register_Address --
+   ---------------------------
+
+   function Data_Register_Address
+     (This : SPI_Port)
+      return System.Address
+   is
+   begin
+      return This.Periph.DR'Address;
+   end Data_Register_Address;
 
    -----------------------------
    -- Send_Receive_16bit_Mode --

--- a/arch/ARM/STM32/drivers/stm32-spi.ads
+++ b/arch/ARM/STM32/drivers/stm32-spi.ads
@@ -44,6 +44,7 @@
 
 private with STM32_SVD.SPI;
 with HAL.SPI;
+with System;
 
 package STM32.SPI is
 
@@ -204,6 +205,11 @@ package STM32.SPI is
       Incoming  : out UInt8);
 
    --  TODO: add the other higher-level HAL routines for interrupts and DMA
+
+   function Data_Register_Address
+     (This : SPI_Port)
+      return System.Address;
+   --  For DMA transfer
 
 private
 

--- a/boards/OpenMV2/src/openmv-lcd_shield.adb
+++ b/boards/OpenMV2/src/openmv-lcd_shield.adb
@@ -129,6 +129,7 @@ package body OpenMV.LCD_Shield is
                    X_End   => 127,
                    Y_Start => 0,
                    Y_End   => 159);
+
       Turn_On (LCD_Driver);
 
       LCD_Driver.Initialize_Layer (Layer  => 1,

--- a/boards/OpenMV2/src/openmv-lcd_shield.adb
+++ b/boards/OpenMV2/src/openmv-lcd_shield.adb
@@ -79,7 +79,7 @@ package body OpenMV.LCD_Shield is
       Initialize (LCD_Driver);
 
       Set_Memory_Data_Access
-        (LCD                 => LCD_Driver,
+        (This                => LCD_Driver,
          Color_Order         => RGB_Order,
          Vertical            => Vertical_Refresh_Top_Bottom,
          Horizontal          => Horizontal_Refresh_Left_Right,
@@ -156,7 +156,7 @@ package body OpenMV.LCD_Shield is
    procedure Rotate_Screen_90 is
    begin
       Set_Memory_Data_Access
-        (LCD                 => LCD_Driver,
+        (This                => LCD_Driver,
          Color_Order         => RGB_Order,
          Vertical            => Vertical_Refresh_Top_Bottom,
          Horizontal          => Horizontal_Refresh_Left_Right,
@@ -172,7 +172,7 @@ package body OpenMV.LCD_Shield is
    procedure Rotate_Screen_0 is
    begin
       Set_Memory_Data_Access
-        (LCD                 => LCD_Driver,
+        (This                => LCD_Driver,
          Color_Order         => RGB_Order,
          Vertical            => Vertical_Refresh_Top_Bottom,
          Horizontal          => Horizontal_Refresh_Left_Right,

--- a/boards/OpenMV2/src/openmv-lcd_shield.adb
+++ b/boards/OpenMV2/src/openmv-lcd_shield.adb
@@ -149,11 +149,11 @@ package body OpenMV.LCD_Shield is
       return LCD_Driver.Hidden_Buffer (1);
    end Get_Bitmap;
 
-   ----------------------
-   -- Rotate_Screen_90 --
-   ----------------------
+   -----------------------
+   -- Rotate_Screen_180 --
+   -----------------------
 
-   procedure Rotate_Screen_90 is
+   procedure Rotate_Screen_180 is
    begin
       Set_Memory_Data_Access
         (This                => LCD_Driver,
@@ -163,7 +163,7 @@ package body OpenMV.LCD_Shield is
          Row_Addr_Order      => Row_Address_Top_Bottom,
          Column_Addr_Order   => Column_Address_Left_Right,
          Row_Column_Exchange => False);
-   end Rotate_Screen_90;
+   end Rotate_Screen_180;
 
    ---------------------
    -- Rotate_Screen_0 --

--- a/boards/OpenMV2/src/openmv-lcd_shield.ads
+++ b/boards/OpenMV2/src/openmv-lcd_shield.ads
@@ -40,7 +40,7 @@ package OpenMV.LCD_Shield is
 
    function Get_Bitmap return not null HAL.Bitmap.Any_Bitmap_Buffer;
 
-   procedure Rotate_Screen_90
+   procedure Rotate_Screen_180
      with Pre => Initialized;
    procedure Rotate_Screen_0
      with Pre => Initialized;

--- a/boards/OpenMV2/src/openmv-sensor.adb
+++ b/boards/OpenMV2/src/openmv-sensor.adb
@@ -30,15 +30,14 @@
 ------------------------------------------------------------------------------
 
 with STM32.DCMI;
-with STM32.DMA;            use STM32.DMA;
-with Ada.Real_Time;        use Ada.Real_Time;
-with OV2640;               use OV2640;
-with OV7725;               use OV7725;
-with Interfaces;           use Interfaces;
-with HAL.I2C;              use HAL.I2C;
-with HAL.Bitmap;           use HAL.Bitmap;
-with HAL;                  use HAL;
-with STM32.PWM;            use STM32.PWM;
+with STM32.DMA;     use STM32.DMA;
+with Ada.Real_Time; use Ada.Real_Time;
+with OV2640;        use OV2640;
+with OV7725;        use OV7725;
+with HAL.I2C;       use HAL.I2C;
+with HAL.Bitmap;    use HAL.Bitmap;
+with HAL;           use HAL;
+with STM32.PWM;     use STM32.PWM;
 with STM32.Setup;
 
 package body OpenMV.Sensor is
@@ -321,20 +320,10 @@ package body OpenMV.Sensor is
          raise Program_Error;
       end if;
 
-<<<<<<< f4e4bb22981169061f6971e1412c40fd437f822d
-      Clear_All_Status (Sensor_DMA, Sensor_DMA_Stream);
-
-      Start_Transfer (This        => Sensor_DMA,
-                      Stream      => Sensor_DMA_Stream,
-                      Source      => DCMI.Data_Register_Address,
-                      Destination => BM.Memory_Address,
-                      Data_Count  => Cnt);
-=======
       Sensor_DMA_Int.Start_Transfer
         (Source      => DCMI.Data_Register_Address,
-         Destination => BM.Addr,
+         Destination => BM.Memory_Address,
          Data_Count  => Cnt);
->>>>>>> OpenMV: Use the new DMA services for sensor and display
 
       DCMI.Start_Capture (DCMI.Snapshot);
 

--- a/boards/OpenMV2/src/openmv-sensor.adb
+++ b/boards/OpenMV2/src/openmv-sensor.adb
@@ -30,14 +30,15 @@
 ------------------------------------------------------------------------------
 
 with STM32.DCMI;
-with STM32.DMA;     use STM32.DMA;
-with Ada.Real_Time; use Ada.Real_Time;
-with OV2640;        use OV2640;
-with OV7725;        use OV7725;
-with HAL.I2C;       use HAL.I2C;
-with HAL.Bitmap;    use HAL.Bitmap;
-with HAL;           use HAL;
-with STM32.PWM;     use STM32.PWM;
+with STM32.DMA;            use STM32.DMA;
+with Ada.Real_Time;        use Ada.Real_Time;
+with OV2640;               use OV2640;
+with OV7725;               use OV7725;
+with Interfaces;           use Interfaces;
+with HAL.I2C;              use HAL.I2C;
+with HAL.Bitmap;           use HAL.Bitmap;
+with HAL;                  use HAL;
+with STM32.PWM;            use STM32.PWM;
 with STM32.Setup;
 
 package body OpenMV.Sensor is
@@ -320,6 +321,7 @@ package body OpenMV.Sensor is
          raise Program_Error;
       end if;
 
+<<<<<<< f4e4bb22981169061f6971e1412c40fd437f822d
       Clear_All_Status (Sensor_DMA, Sensor_DMA_Stream);
 
       Start_Transfer (This        => Sensor_DMA,
@@ -327,14 +329,16 @@ package body OpenMV.Sensor is
                       Source      => DCMI.Data_Register_Address,
                       Destination => BM.Memory_Address,
                       Data_Count  => Cnt);
+=======
+      Sensor_DMA_Int.Start_Transfer
+        (Source      => DCMI.Data_Register_Address,
+         Destination => BM.Addr,
+         Data_Count  => Cnt);
+>>>>>>> OpenMV: Use the new DMA services for sensor and display
 
       DCMI.Start_Capture (DCMI.Snapshot);
 
-      Poll_For_Completion (Sensor_DMA,
-                           Sensor_DMA_Stream,
-                           Full_Transfer,
-                           Milliseconds (100),
-                           Status);
+      Sensor_DMA_Int.Wait_For_Completion (Status);
 
       if Status /= DMA_No_Error then
          if Status = DMA_Timeout_Error then

--- a/boards/OpenMV2/src/openmv.ads
+++ b/boards/OpenMV2/src/openmv.ads
@@ -34,8 +34,10 @@ with STM32.GPIO;    use STM32.GPIO;
 
 use STM32;  -- for base addresses
 with STM32.SPI;
+with STM32.SPI.DMA;
 with STM32.Timers; use STM32.Timers;
 with STM32.DMA;
+with STM32.DMA.Interrupts;
 with STM32.I2C; use STM32.I2C;
 with STM32.USARTs; use STM32.USARTs;
 
@@ -106,11 +108,19 @@ private
    SPI2_MOSI : GPIO_Point renames PB15;
    SPI2_NSS  : GPIO_Point renames PB12;
 
-   Shield_SPI : STM32.SPI.SPI_Port renames STM32.Device.SPI_2;
+   Shield_SPI : STM32.SPI.DMA.SPI_Port_DMA renames STM32.Device.SPI_2_DMA;
    Shield_SPI_Points : constant STM32.GPIO.GPIO_Points :=
      (Shield_MISO,
       Shield_MOSI,
       Shield_SCK);
+
+   Shield_SPI_DMA        : STM32.DMA.DMA_Controller renames DMA_1;
+   Shield_SPI_DMA_Chan   : STM32.DMA.DMA_Channel_Selector renames
+     STM32.DMA.Channel_0;
+   Shield_SPI_DMA_Stream : STM32.DMA.DMA_Stream_Selector renames
+     STM32.DMA.Stream_4;
+   Shield_SPI_DMA_Int    : STM32.DMA.Interrupts.DMA_Interrupt_Controller renames
+     DMA1_Stream4;
 
    ------------
    -- USART3 --
@@ -143,6 +153,8 @@ private
      STM32.DMA.Channel_1;
    Sensor_DMA_Stream : STM32.DMA.DMA_Stream_Selector renames
      STM32.DMA.Stream_1;
+   Sensor_DMA_Int    : STM32.DMA.Interrupts.DMA_Interrupt_Controller renames
+     DMA2_Stream1;
 
    ---------------
    -- I2C2 Pins --

--- a/components/src/screen/ST7735R/st7735r.adb
+++ b/components/src/screen/ST7735R/st7735r.adb
@@ -246,21 +246,23 @@ package body ST7735R is
    -- Initialize --
    ----------------
 
-   procedure Initialize (LCD : in out ST7735R_Screen) is
+   procedure Initialize (This : in out ST7735R_Screen) is
    begin
-      LCD.Layer.LCD := LCD'Unchecked_Access;
+      This.Layer.LCD := This'Unchecked_Access;
 
-      LCD.RST.Clear;
-      LCD.Time.Delay_Milliseconds (100);
-      LCD.RST.Set;
-      LCD.Time.Delay_Milliseconds (100);
+      This.RST.Clear;
+      This.Time.Delay_Milliseconds (100);
+      This.RST.Set;
+      This.Time.Delay_Milliseconds (100);
 
       --  Sleep Exit
-      Write_Command (LCD, 16#11#);
+      Write_Command (This, 16#11#);
 
-      LCD.Time.Delay_Milliseconds (100);
+      This.Time.Delay_Milliseconds (100);
 
-      LCD.Initialized := True;
+      This.Time.Delay_Milliseconds (100);
+
+      This.Initialized := True;
    end Initialize;
 
    -----------------
@@ -268,25 +270,25 @@ package body ST7735R is
    -----------------
 
    overriding
-   function Initialized (LCD : ST7735R_Screen) return Boolean is
-     (LCD.Initialized);
+   function Initialized (This : ST7735R_Screen) return Boolean is
+     (This.Initialized);
 
    -------------
    -- Turn_On --
    -------------
 
-   procedure Turn_On (LCD : ST7735R_Screen) is
+   procedure Turn_On (This : ST7735R_Screen) is
    begin
-      Write_Command (LCD, 16#29#);
+      Write_Command (This, 16#29#);
    end Turn_On;
 
    --------------
    -- Turn_Off --
    --------------
 
-   procedure Turn_Off (LCD : ST7735R_Screen) is
+   procedure Turn_Off (This : ST7735R_Screen) is
    begin
-      Write_Command (LCD, 16#28#);
+      Write_Command (This, 16#28#);
    end Turn_Off;
 
 
@@ -294,9 +296,9 @@ package body ST7735R is
    -- Display_Inversion_On --
    --------------------------
 
-   procedure Display_Inversion_On (LCD : ST7735R_Screen) is
+   procedure Display_Inversion_On (This : ST7735R_Screen) is
    begin
-      Write_Command (LCD, 16#21#);
+      Write_Command (This, 16#21#);
    end Display_Inversion_On;
 
 
@@ -304,31 +306,31 @@ package body ST7735R is
    -- Display_Inversion_Off --
    ---------------------------
 
-   procedure Display_Inversion_Off (LCD : ST7735R_Screen) is
+   procedure Display_Inversion_Off (This : ST7735R_Screen) is
    begin
-      Write_Command (LCD, 16#20#);
+      Write_Command (This, 16#20#);
    end Display_Inversion_Off;
 
    ---------------
    -- Gamma_Set --
    ---------------
 
-   procedure Gamma_Set (LCD : ST7735R_Screen; Gamma_Curve : UInt4) is
+   procedure Gamma_Set (This : ST7735R_Screen; Gamma_Curve : UInt4) is
    begin
-      Write_Command (LCD, 16#26#, (0 => UInt8 (Gamma_Curve)));
+      Write_Command (This, 16#26#, (0 => UInt8 (Gamma_Curve)));
    end Gamma_Set;
 
    ----------------------
    -- Set_Pixel_Format --
    ----------------------
 
-   procedure Set_Pixel_Format (LCD : ST7735R_Screen; Pix_Fmt : Pixel_Format) is
+   procedure Set_Pixel_Format (This : ST7735R_Screen; Pix_Fmt : Pixel_Format) is
       Value : constant UInt8 := (case Pix_Fmt is
                                    when Pixel_12bits => 2#011#,
                                    when Pixel_16bits => 2#101#,
                                    when Pixel_18bits => 2#110#);
    begin
-      Write_Command (LCD, 16#3A#, (0 => Value));
+      Write_Command (This, 16#3A#, (0 => Value));
    end Set_Pixel_Format;
 
    ----------------------------
@@ -336,7 +338,7 @@ package body ST7735R is
    ----------------------------
 
    procedure Set_Memory_Data_Access
-     (LCD                 : ST7735R_Screen;
+     (This                 : ST7735R_Screen;
       Color_Order         : RGB_BGR_Order;
       Vertical            : Vertical_Refresh_Order;
       Horizontal          : Horizontal_Refresh_Order;
@@ -353,7 +355,7 @@ package body ST7735R is
       Value.ML := Vertical;
       Value.RGB := Color_Order;
       Value.MH := Horizontal;
-      Write_Command (LCD, 16#36#, (0 => To_UInt8 (Value)));
+      Write_Command (This, 16#36#, (0 => To_UInt8 (Value)));
    end Set_Memory_Data_Access;
 
    ---------------------------
@@ -361,13 +363,13 @@ package body ST7735R is
    ---------------------------
 
    procedure Set_Frame_Rate_Normal
-     (LCD         : ST7735R_Screen;
+     (This        : ST7735R_Screen;
       RTN         : UInt4;
       Front_Porch : UInt6;
       Back_Porch  : UInt6)
    is
    begin
-      Write_Command (LCD, 16#B1#,
+      Write_Command (This, 16#B1#,
                      (UInt8 (RTN), UInt8 (Front_Porch), UInt8 (Back_Porch)));
    end Set_Frame_Rate_Normal;
 
@@ -376,13 +378,13 @@ package body ST7735R is
    -------------------------
 
    procedure Set_Frame_Rate_Idle
-     (LCD         : ST7735R_Screen;
+     (This        : ST7735R_Screen;
       RTN         : UInt4;
       Front_Porch : UInt6;
       Back_Porch  : UInt6)
    is
    begin
-      Write_Command (LCD, 16#B2#,
+      Write_Command (This, 16#B2#,
                      (UInt8 (RTN), UInt8 (Front_Porch), UInt8 (Back_Porch)));
    end Set_Frame_Rate_Idle;
 
@@ -391,7 +393,7 @@ package body ST7735R is
    ---------------------------------
 
    procedure Set_Frame_Rate_Partial_Full
-     (LCD              : ST7735R_Screen;
+     (This             : ST7735R_Screen;
       RTN_Part         : UInt4;
       Front_Porch_Part : UInt6;
       Back_Porch_Part  : UInt6;
@@ -400,7 +402,7 @@ package body ST7735R is
       Back_Porch_Full  : UInt6)
    is
    begin
-      Write_Command (LCD, 16#B3#,
+      Write_Command (This, 16#B3#,
                      (UInt8 (RTN_Part),
                       UInt8 (Front_Porch_Part),
                       UInt8 (Back_Porch_Part),
@@ -414,7 +416,7 @@ package body ST7735R is
    ---------------------------
 
    procedure Set_Inversion_Control
-     (LCD : ST7735R_Screen;
+     (This : ST7735R_Screen;
       Normal, Idle, Full_Partial : Inversion_Control)
    is
       Value : UInt8 := 0;
@@ -428,7 +430,7 @@ package body ST7735R is
       if Full_Partial = Line_Inversion then
          Value := Value or 2#001#;
       end if;
-      Write_Command (LCD, 16#B4#, (0 => Value));
+      Write_Command (This, 16#B4#, (0 => Value));
    end Set_Inversion_Control;
 
    -------------------------
@@ -436,7 +438,7 @@ package body ST7735R is
    -------------------------
 
    procedure Set_Power_Control_1
-     (LCD  : ST7735R_Screen;
+     (This : ST7735R_Screen;
       AVDD : UInt3;
       VRHP : UInt5;
       VRHN : UInt5;
@@ -447,7 +449,7 @@ package body ST7735R is
       P1 := Shift_Left (UInt8 (AVDD), 5) or UInt8 (VRHP);
       P2 := UInt8 (VRHN);
       P3 := Shift_Left (UInt8 (MODE), 6) or 2#00_0100#;
-      Write_Command (LCD, 16#C0#, (P1, P2, P3));
+      Write_Command (This, 16#C0#, (P1, P2, P3));
    end Set_Power_Control_1;
 
    -------------------------
@@ -455,7 +457,7 @@ package body ST7735R is
    -------------------------
 
    procedure Set_Power_Control_2
-     (LCD   : ST7735R_Screen;
+     (This  : ST7735R_Screen;
       VGH25 : UInt2;
       VGSEL : UInt2;
       VGHBT : UInt2)
@@ -465,7 +467,7 @@ package body ST7735R is
       P1 := Shift_Left (UInt8 (VGH25), 6) or
         Shift_Left (UInt8 (VGSEL), 2) or
         UInt8 (VGHBT);
-      Write_Command (LCD, 16#C1#, (0 => P1));
+      Write_Command (This, 16#C1#, (0 => P1));
    end Set_Power_Control_2;
 
    -------------------------
@@ -473,11 +475,11 @@ package body ST7735R is
    -------------------------
 
    procedure Set_Power_Control_3
-     (LCD : ST7735R_Screen;
+     (This   : ST7735R_Screen;
       P1, P2 : UInt8)
    is
    begin
-      Write_Command (LCD, 16#C2#, (P1, P2));
+      Write_Command (This, 16#C2#, (P1, P2));
    end Set_Power_Control_3;
 
    -------------------------
@@ -485,11 +487,11 @@ package body ST7735R is
    -------------------------
 
    procedure Set_Power_Control_4
-     (LCD : ST7735R_Screen;
+     (This   : ST7735R_Screen;
       P1, P2 : UInt8)
    is
    begin
-      Write_Command (LCD, 16#C3#, (P1, P2));
+      Write_Command (This, 16#C3#, (P1, P2));
    end Set_Power_Control_4;
 
    -------------------------
@@ -497,27 +499,27 @@ package body ST7735R is
    -------------------------
 
    procedure Set_Power_Control_5
-     (LCD : ST7735R_Screen;
+     (This   : ST7735R_Screen;
       P1, P2 : UInt8)
    is
    begin
-      Write_Command (LCD, 16#C4#, (P1, P2));
+      Write_Command (This, 16#C4#, (P1, P2));
    end Set_Power_Control_5;
 
    --------------
    -- Set_Vcom --
    --------------
 
-   procedure Set_Vcom (LCD : ST7735R_Screen; VCOMS : UInt6) is
+   procedure Set_Vcom (This : ST7735R_Screen; VCOMS : UInt6) is
    begin
-      Write_Command (LCD, 16#C5#, (0 => UInt8 (VCOMS)));
+      Write_Command (This, 16#C5#, (0 => UInt8 (VCOMS)));
    end Set_Vcom;
 
    ------------------------
    -- Set_Column_Address --
    ------------------------
 
-   procedure Set_Column_Address (LCD : ST7735R_Screen; X_Start, X_End : UInt16)
+   procedure Set_Column_Address (This : ST7735R_Screen; X_Start, X_End : UInt16)
    is
       P1, P2, P3, P4 : UInt8;
    begin
@@ -525,14 +527,14 @@ package body ST7735R is
       P2 := UInt8 (X_Start and 16#FF#);
       P3 := UInt8 (Shift_Right (X_End and 16#FF#, 8));
       P4 := UInt8 (X_End and 16#FF#);
-      Write_Command (LCD, 16#2A#, (P1, P2, P3, P4));
+      Write_Command (This, 16#2A#, (P1, P2, P3, P4));
    end Set_Column_Address;
 
    ---------------------
    -- Set_Row_Address --
    ---------------------
 
-   procedure Set_Row_Address (LCD : ST7735R_Screen; Y_Start, Y_End : UInt16)
+   procedure Set_Row_Address (This : ST7735R_Screen; Y_Start, Y_End : UInt16)
    is
       P1, P2, P3, P4 : UInt8;
    begin
@@ -540,47 +542,47 @@ package body ST7735R is
       P2 := UInt8 (Y_Start and 16#FF#);
       P3 := UInt8 (Shift_Right (Y_End and 16#FF#, 8));
       P4 := UInt8 (Y_End and 16#FF#);
-      Write_Command (LCD, 16#2B#, (P1, P2, P3, P4));
+      Write_Command (This, 16#2B#, (P1, P2, P3, P4));
    end Set_Row_Address;
 
    -----------------
    -- Set_Address --
    -----------------
 
-   procedure Set_Address (LCD : ST7735R_Screen;
+   procedure Set_Address (This                           : ST7735R_Screen;
                           X_Start, X_End, Y_Start, Y_End : UInt16)
    is
    begin
-      Set_Column_Address (LCD, X_Start, X_End);
-      Set_Row_Address (LCD, Y_Start, Y_End);
+      Set_Column_Address (This, X_Start, X_End);
+      Set_Row_Address (This, Y_Start, Y_End);
    end Set_Address;
 
    ---------------
    -- Set_Pixel --
    ---------------
 
-   procedure Set_Pixel (LCD   : ST7735R_Screen;
+   procedure Set_Pixel (This  : ST7735R_Screen;
                         X, Y  : UInt16;
                         Color : UInt16)
    is
       Data : constant HAL.UInt16_Array (1 .. 1) := (1 => Color);
    begin
-      Set_Address (LCD, X, X + 1, Y, Y + 1);
-      Write_Raw_Pixels (LCD, Data);
+      Set_Address (This, X, X + 1, Y, Y + 1);
+      Write_Raw_Pixels (This, Data);
    end Set_Pixel;
 
    -----------
    -- Pixel --
    -----------
 
-   function Pixel (LCD   : ST7735R_Screen;
-                    X, Y  : UInt16)
-                    return UInt16
+   function Pixel (This  : ST7735R_Screen;
+                   X, Y  : UInt16)
+                   return UInt16
    is
       Ret : UInt16;
    begin
-      Set_Address (LCD, X, X + 1, Y, Y + 1);
-      Read_Data (LCD, Ret);
+      Set_Address (This, X, X + 1, Y, Y + 1);
+      Read_Data (This, Ret);
       return Ret;
    end Pixel;
 
@@ -589,24 +591,24 @@ package body ST7735R is
    -- Write_Raw_Pixels --
    ----------------------
 
-   procedure Write_Raw_Pixels (LCD  : ST7735R_Screen;
+   procedure Write_Raw_Pixels (This : ST7735R_Screen;
                                Data : HAL.UInt8_Array)
    is
    begin
-      Write_Command (LCD, 16#2C#);
-      Write_Data (LCD, Data);
+      Write_Command (This, 16#2C#);
+      Write_Data (This, Data);
    end Write_Raw_Pixels;
 
    ----------------------
    -- Write_Raw_Pixels --
    ----------------------
 
-   procedure Write_Raw_Pixels (LCD  : ST7735R_Screen;
+   procedure Write_Raw_Pixels (This : ST7735R_Screen;
                                Data : HAL.UInt16_Array)
    is
    begin
-      Write_Command (LCD, 16#2C#);
-      Write_Data (LCD, Data);
+      Write_Command (This, 16#2C#);
+      Write_Data (This, Data);
    end Write_Raw_Pixels;
 
    --------------------

--- a/components/src/screen/ST7735R/st7735r.ads
+++ b/components/src/screen/ST7735R/st7735r.ads
@@ -163,9 +163,9 @@ package ST7735R is
                    return UInt16;
 
    procedure Write_Raw_Pixels (This : ST7735R_Screen;
-                               Data : HAL.UInt8_Array);
+                               Data : in out HAL.UInt8_Array);
    procedure Write_Raw_Pixels (This : ST7735R_Screen;
-                               Data : HAL.UInt16_Array);
+                               Data : in out HAL.UInt16_Array);
 
    overriding
    function Max_Layers

--- a/components/src/screen/ST7735R/st7735r.ads
+++ b/components/src/screen/ST7735R/st7735r.ads
@@ -55,20 +55,21 @@ package ST7735R is
 
    type Any_ST7735R_Device is access all ST7735R_Screen'Class;
 
-   procedure Initialize (LCD : in out ST7735R_Screen);
+   procedure Initialize (This : in out ST7735R_Screen);
 
    overriding
-   function Initialized (LCD : ST7735R_Screen) return Boolean;
+   function Initialized (This : ST7735R_Screen) return Boolean;
 
-   procedure Turn_On (LCD : ST7735R_Screen);
-   procedure Turn_Off (LCD : ST7735R_Screen);
-   procedure Display_Inversion_On (LCD : ST7735R_Screen);
-   procedure Display_Inversion_Off (LCD : ST7735R_Screen);
-   procedure Gamma_Set (LCD : ST7735R_Screen; Gamma_Curve : UInt4);
+   procedure Turn_On (This : ST7735R_Screen);
+   procedure Turn_Off (This : ST7735R_Screen);
+   procedure Display_Inversion_On (This : ST7735R_Screen);
+   procedure Display_Inversion_Off (This : ST7735R_Screen);
+   procedure Gamma_Set (This : ST7735R_Screen; Gamma_Curve : UInt4);
 
    type Pixel_Format is (Pixel_12bits, Pixel_16bits, Pixel_18bits);
 
-   procedure Set_Pixel_Format (LCD : ST7735R_Screen; Pix_Fmt : Pixel_Format);
+   procedure Set_Pixel_Format (This     : ST7735R_Screen;
+                               Pix_Fmt  : Pixel_Format);
 
    type RGB_BGR_Order is (RGB_Order, BGR_Order)
      with Size => 1;
@@ -86,7 +87,7 @@ package ST7735R is
      with Size => 1;
 
    procedure Set_Memory_Data_Access
-     (LCD                 : ST7735R_Screen;
+     (This                : ST7735R_Screen;
       Color_Order         : RGB_BGR_Order;
       Vertical            : Vertical_Refresh_Order;
       Horizontal          : Horizontal_Refresh_Order;
@@ -95,19 +96,19 @@ package ST7735R is
       Row_Column_Exchange : Boolean);
 
    procedure Set_Frame_Rate_Normal
-     (LCD         : ST7735R_Screen;
+     (This        : ST7735R_Screen;
       RTN         : UInt4;
       Front_Porch : UInt6;
       Back_Porch  : UInt6);
 
    procedure Set_Frame_Rate_Idle
-     (LCD         : ST7735R_Screen;
+     (This        : ST7735R_Screen;
       RTN         : UInt4;
       Front_Porch : UInt6;
       Back_Porch  : UInt6);
 
    procedure Set_Frame_Rate_Partial_Full
-     (LCD              : ST7735R_Screen;
+     (This             : ST7735R_Screen;
       RTN_Part         : UInt4;
       Front_Porch_Part : UInt6;
       Back_Porch_Part  : UInt6;
@@ -118,52 +119,52 @@ package ST7735R is
    type Inversion_Control is (Dot_Inversion, Line_Inversion);
 
    procedure Set_Inversion_Control
-     (LCD : ST7735R_Screen;
+     (This : ST7735R_Screen;
       Normal, Idle, Full_Partial : Inversion_Control);
 
    procedure Set_Power_Control_1
-     (LCD  : ST7735R_Screen;
+     (This : ST7735R_Screen;
       AVDD : UInt3;
       VRHP : UInt5;
       VRHN : UInt5;
       MODE : UInt2);
 
    procedure Set_Power_Control_2
-     (LCD   : ST7735R_Screen;
+     (This  : ST7735R_Screen;
       VGH25 : UInt2;
       VGSEL : UInt2;
       VGHBT : UInt2);
 
    procedure Set_Power_Control_3
-     (LCD : ST7735R_Screen;
+     (This   : ST7735R_Screen;
       P1, P2 : UInt8);
 
    procedure Set_Power_Control_4
-     (LCD : ST7735R_Screen;
+     (This   : ST7735R_Screen;
       P1, P2 : UInt8);
 
    procedure Set_Power_Control_5
-     (LCD : ST7735R_Screen;
+     (This   : ST7735R_Screen;
       P1, P2 : UInt8);
 
-   procedure Set_Vcom (LCD : ST7735R_Screen; VCOMS : UInt6);
+   procedure Set_Vcom (This : ST7735R_Screen; VCOMS : UInt6);
 
-   procedure Set_Column_Address (LCD : ST7735R_Screen; X_Start, X_End : UInt16);
-   procedure Set_Row_Address (LCD : ST7735R_Screen; Y_Start, Y_End : UInt16);
-   procedure Set_Address (LCD : ST7735R_Screen;
+   procedure Set_Column_Address (This : ST7735R_Screen; X_Start, X_End : UInt16);
+   procedure Set_Row_Address (This : ST7735R_Screen; Y_Start, Y_End : UInt16);
+   procedure Set_Address (This : ST7735R_Screen;
                           X_Start, X_End, Y_Start, Y_End : UInt16);
 
-   procedure Set_Pixel (LCD   : ST7735R_Screen;
+   procedure Set_Pixel (This  : ST7735R_Screen;
                         X, Y  : UInt16;
                         Color : UInt16);
 
-   function Pixel (LCD   : ST7735R_Screen;
-                   X, Y  : UInt16)
+   function Pixel (This : ST7735R_Screen;
+                   X, Y : UInt16)
                    return UInt16;
 
-   procedure Write_Raw_Pixels (LCD  : ST7735R_Screen;
+   procedure Write_Raw_Pixels (This : ST7735R_Screen;
                                Data : HAL.UInt8_Array);
-   procedure Write_Raw_Pixels (LCD  : ST7735R_Screen;
+   procedure Write_Raw_Pixels (This : ST7735R_Screen;
                                Data : HAL.UInt16_Array);
 
    overriding


### PR DESCRIPTION
In this PR, I try provide a common scheme for DMA support in the STM32 communication drivers. 

First, STM32.DMA.Interrupts factorizes the handling of interrupts for DMA transfer. It's a simple protected object, the configuration of DMA streams is the same.

I then use this in the STM32.SPI.DMA driver in a proof of concept that can be applied to I2C, UART, I2S, etc. The idea is that the configuration code is shared, only the transfers primitives differ which makes for a simple and clear implementation.

These new packages are used in OpenMV.Sensor for the DCMI transfer and OpenMV.LCD with SPI port. 

Comments are welcome :)