### PR TITLE
robust, safer version of GPIO_Port_Config and Configure_IO routine

### DIFF
--- a/arch/ARM/STM32/driver_demos/demo_L3GD20_dataready_int/src/demo_l3gd20.adb
+++ b/arch/ARM/STM32/driver_demos/demo_L3GD20_dataready_int/src/demo_l3gd20.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2016, AdaCore                           --
+--                  Copyright (C) 2016-2017, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -129,16 +129,12 @@ procedure Demo_L3GD20 is
    ------------------------------
 
    procedure Configure_Gyro_Interrupt is
-      Config : GPIO_Port_Configuration;
       --  This is the required port/pin configuration on STM32F429 Disco
       --  boards for interrupt 2 on the L3GD20 gyro. See the F429 Disco
       --  User Manual, Table 6, pg 19.
    begin
       Enable_Clock (MEMS_INT2);
-      Config.Mode := Mode_In;
-      Config.Resistors := Floating;
-      Config.Speed := Speed_50MHz;
-      Configure_IO (MEMS_INT2, Config);
+      Configure_IO (MEMS_INT2, (Mode => Mode_In, Resistors => Floating));
 
       Configure_Trigger (MEMS_INT2, Interrupt_Rising_Edge);
 

--- a/arch/ARM/STM32/driver_demos/demo_L3GD20_fifo_int/src/demo_l3gd20.adb
+++ b/arch/ARM/STM32/driver_demos/demo_L3GD20_fifo_int/src/demo_l3gd20.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2016, AdaCore                           --
+--                  Copyright (C) 2016-2017, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -175,16 +175,12 @@ procedure Demo_L3GD20 is
    ------------------------------
 
    procedure Configure_Gyro_Interrupt is
-      Config : GPIO_Port_Configuration;
       --  This is the required port/pin configuration on STM32F429 Disco
       --  boards for interrupt 2 on the L3GD20 gyro. See the F429 Disco
       --  User Manual, Table 6, pg 19.
    begin
       Enable_Clock (MEMS_INT2);
-      Config.Mode := Mode_In;
-      Config.Resistors := Floating;
-      Config.Speed := Speed_50MHz;
-      Configure_IO (MEMS_INT2, Config);
+      Configure_IO (MEMS_INT2, (Mode => Mode_In, Resistors => Floating));
 
       Configure_Trigger (MEMS_INT2, Interrupt_Rising_Edge);
    end Configure_Gyro_Interrupt;

--- a/arch/ARM/STM32/driver_demos/demo_adc_polling/src/demo_adc_gpio_polling.adb
+++ b/arch/ARM/STM32/driver_demos/demo_adc_polling/src/demo_adc_gpio_polling.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2016, AdaCore                           --
+--                  Copyright (C) 2016-2017, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -76,7 +76,6 @@ procedure Demo_ADC_GPIO_Polling is
    Raw : UInt32 := 0;
 
    Successful : Boolean;
-   Timed_Out  : exception;
 
    procedure Print (X, Y : Natural; Value : String);
 
@@ -99,7 +98,7 @@ procedure Demo_ADC_GPIO_Polling is
    procedure Configure_Analog_Input is
    begin
       Enable_Clock (Input);
-      Configure_IO (Input, (Mode => Mode_Analog, others => <>));
+      Configure_IO (Input, (Mode => Mode_Analog, Resistors => Floating));
    end Configure_Analog_Input;
 
 begin
@@ -136,13 +135,12 @@ begin
 
       Poll_For_Status (Converter, Regular_Channel_Conversion_Complete, Successful);
       if not Successful then
