### PR TITLE
2 bitmap improvements

### DIFF
--- a/boards/stm32_common/dma2d/stm32-dma2d_bitmap.adb
+++ b/boards/stm32_common/dma2d/stm32-dma2d_bitmap.adb
@@ -65,12 +65,11 @@ package body STM32.DMA2D_Bitmap is
 
    overriding procedure Set_Pixel
      (Buffer : in out DMA2D_Bitmap_Buffer;
-      Pt     : Point;
-      Value  : UInt32)
+      Pt     : Point)
    is
    begin
       DMA2D_Wait_Transfer;
-      Parent (Buffer).Set_Pixel (Pt, Value);
+      Parent (Buffer).Set_Pixel (Pt);
    end Set_Pixel;
 
    ---------------------
@@ -79,10 +78,10 @@ package body STM32.DMA2D_Bitmap is
 
    overriding procedure Set_Pixel_Blend
      (Buffer : in out DMA2D_Bitmap_Buffer;
-      Pt     : Point;
-      Value  : HAL.Bitmap.Bitmap_Color)
+      Pt     : Point)
    is
       DMA_Buf : constant DMA2D_Buffer := To_DMA2D_Buffer (Buffer);
+      Value   : constant HAL.Bitmap.Bitmap_Color := Buffer.Source;
    begin
       if To_DMA2D_CM (Buffer.Color_Mode) in DMA2D_Dst_Color_Mode then
          if not Buffer.Swapped then
@@ -99,7 +98,7 @@ package body STM32.DMA2D_Bitmap is
                Color  => To_DMA2D_Color (Value));
          end if;
       else
-         Parent (Buffer).Set_Pixel_Blend (Pt, Value);
+         Parent (Buffer).Set_Pixel_Blend (Pt);
       end if;
    end Set_Pixel_Blend;
 
@@ -109,7 +108,7 @@ package body STM32.DMA2D_Bitmap is
 
    overriding function Pixel
      (Buffer : DMA2D_Bitmap_Buffer;
-      Pt     : Point) return UInt32
+      Pt     : Point) return Bitmap_Color
    is
    begin
       DMA2D_Wait_Transfer;
@@ -121,14 +120,13 @@ package body STM32.DMA2D_Bitmap is
    ----------
 
    overriding procedure Fill
-     (Buffer : in out DMA2D_Bitmap_Buffer;
-      Color  : UInt32)
+     (Buffer : in out DMA2D_Bitmap_Buffer)
    is
    begin
       if To_DMA2D_CM (Buffer.Color_Mode) in DMA2D_Dst_Color_Mode then
-         DMA2D_Fill (To_DMA2D_Buffer (Buffer), Color, True);
+         DMA2D_Fill (To_DMA2D_Buffer (Buffer), Buffer.Native_Source, True);
       else
-         Parent (Buffer).Fill (Color);
+         Parent (Buffer).Fill;
       end if;
    end Fill;
 
@@ -138,7 +136,6 @@ package body STM32.DMA2D_Bitmap is
 
    overriding procedure Fill_Rect
      (Buffer : in out DMA2D_Bitmap_Buffer;
-      Color  : UInt32;
       Area   : Rect)
    is
       DMA_Buf : constant DMA2D_Buffer := To_DMA2D_Buffer (Buffer);
@@ -147,7 +144,7 @@ package body STM32.DMA2D_Bitmap is
          if not Buffer.Swapped then
             DMA2D_Fill_Rect
               (DMA_Buf,
-               Color  => Color,
+               Color  => Buffer.Native_Source,
                X      => Area.Position.X,
                Y      => Area.Position.Y,
                Width  => Area.Width,
@@ -155,14 +152,14 @@ package body STM32.DMA2D_Bitmap is
          else
             DMA2D_Fill_Rect
               (DMA_Buf,
-               Color  => Color,
+               Color  => Buffer.Native_Source,
                X      => Area.Position.Y,
                Y      => Buffer.Width - Area.Position.X - Area.Width,
                Width  => Area.Height,
                Height => Area.Width);
          end if;
       else
-         Parent (Buffer).Fill_Rect (Color, Area);
+         Parent (Buffer).Fill_Rect (Area);
       end if;
    end Fill_Rect;
 

--- a/boards/stm32_common/dma2d/stm32-dma2d_bitmap.ads
+++ b/boards/stm32_common/dma2d/stm32-dma2d_bitmap.ads
@@ -46,25 +46,21 @@ package STM32.DMA2D_Bitmap is
 
    overriding procedure Set_Pixel
      (Buffer : in out DMA2D_Bitmap_Buffer;
-      Pt     : Point;
-      Value  : UInt32);
+      Pt     : Point);
 
    overriding procedure Set_Pixel_Blend
      (Buffer : in out DMA2D_Bitmap_Buffer;
-      Pt     : Point;
-      Value  : HAL.Bitmap.Bitmap_Color);
+      Pt     : Point);
 
    overriding function Pixel
      (Buffer : DMA2D_Bitmap_Buffer;
-      Pt     : Point) return UInt32;
+      Pt     : Point) return Bitmap_Color;
 
    overriding procedure Fill
-     (Buffer : in out DMA2D_Bitmap_Buffer;
-      Color  : UInt32);
+     (Buffer : in out DMA2D_Bitmap_Buffer);
 
    overriding procedure Fill_Rect
      (Buffer : in out DMA2D_Bitmap_Buffer;
-      Color  : UInt32;
       Area   : Rect);
 
    overriding procedure Copy_Rect
@@ -99,7 +95,8 @@ package STM32.DMA2D_Bitmap is
                     Actual_Width      => 0,
                     Actual_Height     => 0,
                     Actual_Color_Mode => HAL.Bitmap.L_8,
