### PR TITLE
Various MicroBit fixes

### DIFF
--- a/arch/ARM/Nordic/drivers/nrf51-twi.adb
+++ b/arch/ARM/Nordic/drivers/nrf51-twi.adb
@@ -120,6 +120,8 @@ package body nRF51.TWI is
    is
       pragma Unreferenced (Timeout);
       Index : Integer := Data'First + 1;
+      Evt_Err : UInt32;
+      Err_Src : ERRORSRC_Register with Unreferenced;
    begin
       if Data'Length = 0 then
          Status := Ok;
@@ -132,7 +134,7 @@ package body nRF51.TWI is
       This.Periph.ERRORSRC.DNACK   := Errorsrc_Dnack_Field_Reset;
 
       --  Set Address
-      This.Periph.ADDRESS.ADDRESS := UInt7 (Addr);
+      This.Periph.ADDRESS.ADDRESS := UInt7 (Addr / 2);
 
       --  Prepare first byte
       This.Periph.TXD.TXD := Data (Data'First);
@@ -144,7 +146,9 @@ package body nRF51.TWI is
 
          loop
 
-            if This.Periph.EVENTS_ERROR /= 0 then
+            Evt_Err := This.Periph.EVENTS_ERROR;
+            if Evt_Err /= 0 then
+               Err_Src := This.Periph.ERRORSRC;
                Status := Err_Error;
                --  Clear the error
                This.Periph.EVENTS_ERROR := 0;

--- a/boards/MicroBit/src/microbit-time.adb
+++ b/boards/MicroBit/src/microbit-time.adb
@@ -40,7 +40,7 @@ package body MicroBit.Time is
 
    package Clocks renames nRF51.Clock;
 
-   Clock_Ms  : Time_Ms := 0;
+   Clock_Ms  : Time_Ms := 0 with Volatile;
    Period_Ms : constant Time_Ms := 1;
 
    Subscribers : array (1 .. 10) of Tick_Callback := (others => null);
@@ -188,6 +188,56 @@ package body MicroBit.Time is
       end loop;
       return False;
    end Tick_Unsubscribe;
+
+   ---------------
+   -- HAL_Delay --
+   ---------------
+
+   Delay_Instance : aliased MB_Delays;
+
+   function HAL_Delay return not null HAL.Time.Any_Delays is
+   begin
+      return Delay_Instance'Access;
+   end HAL_Delay;
+
+   ------------------------
+   -- Delay_Microseconds --
+   ------------------------
+
+   overriding
+   procedure Delay_Microseconds (This : in out MB_Delays;
+                                 Us   : Integer)
+   is
+      pragma Unreferenced (This);
+   begin
+      Delay_Ms (UInt64 (Us / 1000));
+   end Delay_Microseconds;
+
+   ------------------------
+   -- Delay_Milliseconds --
+   ------------------------
+
+   overriding
+   procedure Delay_Milliseconds (This : in out MB_Delays;
+                                 Ms   : Integer)
+   is
+      pragma Unreferenced (This);
+   begin
+      Delay_Ms (UInt64 (Ms));
+   end Delay_Milliseconds;
+
+   -------------------
+   -- Delay_Seconds --
+   -------------------
+
+   overriding
+   procedure Delay_Seconds (This : in out MB_Delays;
+                            S    : Integer)
+   is
+      pragma Unreferenced (This);
+   begin
+      Delay_Ms (UInt64 (S * 1000));
+   end Delay_Seconds;
 
 begin
    Initialize;

--- a/boards/MicroBit/src/microbit-time.ads
+++ b/boards/MicroBit/src/microbit-time.ads
@@ -29,7 +29,8 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with HAL; use HAL;
+with HAL;      use HAL;
+with HAL.Time;
 
 package MicroBit.Time is
 
@@ -59,5 +60,22 @@ package MicroBit.Time is
           Post => (if Tick_Unsubscribe'Result then not Tick_Subscriber (Callback));
    --  Unsubscribe a callback to the tick event. The function return True on
    --  success, False if the callback was not a subscriber.
+
+   function HAL_Delay return not null HAL.Time.Any_Delays;
+private
+
+   type MB_Delays is new HAL.Time.Delays with null record;
+
+   overriding
+   procedure Delay_Microseconds (This : in out MB_Delays;
+                                 Us   : Integer);
+
+   overriding
+   procedure Delay_Milliseconds (This : in out MB_Delays;
+                                 Ms   : Integer);
+
+   overriding
+   procedure Delay_Seconds      (This : in out MB_Delays;
+                                 S    : Integer);
 
 end MicroBit.Time;

--- a/components/src/screen/ssd1306/ssd1306.adb
+++ b/components/src/screen/ssd1306/ssd1306.adb
@@ -115,7 +115,12 @@ package body SSD1306 is
       Write_Command (This, COM_SCAN_DEC);
 
       Write_Command (This, SET_COMPINS);
-      Write_Command (This, 16#02#);
+      if This.Height > 32 then
+         Write_Command (This, 16#12#);
+      else
+         Write_Command (This, 16#02#);
+      end if;
+
       Write_Command (This, SET_CONTRAST);
       Write_Command (This, 16#AF#);
 
@@ -297,7 +302,7 @@ package body SSD1306 is
       if Layer /= 1 or else Mode /= M_1 then
          raise Program_Error;
       end if;
-      This.Memory_Layer.Actual_Width := This.Width;
+      This.Memory_Layer.Actual_Width  := This.Width;
       This.Memory_Layer.Actual_Height := This.Height;
       This.Memory_Layer.Addr := This.Memory_Layer.Data'Address;
       This.Memory_Layer.Actual_Color_Mode := Mode;
@@ -401,7 +406,7 @@ package body SSD1306 is
    is
       X     : constant Natural := Buffer.Width - 1 - Pt.X;
       Y     : constant Natural := Buffer.Height - 1 - Pt.Y;
-      Index : constant Natural :=  X + (Y / 8) * Buffer.Actual_Width;
+      Index : constant Natural := X + (Y / 8) * Buffer.Actual_Width;
       Byte  : UInt8 renames Buffer.Data (Buffer.Data'First + Index);
    begin
 

--- a/components/src/screen/ssd1306/ssd1306.adb
+++ b/components/src/screen/ssd1306/ssd1306.adb
@@ -478,4 +478,17 @@ package body SSD1306 is
       end if;
    end Pixel;
 
+   ----------
+   -- Fill --
+   ----------
+
+   overriding
+   procedure Fill
+     (Buffer : in out SSD1306_Bitmap_Buffer)
+   is
+      Val : constant UInt8 := (if Buffer.Native_Source /= 0 then 16#FF# else 0);
+   begin
+      Buffer.Data := (others => Val);
+   end Fill;
+
 end SSD1306;

--- a/components/src/screen/ssd1306/ssd1306.ads
+++ b/components/src/screen/ssd1306/ssd1306.ads
@@ -205,6 +205,10 @@ private
       Pt     : Point)
       return UInt32;
 
+   overriding
+   procedure Fill
+     (Buffer : in out SSD1306_Bitmap_Buffer);
+
    SSD1306_I2C_Addr : constant := 16#78#;
 
    type Bit_Array is array (Natural range <>) of Bit with Pack;


### PR DESCRIPTION
 - Microbit.Time: Add HAL.Time support
 - nRF51.TWI: Fix I2C address handling
 - SSD1306: Override procedure Fill with a faster implementation