-         raise Timed_Out;
+         Red_LED.Toggle;
+      else
+         Green_LED.Toggle;
+         Raw := UInt32 (Conversion_Value (Converter));
+         Print (0, 0, Raw'Img);
       end if;
-
-      Raw := UInt32 (Conversion_Value (Converter));
-      Print (0, 0, Raw'Img);
-
-      Green_LED.Toggle;
 
       delay until Clock + Milliseconds (200); -- slow it down to ease reading
    end loop;

--- a/arch/ARM/STM32/driver_demos/demo_dac_basic/src/demo_dac_basic.adb
+++ b/arch/ARM/STM32/driver_demos/demo_dac_basic/src/demo_dac_basic.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                 Copyright (C) 2015-2016, AdaCore                         --
+--                  Copyright (C) 2015-2017, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -103,12 +103,9 @@ procedure Demo_DAC_Basic is
       Output : constant GPIO_Point := (if Output_Channel = Channel_1
                                        then DAC_Channel_1_IO
                                        else DAC_Channel_2_IO);
-      Config : GPIO_Port_Configuration;
    begin
       Enable_Clock (Output);
-      Config.Mode := Mode_Analog;
-      Config.Resistors := Floating;
-      Configure_IO (Output, Config);
+      Configure_IO (Output, (Mode => Mode_Analog, Resistors => Floating));
    end Configure_DAC_GPIO;
 
 begin

--- a/arch/ARM/STM32/driver_demos/demo_dac_dma/src/demo_dac_dma.adb
+++ b/arch/ARM/STM32/driver_demos/demo_dac_dma/src/demo_dac_dma.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                 Copyright (C) 2015-2016, AdaCore                         --
+--                 Copyright (C) 2015-2017, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -145,16 +145,12 @@ procedure Demo_DAC_DMA is
    ------------------------
 
    procedure Configure_DAC_GPIO (Output_Channel : DAC_Channel) is
-      Config : GPIO_Port_Configuration;
-
       Output : constant GPIO_Point := (if Output_Channel = Channel_1
                                        then DAC_Channel_1_IO
                                        else DAC_Channel_2_IO);
    begin
       Enable_Clock (Output);
-      Config.Mode := Mode_Analog;
-      Config.Resistors := Floating;
-      Configure_IO (Output, Config);
+      Configure_IO (Output, (Mode => Mode_Analog, Resistors => Floating));
    end Configure_DAC_GPIO;
 
    --------------------

--- a/arch/ARM/STM32/driver_demos/demo_dma_mem_to_peripheral/src/demo_usart_dma_continuous.adb
+++ b/arch/ARM/STM32/driver_demos/demo_dma_mem_to_peripheral/src/demo_usart_dma_continuous.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                 Copyright (C) 2015-2016, AdaCore                         --
+--                 Copyright (C) 2015-2017, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -70,18 +70,16 @@ procedure Demo_USART_DMA_Continuous is
    -------------------------------
 
    procedure Initialize_GPIO_Port_Pins is
-      Configuration : GPIO_Port_Configuration;
    begin
       Enable_Clock (RX_Pin & TX_Pin);
 
-      Configuration.Mode := Mode_AF;
-      Configuration.Speed := Speed_50MHz;
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Resistors := Pull_Up;
-
-      Configure_IO (RX_Pin & TX_Pin,  Config => Configuration);
-
-      Configure_Alternate_Function (RX_Pin & TX_Pin,  AF => Transceiver_AF);
+      Configure_IO
+        (RX_Pin & TX_Pin,
+         (Mode           => Mode_AF,
+          AF             => Transceiver_AF,
+          AF_Speed       => Speed_50MHz,
+          AF_Output_Type => Push_Pull,
+          Resistors      => Pull_Up));
    end Initialize_GPIO_Port_Pins;
 
    ----------------------

--- a/arch/ARM/STM32/driver_demos/demo_gpio_direct_leds/demo_gpio.gpr
+++ b/arch/ARM/STM32/driver_demos/demo_gpio_direct_leds/demo_gpio.gpr
@@ -39,7 +39,7 @@ project Demo_GPIO extends "../../../../../examples/shared/common/common.gpr" is
          when "Production" =>
             for Default_Switches ("ada") use (
                 "-g",
-                "-O3",
+                "-O2",
                 "-gnatp",
                 "-gnatn2",    -- honor Inline requests
                 "-Winline",  -- warn if cannot honor Inline aspect/pragma

--- a/arch/ARM/STM32/driver_demos/demo_gpio_direct_leds/src/demo_gpio.adb
+++ b/arch/ARM/STM32/driver_demos/demo_gpio_direct_leds/src/demo_gpio.adb
@@ -71,15 +71,15 @@ procedure Demo_GPIO is
    --  to demonstrate the use of the GPIO interface.
 
    procedure Initialize_LEDs is
-      Configuration : GPIO_Port_Configuration;
    begin
       Enable_Clock (GPIO_D);
 
-      Configuration.Mode        := Mode_Out;
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Speed       := Speed_100MHz;
-      Configuration.Resistors   := Floating;
-      Configure_IO (Pattern, Config => Configuration);
+      Configure_IO
+        (Pattern,
+         (Mode        => Mode_Out,
+          Resistors   => Floating,
+          Speed       => Speed_100MHz,
+          Output_Type => Push_Pull));
    end Initialize_LEDs;
 
 begin

--- a/arch/ARM/STM32/driver_demos/demo_timer_pwm/src/demo_pwm_adt.adb
+++ b/arch/ARM/STM32/driver_demos/demo_timer_pwm/src/demo_pwm_adt.adb
@@ -48,7 +48,6 @@ with Last_Chance_Handler;  pragma Unreferenced (Last_Chance_Handler);
 with STM32.Board;  use STM32.Board;
 with STM32.Device; use STM32.Device;
 with STM32.PWM;    use STM32.PWM;
-with STM32.GPIO;   use STM32.GPIO;
 with STM32.Timers; use STM32.Timers;
 
 procedure Demo_PWM_ADT is  -- demo the higher-level PWM abstract data type
@@ -83,26 +82,6 @@ procedure Demo_PWM_ADT is  -- demo the higher-level PWM abstract data type
    Requested_Frequency : constant Hertz := 30_000;  -- arbitrary
 
    Power_Control : PWM_Modulator;
-
-   procedure Configure_LEDs;
-   --  initialize all of the LEDs to be in the AF mode
-
-   --------------------
-   -- Configure_LEDs --
-   --------------------
-
-   procedure Configure_LEDs is
-      Configuration : GPIO_Port_Configuration;
-   begin
-      Enable_Clock (GPIO_D);
-
-      Configuration.Mode        := Mode_AF;  -- essential
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Speed       := Speed_50MHz;
-      Configuration.Resistors   := Floating;
-
-      Configure_IO (All_LEDs, Configuration);
-   end Configure_LEDs;
 
    --  The SFP run-time library for these boards is intended for certified
    --  environments and so does not contain the full set of facilities defined
@@ -139,8 +118,6 @@ procedure Demo_PWM_ADT is  -- demo the higher-level PWM abstract data type
    --  that value, thus the waxing/waning effect.
 
 begin
-   Configure_LEDs;
-
    Configure_PWM_Timer (Selected_Timer'Access, Requested_Frequency);
 
    Power_Control.Attach_PWM_Channel

--- a/arch/ARM/STM32/driver_demos/demo_timer_pwm/src/demo_timer_pwm.adb
+++ b/arch/ARM/STM32/driver_demos/demo_timer_pwm/src/demo_timer_pwm.adb
@@ -72,16 +72,16 @@ procedure Demo_Timer_PWM is -- low-level demo of the PWM capabilities
    procedure Configure_LEDs;
 
    procedure Configure_LEDs is
-      Configuration : GPIO_Port_Configuration;
    begin
       Enable_Clock (GPIO_D);
 
-      Configuration.Mode        := Mode_AF;  -- essential
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Speed       := Speed_50MHz;
-      Configuration.Resistors   := Floating;
-
-      Configure_IO (All_LEDs, Configuration);
+      Configure_IO
+        (All_LEDs,
+         (Mode_AF,
+          AF             => GPIO_AF_TIM4_2,
+          AF_Speed       => Speed_50MHz,
+          AF_Output_Type => Push_Pull,
+          Resistors      => Floating));
    end Configure_LEDs;
 
    --  The SFP run-time library for these boards is intended for certified
@@ -142,9 +142,6 @@ begin
       Polarity => High);
 
    Set_Autoreload_Preload (Timer_4, True);
-
-   Configure_Alternate_Function (All_LEDs, AF => GPIO_AF_TIM4_2);
-   --  Note we configured the LEDs to be in the AF mode in Configure_LEDs
 
    Enable_Channel (Timer_4, Output_Channel);
 

--- a/arch/ARM/STM32/driver_demos/demo_timer_quad_encoder/readme.md
+++ b/arch/ARM/STM32/driver_demos/demo_timer_quad_encoder/readme.md
@@ -32,5 +32,10 @@ that rate. The red LED indicates backward, the green forward.
 This demonstration should work on any STM32 board (that has two LEDs), and
 is known to work on F4 Discovery and F429 Discovery boards.
 
+The emulated motor alternates direction once per second. The two LEDs, one
+red and one green, are lit when the motor is under way in the corresponding
+direction. Hence the two LEDs will blink on and off when the program is
+functioning as intended.
+
 Based on a demonstration provided by ST Micro:
 C:\STM32Cube_FW_F4_V1.6.0\Projects\STM324x9I_EVAL\Examples\TIM\TIM_Encoder

--- a/arch/ARM/STM32/driver_demos/demo_timer_quad_encoder/src/encoder_emulator.adb
+++ b/arch/ARM/STM32/driver_demos/demo_timer_quad_encoder/src/encoder_emulator.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                 Copyright (C) 2015-2016, AdaCore                         --
+--                 Copyright (C) 2015-2017, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -104,19 +104,17 @@ package body Encoder_Emulator is
    ----------------
 
    procedure Initialize is
-      Configuration : GPIO_Port_Configuration;
    begin
       Enable_Clock (Emulator_Points);
-
       Enable_Clock (Emulator_Timer);
 
-      Configuration.Mode := Mode_AF;
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Resistors := Pull_Up;
-      Configuration.Speed := Speed_100MHz;
-
-      Configure_IO (Emulator_Points, Configuration);
-      Configure_Alternate_Function (Emulator_Points, Emulator_AF);
+      Configure_IO
+        (Emulator_Points,
+         (Mode           => Mode_AF,
+          AF             => Emulator_AF,
+          Resistors      => Pull_Up,
+          AF_Output_Type => Push_Pull,
+          AF_Speed       => Speed_100MHz));
 
       Configure
         (Emulator_Timer,

--- a/arch/ARM/STM32/driver_demos/demo_timer_quad_encoder/src/motor.adb
+++ b/arch/ARM/STM32/driver_demos/demo_timer_quad_encoder/src/motor.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                 Copyright (C) 2015-2016, AdaCore                         --
+--                 Copyright (C) 2015-2017, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -60,23 +60,19 @@ package body Motor is
    ----------------
 
    procedure Initialize is
-      Configuration : GPIO_Port_Configuration;
    begin
       Enable_Clock (Encoder_Tach0);
       Enable_Clock (Encoder_Tach1);
 
       Enable_Clock (Encoder_Timer);
 
-      Configuration.Mode := Mode_AF;
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Resistors := Pull_Up;
-      Configuration.Speed := Speed_100MHz;
-
-      Configure_IO (Encoder_Tach0, Configuration);
-      Configure_Alternate_Function (Encoder_Tach0, Encoder_AF);
-
-      Configure_IO (Encoder_Tach1, Configuration);
-      Configure_Alternate_Function (Encoder_Tach1, Encoder_AF);
+      Configure_IO
+        (Encoder_Tach0 & Encoder_Tach1,
+         (Mode           => Mode_AF,
+          AF             => Encoder_AF,
+          Resistors      => Pull_Up,
+          AF_Output_Type => Push_Pull,
+          AF_Speed       => Speed_100MHz));
 
       Configure_Encoder_Interface
         (Encoder_Timer,

--- a/arch/ARM/STM32/driver_demos/demo_usart_interrupts/src/demo_usart_interrupts.adb
+++ b/arch/ARM/STM32/driver_demos/demo_usart_interrupts/src/demo_usart_interrupts.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                 Copyright (C) 2015-2016, AdaCore                         --
+--                 Copyright (C) 2015-2017, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -62,19 +62,17 @@ procedure Demo_USART_Interrupts is
    -----------------------------
 
    procedure Initialize_STMicro_UART is
-      Configuration : GPIO_Port_Configuration;
    begin
       Enable_Clock (Transceiver);
       Enable_Clock (RX_Pin & TX_Pin);
 
-      Configuration.Mode := Mode_AF;
-      Configuration.Speed := Speed_50MHz;
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Resistors := Pull_Up;
-
-      Configure_IO (RX_Pin & TX_Pin, Config => Configuration);
-
-      Configure_Alternate_Function (RX_Pin & TX_Pin,  AF => Transceiver_AF);
+      Configure_IO
+        (RX_Pin & TX_Pin,
+         (Mode           => Mode_AF,
+          AF             => Transceiver_AF,
+          Resistors      => Pull_Up,
+          AF_Output_Type => Push_Pull,
+          AF_Speed       => Speed_50MHz));
    end Initialize_STMicro_UART;
 
    ----------------

--- a/arch/ARM/STM32/driver_demos/demo_usart_polling/src/demo_usart_polling.adb
+++ b/arch/ARM/STM32/driver_demos/demo_usart_polling/src/demo_usart_polling.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                 Copyright (C) 2015-2016, AdaCore                         --
+--                 Copyright (C) 2015-2017, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -55,19 +55,17 @@ procedure Demo_USART_Polling is
    --------------------------
 
    procedure Initialize_UART_GPIO is
-      Configuration : GPIO_Port_Configuration;
    begin
       Enable_Clock (USART_1);
       Enable_Clock (RX_Pin & TX_Pin);
 
-      Configuration.Mode := Mode_AF;
-      Configuration.Speed := Speed_50MHz;
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Resistors := Pull_Up;
-
-      Configure_IO (RX_Pin & TX_Pin, Configuration);
-
-      Configure_Alternate_Function (RX_Pin & TX_Pin, AF => GPIO_AF_USART1_7);
+      Configure_IO
+        (RX_Pin & TX_Pin,
+         (Mode           => Mode_AF,
+          AF             => GPIO_AF_USART1_7,
+          Resistors      => Pull_Up,
+          AF_Speed       => Speed_50MHz,
+          AF_Output_Type => Push_Pull));
    end Initialize_UART_GPIO;
 
    ----------------

--- a/arch/ARM/STM32/drivers/stm32-gpio.adb
+++ b/arch/ARM/STM32/drivers/stm32-gpio.adb
@@ -347,10 +347,20 @@ package body STM32.GPIO is
    is
       Index : constant GPIO_Pin_Index := GPIO_Pin'Pos (This.Pin);
    begin
-      This.Periph.MODER.Arr (Index)     := Pin_IO_Modes'Enum_Rep (Config.Mode);
-      This.Periph.OTYPER.OT.Arr (Index) := Config.Output_Type = Open_Drain;
-      This.Periph.OSPEEDR.Arr (Index)   := Pin_Output_Speeds'Enum_Rep (Config.Speed);
-      This.Periph.PUPDR.Arr (Index)     := Internal_Pin_Resistors'Enum_Rep (Config.Resistors);
+      This.Periph.MODER.Arr (Index) := Pin_IO_Modes'Enum_Rep (Config.Mode);
+      This.Periph.PUPDR.Arr (Index) := Internal_Pin_Resistors'Enum_Rep (Config.Resistors);
+
+      case Config.Mode is
+         when Mode_In | Mode_Analog =>
+            null;
+         when Mode_Out =>
+            This.Periph.OTYPER.OT.Arr (Index) := Config.Output_Type = Open_Drain;
+            This.Periph.OSPEEDR.Arr (Index)   := Pin_Output_Speeds'Enum_Rep (Config.Speed);
+         when Mode_AF =>
+            This.Periph.OTYPER.OT.Arr (Index) := Config.AF_Output_Type = Open_Drain;
+            This.Periph.OSPEEDR.Arr (Index)   := Pin_Output_Speeds'Enum_Rep (Config.AF_Speed);
+            Configure_Alternate_Function (This, Config.AF);
+      end case;
    end Configure_IO;
 
    ------------------

--- a/arch/ARM/STM32/drivers/stm32-gpio.ads
+++ b/arch/ARM/STM32/drivers/stm32-gpio.ads
@@ -119,11 +119,20 @@ package STM32.GPIO is
                                    Pull_Up   => 1,
                                    Pull_Down => 2);
 
-   type GPIO_Port_Configuration is record
-      Mode        : Pin_IO_Modes;
-      Output_Type : Pin_Output_Types;
-      Speed       : Pin_Output_Speeds;
-      Resistors   : Internal_Pin_Resistors;
+   --  see the Reference Manual, table 35, section 8.3
+   type GPIO_Port_Configuration (Mode : Pin_IO_Modes := Mode_In) is record
+      Resistors : Internal_Pin_Resistors;
+      case Mode is
+         when Mode_In | Mode_Analog =>
+            null;
+         when Mode_Out =>
+            Output_Type : Pin_Output_Types;
+            Speed       : Pin_Output_Speeds;
+         when Mode_AF =>
+            AF_Output_Type : Pin_Output_Types;
+            AF_Speed       : Pin_Output_Speeds;
+            AF             : GPIO_Alternate_Function;
+      end case;
    end record;
 
    type GPIO_Point is new HAL.GPIO.GPIO_Point with record

--- a/arch/ARM/STM32/drivers/stm32-pwm.adb
+++ b/arch/ARM/STM32/drivers/stm32-pwm.adb
@@ -321,16 +321,13 @@ package body STM32.PWM is
      (Output : GPIO_Point;
       PWM_AF : GPIO_Alternate_Function)
    is
-      Configuration : GPIO_Port_Configuration;
    begin
-      Configuration.Mode        := Mode_AF;
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Speed       := Speed_100MHz;
-      Configuration.Resistors   := Floating;
-
-      Output.Configure_IO (Configuration);
-
-      Output.Configure_Alternate_Function (PWM_AF);
+      Output.Configure_IO
+        ((Mode_AF,
+          AF             => PWM_AF,
+          Resistors      => Floating,
+          AF_Output_Type => Push_Pull,
+          AF_Speed       => Speed_100MHz));
 
       Output.Lock;
    end Configure_PWM_GPIO;

--- a/arch/ARM/STM32/drivers/stm32-setup.adb
+++ b/arch/ARM/STM32/drivers/stm32-setup.adb
@@ -51,11 +51,18 @@ package body STM32.Setup is
       Configure_Alternate_Function (SDA, SDA_AF);
       Configure_Alternate_Function (SCL, SCL_AF);
 
-      Configure_IO (SDA & SCL,
-                    (Speed       => Speed_High,
-                     Mode        => Mode_AF,
-                     Output_Type => Open_Drain,
-                     Resistors   => Floating));
+      Configure_IO (SDA,
+                    (Mode           => Mode_AF,
+                     AF             => SDA_AF,
+                     AF_Speed       => Speed_High,
+                     AF_Output_Type => Open_Drain,
+                     Resistors      => Floating));
+      Configure_IO (SCL,
+                    (Mode           => Mode_AF,
+                     AF             => SCL_AF,
+                     AF_Speed       => Speed_High,
+                     AF_Output_Type => Open_Drain,
+                     Resistors      => Floating));
       Lock (SDA & SCL);
 
       -- I2C --

--- a/boards/OpenMV2/src/openmv-lcd_shield.adb
+++ b/boards/OpenMV2/src/openmv-lcd_shield.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2017, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -69,10 +69,10 @@ package body OpenMV.LCD_Shield is
 
       STM32.Device.Enable_Clock (All_Points);
 
-      GPIO_Conf.Mode        := STM32.GPIO.Mode_Out;
-      GPIO_Conf.Output_Type := STM32.GPIO.Push_Pull;
-      GPIO_Conf.Speed       := STM32.GPIO.Speed_100MHz;
-      GPIO_Conf.Resistors   := STM32.GPIO.Floating;
+      GPIO_Conf := (Mode        => STM32.GPIO.Mode_Out;
+                    Output_Type => STM32.GPIO.Push_Pull;
+                    Speed       => STM32.GPIO.Speed_100MHz;
+                    Resistors   => STM32.GPIO.Floating);
 
       STM32.GPIO.Configure_IO (All_Points, GPIO_Conf);
 

--- a/boards/OpenMV2/src/openmv-sensor.adb
+++ b/boards/OpenMV2/src/openmv-sensor.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2017, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -216,18 +216,21 @@ package body OpenMV.Sensor is
 
          Enable_Clock (DCMI_Out_Points);
          --  Sensor PowerDown, Reset and FSIN
-         GPIO_Conf.Mode := Mode_Out;
-         GPIO_Conf.Output_Type := Push_Pull;
-         GPIO_Conf.Resistors := Pull_Down;
+         GPIO_Conf := (Mode        => Mode_Out,
+                       Output_Type => Push_Pull,
+                       Speed       => Speed_100MHz,  -- not specified in previous version of this module
+                       Resistors   => Pull_Down);
          Configure_IO (DCMI_Out_Points, GPIO_Conf);
 
          Clear (DCMI_Out_Points);
 
-         GPIO_Conf.Mode := Mode_AF;
-         GPIO_Conf.Output_Type := Push_Pull;
-         GPIO_Conf.Resistors := Pull_Down;
+         GPIO_Conf := (Mode           => Mode_AF,
+                       AF             => GPIO_AF_DCMI_13,
+                       AF_Speed       => Speed_100MHz,  -- not specified in previous version of this module
+                       AF_Output_Type => Push_Pull,
+                       Resistors      => Pull_Down);
+
          Configure_IO (DCMI_AF_Points, GPIO_Conf);
-         Configure_Alternate_Function (DCMI_AF_Points, GPIO_AF_DCMI_13);
       end Initialize_IO;
 
       ---------------------

--- a/boards/OpenMV2/src/openmv.adb
+++ b/boards/OpenMV2/src/openmv.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2017, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -39,16 +39,15 @@ package body OpenMV is
    ---------------------
 
    procedure Initialize_LEDs is
-      Conf : GPIO_Port_Configuration;
    begin
       Enable_Clock (All_LEDs);
 
-      Conf.Mode        := Mode_Out;
-      Conf.Output_Type := Push_Pull;
-      Conf.Speed       := Speed_100MHz;
-      Conf.Resistors   := Floating;
-
-      Configure_IO (All_LEDs, Conf);
+      Configure_IO
+        (All_LEDs,
+         (Mode        => Mode_Out,
+          Output_Type => Push_Pull,
+          Speed       => Speed_100MHz,
+          Resistors   => Floating));
    end Initialize_LEDs;
 
    -----------------
@@ -139,16 +138,13 @@ package body OpenMV is
 
       STM32.Device.Enable_Clock (Shield_SPI_Points);
 
-      GPIO_Conf.Speed       := STM32.GPIO.Speed_100MHz;
-      GPIO_Conf.Mode        := STM32.GPIO.Mode_AF;
-      GPIO_Conf.Output_Type := STM32.GPIO.Push_Pull;
-      GPIO_Conf.Resistors   := STM32.GPIO.Pull_Down; --  SPI low polarity
+      GPIO_Conf := (Mode           => STM32.GPIO.Mode_AF,
+                    AF             => GPIO_AF_SPI2_5,
+                    Resistors      => STM32.GPIO.Pull_Down, --  SPI low polarity
+                    AF_Speed       => STM32.GPIO.Speed_100MHz,
+                    AF_Output_Type => STM32.GPIO.Push_Pull);
 
       STM32.GPIO.Configure_IO (Shield_SPI_Points, GPIO_Conf);
-
-      STM32.GPIO.Configure_Alternate_Function
-        (Shield_SPI_Points,
-         GPIO_AF_SPI2_5);
 
       STM32.Device.Enable_Clock (Shield_SPI);
 
@@ -179,14 +175,13 @@ package body OpenMV is
       Enable_Clock (Shield_USART);
       Enable_Clock (Shield_USART_Points);
 
-      Configuration.Mode := Mode_AF;
-      Configuration.Speed := Speed_50MHz;
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Resistors := Pull_Up;
+      Configuration := (Mode           => STM32.GPIO.Mode_AF,
+                        AF             => Shield_USART_AF,
+                        Resistors      => STM32.GPIO.Pull_Up,
+                        AF_Speed       => STM32.GPIO.Speed_50MHz,
+                        AF_Output_Type => STM32.GPIO.Push_Pull);
 
       Configure_IO (Shield_USART_Points, Configuration);
-
-      Configure_Alternate_Function (Shield_USART_Points, Shield_USART_AF);
 
       Disable (Shield_USART);
 

--- a/boards/crazyflie/src/stm32-board.adb
+++ b/boards/crazyflie/src/stm32-board.adb
@@ -110,16 +110,16 @@ package body STM32.Board is
    ---------------------
 
    procedure Initialize_LEDs is
-      Configuration : GPIO_Port_Configuration;
    begin
       Enable_Clock (All_LEDs);
 
-      Configuration.Mode        := Mode_Out;
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Speed       := Speed_100MHz;
-      Configuration.Resistors   := Floating;
-      Configure_IO (All_LEDs,
-                    Config => Configuration);
+      Configure_IO
+        (All_LEDs,
+         (Mode        => Mode_Out,
+          Output_Type => Push_Pull,
+          Speed       => Speed_100MHz,
+          Resistors   => Floating));
+
       All_LEDs_Off;
    end Initialize_LEDs;
 
@@ -144,12 +144,12 @@ package body STM32.Board is
       Enable_Clock (Port);
       Reset (Port);
 
-      Configure_Alternate_Function (Points, GPIO_AF_I2C2_4);
       Configure_IO (Points,
-                    (Speed       => Speed_25MHz,
-                     Mode        => Mode_AF,
-                     Output_Type => Open_Drain,
-                     Resistors   => Floating));
+                    (AF_Speed       => Speed_25MHz,
+                     Mode           => Mode_AF,
+                     AF             => GPIO_AF_I2C2_4,
+                     AF_Output_Type => Open_Drain,
+                     Resistors      => Floating));
       Lock (Points);
    end Initialize_I2C_GPIO;
 

--- a/boards/stm32_common/common/stm32-user_button.adb
+++ b/boards/stm32_common/common/stm32-user_button.adb
@@ -125,10 +125,8 @@ package body STM32.User_Button is
       Enable_Clock (User_Button_Point);
 
       User_Button_Point.Configure_IO
-        ((Mode        => Mode_In,
-          Output_Type => Open_Drain,
-          Speed       => Speed_50MHz,
-          Resistors   => (if Use_Rising_Edge then Pull_Down else Pull_Up)));
+        ((Mode      => Mode_In,
+          Resistors => (if Use_Rising_Edge then Pull_Down else Pull_Up)));
 
       --  Connect the button's pin to the External Interrupt Handler
       User_Button_Point.Configure_Trigger (Edge);

--- a/boards/stm32_common/sdcard/sdcard.adb
+++ b/boards/stm32_common/sdcard/sdcard.adb
@@ -59,20 +59,27 @@ package body SDCard is
 
       --  GPIO configuration for the SDIO pins
       Configure_IO
-        (SD_Pins & SD_Pins_2,
-         (Mode        => Mode_AF,
-          Output_Type => Push_Pull,
-          Speed       => Speed_High,
-          Resistors   => Pull_Up));
-      Configure_Alternate_Function (SD_Pins, SD_Pins_AF);
-      Configure_Alternate_Function (SD_Pins_2, SD_Pins_AF_2);
+        (SD_Pins,
+         (Mode           => Mode_AF,
+          AF             => SD_Pins_AF,
+          AF_Output_Type => Push_Pull,
+          AF_Speed       => Speed_High,
+          Resistors      => Pull_Up));
+
+      Configure_IO
+        (SD_Pins_2,
+         (Mode           => Mode_AF,
+          AF             => SD_Pins_AF_2,
+          AF_Output_Type => Push_Pull,
+          AF_Speed       => Speed_High,
+          Resistors      => Pull_Up));
 
       --  GPIO configuration for the SD-Detect pin
       Configure_IO
         (SD_Detect_Pin,
          (Mode        => Mode_In,
-          Output_Type => Open_Drain,
-          Speed       => Speed_High,
+--            Output_Type => Open_Drain,
+--            Speed       => Speed_High,
           Resistors   => Pull_Up));
 
       --  Enable the SDIO clock

--- a/boards/stm32_common/sdram/stm32-sdram.adb
+++ b/boards/stm32_common/sdram/stm32-sdram.adb
@@ -59,11 +59,12 @@ package body STM32.SDRAM is
       Enable_Clock (SDRAM_PINS);
 
       Configure_IO (SDRAM_PINS,
-                    (Speed       => Speed_50MHz,
-                     Mode        => Mode_AF,
-                     Output_Type => Push_Pull,
-                     Resistors   => Pull_Up));
-      Configure_Alternate_Function (SDRAM_PINS, GPIO_AF_FMC_12);
+                    (Mode           => Mode_AF,
+                     AF             => GPIO_AF_FMC_12,
+                     AF_Speed       => Speed_50MHz,
+                     AF_Output_Type => Push_Pull,
+                     Resistors      => Pull_Up));
+
       Lock (SDRAM_PINS);
    end SDRAM_GPIOConfig;
 

--- a/boards/stm32_common/stm32f407disco/stm32-board.adb
+++ b/boards/stm32_common/stm32f407disco/stm32-board.adb
@@ -71,16 +71,15 @@ package body STM32.Board is
    ---------------------
 
    procedure Initialize_LEDs is
-      Configuration : GPIO_Port_Configuration;
    begin
       Enable_Clock (All_LEDs);
 
-      Configuration.Mode        := Mode_Out;
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Speed       := Speed_100MHz;
-      Configuration.Resistors   := Floating;
-      Configure_IO (All_LEDs,
-                    Config => Configuration);
+      Configure_IO
+        (All_LEDs,
+         (Mode_Out,
+          Resistors   => Floating,
+          Output_Type => Push_Pull,
+          Speed       => Speed_100MHz));
    end Initialize_LEDs;
 
    ----------------------
@@ -103,12 +102,11 @@ package body STM32.Board is
          Enable_Clock (Audio_I2S_Points);
 
          Configure_IO (Audio_I2S_Points,
-                       (Speed       => Speed_High,
-                        Mode        => Mode_AF,
-                        Output_Type => Push_Pull,
-                        Resistors   => Floating));
-
-         Configure_Alternate_Function (Audio_I2S_Points, GPIO_AF_I2S3_6);
+            (Mode           => Mode_AF,
+             Resistors      => Floating,
+             AF_Speed       => Speed_High,
+             AF_Output_Type => Push_Pull,
+             AF             => GPIO_AF_I2S3_6));
 
          Lock (Audio_I2S_Points);
 
@@ -172,14 +170,9 @@ package body STM32.Board is
    --------------------------------
 
    procedure Configure_User_Button_GPIO is
-      Config : GPIO_Port_Configuration;
    begin
       Enable_Clock (User_Button_Point);
-
-      Config.Mode := Mode_In;
-      Config.Resistors := Floating;
-
-      Configure_IO (User_Button_Point, Config);
+      Configure_IO (User_Button_Point, (Mode_In, Resistors => Floating));
    end Configure_User_Button_GPIO;
 
    ------------------------------
@@ -220,28 +213,26 @@ package body STM32.Board is
       ---------------
 
       procedure Init_GPIO is
-         Config : GPIO_Port_Configuration;
          SPI_Points : constant GPIO_Points := Acc_SPI_MOSI_Pin &
            Acc_SPI_MISO_Pin & Acc_SPI_SCK_Pin;
       begin
          Enable_Clock (SPI_Points);
 
-         Config.Output_Type := Push_Pull;
-         Config.Resistors   := Floating;
-         Config.Speed       := Speed_50MHz;
-         Config.Mode        := Mode_AF;
-
-         Configure_IO (SPI_Points, Config);
-         Configure_Alternate_Function (SPI_Points, Acc_SPI_AF);
+         Configure_IO (SPI_Points,
+            (Mode_AF,
+             AF             => Acc_SPI_AF,
+             Resistors      => Floating,
+             AF_Speed       => Speed_50MHz,
+             AF_Output_Type => Push_Pull));
 
          Enable_Clock (Acc_Chip_Select_Pin);
 
-         Config.Mode        := Mode_Out;
-         Config.Output_Type := Push_Pull;
-         Config.Resistors   := Pull_Up;
-         Config.Speed       := Speed_25MHz;
+         Acc_Chip_Select_Pin.Configure_IO
+           ((Mode_Out,
+            Resistors   => Pull_Up,
+            Output_Type => Push_Pull,
+            Speed       => Speed_25MHz));
 
-         Acc_Chip_Select_Pin.Configure_IO (Config);
          Acc_Chip_Select_Pin.Set;
       end Init_GPIO;
 

--- a/boards/stm32_common/stm32f429disco/framebuffer_ili9341.adb
+++ b/boards/stm32_common/stm32f429disco/framebuffer_ili9341.adb
@@ -62,12 +62,12 @@ package body Framebuffer_ILI9341 is
       Enable_Clock (SPI_Pins);
       Enable_Clock (LCD_SPI);
 
-      Conf.Speed       := Speed_100MHz;
-      Conf.Mode        := Mode_AF;
-      Conf.Output_Type := Push_Pull;
-      Conf.Resistors   := Floating;
+      Conf := (Mode           => Mode_AF,
+               AF             => GPIO_AF_SPI5_5,
+               AF_Speed       => Speed_100MHz,
+               AF_Output_Type => Push_Pull,
+               Resistors      => Floating);
 
-      Configure_Alternate_Function (SPI_Pins, GPIO_AF_SPI5_5);
       Configure_IO (SPI_Pins, Conf);
 
       Reset (LCD_SPI);
@@ -104,14 +104,15 @@ package body Framebuffer_ILI9341 is
                     Output_Type => Push_Pull,
                     Resistors   => Floating));
 