-                    Currently_Swapped => False);
+                    Currently_Swapped => False,
+                    Native_Source     => 0);
 
    function To_DMA2D_Buffer
      (Buffer : HAL.Bitmap.Bitmap_Buffer'Class) return STM32.DMA2D.DMA2D_Buffer

--- a/boards/stm32_common/ltdc/framebuffer_ltdc.adb
+++ b/boards/stm32_common/ltdc/framebuffer_ltdc.adb
@@ -129,7 +129,8 @@ package body Framebuffer_LTDC is
                Display.Buffers (Layer, Buf).Actual_Width :=
                  Display.Buffers (Layer, Buf).Height;
                Display.Buffers (Layer, Buf).Actual_Height := Tmp;
-               Display.Buffers (Layer, Buf).Fill (0);
+               Display.Buffers (Layer, Buf).Set_Source (HAL.Bitmap.Black);
+               Display.Buffers (Layer, Buf).Fill;
             end if;
          end loop;
       end loop;
@@ -309,8 +310,10 @@ package body Framebuffer_LTDC is
                Actual_Width      => W,
                Actual_Height     => H,
                Actual_Color_Mode => Mode,
-               Currently_Swapped => False);
-            Display.Buffers (LCD_Layer, Buf).Fill (0);
+               Currently_Swapped => False,
+               Native_Source     => 0);
+            Display.Buffers (LCD_Layer, Buf).Set_Source (HAL.Bitmap.Black);
+            Display.Buffers (LCD_Layer, Buf).Fill;
          end loop;
       else
          for Buf in 1 .. 2 loop
@@ -320,8 +323,10 @@ package body Framebuffer_LTDC is
                Actual_Width      => H,
                Actual_Height     => W,
                Actual_Color_Mode => Mode,
-               Currently_Swapped => True);
-            Display.Buffers (LCD_Layer, Buf).Fill (0);
+               Currently_Swapped => True,
+               Native_Source     => 0);
+            Display.Buffers (LCD_Layer, Buf).Set_Source (HAL.Bitmap.Black);
+            Display.Buffers (LCD_Layer, Buf).Fill;
          end loop;
       end if;
 

--- a/boards/stm32f469_discovery/src/framebuffer_otm8009a.adb
+++ b/boards/stm32f469_discovery/src/framebuffer_otm8009a.adb
@@ -463,8 +463,9 @@ package body Framebuffer_OTM8009A is
          Actual_Width      => W,
          Actual_Height     => H,
          Actual_Color_Mode => Mode,
-         Currently_Swapped => False);
-      Display.Buffers (LCD_Layer).Fill (0);
+         Currently_Swapped => False,
+         Native_Source     => 0);
+      Display.Buffers (LCD_Layer).Fill;
 
       DSIHOST.DSI_Wrapper_Disable;
 

--- a/boards/stm32f769_discovery/src/framebuffer_otm8009a.adb
+++ b/boards/stm32f769_discovery/src/framebuffer_otm8009a.adb
@@ -465,8 +465,9 @@ package body Framebuffer_OTM8009A is
          Actual_Width      => W,
          Actual_Height     => H,
          Actual_Color_Mode => Mode,
-         Currently_Swapped => False);
-      Display.Buffers (LCD_Layer).Fill (0);
+         Currently_Swapped => False,
+         Native_Source     => 0);
+      Display.Buffers (LCD_Layer).Fill;
 
       DSIHOST.DSI_Wrapper_Disable;
 

--- a/components/src/screen/ST7735R/st7735r.adb
+++ b/components/src/screen/ST7735R/st7735r.adb
@@ -30,7 +30,6 @@
 ------------------------------------------------------------------------------
 
 with Ada.Unchecked_Conversion;
-with Bitmap_Color_Conversion;  use Bitmap_Color_Conversion;
 
 package body ST7735R is
 
@@ -787,15 +786,41 @@ package body ST7735R is
       return Display.Layer'Unchecked_Access;
    end Hidden_Buffer;
 
-   --------------------
-   -- Get_Pixel_Size --
-   --------------------
+   ----------------
+   -- Pixel_Size --
+   ----------------
 
    overriding
    function Pixel_Size
      (Display : ST7735R_Screen;
       Layer   : Positive) return Positive is (16);
 
+   ----------------
+   -- Set_Source --
+   ----------------
+
+   overriding
+   procedure Set_Source (Buffer : in out ST7735R_Bitmap_Buffer;
+                         Native : UInt32)
+   is
+   begin
+      Buffer.Native_Source := Native;
+   end Set_Source;
+
+   ------------
+   -- Source --
+   ------------
+
+   overriding
+   function Source
+     (Buffer : ST7735R_Bitmap_Buffer)
+      return UInt32
+   is
+   begin
+      return Buffer.Native_Source;
+   end Source;
+
+
    ---------------
    -- Set_Pixel --
    ---------------
@@ -803,25 +828,11 @@ package body ST7735R is
    overriding
    procedure Set_Pixel
      (Buffer  : in out ST7735R_Bitmap_Buffer;
-      Pt      : Point;
-      Value   : Bitmap_Color)
+      Pt      : Point)
    is
    begin
-      Buffer.Set_Pixel (Pt, Bitmap_Color_To_Word (RGB_565, Value));
-   end Set_Pixel;
-
-   ---------------
-   -- Set_Pixel --
-   ---------------
-
-   overriding
-   procedure Set_Pixel
-     (Buffer  : in out ST7735R_Bitmap_Buffer;
-      Pt      : Point;
-      Value   : UInt32)
-   is
-   begin
-      Buffer.LCD.Set_Pixel (UInt16 (Pt.X), UInt16 (Pt.Y), UInt16 (Value));
+      Buffer.LCD.Set_Pixel (UInt16 (Pt.X), UInt16 (Pt.Y),
+                            UInt16 (Buffer.Native_Source));
    end Set_Pixel;
 
    ---------------------
