### PR TITLE
Dont lock pins

### DIFF
--- a/arch/ARM/STM32/drivers/stm32-pwm.adb
+++ b/arch/ARM/STM32/drivers/stm32-pwm.adb
@@ -328,8 +328,6 @@ package body STM32.PWM is
           Resistors      => Floating,
           AF_Output_Type => Push_Pull,
           AF_Speed       => Speed_100MHz));
-
-      Output.Lock;
    end Configure_PWM_GPIO;
 
    ----------------------------------

--- a/arch/ARM/STM32/drivers/stm32-setup.adb
+++ b/arch/ARM/STM32/drivers/stm32-setup.adb
@@ -60,6 +60,7 @@ package body STM32.Setup is
                      AF_Speed       => Speed_High,
                      AF_Output_Type => Open_Drain,
                      Resistors      => Floating));
+      Lock (SDA & SCL);
 
       -- I2C --
 

--- a/arch/ARM/STM32/drivers/stm32-setup.adb
+++ b/arch/ARM/STM32/drivers/stm32-setup.adb
@@ -48,9 +48,6 @@ package body STM32.Setup is
       --  GPIO --
       Enable_Clock (SDA & SCL);
 
-      Configure_Alternate_Function (SDA, SDA_AF);
-      Configure_Alternate_Function (SCL, SCL_AF);
-
       Configure_IO (SDA,
                     (Mode           => Mode_AF,
                      AF             => SDA_AF,
@@ -63,7 +60,6 @@ package body STM32.Setup is
                      AF_Speed       => Speed_High,
                      AF_Output_Type => Open_Drain,
                      Resistors      => Floating));
-      Lock (SDA & SCL);
 
       -- I2C --
 

--- a/arch/ARM/STM32/drivers/stm32-spi.ads
+++ b/arch/ARM/STM32/drivers/stm32-spi.ads
@@ -61,9 +61,9 @@ package STM32.SPI is
 
    type SPI_Mode is (Master, Slave);
 
-   type SPI_CLock_Polarity is (High, Low);
+   type SPI_Clock_Polarity is (High, Low);
 
-   type SPI_CLock_Phase is (P1Edge, P2Edge);
+   type SPI_Clock_Phase is (P1Edge, P2Edge);
 
    type SPI_Slave_Management is (Software_Managed, Hardware_Managed);
 
@@ -76,8 +76,8 @@ package STM32.SPI is
       Direction           : SPI_Data_Direction;
       Mode                : SPI_Mode;
       Data_Size           : HAL.SPI.SPI_Data_Size;
-      Clock_Polarity      : SPI_CLock_Polarity;
-      Clock_Phase         : SPI_CLock_Phase;
+      Clock_Polarity      : SPI_Clock_Polarity;
+      Clock_Phase         : SPI_Clock_Phase;
       Slave_Management    : SPI_Slave_Management;
       Baud_Rate_Prescaler : SPI_Baud_Rate_Prescaler;
       First_Bit           : SPI_First_Bit;


### PR DESCRIPTION
Don't lock PWM pins since we may want to override them later, especially with respect to LEDs.
Remove redundant calls to configure alternate function for GPIO pins, since Configure_IO does that now.
Minor casing correction in type name.