-      Configure_Alternate_Function (LCD_PINS, GPIO_AF_LTDC_14);
-      Configure_Alternate_Function (LCD_RGB_AF9, GPIO_AF_LTDC_9);
       Configure_IO
         (Points => LCD_PINS,
-         Config => (Speed       => Speed_50MHz,
-                    Mode        => Mode_AF,
-                    Output_Type => Push_Pull,
-                    Resistors   => Floating));
+         Config => (AF_Speed       => Speed_50MHz,
+                    AF             => GPIO_AF_LTDC_14,
+                    Mode           => Mode_AF,
+                    AF_Output_Type => Push_Pull,
+                    Resistors      => Floating));
+
+      Configure_Alternate_Function (LCD_RGB_AF9, GPIO_AF_LTDC_9);
 
       --  Set LCD_CSX: Chip Unselect
       Set (LCD_CSX);

--- a/boards/stm32_common/stm32f429disco/stm32-board.adb
+++ b/boards/stm32_common/stm32f429disco/stm32-board.adb
@@ -68,16 +68,15 @@ package body STM32.Board is
    ---------------------
 
    procedure Initialize_LEDs is
-      Conf : GPIO_Port_Configuration;
    begin
       Enable_Clock (All_LEDs);
 
-      Conf.Mode        := Mode_Out;
-      Conf.Output_Type := Push_Pull;
-      Conf.Speed       := Speed_100MHz;
-      Conf.Resistors   := Floating;
-
-      Configure_IO (All_LEDs, Conf);
+      Configure_IO
+        (All_LEDs,
+         (Mode        => Mode_Out,
+          Output_Type => Push_Pull,
+          Speed       => Speed_100MHz,
+          Resistors   => Floating));
    end Initialize_LEDs;
 
    ------------------------
