### PR TITLE
Examples: Bring back the blinky and serial examples for the STM32F4 disco

### DIFF
--- a/examples/STM32F4_DISCO/blinky_f4disco.gpr
+++ b/examples/STM32F4_DISCO/blinky_f4disco.gpr
@@ -1,0 +1,13 @@
+with "../../boards/stm32f407_discovery/stm32f407_discovery.gpr";
+
+project Blinky_F4Disco extends "../shared/common/common.gpr" is
+
+  for Runtime ("Ada") use STM32F407_Discovery'Runtime("Ada");
+  for Target use "arm-eabi";
+  for Main use ("blinky.adb");
+  for Languages use ("Ada");
+  for Source_Dirs use ("../shared/hello_world_blinky/src");
+  for Object_Dir use "../shared/hello_world_blinky/obj/stm32f429disco";
+  for Create_Missing_Dirs use "True";
+
+end Blinky_F4Disco;

--- a/examples/STM32F4_DISCO/serial_ports_f4disco.gpr
+++ b/examples/STM32F4_DISCO/serial_ports_f4disco.gpr
@@ -1,6 +1,6 @@
-with "../../boards/stm32f429_discovery/stm32f429_discovery_full.gpr";
+with "../../boards/stm32f407_discovery/stm32f407_discovery_full.gpr";
 
-project Serial_Ports_F429Disco extends "../shared/common/common.gpr" is
+project Serial_Ports_F4Disco extends "../shared/common/common.gpr" is
 
    for Languages use ("Ada");
 
@@ -8,9 +8,9 @@ project Serial_Ports_F429Disco extends "../shared/common/common.gpr" is
 
    for Source_Dirs use ("../shared/serial_ports/src");
 
-   for Object_Dir use "../shared/serial_ports/obj/stm32f429disco";
+   for Object_Dir use "../shared/serial_ports/obj/stm32f407disco";
 
-   for Runtime ("Ada") use STM32F429_Discovery_Full'Runtime("Ada");
+   for Runtime ("Ada") use STM32F407_Discovery_Full'Runtime("Ada");
 
    for Create_Missing_Dirs use "True";
 
@@ -18,4 +18,4 @@ project Serial_Ports_F429Disco extends "../shared/common/common.gpr" is
       for Global_Configuration_Pragmas use "../shared/serial_ports/gnat.adc";
    end Builder;
 
-end Serial_Ports_F429Disco;
+end Serial_Ports_F4Disco;

--- a/examples/shared/hello_world_blinky/src/blinky.adb
+++ b/examples/shared/hello_world_blinky/src/blinky.adb
@@ -45,7 +45,6 @@ with Last_Chance_Handler;  pragma Unreferenced (Last_Chance_Handler);
 --  an exception is propagated. We need it in the executable, therefore it
 --  must be somewhere in the closure of the context clauses.
 
-with STM32.Device;  use STM32.Device;
 with STM32.Board;   use STM32.Board;
 
 with STM32.GPIO;    use STM32.GPIO;
@@ -57,27 +56,8 @@ procedure Blinky is
 
    Next_Release : Time := Clock;
 
-   procedure Initialize_LEDs;
-   --  Enables the clock and configures the GPIO pins and port connected to the
-   --  LEDs on the target board so that we can drive them via GPIO commands.
-   --  Note that the STM32.Board package provides a procedure (with the same
-   --  name) to do this directly, for convenience, but we do not use it here
-   --  for the sake of illustration.
-
-   procedure Initialize_LEDs is
-   begin
-      Enable_Clock (All_LEDs);
-
-      Configure_IO
-        (All_LEDs,
-         (Mode       => Mode_Out,
-         Output_Type => Push_Pull,
-         Speed       => Speed_100MHz,
-         Resistors   => Floating));
-   end Initialize_LEDs;
-
 begin
-   Initialize_LEDs;
+   STM32.Board.Initialize_LEDs;
 
    loop
       Toggle (All_LEDs);

--- a/scripts/build_all_examples.py
+++ b/scripts/build_all_examples.py
@@ -86,6 +86,8 @@ projects = [
             ("/examples/STM32F4_DISCO/accelerometer/accelerometer.gpr",                                  BOTH_RAVENSCAR),
             ("/examples/STM32F4_DISCO/simple_audio/simple_audio.gpr",                                    BOTH_RAVENSCAR),
             ("/examples/STM32F4_DISCO/filesystem/filesystem.gpr",                                        BOTH_RAVENSCAR),
+            ("/examples/STM32F4_DISCO/blinky_f4disco.gpr",                                               BOTH_RAVENSCAR),
+            ("/examples/STM32F4_DISCO/serial_ports_f4disco.gpr",                                         RAVENSCAR_FULL),
 
             # STM32F469 Discovery
             ("/examples/STM32F469_Discovery/dma2d_stm32f469disco.gpr",                                   BOTH_RAVENSCAR),


### PR DESCRIPTION
Also fixes the serial example on the F429 to use only the Ravenscar full
run-time, and simplify the blinky example.