### PR TITLE
Suppress 'not referenced' warning

### DIFF
--- a/arch/ARM/cortex_m/src/semihosting-filesystem.ads
+++ b/arch/ARM/cortex_m/src/semihosting-filesystem.ads
@@ -95,6 +95,7 @@ package Semihosting.Filesystem is
                   Handle : out Any_Directory_Handle)
                   return Status_Code;
 
+   pragma Warnings (Off, "formal * not referenced");
    overriding
    function Root_Node
      (This   : in out SHFS;
@@ -102,6 +103,7 @@ package Semihosting.Filesystem is
       Handle : out Any_Node_Handle)
       return Status_Code
    is (Operation_Not_Permitted);
+   pragma Warnings (On, "formal * not referenced");
 
    overriding
    procedure Close (This : in out SHFS);


### PR DESCRIPTION
I’m building using the project wizard, for Crazyflie, which compiles with `-gnatwe`, giving
```
Compiling: /Users/simon/adacore/Ada_Drivers_Library/arch/ARM/cortex_m/src/semihosting-filesystem.ads
[...]
    98.    overriding
    99.    function Root_Node
   100.      (This   : in out SHFS;
   101.       As     : String;
              |
        >>> warning: formal parameter "As" is not referenced

   102.       Handle : out Any_Node_Handle)
              |
        >>> warning: formal parameter "Handle" is not referenced

   103.       return Status_Code
   104.    is (Operation_Not_Permitted);
[...]
   174. end Semihosting.Filesystem;
 383 lines: No errors, 2 warnings (treated as errors)
gprbuild: *** compilation phase failed
```

  * arch/ARM/cortex_m/src/semihosting-filesystem.ads (Root_Node):
      Surround with pragma Warnings (Off, On).