@@ -93,10 +92,10 @@ package body STM32.Board is
       Init_Chip_Select : declare
          Config : GPIO_Port_Configuration;
       begin
-         Config.Speed := Speed_25MHz;
-         Config.Mode := Mode_Out;
-         Config.Output_Type := Push_Pull;
-         Config.Resistors := Pull_Up;
+         Config := (Mode        => Mode_Out,
+                    Speed       => Speed_25MHz,
+                    Output_Type => Push_Pull,
+                    Resistors   => Pull_Up);
 
          Configure_IO (NCS_MEMS_SPI, Config);
       end Init_Chip_Select;
@@ -104,16 +103,13 @@ package body STM32.Board is
       Init_SPI_IO_Pins : declare
          Config : GPIO_Port_Configuration;
       begin
-         Config.Speed       := Speed_100MHz;
-         Config.Mode        := Mode_AF;
-         Config.Output_Type := Push_Pull;
-         Config.Resistors   := Floating;
+         Config := (Mode           => Mode_AF,
+                    AF             => GPIO_AF_SPI5_5,
+                    AF_Speed       => Speed_100MHz,
+                    AF_Output_Type => Push_Pull,
+                    Resistors      => Floating);
 
          Configure_IO (SPI5_SCK & SPI5_MISO & SPI5_MOSI, Config);