@@ -831,8 +842,7 @@ package body ST7735R is
    overriding
    procedure Set_Pixel_Blend
      (Buffer : in out ST7735R_Bitmap_Buffer;
-      Pt     : Point;
-      Value  : Bitmap_Color) renames Set_Pixel;
+      Pt     : Point) renames Set_Pixel;
 
    -----------
    -- Pixel --
@@ -842,20 +852,7 @@ package body ST7735R is
    function Pixel
      (Buffer : ST7735R_Bitmap_Buffer;
       Pt     : Point)
-      return Bitmap_Color
-   is
-   begin
-      return Word_To_Bitmap_Color (RGB_565, Buffer.Pixel (Pt));
-   end Pixel;
-
-   overriding
-   function Pixel
-     (Buffer : ST7735R_Bitmap_Buffer;
-      Pt     : Point)
       return UInt32
-   is
-   begin
-      return UInt32 (Buffer.LCD.Pixel (UInt16 (Pt.X), UInt16 (Pt.Y)));
-   end Pixel;
+   is (UInt32 (Buffer.LCD.Pixel (UInt16 (Pt.X), UInt16 (Pt.Y))));
 
 end ST7735R;

--- a/components/src/screen/ST7735R/st7735r.ads
+++ b/components/src/screen/ST7735R/st7735r.ads
@@ -280,7 +280,8 @@ private
       Column_Address_Right_Left => 1);
 
    type ST7735R_Bitmap_Buffer is new Soft_Drawing_Bitmap_Buffer with record
-      LCD : Any_ST7735R_Device := null;
+      LCD           : Any_ST7735R_Device := null;
+      Native_Source : UInt32;
    end record;
 
    overriding
@@ -308,35 +309,25 @@ private
      (System.Null_Address);
 
    overriding
-   procedure Set_Pixel
-     (Buffer  : in out ST7735R_Bitmap_Buffer;
-      Pt      : Point;
-      Value   : Bitmap_Color)
-     with Pre => Buffer.LCD /= null;
+   procedure Set_Source (Buffer : in out ST7735R_Bitmap_Buffer;
+                         Native : UInt32);
+
+   overriding
+   function Source
+     (Buffer : ST7735R_Bitmap_Buffer)
+      return UInt32;
 
    overriding
    procedure Set_Pixel
      (Buffer  : in out ST7735R_Bitmap_Buffer;
-      Pt      : Point;
-      Value   : UInt32)
+      Pt      : Point)
      with Pre => Buffer.LCD /= null;
-
 
    overriding
    procedure Set_Pixel_Blend
      (Buffer : in out ST7735R_Bitmap_Buffer;
-      Pt     : Point;
-      Value  : Bitmap_Color)
-     with Pre => Buffer.LCD /= null;
-
-
-   overriding
-   function Pixel
-     (Buffer : ST7735R_Bitmap_Buffer;
       Pt     : Point)
-      return Bitmap_Color
      with Pre => Buffer.LCD /= null;
-
 
    overriding
    function Pixel
@@ -344,7 +335,6 @@ private
       Pt     : Point)
       return UInt32
      with Pre => Buffer.LCD /= null;
-
 
    overriding
    function Buffer_Size (Buffer : ST7735R_Bitmap_Buffer) return Natural is
@@ -358,7 +348,7 @@ private
       Time : not null HAL.Time.Any_Delays)
    is limited new HAL.Framebuffer.Frame_Buffer_Display with record
       Initialized : Boolean := True;
-      Layer : aliased ST7735R_Bitmap_Buffer;
+      Layer       : aliased ST7735R_Bitmap_Buffer;
    end record;
 
 end ST7735R;

--- a/components/src/screen/ssd1306/ssd1306.adb
+++ b/components/src/screen/ssd1306/ssd1306.adb
@@ -397,14 +397,13 @@ package body SSD1306 is
    overriding
    procedure Set_Pixel
      (Buffer  : in out SSD1306_Bitmap_Buffer;
-      Pt      : Point;
-      Value   : UInt32)
+      Pt      : Point)
    is
       Index : constant Natural := Pt.X + (Pt.Y / 8) * Buffer.Actual_Width;
       Byte  : UInt8 renames Buffer.Data (Buffer.Data'First + Index);
    begin
 
-      if Value = 0 then
+      if Buffer.Native_Source = 0 then
          Byte := Byte and not (Shift_Left (1, Pt.Y mod 8));
       else
          Byte := Byte or Shift_Left (1, Pt.Y mod 8);
@@ -419,12 +418,12 @@ package body SSD1306 is
    function Pixel
      (Buffer : SSD1306_Bitmap_Buffer;
       Pt     : Point)
-      return UInt32
+      return Bitmap_Color
    is
       Index : constant Natural := Pt.X + (Pt.Y / 8) * Buffer.Actual_Width;
       Byte  : UInt8 renames Buffer.Data (Buffer.Data'First + Index);
    begin
-      return UInt32 (Byte);
+      return (if Byte = 0 then Black else White);
    end Pixel;
 
 end SSD1306;

--- a/components/src/screen/ssd1306/ssd1306.ads
+++ b/components/src/screen/ssd1306/ssd1306.ads
@@ -173,20 +173,19 @@ private
    --  Set_Pixel () and Pixel () correctly.
    type SSD1306_Bitmap_Buffer (Buffer_Size_In_Byte : Positive) is
      new Memory_Mapped_Bitmap_Buffer with record
-       Data : UInt8_Array (1 .. Buffer_Size_In_Byte);
+      Data : UInt8_Array (1 .. Buffer_Size_In_Byte);
      end record;
 
    overriding
    procedure Set_Pixel
      (Buffer  : in out SSD1306_Bitmap_Buffer;
-      Pt      : Point;
-      Value   : UInt32);
+      Pt      : Point);
 
    overriding
    function Pixel
      (Buffer : SSD1306_Bitmap_Buffer;
       Pt     : Point)
-      return UInt32;
+      return Bitmap_Color;
 
    SSD1306_I2C_Addr : constant := 16#78#;
 

--- a/examples/common/gui/bitmapped_drawing.adb
+++ b/examples/common/gui/bitmapped_drawing.adb
@@ -49,11 +49,11 @@ package body Bitmapped_Drawing is
       for H in 0 .. Char_Height (Font) - 1 loop
          for W in 0 .. Char_Width (Font) - 1 loop
             if (Data (Font, Char, H) and Mask (Font, W)) /= 0 then
-               Buffer.Set_Pixel
-                 ((Start.X + W, Start.Y + H), Foreground);
+               Buffer.Set_Source (Word_To_Bitmap_Color (Buffer.Color_Mode, Foreground));
+               Buffer.Set_Pixel ((Start.X + W, Start.Y + H));
             else
-               Buffer.Set_Pixel
-                 ((Start.X + W, Start.Y + H), Background);
+               Buffer.Set_Source (Word_To_Bitmap_Color (Buffer.Color_Mode, Background));
+               Buffer.Set_Pixel ((Start.X + W, Start.Y + H));
             end if;
          end loop;
       end loop;
@@ -104,9 +104,6 @@ package body Bitmapped_Drawing is
       Foreground : Bitmap_Color;
       Fast       : Boolean := True)
    is
