### PR TITLE
STM32F4 extended I2S support

### DIFF
--- a/arch/ARM/STM32/devices/stm32f40x/stm32-device.adb
+++ b/arch/ARM/STM32/devices/stm32f40x/stm32-device.adb
@@ -441,9 +441,15 @@ package body STM32.Device is
    begin
       if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2ENR.SPI1EN := True;
-      elsif This.Periph.all'Address = SPI2_Base then
+      elsif This.Periph.all'Address = SPI2_Base
+        or else
+            This.Periph.all'Address = I2S2ext_Base
+      then
          RCC_Periph.APB1ENR.SPI2EN := True;
-      elsif This.Periph.all'Address = SPI3_Base then
+      elsif This.Periph.all'Address = SPI3_Base
+        or else
+            This.Periph.all'Address = I2S3ext_Base
+      then
          RCC_Periph.APB1ENR.SPI3EN := True;
       else
          raise Unknown_Device;

--- a/arch/ARM/STM32/devices/stm32f40x/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f40x/stm32-device.ads
@@ -404,13 +404,18 @@ package STM32.Device is
    procedure Enable_Clock (This : SPI_Port'Class);
    procedure Reset (This : in out SPI_Port'Class);
 
-   Internal_I2S_1 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI1_Base;
-   Internal_I2S_2 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI2_Base;
-   Internal_I2S_3 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI3_Base;
+   Internal_I2S_1     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI1_Base;
+   Internal_I2S_2     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI2_Base;
+   Internal_I2S_3     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI3_Base;
+   Internal_I2S_2_Ext : aliased Internal_I2S_Port with Import, Volatile, Address => I2S2ext_Base;
+   Internal_I2S_3_Ext : aliased Internal_I2S_Port with Import, Volatile, Address => I2S3ext_Base;
 
-   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access);
-   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access);
-   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access);
+   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access, Extended => False);
+   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access, Extended => False);
+   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access, Extended => False);
+
+   I2S_2_Ext : aliased I2S_Port (Internal_I2S_2_Ext'Access, Extended => True);
+   I2S_3_Ext : aliased I2S_Port (Internal_I2S_3_Ext'Access, Extended => True);
 
    procedure Enable_Clock (This : I2S_Port);
    procedure Reset (This : in out I2S_Port);

--- a/arch/ARM/STM32/devices/stm32f42x/stm32-device.adb
+++ b/arch/ARM/STM32/devices/stm32f42x/stm32-device.adb
@@ -492,9 +492,15 @@ package body STM32.Device is
    begin
       if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2ENR.SPI1EN := True;
-      elsif This.Periph.all'Address = SPI2_Base then
+      elsif This.Periph.all'Address = SPI2_Base
+        or else
+            This.Periph.all'Address = I2S2ext_Base
+      then
          RCC_Periph.APB1ENR.SPI2EN := True;
-      elsif This.Periph.all'Address = SPI3_Base then
+      elsif This.Periph.all'Address = SPI3_Base
+        or else
+            This.Periph.all'Address = I2S3ext_Base
+      then
          RCC_Periph.APB1ENR.SPI3EN := True;
       elsif This.Periph.all'Address = SPI4_Base then
          RCC_Periph.APB2ENR.SPI5ENR := True;
@@ -516,10 +522,16 @@ package body STM32.Device is
       if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2RSTR.SPI1RST := True;
          RCC_Periph.APB2RSTR.SPI1RST := False;
-      elsif This.Periph.all'Address = SPI2_Base then
+      elsif This.Periph.all'Address = SPI2_Base
+        or else
+            This.Periph.all'Address = I2S2ext_Base
+      then
          RCC_Periph.APB1RSTR.SPI2RST := True;
          RCC_Periph.APB1RSTR.SPI2RST := False;
-      elsif This.Periph.all'Address = SPI3_Base then
+      elsif This.Periph.all'Address = SPI3_Base
+        or else
+            This.Periph.all'Address = I2S3ext_Base
+      then
          RCC_Periph.APB1RSTR.SPI3RST := True;
          RCC_Periph.APB1RSTR.SPI3RST := False;
       elsif This.Periph.all'Address = SPI4_Base then

--- a/arch/ARM/STM32/devices/stm32f42x/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f42x/stm32-device.ads
@@ -458,19 +458,23 @@ package STM32.Device is
    procedure Enable_Clock (This : SPI_Port'Class);
    procedure Reset (This : SPI_Port'Class);
 
-   Internal_I2S_1 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI1_Base;
-   Internal_I2S_2 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI2_Base;
-   Internal_I2S_3 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI3_Base;
-   Internal_I2S_4 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI4_Base;
-   Internal_I2S_5 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI5_Base;
-   Internal_I2S_6 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI6_Base;
+   Internal_I2S_1     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI1_Base;
+   Internal_I2S_2     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI2_Base;
+   Internal_I2S_3     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI3_Base;
+   Internal_I2S_4     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI4_Base;
+   Internal_I2S_5     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI5_Base;
+   Internal_I2S_6     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI6_Base;
+   Internal_I2S_2_Ext : aliased Internal_I2S_Port with Import, Volatile, Address => I2S2ext_Base;
+   Internal_I2S_3_Ext : aliased Internal_I2S_Port with Import, Volatile, Address => I2S3ext_Base;
 
-   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access);
-   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access);
-   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access);
-   I2S_4 : aliased I2S_Port (Internal_I2S_4'Access);
-   I2S_5 : aliased I2S_Port (Internal_I2S_5'Access);
-   I2S_6 : aliased I2S_Port (Internal_I2S_6'Access);
+   I2S_1     : aliased I2S_Port (Internal_I2S_1'Access, Extended => False);
+   I2S_2     : aliased I2S_Port (Internal_I2S_2'Access, Extended => False);
+   I2S_3     : aliased I2S_Port (Internal_I2S_3'Access, Extended => False);
+   I2S_4     : aliased I2S_Port (Internal_I2S_4'Access, Extended => False);
+   I2S_5     : aliased I2S_Port (Internal_I2S_5'Access, Extended => False);
+   I2S_6     : aliased I2S_Port (Internal_I2S_6'Access, Extended => False);
+   I2S_2_Ext : aliased I2S_Port (Internal_I2S_2_Ext'Access, Extended => True);
+   I2S_3_Ext : aliased I2S_Port (Internal_I2S_3_Ext'Access, Extended => True);
 
    procedure Enable_Clock (This : I2S_Port);
    procedure Reset (This : in out I2S_Port);

--- a/arch/ARM/STM32/devices/stm32f46_79x/stm32-device.adb
+++ b/arch/ARM/STM32/devices/stm32f46_79x/stm32-device.adb
@@ -493,9 +493,15 @@ package body STM32.Device is
    begin
       if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2ENR.SPI1EN := True;
-      elsif This.Periph.all'Address = SPI2_Base then
+      elsif This.Periph.all'Address = SPI2_Base
+        or else
+            This.Periph.all'Address = I2S2ext_Base
+      then
          RCC_Periph.APB1ENR.SPI2EN := True;
-      elsif This.Periph.all'Address = SPI3_Base then
+      elsif This.Periph.all'Address = SPI3_Base
+        or else
+            This.Periph.all'Address = I2S3ext_Base
+      then
          RCC_Periph.APB1ENR.SPI3EN := True;
       elsif This.Periph.all'Address = SPI4_Base then
          RCC_Periph.APB2ENR.SPI5ENR := True;
@@ -517,10 +523,16 @@ package body STM32.Device is
       if This.Periph.all'Address = SPI1_Base then
          RCC_Periph.APB2RSTR.SPI1RST := True;
          RCC_Periph.APB2RSTR.SPI1RST := False;
-      elsif This.Periph.all'Address = SPI2_Base then
+      elsif This.Periph.all'Address = SPI2_Base
+        or else
+            This.Periph.all'Address = I2S2ext_Base
+      then
          RCC_Periph.APB1RSTR.SPI2RST := True;
          RCC_Periph.APB1RSTR.SPI2RST := False;
-      elsif This.Periph.all'Address = SPI3_Base then
+      elsif This.Periph.all'Address = SPI3_Base
+        or else
+            This.Periph.all'Address = I2S3ext_Base
+      then
          RCC_Periph.APB1RSTR.SPI3RST := True;
          RCC_Periph.APB1RSTR.SPI3RST := False;
       elsif This.Periph.all'Address = SPI4_Base then

--- a/arch/ARM/STM32/devices/stm32f46_79x/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f46_79x/stm32-device.ads
@@ -511,19 +511,23 @@ package STM32.Device is
    procedure Enable_Clock (This : aliased in out SPI_Port'Class);
    procedure Reset (This : in out SPI_Port'Class);
 
-   Internal_I2S_1 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI1_Base;
-   Internal_I2S_2 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI2_Base;
-   Internal_I2S_3 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI3_Base;
-   Internal_I2S_4 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI4_Base;
-   Internal_I2S_5 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI5_Base;
-   Internal_I2S_6 : aliased Internal_I2S_Port with Import, Volatile, Address => SPI6_Base;
+   Internal_I2S_1     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI1_Base;
+   Internal_I2S_2     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI2_Base;
+   Internal_I2S_3     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI3_Base;
+   Internal_I2S_4     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI4_Base;
+   Internal_I2S_5     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI5_Base;
+   Internal_I2S_6     : aliased Internal_I2S_Port with Import, Volatile, Address => SPI6_Base;
+   Internal_I2S_2_Ext : aliased Internal_I2S_Port with Import, Volatile, Address => I2S2ext_Base;
+   Internal_I2S_3_Ext : aliased Internal_I2S_Port with Import, Volatile, Address => I2S3ext_Base;
 
-   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access);
-   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access);
-   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access);
-   I2S_4 : aliased I2S_Port (Internal_I2S_4'Access);
-   I2S_5 : aliased I2S_Port (Internal_I2S_5'Access);
-   I2S_6 : aliased I2S_Port (Internal_I2S_6'Access);
+   I2S_1     : aliased I2S_Port (Internal_I2S_1'Access, Extended => False);
+   I2S_2     : aliased I2S_Port (Internal_I2S_2'Access, Extended => False);
+   I2S_3     : aliased I2S_Port (Internal_I2S_3'Access, Extended => False);
+   I2S_4     : aliased I2S_Port (Internal_I2S_4'Access, Extended => False);
+   I2S_5     : aliased I2S_Port (Internal_I2S_5'Access, Extended => False);
+   I2S_6     : aliased I2S_Port (Internal_I2S_6'Access, Extended => False);
+   I2S_2_Ext : aliased I2S_Port (Internal_I2S_2_Ext'Access, Extended => True);
+   I2S_3_Ext : aliased I2S_Port (Internal_I2S_3_Ext'Access, Extended => True);
 
    procedure Enable_Clock (This : I2S_Port);
    procedure Reset (This : in out I2S_Port);

--- a/arch/ARM/STM32/devices/stm32f7x/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f7x/stm32-device.ads
@@ -521,12 +521,12 @@ package STM32.Device is
    Internal_I2S_6 : aliased Internal_I2S_Port
      with Import, Volatile, Address => SPI6_Base;
 
-   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access);
-   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access);
-   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access);
-   I2S_4 : aliased I2S_Port (Internal_I2S_4'Access);
-   I2S_5 : aliased I2S_Port (Internal_I2S_5'Access);
-   I2S_6 : aliased I2S_Port (Internal_I2S_6'Access);
+   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access, Extended => False);
+   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access, Extended => False);
+   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access, Extended => False);
+   I2S_4 : aliased I2S_Port (Internal_I2S_4'Access, Extended => False);
+   I2S_5 : aliased I2S_Port (Internal_I2S_5'Access, Extended => False);
+   I2S_6 : aliased I2S_Port (Internal_I2S_6'Access, Extended => False);
 
    procedure Enable_Clock (This : I2S_Port);
    procedure Reset (This : in out I2S_Port);

--- a/arch/ARM/STM32/devices/stm32f7x9/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f7x9/stm32-device.ads
@@ -533,12 +533,12 @@ package STM32.Device is
    Internal_I2S_6 : aliased Internal_I2S_Port
      with Import, Volatile, Address => SPI6_Base;
 
-   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access);
-   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access);
-   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access);
-   I2S_4 : aliased I2S_Port (Internal_I2S_4'Access);
-   I2S_5 : aliased I2S_Port (Internal_I2S_5'Access);
-   I2S_6 : aliased I2S_Port (Internal_I2S_6'Access);
+   I2S_1 : aliased I2S_Port (Internal_I2S_1'Access, Extended => False);
+   I2S_2 : aliased I2S_Port (Internal_I2S_2'Access, Extended => False);
+   I2S_3 : aliased I2S_Port (Internal_I2S_3'Access, Extended => False);
+   I2S_4 : aliased I2S_Port (Internal_I2S_4'Access, Extended => False);
+   I2S_5 : aliased I2S_Port (Internal_I2S_5'Access, Extended => False);
+   I2S_6 : aliased I2S_Port (Internal_I2S_6'Access, Extended => False);
 
    procedure Enable_Clock (This : I2S_Port);
    procedure Reset (This : in out I2S_Port);

--- a/arch/ARM/STM32/drivers/stm32-i2s.ads
+++ b/arch/ARM/STM32/drivers/stm32-i2s.ads
@@ -83,15 +83,23 @@ package STM32.I2S is
 
    type Internal_I2S_Port is private;
 
-   type I2S_Port (Periph : not null access Internal_I2S_Port) is
+   type I2S_Port (Periph   : not null access Internal_I2S_Port;
+                  Extended : Boolean) is
       limited new Audio_Stream with private;
 
    function In_I2S_Mode (This : in out I2S_Port) return Boolean;
    --  I2S peripherals are shared with SPI, this function returns True only if
    --  the periperal is configure in I2S mode.
 
+   function Valid_Extended_Config (Conf : I2S_Configuration) return Boolean
+   is ((Conf.Mode = Slave_Transmit or else Conf.Mode = Slave_Receive)
+         and then
+       not Conf.Master_Clock_Out_Enabled);
+
    procedure Configure (This : in out I2S_Port; Conf : I2S_Configuration)
-     with Pre  => not This.Enabled,
+     with Pre  => not This.Enabled
+                    and then
+                  (not This.Extended or else Valid_Extended_Config (Conf)),
           Post => not This.Enabled;
 
    procedure Enable (This : in out I2S_Port)
@@ -125,7 +133,8 @@ private
 
    type Internal_I2S_Port is new STM32_SVD.SPI.SPI_Peripheral;
 
-   type I2S_Port (Periph : not null access Internal_I2S_Port) is
+   type I2S_Port (Periph   : not null access Internal_I2S_Port;
+                  Extended : Boolean) is
      limited new Audio_Stream with null record;
 
 end STM32.I2S;

--- a/boards/stm32_common/stm32f469disco/audio.adb
+++ b/boards/stm32_common/stm32f469disco/audio.adb
@@ -81,7 +81,8 @@ package body Audio is
       --  We need to find a value of SAI_CK that allows such integer master
       --  clock divider
       case Freq is
-         when Audio_Freq_11kHz | Audio_Freq_22kHz | Audio_Freq_44kHz =>
+         when Audio_Freq_11kHz | Audio_Freq_22kHz |
+              Audio_Freq_32kHz | Audio_Freq_44kHz =>
             --  HSE/PLLM = 1MHz = PLLI2S VCO Input
             Configure_SAI_I2S_Clock
               (Audio_SAI,

--- a/boards/stm32_common/stm32f746disco/audio.adb
+++ b/boards/stm32_common/stm32f746disco/audio.adb
@@ -77,7 +77,8 @@ package body Audio is
       --  We need to find a value of SAI_CK that allows such integer master
       --  clock divider
       case Freq is
-         when Audio_Freq_11kHz | Audio_Freq_22kHz | Audio_Freq_44kHz =>
+         when Audio_Freq_11kHz | Audio_Freq_22kHz |
+              Audio_Freq_32kHz | Audio_Freq_44kHz =>
             --  HSE/PLLM = 1MHz = PLLI2S VCO Input
             Configure_SAI_I2S_Clock
               (Audio_SAI,

--- a/boards/stm32_common/stm32f769disco/audio.adb
+++ b/boards/stm32_common/stm32f769disco/audio.adb
@@ -80,7 +80,8 @@ package body Audio is
       --  We need to find a value of SAI_CK that allows such integer master
       --  clock divider
       case Freq is
-         when Audio_Freq_11kHz | Audio_Freq_22kHz | Audio_Freq_44kHz =>
+         when Audio_Freq_11kHz | Audio_Freq_22kHz |
+              Audio_Freq_32kHz | Audio_Freq_44kHz =>
             --  HSE/PLLM = 1MHz = PLLI2S VCO Input
             Configure_SAI_I2S_Clock
               (Audio_SAI,

--- a/examples/STM32F4_DISCO/simple_audio/simple_audio.gpr
+++ b/examples/STM32F4_DISCO/simple_audio/simple_audio.gpr
@@ -1,0 +1,17 @@
+with "../../../boards/stm32f407_discovery/stm32f407_discovery.gpr";
+
+project Simple_Audio extends "../../shared/common/common.gpr" is
+
+  for Runtime ("Ada") use STM32F407_Discovery'Runtime ("Ada");
+  for Target use "arm-eabi";
+  for Main use ("main.adb");
+  for Languages use ("Ada");
+  for Source_Dirs use ("src");
+  for Object_Dir use "obj";
+  for Create_Missing_Dirs use "True";
+   
+  package Linker is
+     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage");
+  end Linker;
+
+end Simple_Audio;

--- a/examples/STM32F4_DISCO/simple_audio/src/audio_stream.adb
+++ b/examples/STM32F4_DISCO/simple_audio/src/audio_stream.adb
@@ -1,0 +1,139 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                        Copyright (C) 2017, AdaCore                       --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+package body Audio_Stream is
+
+   ------------------------------
+   -- Double_Buffer_Controller --
+   ------------------------------
+
+   protected body Double_Buffer_Controller is
+
+      -----------
+      -- Start --
+      -----------
+
+      procedure Start
+        (Destination : Address;
+         Source_0    : Address;
+         Source_1    : Address;
+         Data_Count  : UInt16)
+      is
+         Config : DMA_Stream_Configuration;
+      begin
+         Enable_Clock (Controller.all);
+
+         Config.Channel := Audio_TX_DMA_Chan;
+         Config.Direction := Memory_To_Peripheral;
+         Config.Increment_Peripheral_Address := False;
+         Config.Increment_Memory_Address := True;
+         Config.Peripheral_Data_Format := HalfWords;
+         Config.Memory_Data_Format := HalfWords;
+         Config.Operation_Mode := Circular_Mode;
+         Config.Priority := Priority_High;
+         Config.FIFO_Enabled := False;
+         Config.FIFO_Threshold := FIFO_Threshold_Full_Configuration;
+         Config.Memory_Burst_Size := Memory_Burst_Single;
+         Config.Peripheral_Burst_Size := Peripheral_Burst_Single;
+         Configure (Controller.all, Stream, Config);
+
+         Configure_Data_Flow
+           (Controller.all,
+            Stream,
+            Source      => Source_0,
+            Destination => Destination,
+            Data_Count  => Data_Count);
+
+         for Selected_Interrupt in DMA_Interrupt loop
+            Enable_Interrupt (Controller.all, Stream, Selected_Interrupt);
+         end loop;
+
+         Configure_Double_Buffered_Mode (This              => Controller.all,
+                                         Stream            => Stream,
+                                         Buffer_0_Value    => Source_0,
+                                         Buffer_1_Value    => Source_1,
+                                         First_Buffer_Used => Memory_Buffer_0);
+
+         Buffer_0 := Source_0;
+         Buffer_1 := Source_1;
+
+         Enable_Double_Buffered_Mode (Controller.all, Stream);
+
+         Clear_All_Status (Controller.all, Stream);
+
+         Enable (Controller.all, Stream);
+      end Start;
+
+      --------------------------------
+      -- Wait_For_Transfer_Complete --
+      --------------------------------
+
+      entry Wait_For_Transfer_Complete when Interrupt_Triggered is
+      begin
+         Interrupt_Triggered := False;
+      end Wait_For_Transfer_Complete;
+
+      ---------------------
+      -- Not_In_Transfer --
+      ---------------------
+
+      function Not_In_Transfer return Address is
+      begin
+         case Current_Memory_Buffer (Controller.all, Stream) is
+            when Memory_Buffer_0 =>
+               return Buffer_1;
+            when Memory_Buffer_1 =>
+               return Buffer_0;
+         end case;
+      end Not_In_Transfer;
+
+      -----------------------
+      -- Interrupt_Handler --
+      -----------------------
+
+      procedure Interrupt_Handler is
+      begin
+         for Flag in DMA_Status_Flag loop
+            if Status (Controller.all, Stream, Flag) then
+               case Flag is
+                  when Transfer_Complete_Indicated =>
+                     Interrupt_Triggered := True;
+                  when others =>
+                     null;
+               end case;
+               Clear_Status (Controller.all, Stream, Flag);
+            end if;
+         end loop;
+      end Interrupt_Handler;
+
+   end Double_Buffer_Controller;
+
+end Audio_Stream;

--- a/hal/src/hal-audio.ads
+++ b/hal/src/hal-audio.ads
@@ -43,6 +43,7 @@ package HAL.Audio is
       Audio_Freq_11kHz,
       Audio_Freq_16kHz,
       Audio_Freq_22kHz,
+      Audio_Freq_32kHz,
       Audio_Freq_44kHz,
       Audio_Freq_48kHz,
       Audio_Freq_96kHz)
@@ -52,6 +53,7 @@ package HAL.Audio is
       Audio_Freq_11kHz => 11_025,
       Audio_Freq_16kHz => 16_000,
       Audio_Freq_22kHz => 22_050,
+      Audio_Freq_32kHz => 32_000,
       Audio_Freq_44kHz => 44_100,
       Audio_Freq_48kHz => 48_000,
       Audio_Freq_96kHz => 96_000);

--- a/scripts/build_all_examples.py
+++ b/scripts/build_all_examples.py
@@ -84,6 +84,7 @@ projects = [
 
             # STM32F4 DISCO
             ("/examples/STM32F4_DISCO/accelerometer/accelerometer.gpr",                                  BOTH_RAVENSCAR),
+            ("/examples/STM32F4_DISCO/simple_audio/simple_audio.gpr",                                    BOTH_RAVENSCAR),
             ("/examples/STM32F4_DISCO/filesystem/filesystem.gpr",                                        BOTH_RAVENSCAR),
 
             # STM32F469 Discovery


### PR DESCRIPTION
This PR adds support of the extended I2S devices of the STM32F4. The extended I2S can act as a slave to provide RX when the main I2S in master mode does TX.

I also remove the audio part of the STM32F4_DISCO accelerometer example, and put it in a separate example.