-
-         Configure_Alternate_Function
-           (SPI5_SCK & SPI5_MISO & SPI5_MOSI,
-            GPIO_AF_SPI5_5);
       end Init_SPI_IO_Pins;
 
       Init_SPI_Port : declare
@@ -149,14 +145,9 @@ package body STM32.Board is
    --------------------------------
 
    procedure Configure_User_Button_GPIO is
-      Config : GPIO_Port_Configuration;
    begin
       Enable_Clock (User_Button_Point);
-
-      Config.Mode := Mode_In;
-      Config.Resistors := Floating;
-
-      User_Button_Point.Configure_IO (Config);
+      User_Button_Point.Configure_IO ((Mode_In, Resistors => Floating));
    end Configure_User_Button_GPIO;
 
 end STM32.Board;

--- a/boards/stm32_common/stm32f469disco/audio.adb
+++ b/boards/stm32_common/stm32f469disco/audio.adb
@@ -122,11 +122,11 @@ package body Audio is
       Enable_Clock (SAI_Pins);
       Configure_IO
         (SAI_Pins,
-         (Mode        => Mode_AF,
-          Output_Type => Push_Pull,
-          Speed       => Speed_High,
-          Resistors   => Floating));
-      Configure_Alternate_Function (SAI_Pins, SAI_Pins_AF);
+         (Mode           => Mode_AF,
+          AF             => SAI_Pins_AF,
+          AF_Output_Type => Push_Pull,
+          AF_Speed       => Speed_High,
+          Resistors      => Floating));
 
       Enable_Clock (Audio_DMA);
 