-      FG    : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
-                                                     Foreground);
-
       procedure Internal_Draw_Line
         (X0, Y0, X1, Y1 : Natural;
          Width          : Positive);
@@ -116,8 +113,8 @@ package body Bitmapped_Drawing is
          Width          : Positive)
       is
       begin
+
          Draw_Line (Buffer,
-                    FG,
                     (X0, Y0),
                     (X1, Y1),
                     Width,
@@ -130,6 +127,7 @@ package body Bitmapped_Drawing is
       Current : Point := Start;
 
    begin
+      Buffer.Set_Source (Foreground);
       for C of Msg loop
          exit when Current.X > Buffer.Width;
          Draw_Glyph
@@ -162,9 +160,9 @@ package body Bitmapped_Drawing is
       Current : Point := (0, 0);
       Prev    : UInt32;
       FG      : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
-                                                       Foreground);
+                                                         Foreground);
       Blk     : constant UInt32 := Bitmap_Color_To_Word (Buffer.Color_Mode,
-                                                       Black);
+                                                         Black);
 
       procedure Internal_Draw_Line
         (X0, Y0, X1, Y1 : Natural;
@@ -176,7 +174,6 @@ package body Bitmapped_Drawing is
       is
       begin
          Draw_Line (Buffer,
-                    Foreground,
                     (Area.Position.X + Natural (Float (X0) * Ratio),
                      Area.Position.Y + Y0),
                     (Area.Position.X + Natural (Float (X1) * Ratio),
@@ -195,6 +192,8 @@ package body Bitmapped_Drawing is
          Ratio := 1.0;
          Current.X := (Area.Width - Length) / 2;
       end if;
+
+      Buffer.Set_Source (Foreground);
 
       for C of Msg loop
          Draw_Glyph

--- a/examples/common/gui/lcd_std_out.adb
+++ b/examples/common/gui/lcd_std_out.adb
@@ -143,7 +143,8 @@ package body LCD_Std_Out is
    procedure Clear_Screen is
    begin
       Check_Initialized;
-      Display.Hidden_Buffer (1).Fill (Current_Background_Color);
+      Display.Hidden_Buffer (1).Set_Source (Current_Background_Color);
+      Display.Hidden_Buffer (1).Fill;
       Current_Y := 0;
       Char_Count := 0;
       Display.Update_Layer (1, True);

--- a/examples/draw/src/draw.adb
+++ b/examples/draw/src/draw.adb
@@ -56,7 +56,8 @@ is
 
    procedure Clear is
    begin
-      Display.Hidden_Buffer (1).Fill (BG);
+      Display.Hidden_Buffer (1).Set_Source (BG);
+      Display.Hidden_Buffer (1).Fill;
 
       LCD_Std_Out.Clear_Screen;
       LCD_Std_Out.Put_Line ("Touch the screen to draw or");
@@ -106,6 +107,8 @@ begin
 
       if Current_Mode = Drawing_Mode then
 
+         Display.Hidden_Buffer (1).Set_Source (HAL.Bitmap.Green);
+
          declare
             State : constant TP_State := Touch_Panel.Get_All_Touch_Points;
          begin
@@ -120,7 +123,6 @@ begin
                if Last_X > 0 then
                   Draw_Line
                     (Display.Hidden_Buffer (1).all,
-                     Color     => HAL.Bitmap.Green,
                      Start     => (Last_X, Last_Y),
                      Stop      => (State (State'First).X, State (State'First).Y),
                      Thickness => State (State'First).Weight / 2,
@@ -138,7 +140,6 @@ begin
             for Id in State'Range loop
                Fill_Circle
                  (Display.Hidden_Buffer (1).all,
-                  Color => HAL.Bitmap.Green,
                   Center => (State (Id).X, State (Id).Y),
                   Radius => State (Id).Weight / 4);
             end loop;
@@ -151,21 +152,25 @@ begin
 
          --  Show some of the supported drawing primitives
 
-         Display.Hidden_Buffer (1).Fill (Black);
+         Display.Hidden_Buffer (1).Set_Source (Black);
+         Display.Hidden_Buffer (1).Fill;
 
+         Display.Hidden_Buffer (1).Set_Source (Green);
          Display.Hidden_Buffer (1).Fill_Rounded_Rect
-           (HAL.Bitmap.Green, ((10, 10), 100, 100), 20);
+           (((10, 10), 100, 100), 20);
 
+         Display.Hidden_Buffer (1).Set_Source (HAL.Bitmap.Red);
          Display.Hidden_Buffer (1).Draw_Rounded_Rect
-           (HAL.Bitmap.Red, ((10, 10), 100, 100), 20, Thickness => 4);
+           (((10, 10), 100, 100), 20, Thickness => 4);
 
-         Display.Hidden_Buffer (1).Fill_Circle (HAL.Bitmap.Yellow,
-                                                (60, 60), 20);
-         Display.Hidden_Buffer (1).Draw_Circle (HAL.Bitmap.Blue,
-                                                (60, 60), 20);
+         Display.Hidden_Buffer (1).Set_Source (HAL.Bitmap.Yellow);
+         Display.Hidden_Buffer (1).Fill_Circle ((60, 60), 20);
 
-         Display.Hidden_Buffer (1).Cubic_Bezier (Color     => HAL.Bitmap.Violet,
-                                                 P1        => (10, 10),
+         Display.Hidden_Buffer (1).Set_Source (HAL.Bitmap.Blue);
+         Display.Hidden_Buffer (1).Draw_Circle ((60, 60), 20);
+
+         Display.Hidden_Buffer (1).Set_Source (HAL.Bitmap.Violet);
+         Display.Hidden_Buffer (1).Cubic_Bezier (P1        => (10, 10),
                                                  P2        => (60, 10),
                                                  P3        => (60, 60),
                                                  P4        => (100, 100),

--- a/examples/stm32_dma2d/src/dma2d.adb
+++ b/examples/stm32_dma2d/src/dma2d.adb
@@ -104,17 +104,18 @@ begin
    Height := Display.Hidden_Buffer (1).Height;
 
    loop
-      Bitmap_Buffer.Fill (HAL.Bitmap.Dark_Green);
+      Bitmap_Buffer.Set_Source (HAL.Bitmap.Dark_Green);
+      Bitmap_Buffer.Fill;
 
       --  Draw blue filled rectangle in the upper left corner
-      Bitmap_Buffer.Fill_Rect (HAL.Bitmap.Blue,
-                               (Position => (0, 0),
+      Bitmap_Buffer.Set_Source (HAL.Bitmap.Blue);
+      Bitmap_Buffer.Fill_Rect ((Position => (0, 0),
                                 Width    => Width / 2,
                                 Height   => Height / 2));
 
       --  Drawn yellow rectangle outline in the lower left corner
-      Bitmap_Buffer.Draw_Rect (HAL.Bitmap.Yellow,
-                               (Position => (0, Height / 2),
+      Bitmap_Buffer.Set_Source (HAL.Bitmap.Yellow);
+      Bitmap_Buffer.Draw_Rect ((Position => (0, Height / 2),
                                 Width  => Width / 2,
                                 Height => Height / 2));
 
@@ -134,7 +135,8 @@ begin
       Y := Height / 2;
       while X < Width / 2 and then Y < Height - 10 loop
          for Cnt in 0 .. 10 loop
-            Bitmap_Buffer.Set_Pixel_Blend ((X, Y + Cnt), (100, 255, 0, 0));
+            Bitmap_Buffer.Set_Source ((100, 255, 0, 0));
+            Bitmap_Buffer.Set_Pixel_Blend ((X, Y + Cnt));
          end loop;
          X := X + 1;
          Y := Y + 1;

--- a/hal/src/hal-bitmap.ads
+++ b/hal/src/hal-bitmap.ads
@@ -137,41 +137,59 @@ package HAL.Bitmap is
    --  Return the address of the bitmap in the CPU address space. If the bitmap
    --  is not in the CPU address space, the result is undefined.
 
+   procedure Set_Source (Buffer : in out Bitmap_Buffer;
+                         ARGB   : Bitmap_Color) is abstract;
+   --  Set the source color for the following drawing operations
+
+   procedure Set_Source (Buffer : in out Bitmap_Buffer;
+                         Native : UInt32) is abstract;
+   --  Set the source color for the following drawing operations
+
+   function Source
+     (Buffer : Bitmap_Buffer)
+      return Bitmap_Color is abstract;
+   --  Current source color in ARGB format
+
+   function Source
+     (Buffer : Bitmap_Buffer)
+      return UInt32 is abstract;
+   --  Current source color in native format
+
    procedure Set_Pixel
      (Buffer  : in out Bitmap_Buffer;
-      Pt      : Point;
-      Value   : Bitmap_Color) is abstract;
+      Pt      : Point) is abstract;
+   --  Set pixel with current source color
 
    procedure Set_Pixel
      (Buffer  : in out Bitmap_Buffer;
       Pt      : Point;
-      Value   : UInt32) is abstract;
+      Color   : Bitmap_Color) is abstract;
+   --  Set pixel with Color and update source color
+
+   procedure Set_Pixel
+     (Buffer  : in out Bitmap_Buffer;
+      Pt      : Point;
+      Native  : UInt32) is abstract;
+   --  Set pixel with low level native pixel value Color and update source color
 
    procedure Set_Pixel_Blend
      (Buffer : in out Bitmap_Buffer;
-      Pt      : Point;
-      Value  : Bitmap_Color) is abstract;
+      Pt     : Point) is abstract;
 
    function Pixel
      (Buffer : Bitmap_Buffer;
       Pt     : Point)
       return Bitmap_Color is abstract;
+   --  Return ARGB pixel value
 
    function Pixel
      (Buffer : Bitmap_Buffer;
       Pt     : Point)
       return UInt32 is abstract;
+   --  Return raw pixel value
 
    procedure Draw_Line
      (Buffer      : in out Bitmap_Buffer;
-      Color       : UInt32;
-      Start, Stop : Point;
-      Thickness   : Natural := 1;
-      Fast        : Boolean := True) is abstract;
-
-   procedure Draw_Line
-     (Buffer      : in out Bitmap_Buffer;
-      Color       : Bitmap_Color;
       Start, Stop : Point;
       Thickness   : Natural := 1;
       Fast        : Boolean := True) is abstract;
@@ -180,26 +198,13 @@ package HAL.Bitmap is
    --  draw but providing nicer line cap.
 
    procedure Fill
-     (Buffer : in out Bitmap_Buffer;
-      Color  : Bitmap_Color) is abstract;
-   --  Fill the specified buffer with 'Color'
-
-   procedure Fill
-     (Buffer : in out Bitmap_Buffer;
-      Color  : UInt32) is abstract;
-   --  Same as above, using the destination buffer native color representation
+     (Buffer : in out Bitmap_Buffer) is abstract;
+   --  Fill the entire buffer with the source color
 
    procedure Fill_Rect
      (Buffer : in out Bitmap_Buffer;
-      Color  : Bitmap_Color;
       Area   : Rect) is abstract;
-   --  Fill the specified area of the buffer with 'Color'
-
-   procedure Fill_Rect
-     (Buffer : in out Bitmap_Buffer;
-      Color  : UInt32;
-      Area   : Rect) is abstract;
-   --  Same as above, using the destination buffer native color representation
+   --  Fill the specified area of the buffer with the source color
 
    procedure Copy_Rect
      (Src_Buffer  : Bitmap_Buffer'Class;
@@ -232,75 +237,43 @@ package HAL.Bitmap is
 
    procedure Draw_Vertical_Line
      (Buffer : in out Bitmap_Buffer;
-      Color  : UInt32;
-      Pt     : Point;
-      Height : Integer) is abstract;
-
-   procedure Draw_Vertical_Line
-     (Buffer : in out Bitmap_Buffer;
-      Color  : Bitmap_Color;
       Pt     : Point;
       Height : Integer) is abstract;
 
    procedure Draw_Horizontal_Line
      (Buffer : in out Bitmap_Buffer;
-      Color  : UInt32;
-      Pt     : Point;
-      Width  : Integer) is abstract;
-
-   procedure Draw_Horizontal_Line
-     (Buffer : in out Bitmap_Buffer;
-      Color  : Bitmap_Color;
       Pt     : Point;
       Width  : Integer) is abstract;
 
    procedure Draw_Rect
      (Buffer    : in out Bitmap_Buffer;
-      Color     : Bitmap_Color;
       Area      : Rect;
       Thickness : Natural := 1) is abstract;
    --  Draws a rectangle
 
    procedure Draw_Rounded_Rect
      (Buffer    : in out Bitmap_Buffer;
-      Color     : Bitmap_Color;
       Area      : Rect;
       Radius    : Natural;
       Thickness : Natural := 1) is abstract;
 
    procedure Fill_Rounded_Rect
      (Buffer : in out Bitmap_Buffer;
-      Color  : Bitmap_Color;
       Area   : Rect;
       Radius : Natural) is abstract;
 
    procedure Draw_Circle
      (Buffer : in out Bitmap_Buffer;
-      Color  : UInt32;
-      Center : Point;
-      Radius : Natural) is abstract;
-
-   procedure Draw_Circle
-     (Buffer : in out Bitmap_Buffer;
-      Color  : Bitmap_Color;
       Center : Point;
       Radius : Natural) is abstract;
 
    procedure Fill_Circle
      (Buffer : in out Bitmap_Buffer;
-      Color  : UInt32;
-      Center : Point;
-      Radius : Natural) is abstract;
-
-   procedure Fill_Circle
-     (Buffer : in out Bitmap_Buffer;
-      Color  : Bitmap_Color;
       Center : Point;
       Radius : Natural) is abstract;
 
    procedure Cubic_Bezier
      (Buffer         : in out Bitmap_Buffer;
-      Color          : Bitmap_Color;
       P1, P2, P3, P4 : Point;
       N              : Positive := 20;
       Thickness      : Natural := 1) is abstract;

--- a/middleware/src/bitmap/memory_mapped_bitmap.ads
+++ b/middleware/src/bitmap/memory_mapped_bitmap.ads
@@ -67,6 +67,9 @@ package Memory_Mapped_Bitmap is
       --  So Put_Pixel (Buffer, 30, 10, Color) will place the pixel at
       --  Y0 = 320 - 30 - 1 = 289
       --  X0 = 10
+
+      Native_Source : UInt32 := 0;
+      --  Source color in native format
    end record;
 
    type Any_Memory_Mapped_Bitmap_Buffer is access all Memory_Mapped_Bitmap_Buffer'Class;
@@ -96,22 +99,42 @@ package Memory_Mapped_Bitmap is
      (Buffer.Addr);
 
    overriding
+   procedure Set_Source (Buffer : in out Memory_Mapped_Bitmap_Buffer;
+                         ARGB   : Bitmap_Color);
+
+   overriding
+   procedure Set_Source (Buffer : in out Memory_Mapped_Bitmap_Buffer;
+                         Native : UInt32);
+
+   overriding
+   function Source (Buffer : Memory_Mapped_Bitmap_Buffer)
+                    return Bitmap_Color;
+
+   overriding
+   function Source (Buffer : Memory_Mapped_Bitmap_Buffer)
+                    return UInt32;
+
+   overriding
    procedure Set_Pixel
      (Buffer  : in out Memory_Mapped_Bitmap_Buffer;
-      Pt      : Point;
-      Value   : Bitmap_Color);
+      Pt      : Point);
 
    overriding
    procedure Set_Pixel
      (Buffer  : in out Memory_Mapped_Bitmap_Buffer;
       Pt      : Point;
-      Value   : UInt32);
+      Color   : Bitmap_Color);
+
+   overriding
+   procedure Set_Pixel
+     (Buffer  : in out Memory_Mapped_Bitmap_Buffer;
+      Pt      : Point;
+      Raw     : UInt32);
 
    overriding
    procedure Set_Pixel_Blend
      (Buffer : in out Memory_Mapped_Bitmap_Buffer;
-      Pt      : Point;
-      Value  : Bitmap_Color);
+      Pt     : Point);
 
    overriding
    function Pixel

--- a/middleware/src/bitmap/soft_drawing_bitmap.adb
+++ b/middleware/src/bitmap/soft_drawing_bitmap.adb
@@ -559,6 +559,9 @@ package body Soft_Drawing_Bitmap is
       Center : Point;
       Radius : Natural)
    is
+      Buffer_Width  : constant Natural := Dispatch (Buffer).Width;
+      Buffer_Height : constant Natural := Dispatch (Buffer).Height;
+
       procedure Draw_Horizontal_Line (X, Y : Integer; Width : Natural);
       ------------------------
       -- Draw_Vertical_Line --
@@ -577,10 +580,10 @@ package body Soft_Drawing_Bitmap is
          if Width = 0 then
             return;
 
-         elsif Y < 0 or else Y >= Dispatch (Buffer).Height then
+         elsif Y < 0 or else Y >= Buffer_Height then
             return;
 
-         elsif X + Width < 0 or else X >= Dispatch (Buffer).Width then
+         elsif X + Width < 0 or else X >= Buffer_Width then
             return;
          end if;
 
@@ -592,8 +595,8 @@ package body Soft_Drawing_Bitmap is
             W1 := Width;
          end if;
 
-         if X1 + W1 >= Dispatch (Buffer).Width then
-            W1 := Dispatch (Buffer).Width - X1 - 1;
+         if X1 + W1 >= Buffer_Width then
+            W1 := Buffer_Width - X1 - 1;
          end if;
 
          if W1 = 0 then
@@ -614,10 +617,10 @@ package body Soft_Drawing_Bitmap is
          if Height = 0 then
             return;
 
-         elsif X < 0 or else X >= Dispatch (Buffer).Width then
+         elsif X < 0 or else X >= Buffer_Width then
             return;
 
-         elsif Y + Height < 0 or else Y >= Dispatch (Buffer).Height then
+         elsif Y + Height < 0 or else Y >= Buffer_Height then
             return;
          end if;
 
@@ -629,8 +632,8 @@ package body Soft_Drawing_Bitmap is
             H1 := Height;
          end if;
 
-         if Y1 + H1 >= Dispatch (Buffer).Height then
-            H1 := Dispatch (Buffer).Height - Y1 - 1;
+         if Y1 + H1 >= Buffer_Height then
+            H1 := Buffer_Height - Y1 - 1;
          end if;
 
          if H1 = 0 then

--- a/middleware/src/bitmap/soft_drawing_bitmap.ads
+++ b/middleware/src/bitmap/soft_drawing_bitmap.ads
@@ -45,46 +45,49 @@ package Soft_Drawing_Bitmap is
      access all Soft_Drawing_Bitmap_Buffer'Class;
 
    overriding
-   procedure Draw_Line
-     (Buffer      : in out Soft_Drawing_Bitmap_Buffer;
-      Color       : UInt32;
-      Start, Stop : Point;
-      Thickness   : Natural := 1;
-      Fast        : Boolean := True);
+   procedure Set_Source (Buffer : in out Soft_Drawing_Bitmap_Buffer;
+                         ARGB   : Bitmap_Color);
+
+   overriding
+   function Source
+     (Buffer : Soft_Drawing_Bitmap_Buffer)
+      return Bitmap_Color;
+
+   overriding
+   procedure Set_Pixel
+     (Buffer  : in out Soft_Drawing_Bitmap_Buffer;
+      Pt      : Point;
+      Color   : Bitmap_Color);
+
+   overriding
+   procedure Set_Pixel
+     (Buffer  : in out Soft_Drawing_Bitmap_Buffer;
+      Pt      : Point;
+      Native  : UInt32);
+
+   overriding
+   function Pixel
+     (Buffer : Soft_Drawing_Bitmap_Buffer;
+      Pt     : Point)
+      return Bitmap_Color;
 
    overriding
    procedure Draw_Line
      (Buffer      : in out Soft_Drawing_Bitmap_Buffer;
-      Color       : Bitmap_Color;
       Start, Stop : Point;
       Thickness   : Natural := 1;
       Fast        : Boolean := True);
 
    overriding
    procedure Fill
-     (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : Bitmap_Color);
-   --  Fill the specified buffer with 'Color'
-
-   overriding
-   procedure Fill
-     (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : UInt32);
-   --  Same as above, using the destination buffer native color representation
+     (Buffer : in out Soft_Drawing_Bitmap_Buffer);
+   --  Fill the entire buffer with the source color
 
    overriding
    procedure Fill_Rect
      (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : Bitmap_Color;
       Area   : Rect);
-   --  Fill the specified area of the buffer with 'Color'
-
-   overriding
-   procedure Fill_Rect
-     (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : UInt32;
-      Area   : Rect);
-   --  Same as above, using the destination buffer native color representation
+   --  Fill the specified area of the buffer with the source color
 
    overriding
    procedure Copy_Rect
@@ -121,35 +124,18 @@ package Soft_Drawing_Bitmap is
    overriding
    procedure Draw_Vertical_Line
      (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : UInt32;
-      Pt     : Point;
-      Height : Integer);
-
-   overriding
-   procedure Draw_Vertical_Line
-     (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : Bitmap_Color;
       Pt     : Point;
       Height : Integer);
 
    overriding
    procedure Draw_Horizontal_Line
      (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : UInt32;
-      Pt     : Point;
-      Width  : Integer);
-
-   overriding
-   procedure Draw_Horizontal_Line
-     (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : Bitmap_Color;
       Pt     : Point;
       Width  : Integer);
 
    overriding
    procedure Draw_Rect
      (Buffer    : in out Soft_Drawing_Bitmap_Buffer;
-      Color     : Bitmap_Color;
       Area      : Rect;
       Thickness : Natural := 1);
    --  Draws a rectangle
@@ -157,7 +143,6 @@ package Soft_Drawing_Bitmap is
    overriding
    procedure Draw_Rounded_Rect
      (Buffer    : in out Soft_Drawing_Bitmap_Buffer;
-      Color     : Bitmap_Color;
       Area      : Rect;
       Radius    : Natural;
       Thickness : Natural := 1);
@@ -165,42 +150,24 @@ package Soft_Drawing_Bitmap is
    overriding
    procedure Fill_Rounded_Rect
      (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : Bitmap_Color;
       Area   : Rect;
       Radius : Natural);
 
    overriding
    procedure Draw_Circle
      (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : UInt32;
-      Center : Point;
-      Radius : Natural);
-
-   overriding
-   procedure Draw_Circle
-     (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : Bitmap_Color;
       Center : Point;
       Radius : Natural);
 
    overriding
    procedure Fill_Circle
      (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : UInt32;
-      Center : Point;
-      Radius : Natural);
-
-   overriding
-   procedure Fill_Circle
-     (Buffer : in out Soft_Drawing_Bitmap_Buffer;
-      Color  : Bitmap_Color;
       Center : Point;
       Radius : Natural);
 
    overriding
    procedure Cubic_Bezier
      (Buffer         : in out Soft_Drawing_Bitmap_Buffer;
-      Color          : Bitmap_Color;
       P1, P2, P3, P4 : Point;
       N              : Positive := 20;
       Thickness      : Natural := 1);

--- a/testsuite/tests/bitmap_drawing/src/tc_bitmap_drawing.adb
+++ b/testsuite/tests/bitmap_drawing/src/tc_bitmap_drawing.adb
@@ -56,41 +56,46 @@ begin
       raise Program_Error with "Cannot open BMP file";
    end if;
 
-   BM.Fill (Black);
-   BM.Fill_Rounded_Rect (Color  => Green,
-                         Area   => ((5, 5), BM_Width / 2, BM_Height / 2),
+   BM.Set_Source (Black);
+   BM.Fill;
+
+   BM.Set_Source (Green);
+   BM.Fill_Rounded_Rect (Area   => ((5, 5), BM_Width / 2, BM_Height / 2),
                          Radius => 10);
 
-   BM.Draw_Rounded_Rect (Color  => Red,
-                         Area   => ((5, 5), BM_Width / 2, BM_Height / 2),
+   BM.Set_Source (Red);
+   BM.Draw_Rounded_Rect (Area   => ((5, 5), BM_Width / 2, BM_Height / 2),
                          Radius => 10,
                          Thickness => 3);
 
-   BM.Fill_Circle (Color  => Yellow,
-                   Center => (BM_Width / 2, BM_Height / 2),
+   BM.Set_Source (Yellow);
+   BM.Fill_Circle (Center => (BM_Width / 2, BM_Height / 2),
                    Radius => BM_Width / 4);
 
-   BM.Draw_Circle (Color  => Blue,
-                   Center => (BM_Width / 2, BM_Height / 2),
+   BM.Set_Source (Blue);
+   BM.Draw_Circle (Center => (BM_Width / 2, BM_Height / 2),
                    Radius => BM_Width / 4);
 
-   BM.Cubic_Bezier (Color     => Violet,
-                    P1        => (5, 5),
+   BM.Set_Source (Violet);
+   BM.Cubic_Bezier (P1        => (5, 5),
                     P2        => (0, BM_Height / 2),
                     P3        => (BM_Width / 2, BM_Height / 2),
                     P4        => (BM_Width - 5, BM_Height - 5),
                     N         => 100,
                     Thickness => 3);
 
-   BM.Draw_Line (Color     => White,
-                 Start     => (0, 0),
+   BM.Set_Source (White);
+   BM.Draw_Line (Start     => (0, 0),
                  Stop      => (BM_Width - 1, BM_Height / 2),
                  Thickness => 1,
                  Fast      => True);
 
-   BM.Set_Pixel ((0, 0), Red);
-   BM.Set_Pixel ((0, 1), Green);
-   BM.Set_Pixel ((0, 2), Blue);
+   BM.Set_Source (Red);
+   BM.Set_Pixel ((0, 0));
+   BM.Set_Source (Green);
+   BM.Set_Pixel ((0, 1));
+   BM.Set_Source (Blue);
+   BM.Set_Pixel ((0, 2));
 
    Copy_Rect (Src_Buffer  => BM.all,
               Src_Pt      => (0, 0),


### PR DESCRIPTION
- HAL.Bitmap: Simplify interface with notion of source color

  There are two color formats in HAL.Bitmap, the Bitmap_Color (with Alpha,
  Red, Green, Blue components) and the "native" raw value of the pixel.

  In the current interface users select a color for each operations (Fill,
  Draw_Line, Draw_Circle, etc.) which means each operation has to be
  declared twice, one with a Bitmap_Color and one with native pixel value.

  Inspired by the Cairo graphics library, this patch add a Set_Source
  primitive which allows to specify the color that will be use. Each
  drawing operation then uses this color for rendering.

  This simplifies the interface since drawing operation only have to be
  declared once. It may also allow for more advanced sources in the future
  like gradients or textures.

 - Soft_Drawing_Bitmap: Avoid unnecessary dispatching calls in Fill_Circle 