### PR TITLE
Bring back the IO Functions definitions.

### DIFF
--- a/arch/RISC-V/SiFive/devices/FE310/fe310-device.ads
+++ b/arch/RISC-V/SiFive/devices/FE310/fe310-device.ads
@@ -70,6 +70,14 @@ package FE310.Device is
    P30 : aliased GPIO_Point (Pin => 30);
    P31 : aliased GPIO_Point (Pin => 31);
 
+   IOF_UART0 : constant IO_Function := IOF0;
+   IOF_UART1 : constant IO_Function := IOF0;
+   IOF_QSPI1 : constant IO_Function := IOF0;
+   IOF_QSPI2 : constant IO_Function := IOF0;
+   IOF_PWM0  : constant IO_Function := IOF1;
+   IOF_PWM1  : constant IO_Function := IOF1;
+   IOF_PWM2  : constant IO_Function := IOF1;
+
    Internal_UART0 : aliased Internal_UART with Import, Volatile, Address => FE310_SVD.UART0_Base;
    Internal_UART1 : aliased Internal_UART with Import, Volatile, Address => FE310_SVD.UART1_Base;
 


### PR DESCRIPTION
I suggest to bring back the IO Functions definitions. I think they are useful because they avoid us to open the MCU doc to check what is the IOF number for a particular peripheral and I think they are more meaningful when reading the code. Example: If I need to assign a pin to the UART, I prefer to write Set_IO_Function (P16, IOF_UART0); than Set_IO_Function (P16, IOF0);.