--- a/boards/stm32_common/stm32f469disco/stm32-board.adb
+++ b/boards/stm32_common/stm32f469disco/stm32-board.adb
@@ -54,16 +54,16 @@ package body STM32.Board is
    ---------------------
 
    procedure Initialize_LEDs is
-      Conf : GPIO_Port_Configuration;
    begin
       Enable_Clock (All_LEDs);
 
-      Conf.Mode        := Mode_Out;
-      Conf.Output_Type := Push_Pull;
-      Conf.Speed       := Speed_100MHz;
-      Conf.Resistors   := Floating;
+      Configure_IO
+        (All_LEDs,
+         (Mode        => Mode_Out,
+          Output_Type => Push_Pull,
+          Speed       => Speed_100MHz,
+          Resistors   => Floating));
 
-      Configure_IO (All_LEDs, Conf);
       All_LEDs_Off;
    end Initialize_LEDs;
 
@@ -93,17 +93,12 @@ package body STM32.Board is
 
       Enable_Clock (Points);
 
-      if Id = I2C_Id_1 then
-         Configure_Alternate_Function (Points, GPIO_AF_I2C1_4);
-      else
-         Configure_Alternate_Function (Points, GPIO_AF_I2C2_4);
-      end if;
-
       Configure_IO (Points,
-                    (Speed       => Speed_High,
-                     Mode        => Mode_AF,
-                     Output_Type => Open_Drain,
-                     Resistors   => Floating));
+                    (Mode           => Mode_AF,
+                     AF             => (if Id = I2C_Id_1 then GPIO_AF_I2C1_4 else GPIO_AF_I2C2_4),
+                     AF_Speed       => Speed_High,
+                     AF_Output_Type => Open_Drain,
+                     Resistors      => Floating));
       Lock (Points);
 
       Enable_Clock (Port);
