### PR TITLE
Added Ide info to micro:bit text/button GPR files

### DIFF
--- a/examples/MicroBit/BLE_beacon/BLE_beacon.gpr
+++ b/examples/MicroBit/BLE_beacon/BLE_beacon.gpr
@@ -20,6 +20,7 @@ project BLE_Beacon is
   package Ide is
      for Program_Host use ":1234";
      for Communication_Protocol use "remote";
+     for Connection_Tool use "pyocd";
   end Ide;
 
 end BLE_Beacon;

--- a/examples/MicroBit/analog_in/analog_in.gpr
+++ b/examples/MicroBit/analog_in/analog_in.gpr
@@ -17,4 +17,10 @@ project Analog_In is
                                        "-Wl,--gc-sections");
   end Linker;
 
+  package Ide is
+     for Program_Host use ":1234";
+     for Communication_Protocol use "remote";
+     for Connection_Tool use "pyocd";
+  end Ide;
+
 end Analog_In;

--- a/examples/MicroBit/analog_out/analog_out.gpr
+++ b/examples/MicroBit/analog_out/analog_out.gpr
@@ -17,4 +17,10 @@ project Analog_Out is
                                        "-Wl,--gc-sections");
   end Linker;
 
+  package Ide is
+     for Program_Host use ":1234";
+     for Communication_Protocol use "remote";
+     for Connection_Tool use "pyocd";
+  end Ide;
+
 end Analog_Out;

--- a/examples/MicroBit/buttons/buttons.gpr
+++ b/examples/MicroBit/buttons/buttons.gpr
@@ -17,4 +17,10 @@ project Buttons is
                                        "-Wl,--gc-sections");
   end Linker;
 
+  package Ide is
+    for Program_Host use ":1234";
+    for Communication_Protocol use "remote";
+    for Connection_Tool use "pyocd";
+  end Ide;
+
 end Buttons;

--- a/examples/MicroBit/digital_in/digital_in.gpr
+++ b/examples/MicroBit/digital_in/digital_in.gpr
@@ -17,4 +17,10 @@ project Digital_In is
                                        "-Wl,--gc-sections");
   end Linker;
 
+  package Ide is
+     for Program_Host use ":1234";
+     for Communication_Protocol use "remote";
+     for Connection_Tool use "pyocd";
+  end Ide;
+
 end Digital_In;

--- a/examples/MicroBit/digital_out/digital_out.gpr
+++ b/examples/MicroBit/digital_out/digital_out.gpr
@@ -17,4 +17,10 @@ project Digital_Out is
                                        "-Wl,--gc-sections");
   end Linker;
 
+  package Ide is
+     for Program_Host use ":1234";
+     for Communication_Protocol use "remote";
+     for Connection_Tool use "pyocd";
+  end Ide;
+
 end Digital_Out;

--- a/examples/MicroBit/music/music.gpr
+++ b/examples/MicroBit/music/music.gpr
@@ -17,4 +17,10 @@ project Music is
                                        "-Wl,--gc-sections");
   end Linker;
 
+  package Ide is
+     for Program_Host use ":1234";
+     for Communication_Protocol use "remote";
+     for Connection_Tool use "pyocd";
+  end Ide;
+
 end Music;

--- a/examples/MicroBit/text_scrolling/text_scrolling.gpr
+++ b/examples/MicroBit/text_scrolling/text_scrolling.gpr
@@ -20,6 +20,7 @@ project Text_Scrolling is
   package Ide is
      for Program_Host use ":1234";
      for Communication_Protocol use "remote";
+     for Connection_Tool use "pyocd";
   end Ide;
 
 end Text_Scrolling;


### PR DESCRIPTION
Without those the "Flash to board" button does not appear in GPS toolbar. 
Copied from the example project that comes with GPS 2018.