### PR TITLE
Don't require pin to be an output before setting or clearing.

### DIFF
--- a/hal/src/hal-gpio.ads
+++ b/hal/src/hal-gpio.ads
@@ -71,11 +71,9 @@ package HAL.GPIO is
    --  no actual effect on the line. For example trying to set the IO when
    --  another device is pulling the line to low.
 
-   procedure Set (This : in out GPIO_Point) is abstract
-     with Pre'Class => This.Mode = Output;
+   procedure Set (This : in out GPIO_Point) is abstract;
 
-   procedure Clear (This : in out GPIO_Point) is abstract
-     with Pre'Class => This.Mode = Output;
+   procedure Clear (This : in out GPIO_Point) is abstract;
 
    procedure Toggle (This : in out GPIO_Point) is abstract
      with Pre'Class => This.Mode = Output;


### PR DESCRIPTION
Otherwise we cannot "pre-set" the pin state before setting the pin to be an output. The issue is that the pin comes up with a default 1/0 value and that default value is what is applied immediately when we set the mode to output. If we want the non-default pin (bit) value immediately on setting the mode it is too late if we have to set the mode first, because setting the mode to output applies whatever the current bit value is. If we cannot set the bit before the output mode, the initial applied value will always be the default value and that is sometimes undesirable. (Found when bit-banging an I2C device, where a zero pin output value actively drives the line low, claiming it, but 1 passively allows it to float high.)