### PR TITLE
MicroBit: Fix button B

### DIFF
--- a/boards/MicroBit/src/microbit-buttons.adb
+++ b/boards/MicroBit/src/microbit-buttons.adb
@@ -97,13 +97,6 @@ package body MicroBit.Buttons is
 
    function State (Button : Button_Id) return Button_State is
    begin
-      if Button =  Button_B then
-         --  For a reason that I don't understand right now, the B button is a
-         --  always detected as pressed (low). As far as I can see the code is
-         --  the same as button A and probing the hardware didn't show any
-         --  problem...
-         raise Program_Error with "Button B is not working...";
-      end if;
       return States (Button);
    end State;
 

--- a/boards/MicroBit/src/microbit-time.adb
+++ b/boards/MicroBit/src/microbit-time.adb
@@ -56,7 +56,7 @@ package body MicroBit.Time is
    procedure Initialize is
    begin
       if not Clocks.Low_Freq_Running then
-         Clocks.Set_Low_Freq_Source (Clocks.LFCLK_XTAL);
+         Clocks.Set_Low_Freq_Source (Clocks.LFCLK_SYNTH);
          Clocks.Start_Low_Freq;
 
          loop


### PR DESCRIPTION
As discussed in #267, MicroBit.Time was configuring the Low Frequency
Clock to use an external crystal, but there is no LFC external crystal
on the micro:bit. Also the button B is connected to the pin used for the
LFC crystal, so this configuration meant the pin was actually not
available as GPIO for the button code.

MicroBit.Time now uses synthesized clock for LFC so the pin is available
for button B.