@@ -115,14 +110,10 @@ package body STM32.Board is
    --------------------------------
 
    procedure Configure_User_Button_GPIO is
-      Config : GPIO_Port_Configuration;
    begin
       Enable_Clock (User_Button_Point);
 
-      Config.Mode := Mode_In;
-      Config.Resistors := Floating;
-
-      Configure_IO (User_Button_Point, Config);
+      Configure_IO (User_Button_Point, (Mode_In, Resistors => Floating));
    end Configure_User_Button_GPIO;
 
 end STM32.Board;

--- a/boards/stm32_common/stm32f469disco/touch_panel_ft6x06.adb
+++ b/boards/stm32_common/stm32f469disco/touch_panel_ft6x06.adb
@@ -59,11 +59,14 @@ package body Touch_Panel_FT6x06 is
    begin
       Enable_Clock (TP_INT);
 
+--        Configure_IO (TP_INT,
+--                      (Speed       => Speed_50MHz,
+--                       Mode        => Mode_In,
+--                       Output_Type => Open_Drain,
+--                       Resistors   => Pull_Up));
       Configure_IO (TP_INT,
-                    (Speed       => Speed_50MHz,
-                     Mode        => Mode_In,
-                     Output_Type => Open_Drain,
-                     Resistors   => Pull_Up));
+                    (Mode      => Mode_In,
+                     Resistors => Pull_Up));
       Lock (TP_INT);
    end TP_Init_Pins;
 

--- a/boards/stm32_common/stm32f746disco/audio.adb
+++ b/boards/stm32_common/stm32f746disco/audio.adb
@@ -108,11 +108,11 @@ package body Audio is
 
       Configure_IO
         (SAI_Pins,
-         (Mode        => Mode_AF,
-          Output_Type => Push_Pull,
-          Speed       => Speed_High,
-          Resistors   => Floating));
-      Configure_Alternate_Function (SAI_Pins, SAI_Pins_AF);
+         (Mode           => Mode_AF,
+          AF             => SAI_Pins_AF,
+          AF_Output_Type => Push_Pull,
+          AF_Speed       => Speed_High,
+          Resistors      => Floating));
 
       Enable_Clock (Audio_DMA);
 

--- a/boards/stm32_common/stm32f746disco/framebuffer_rk043fn48h.adb
+++ b/boards/stm32_common/stm32f746disco/framebuffer_rk043fn48h.adb
@@ -69,15 +69,16 @@ package body Framebuffer_RK043FN48H is
    begin
       Enable_Clock (LTDC_Pins);
 
-      Configure_Alternate_Function
-        (LCD_CTRL_PINS & LCD_RGB_AF14, GPIO_AF_LTDC_14);
-      Configure_Alternate_Function (LCD_RGB_AF9, GPIO_AF_LTDC_9);
       Configure_IO
         (Points => LTDC_Pins,
-         Config => (Speed       => Speed_50MHz,
-                    Mode        => Mode_AF,
-                    Output_Type => Push_Pull,
-                    Resistors   => Floating));
+         Config => (Mode           => Mode_AF,
+                    AF             => GPIO_AF_LTDC_14,
+                    AF_Speed       => Speed_50MHz,
+                    AF_Output_Type => Push_Pull,
+                    Resistors      => Floating));
+
+      Configure_Alternate_Function (LCD_RGB_AF9, GPIO_AF_LTDC_9);
+
       Lock (LTDC_Pins);
 
       Configure_IO
@@ -86,6 +87,7 @@ package body Framebuffer_RK043FN48H is
                     Mode        => Mode_Out,
                     Output_Type => Push_Pull,
                     Resistors   => Pull_Down));
+
       Lock (LCD_ENABLE & LCD_BL_CTRL);
    end Init_Pins;
 

--- a/boards/stm32_common/stm32f746disco/stm32-board.adb
+++ b/boards/stm32_common/stm32f746disco/stm32-board.adb
@@ -54,16 +54,14 @@ package body STM32.Board is
    ---------------------
 
    procedure Initialize_LEDs is
-      Conf : GPIO_Port_Configuration;
    begin
       Enable_Clock (All_LEDs);
 
-      Conf.Mode        := Mode_Out;
-      Conf.Output_Type := Push_Pull;
-      Conf.Speed       := Speed_100MHz;
-      Conf.Resistors   := Floating;
-
-      Configure_IO (All_LEDs, Conf);
+      Configure_IO (All_LEDs,
+                    (Mode        => Mode_Out,
+                     Output_Type => Push_Pull,
+                     Speed       => Speed_100MHz,
+                     Resistors   => Floating));
    end Initialize_LEDs;
 
    -------------------------
