### PR TITLE
Various fixes

### DIFF
--- a/arch/ARM/STM32/drivers/stm32-setup.adb
+++ b/arch/ARM/STM32/drivers/stm32-setup.adb
@@ -45,6 +45,10 @@ package body STM32.Setup is
    is
       I2C_Conf : I2C_Configuration;
    begin
+      if STM32.I2C.Port_Enabled (Port) then
+         return;
+      end if;
+
       --  GPIO --
       Enable_Clock (SDA & SCL);
 

--- a/hal/src/hal-audio.ads
+++ b/hal/src/hal-audio.ads
@@ -34,7 +34,7 @@ with Interfaces; use Interfaces;
 package HAL.Audio is
 
    type Audio_Buffer is array (Natural range <>) of Integer_16
-     with Component_Size => 16, Alignment => 16;
+     with Component_Size => 16, Alignment => 2;
 
    type Audio_Volume is new Natural range 0 .. 100;
 


### PR DESCRIPTION
This fixes various issues I discovered while moving the demos to master.

* STM32.Setup: automatically calling this function fails if two I2C peripherals are used. This is the case for example when using the Touch Panel and the Audio drivers. This pull request checks that the port is uninitialised before trying to re-initialising it.
* HAL.Audio: fix the alignment of the Audio buffer. By default, it should be at least 16-bit aligned (for compatibility with DMA transfers).