### PR TITLE
Allow control of interrupts to be enabled in DMA transfer.

### DIFF
--- a/arch/ARM/STM32/drivers/dma_interrupts/stm32-dma-interrupts.adb
+++ b/arch/ARM/STM32/drivers/dma_interrupts/stm32-dma-interrupts.adb
@@ -38,12 +38,30 @@ package body STM32.DMA.Interrupts is
       --------------------
 
       procedure Start_Transfer
+        (Source      : Address;
+         Destination : Address;
+         Data_Count  : UInt16)
+      is
+      begin
+         Start_Transfer_With_Interrupts
+           (Source             => Source,
+            Destination        => Destination,
+            Data_Count         => Data_Count,
+            Enabled_Interrupts => (others => True));
+      end Start_Transfer;
+
+      ------------------------------------
+      -- Start_Transfer_With_Interrupts --
+      ------------------------------------
+
+      procedure Start_Transfer_With_Interrupts
         (Source             : Address;
          Destination        : Address;
          Data_Count         : UInt16;
          Enabled_Interrupts : Interrupt_Selections := (others => True))
       is
       begin
+         DMA_Interrupt_Controller.Enabled_Interrupts := Enabled_Interrupts;
          No_Transfer_In_Progess := False;
          Had_Buffer_Error := False;
 
@@ -56,7 +74,7 @@ package body STM32.DMA.Interrupts is
             Destination        => Destination,
             Data_Count         => Data_Count,
             Enabled_Interrupts => Enabled_Interrupts);
-      end Start_Transfer;
+      end Start_Transfer_With_Interrupts;
 
       --------------------
       -- Abort_Transfer --
@@ -106,23 +124,42 @@ package body STM32.DMA.Interrupts is
       -----------------------
 
       procedure Interrupt_Handler is
+         Candidate_Flags : constant array (DMA_Interrupt) of DMA_Status_Flag
+           := (Direct_Mode_Error_Interrupt
+                 => Direct_Mode_Error_Indicated,
+               Transfer_Error_Interrupt
+                 => Transfer_Error_Indicated,
+               Half_Transfer_Complete_Interrupt
+                 => Half_Transfer_Complete_Indicated,
+               Transfer_Complete_Interrupt
+                 => Transfer_Complete_Indicated,
+               FIFO_Error_Interrupt
+                 => FIFO_Error_Indicated);
       begin
-         for Flag in DMA_Status_Flag loop
-            if Status (Controller.all, Stream, Flag) then
-               case Flag is
+         for Interrupt in DMA_Interrupt loop
+            --  Only check the interrupts that are actually enabled
+            if Enabled_Interrupts (Interrupt)
+              and then Status (Controller.all,
+                               Stream,
+                               Candidate_Flags (Interrupt))
+            then
+               --  Treat the indicated interrupt appropriately
+               case Candidate_Flags (Interrupt) is
                   when FIFO_Error_Indicated =>
                      Last_Status := DMA_FIFO_Error;
                      Had_Buffer_Error := True;
                      if not Enabled (Controller.all, Stream) then
-                        --  If the stream was disabled by hardware, the transfer
-                        --  is stopped. Otherwise we can ignore the even.
+                        --  If the stream was disabled by hardware,
+                        --  the transfer is stopped. Otherwise we can
+                        --  ignore the event.
                         No_Transfer_In_Progess := True;
                      end if;
                   when Direct_Mode_Error_Indicated =>
                      Last_Status := DMA_Direct_Mode_Error;
                      if not Enabled (Controller.all, Stream) then
-                        --  If the stream was disabled by hardware, the transfer
-                        --  is stopped. Otherwise we can ignore the even.
+                        --  If the stream was disabled by hardware,
+                        --  the transfer is stopped. Otherwise we can
+                        --  ignore the even.
                         No_Transfer_In_Progess := True;
                      end if;
                   when Transfer_Error_Indicated =>
@@ -134,10 +171,13 @@ package body STM32.DMA.Interrupts is
                      Last_Status := DMA_No_Error;
                      No_Transfer_In_Progess := True;
                end case;
-               Clear_Status (Controller.all, Stream, Flag);
+               Clear_Status (Controller.all,
+                             Stream,
+                             Candidate_Flags (Interrupt));
             end if;
          end loop;
       end Interrupt_Handler;
+
    end DMA_Interrupt_Controller;
 
 end STM32.DMA.Interrupts;

--- a/arch/ARM/STM32/drivers/dma_interrupts/stm32-dma-interrupts.adb
+++ b/arch/ARM/STM32/drivers/dma_interrupts/stm32-dma-interrupts.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2016-2017, AdaCore                      --
+--                    Copyright (C) 2016-2018, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -37,9 +37,11 @@ package body STM32.DMA.Interrupts is
       -- Start_Transfer --
       --------------------
 
