### PR TITLE
start DMA transfers before ADC conversions, to prevent ADC overrun error

### DIFF
--- a/arch/ARM/STM32/driver_demos/demo_adc_dma/src/demo_adc_vbat_dma.adb
+++ b/arch/ARM/STM32/driver_demos/demo_adc_dma/src/demo_adc_vbat_dma.adb
@@ -150,14 +150,14 @@ begin
 
    Enable (VBat.ADC.all);
 
-   Start_Conversion (VBat.ADC.all);
-
    Start_Transfer
      (Controller,
       Stream,
       Source      => Data_Register_Address (VBat.ADC.all),
       Destination => Counts'Address,
       Data_Count  => 1);  -- ie, 1 halfword
+
+   Start_Conversion (VBat.ADC.all);
 
    loop
       Voltage := ((UInt32 (Counts) * VBat_Bridge_Divisor) * ADC_Supply_Voltage) / 16#FFF#;


### PR DESCRIPTION
Although not seen in this demo, DMA overrun error is consistent in a project based on this demo (Robotics_with_Ada) and this change solved the problem there. 