### PR TITLE
Fix crash when negative pixels are drawn

### DIFF
--- a/hal/src/hal-bitmap.ads
+++ b/hal/src/hal-bitmap.ads
@@ -65,8 +65,8 @@ package HAL.Bitmap is
          when M_1 => 1);
 
    type Point is record
-      X : Natural;
-      Y : Natural;
+      X : Integer;
+      Y : Integer;
    end record;
 
    function "+" (P1, P2 : Point) return Point

--- a/middleware/src/bitmap/memory_mapped_bitmap.adb
+++ b/middleware/src/bitmap/memory_mapped_bitmap.adb
@@ -116,17 +116,21 @@ package body Memory_Mapped_Bitmap is
      (Buffer : in out Memory_Mapped_Bitmap_Buffer;
       Pt     : Point)
    is
-      X0     : Natural := Pt.X;
-      Y0     : Natural := Pt.Y;
+      X0     : Natural;
+      Y0     : Natural;
       Offset : Natural;
 
       Value  : constant UInt32 := Buffer.Native_Source;
    begin
       if Pt.X >= Buffer.Width
         or else Pt.Y >= Buffer.Height
+        or else Pt.X < 0
+        or else Pt.Y < 0
       then
          return;
       end if;
+      X0 := Pt.X;
+      Y0 := Pt.Y;
 
       if Buffer.Swapped then
          Handle_Swap (Buffer, X0, Y0);


### PR DESCRIPTION
When drawing shapes near the negative edges of the screen, if the shape is too big, then the algorithms used to draw the shape will try to draw pixels in the negatives. For example, in `./middleware/src/bitmap/soft_drawing_bitmap.adb`, inside `Draw_Circle` :
```ada
Dispatch (Buffer).Set_Pixel ((Center.X, Center.Y + Radius));
Dispatch (Buffer).Set_Pixel ((Center.X, Center.Y - Radius));
Dispatch (Buffer).Set_Pixel ((Center.X + Radius, Center.Y));
Dispatch (Buffer).Set_Pixel ((Center.X - Radius, Center.Y));
```
If you try to draw a circle at (1,1) with radius 5, this would try to create a `Point` record with a negative value. Since `Point` holds `Natural`s and not `Integer`s, it crashes. Note that if you try to do the same but at the opposite side of the screen, where values can't become negative, it does not crash.

My fix changes the types of the `Point` record to `Integer`s, and adds a check inside `./middleware/src/bitmap/memory_mapped_bitmap.adb` inside `Set_Pixel` to make sure the passed `Point` does not contain a negative value, and if so, dismisses it, like it is already done for pixel bigger than `(Buffer.Width, Buffer.Height)`