-      procedure Start_Transfer (Source      : Address;
-                                Destination : Address;
-                                Data_Count  : UInt16)
+      procedure Start_Transfer
+        (Source             : Address;
+         Destination        : Address;
+         Data_Count         : UInt16;
+         Enabled_Interrupts : Interrupt_Selections := (others => True))
       is
       begin
          No_Transfer_In_Progess := False;
@@ -47,11 +49,13 @@ package body STM32.DMA.Interrupts is
 
          Clear_All_Status (Controller.all, Stream);
 
-         Start_Transfer_with_Interrupts (This               => Controller.all,
-                                         Stream             => Stream,
-                                         Source             => Source,
-                                         Destination        => Destination,
-                                         Data_Count         => Data_Count);
+         Start_Transfer_with_Interrupts
+           (This               => Controller.all,
+            Stream             => Stream,
+            Source             => Source,
+            Destination        => Destination,
+            Data_Count         => Data_Count,
+            Enabled_Interrupts => Enabled_Interrupts);
       end Start_Transfer;
 
       --------------------

--- a/arch/ARM/STM32/drivers/dma_interrupts/stm32-dma-interrupts.ads
+++ b/arch/ARM/STM32/drivers/dma_interrupts/stm32-dma-interrupts.ads
@@ -42,6 +42,11 @@ package STM32.DMA.Interrupts is
       pragma Interrupt_Priority (Priority);
 
       procedure Start_Transfer
+        (Source      : Address;
+         Destination : Address;
+         Data_Count  : UInt16);
+
+      procedure Start_Transfer_With_Interrupts
         (Source             : Address;
          Destination        : Address;
          Data_Count         : UInt16;
@@ -60,9 +65,10 @@ package STM32.DMA.Interrupts is
       procedure Interrupt_Handler;
       pragma Attach_Handler (Interrupt_Handler, ID);
 
-      No_Transfer_In_Progess : Boolean := True;
-      Last_Status            : DMA_Error_Code := DMA_No_Error;
-      Had_Buffer_Error       : Boolean := False;
+      No_Transfer_In_Progess : Boolean              := True;
+      Last_Status            : DMA_Error_Code       := DMA_No_Error;
+      Had_Buffer_Error       : Boolean              := False;
+      Enabled_Interrupts     : Interrupt_Selections := (others => False);
    end DMA_Interrupt_Controller;
 
    type DMA_Interrupt_Controller_Access is access all DMA_Interrupt_Controller;

--- a/arch/ARM/STM32/drivers/dma_interrupts/stm32-dma-interrupts.ads
+++ b/arch/ARM/STM32/drivers/dma_interrupts/stm32-dma-interrupts.ads
@@ -41,9 +41,11 @@ package STM32.DMA.Interrupts is
    is
       pragma Interrupt_Priority (Priority);
 
-      procedure Start_Transfer (Source      : Address;
-                                Destination : Address;
-                                Data_Count  : UInt16);
+      procedure Start_Transfer
+        (Source             : Address;
+         Destination        : Address;
+         Data_Count         : UInt16;
+         Enabled_Interrupts : Interrupt_Selections := (others => True));
 
       procedure Abort_Transfer (Result : out DMA_Error_Code);
 


### PR DESCRIPTION
I had a problem with Certyflie in that after a considerable time (an hour, maybe) I’d get an assertion failure in the postcondition of the `Clear_Status` call at the end of `DMA_Interrupt_Controller.Interrupt_Handler`, because the `Half_Transfer_Complete_Interrupt` hadn’t cleared. (I do question whether it’s OK to use assertions as a check on whether some external hardware behaved as expected? on the other hand, what else to do?)

I made this change, then changed the Certyflie code to enable all interrupts except `Half_Transfer_Complete_Interrupt`, and the drone ran without error for two hours. (The Crazyflie code only enabled `Transfer_Complete` last time I looked).

You might wonder whether to eliminate `STM32.DMA.Start_Transfer_With_Interrupts` and simply give `Start_Transfer` the same `Enabled_Interrupts` parameter? I could add that to this request if considered helpful.

  * arch/ARM/STM32/drivers/dma_interrupts/stm32-dma-interrupts.ads
    (DMA_Interrupt_Controller.Start_Transfer): new parameter
    Enabled_Interrupts (defaulted to all interrupts).

  * arch/ARM/STM32/drivers/dma_interrupts/stm32-dma-interrupts.adb
    (DMA_Interrupt_Controller.Start_Transfer): likewise. Pass
    Enabled_Interrupts through to DMA.Start_Transfer_with_Interrupts.