@@ -86,12 +84,12 @@ package body STM32.Board is
 
       Enable_Clock (Points);
 
-      Configure_Alternate_Function (Points, GPIO_AF_I2C2_4);
       Configure_IO (Points,
-                    (Speed       => Speed_25MHz,
-                     Mode        => Mode_AF,
-                     Output_Type => Open_Drain,
-                     Resistors   => Floating));
+                    (Mode           => Mode_AF,
+                     AF             => GPIO_AF_I2C2_4,
+                     AF_Speed       => Speed_25MHz,
+                     AF_Output_Type => Open_Drain,
+                     Resistors      => Floating));
       Lock (Points);
    end Initialize_I2C_GPIO;
 
@@ -100,14 +98,9 @@ package body STM32.Board is
    --------------------------------
 
    procedure Configure_User_Button_GPIO is
-      Config : GPIO_Port_Configuration;
    begin
       Enable_Clock (User_Button_Point);
-
-      Config.Mode := Mode_In;
-      Config.Resistors := Floating;
-
-      Configure_IO (User_Button_Point, Config);
+      Configure_IO (User_Button_Point, (Mode_In, Resistors => Floating));
    end Configure_User_Button_GPIO;
 
 end STM32.Board;

--- a/boards/stm32_common/stm32f769disco/audio.adb
+++ b/boards/stm32_common/stm32f769disco/audio.adb
@@ -111,11 +111,11 @@ package body Audio is
 
       Configure_IO
         (SAI_Pins,
-         (Mode        => Mode_AF,
-          Output_Type => Push_Pull,
-          Speed       => Speed_High,
-          Resistors   => Floating));
-      Configure_Alternate_Function (SAI_Pins, SAI_Pins_AF);
+         (Mode           => Mode_AF,
+          AF             => SAI_Pins_AF,
+          AF_Output_Type => Push_Pull,
+          AF_Speed       => Speed_High,
+          Resistors      => Floating));
 
       Enable_Clock (Audio_DMA);
 

--- a/boards/stm32_common/stm32f769disco/stm32-board.adb
+++ b/boards/stm32_common/stm32f769disco/stm32-board.adb
@@ -54,16 +54,15 @@ package body STM32.Board is
    ---------------------
 
    procedure Initialize_LEDs is
-      Conf : GPIO_Port_Configuration;
    begin
       Enable_Clock (All_LEDs);
 
-      Conf.Mode        := Mode_Out;
-      Conf.Output_Type := Push_Pull;
-      Conf.Speed       := Speed_100MHz;
-      Conf.Resistors   := Floating;
-
-      Configure_IO (All_LEDs, Conf);
+      Configure_IO
+        (All_LEDs,
+         (Mode        => Mode_Out,
+          Output_Type => Push_Pull,
+          Speed       => Speed_100MHz,
+          Resistors   => Floating));
    end Initialize_LEDs;
 
    -------------------------
@@ -92,18 +91,18 @@ package body STM32.Board is
 
       Enable_Clock (Points);
 
-      if Id = I2C_Id_1 then
-         Configure_Alternate_Function (Points, GPIO_AF_I2C1_4);
-      else
+      Configure_IO (Points,
+                    (Mode           => Mode_AF,
+                     AF             => GPIO_AF_I2C1_4,
+                     AF_Speed       => Speed_50MHz,
+                     AF_Output_Type => Open_Drain,
+                     Resistors      => Floating));
+
+      if Id /= I2C_Id_1 then
          Configure_Alternate_Function (I2C4_SCL, GPIO_AF_I2C4_4);
          Configure_Alternate_Function (I2C4_SDA, GPIO_AF_I2C4_11);
       end if;
 
-      Configure_IO (Points,
-                    (Speed       => Speed_50MHz,
-                     Mode        => Mode_AF,
-                     Output_Type => Open_Drain,
-                     Resistors   => Floating));
       Lock (Points);
    end Initialize_I2C_GPIO;
 
@@ -112,14 +111,9 @@ package body STM32.Board is
    --------------------------------
 
    procedure Configure_User_Button_GPIO is
-      Config : GPIO_Port_Configuration;
    begin
       Enable_Clock (User_Button_Point);
-
-      Config.Mode := Mode_In;
-      Config.Resistors := Floating;
-
-      Configure_IO (User_Button_Point, Config);
+      Configure_IO (User_Button_Point, (Mode_In, Resistors => Floating));
    end Configure_User_Button_GPIO;
 
 end STM32.Board;

--- a/examples/shared/hello_world_blinky/src/blinky.adb
+++ b/examples/shared/hello_world_blinky/src/blinky.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                  Copyright (C) 2015-2016, AdaCore                        --
+--                  Copyright (C) 2015-2017, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -65,15 +65,15 @@ procedure Blinky is
    --  for the sake of illustration.
 
    procedure Initialize_LEDs is
-      Configuration : GPIO_Port_Configuration;
    begin
       Enable_Clock (All_LEDs);
 
-      Configuration.Mode        := Mode_Out;
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Speed       := Speed_100MHz;
-      Configuration.Resistors   := Floating;
-      Configure_IO (All_LEDs, Configuration);
+      Configure_IO
+        (All_LEDs,
+         (Mode       => Mode_Out,
+         Output_Type => Push_Pull,
+         Speed       => Speed_100MHz,
+         Resistors   => Floating));
    end Initialize_LEDs;
 
 begin

--- a/examples/shared/serial_ports/src/serial_io.adb
+++ b/examples/shared/serial_ports/src/serial_io.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2017, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -44,14 +44,13 @@ package body Serial_IO is
       Enable_Clock (Device_Pins);
       Enable_Clock (Device.Transceiver.all);
 
-      Configuration.Mode        := Mode_AF;
-      Configuration.Speed       := Speed_50MHz;
-      Configuration.Output_Type := Push_Pull;
-      Configuration.Resistors   := Pull_Up;
+      Configuration := (Mode           => Mode_AF,
+                        AF             => Device.Transceiver_AF,
+                        AF_Speed       => Speed_50MHz,
+                        AF_Output_Type => Push_Pull,
+                        Resistors      => Pull_Up);
 
       Configure_IO (Device_Pins, Configuration);
-
-      Configure_Alternate_Function (Device_Pins, Device.Transceiver_AF);
    end Initialize_Peripheral;
 
    ---------------


### PR DESCRIPTION
Now type GPIO_Port_Configuration is a discriminated record with a variant part, so we cannot accidentally specify configuration components that don't apply to the specified mode. The record type now also includes the alternate function component value so that when Mode_AF is specified the AF value must also be specified. The procedure Configure_IO now also configures the AF value. Note that the separate procedure for configuring the AF value is still available, and occasionally useful.

The code now uses aggregates for most uses of GPIO_Port_Configuration values and caught a couple of places where some expected values were not specified (the pin speed, in particular).

I compiled everything using this type but not the OpenMV2 stuff, for lack of a toolchain and board.
I compiled and tested all the STM32 boards stuff but did not test the F769 Disco stuff for lack of a board. I did test it on the F746.