### PR TITLE
Add support for startup-gen

### DIFF
--- a/arch/ARM/Nordic/drivers/nrf51-interrupts.adb
+++ b/arch/ARM/Nordic/drivers/nrf51-interrupts.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2016-2018, AdaCore                      --
+--                    Copyright (C) 2016-2019, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -38,7 +38,7 @@ package body nRF51.Interrupts is
      := (others => null);
 
    procedure GNAT_IRQ_Handler;
-   pragma Export (Asm, GNAT_IRQ_Handler, "__gnat_irq_trap");
+   pragma Export (Asm, GNAT_IRQ_Handler, "__adl_irq_handler");
 
    ------------------
    -- Set_Priority --

--- a/boards/HiFive1/hifive1_zfp.gpr
+++ b/boards/HiFive1/hifive1_zfp.gpr
@@ -66,6 +66,7 @@ library project HiFive1_ZFP is
 
    package Device_Configuration is
       for CPU_Name use "RISC-V32";
+      for Number_Of_Interrupts use "0";
 
       for Memories use ("board_flash", "RAM");
 
@@ -82,17 +83,18 @@ library project HiFive1_ZFP is
 
    Vendor                         := "SiFive";            -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
+   Boot_Memory                    := "board_flash";       -- From default value
    Max_Mount_Name_Length          := "128";               -- From default value
    Runtime_Profile                := "zfp";               -- From command line
    Device_Name                    := "FE310";             -- From board definition
    Device_Family                  := "FE3";               -- From board definition
-   Boot_Memory                    := "board_flash";       -- From default value
+   Has_Ravenscar_SFP_Runtime      := "False";             -- From board definition
    Runtime_Name                   := "zfp-rv32imc";       -- From default value
    Has_Ravenscar_Full_Runtime     := "False";             -- From board definition
    CPU_Core                       := "RISC-V32";          -- From mcu definition
    Board                          := "HiFive1";           -- From command line
    Has_ZFP_Runtime                := "True";              -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "False";             -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    Has_Custom_Memory_Area_1       := "False";             -- From default value
    Use_Startup_Gen                := "True";              -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/HiFive1/hifive1_zfp.gpr
+++ b/boards/HiFive1/hifive1_zfp.gpr
@@ -52,14 +52,33 @@ library project HiFive1_ZFP is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
-   for Languages use ("Ada");
+
+   for Languages use ("Ada", "Asm_CPP");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/zfp_" & Build;
    for Library_Dir use "obj/zfp_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ("-T", Project'Project_dir & "/src/zfp/link.ld");
    for Target use "riscv32-elf";
-   for Runtime ("Ada") use "zfp-hifive1";
+   for Runtime ("Ada") use "zfp-rv32imc";
+
+   package Device_Configuration is
+      for CPU_Name use "RISC-V32";
+
+      for Memories use ("board_flash", "RAM");
+
+      for Mem_Kind ("board_flash") use "rom";
+      for Address  ("board_flash") use "0x20400000";
+      for Size     ("board_flash") use "512M";
+
+      for Mem_Kind ("RAM") use "ram";
+      for Address  ("RAM") use "0x80000000";
+      for Size     ("RAM") use "16K";
+
+      for Boot_Memory use "board_flash";
+   end Device_Configuration;
 
    Vendor                         := "SiFive";            -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -67,14 +86,17 @@ library project HiFive1_ZFP is
    Runtime_Profile                := "zfp";               -- From command line
    Device_Name                    := "FE310";             -- From board definition
    Device_Family                  := "FE3";               -- From board definition
-   Runtime_Name                   := "zfp-hifive1";       -- From default value
+   Boot_Memory                    := "board_flash";       -- From default value
+   Runtime_Name                   := "zfp-rv32imc";       -- From default value
    Has_Ravenscar_Full_Runtime     := "False";             -- From board definition
    CPU_Core                       := "RISC-V32";          -- From mcu definition
    Board                          := "HiFive1";           -- From command line
    Has_ZFP_Runtime                := "True";              -- From board definition
    Has_Ravenscar_SFP_Runtime      := "False";             -- From board definition
+   Has_Custom_Memory_Area_1       := "False";             -- From default value
+   Use_Startup_Gen                := "True";              -- From command line
    Max_Path_Length                := "1024";              -- From default value
-   Runtime_Name_Suffix            := "hifive1";           -- From board definition
+   Runtime_Name_Suffix            := "rv32imc";           -- From board definition
    Architecture                   := "RISC-V";            -- From board definition
 
    --  Project source directories

--- a/boards/HiFive1/src/zfp/adl_config.ads
+++ b/boards/HiFive1/src/zfp/adl_config.ads
@@ -2,17 +2,18 @@
 package ADL_Config is
    Vendor                         : constant String  := "SiFive";            -- From board definition
    Max_Mount_Points               : constant         := 2;                   -- From default value
+   Boot_Memory                    : constant String  := "board_flash";       -- From default value
    Max_Mount_Name_Length          : constant         := 128;                 -- From default value
    Runtime_Profile                : constant String  := "zfp";               -- From command line
    Device_Name                    : constant String  := "FE310";             -- From board definition
    Device_Family                  : constant String  := "FE3";               -- From board definition
-   Boot_Memory                    : constant String  := "board_flash";       -- From default value
+   Has_Ravenscar_SFP_Runtime      : constant String  := "False";             -- From board definition
    Runtime_Name                   : constant String  := "zfp-rv32imc";       -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "False";             -- From board definition
    CPU_Core                       : constant String  := "RISC-V32";          -- From mcu definition
    Board                          : constant String  := "HiFive1";           -- From command line
    Has_ZFP_Runtime                : constant String  := "True";              -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "False";             -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    Has_Custom_Memory_Area_1       : constant Boolean := False;               -- From default value
    Use_Startup_Gen                : constant Boolean := True;                -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/HiFive1/src/zfp/adl_config.ads
+++ b/boards/HiFive1/src/zfp/adl_config.ads
@@ -6,13 +6,16 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "zfp";               -- From command line
    Device_Name                    : constant String  := "FE310";             -- From board definition
    Device_Family                  : constant String  := "FE3";               -- From board definition
-   Runtime_Name                   : constant String  := "zfp-hifive1";       -- From default value
+   Boot_Memory                    : constant String  := "board_flash";       -- From default value
+   Runtime_Name                   : constant String  := "zfp-rv32imc";       -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "False";             -- From board definition
    CPU_Core                       : constant String  := "RISC-V32";          -- From mcu definition
    Board                          : constant String  := "HiFive1";           -- From command line
    Has_ZFP_Runtime                : constant String  := "True";              -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "False";             -- From board definition
+   Has_Custom_Memory_Area_1       : constant Boolean := False;               -- From default value
+   Use_Startup_Gen                : constant Boolean := True;                -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
-   Runtime_Name_Suffix            : constant String  := "hifive1";           -- From board definition
+   Runtime_Name_Suffix            : constant String  := "rv32imc";           -- From board definition
    Architecture                   : constant String  := "RISC-V";            -- From board definition
 end ADL_Config;

--- a/boards/HiFive1/src/zfp/crt0.S
+++ b/boards/HiFive1/src/zfp/crt0.S
@@ -1,0 +1,64 @@
+        /**********/
+        /* _start */
+        /**********/
+
+        .section .start
+        .globl _start
+        .type _start,@function
+
+_start:
+.option push
+.option norelax
+        la gp, __global_pointer$
+.option pop
+        la sp, __stack_end
+
+        /* Load data section */
+        .type _startup_copy_data,@function
+_startup_copy_data:
+        la a0, __data_load
+        la a1, __data_start
+        la a2, __data_end
+        bgeu a1, a2, 2f
+1:
+        lw t0, (a0)
+        sw t0, (a1)
+        addi a0, a0, 4
+        addi a1, a1, 4
+        bltu a1, a2, 1b
+2:
+        .size _startup_copy_data, . - _startup_copy_data
+
+
+        /* Clear bss section */
+        .type _startup_clear_bss,@function
+_startup_clear_bss:
+        la a0, __bss_start
+        la a1, __bss_end
+        bgeu a0, a1, 2f
+1:
+        sw zero, (a0)
+        addi a0, a0, 4
+        bltu a0, a1, 1b
+2:
+        .size _startup_clear_bss, . - _startup_clear_bss
+
+        call main
+        call __gnat_exit
+2:      j 2b
+
+        .globl __gnat_exit
+        .type __gnat_exit,@function
+        .globl _abort
+        .type abort,@function
+abort:
+__gnat_exit:
+
+        /* Use ebreak on RISC-V32 until QEMU is updated to 4.0 */
+        ebreak
+
+        j __gnat_exit
+
+        /* Weak alias _exit to __gnat_exit */
+        .weak      _exit
+        .set _exit,__gnat_exit

--- a/boards/HiFive1/src/zfp/link.ld
+++ b/boards/HiFive1/src/zfp/link.ld
@@ -1,0 +1,119 @@
+/* This is a RISC-V specific version of this file */
+
+_DEFAULT_STACK_SIZE = 2*1024;
+
+OUTPUT_ARCH("riscv")
+
+ENTRY(_start);
+
+MEMORY
+{
+  board_flash (rx) : ORIGIN = 0x20400000, LENGTH = 0x20000000
+  RAM (rwx) : ORIGIN = 0x80000000, LENGTH = 0x4000
+}
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP (*(SORT_NONE(.start)))
+    *(.text .text.* .gnu.linkonce.t*)
+    *(.gnu.warning)
+  } >  board_flash
+
+  .rodata :
+  {
+    *(.rdata)
+    *(.rodata .rodata.* .gnu.linkonce.r*)
+    . = ALIGN(0x4);
+    __rom_end = .;
+  } >  board_flash
+
+  .data :
+  {
+    __data_start = .;
+    *(.data .data.* .gnu.linkonce.d*)
+  } > RAM AT > board_flash
+
+  .srodata ALIGN(4) : ALIGN(4) /* Align both virtual and load addresses */
+  {
+    PROVIDE( __global_pointer$ = . + 0x800 );
+    *(.srodata.cst16)
+    *(.srodata.cst8)
+    *(.srodata.cst4)
+    *(.srodata.cst2)
+    *(.srodata .srodata.*)
+  } > RAM  AT > board_flash
+
+  .sdata ALIGN(4) : ALIGN(4) /* Align both virtual and load addresses */
+  {
+    *(.sdata .sdata.*)
+    *(.gnu.linkonce.s.*)
+  } > RAM  AT > board_flash
+
+  __data_end = .;
+
+  /* Size of all data sections (.data, .srodata, .sdata) in number of 32bit
+   * words.
+   */
+  __data_words = (__data_end - __data_start) >> 2;
+
+  /* Base address of all data sections in ROM. The startup code copies these
+   * sections from __data_load (in ROM) to __data_start (in RAM).
+   */
+  __data_load = LOADADDR(.data);
+
+
+
+  .bss (NOLOAD): {
+    . = ALIGN(0x8);
+    __bss_start = .;
+    *(.sbss*)
+    *(.gnu.linkonce.sb.*)
+    *(.bss .bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    /* Interrupt stacks. Statically allocated in System.BB.Interrupts */
+    . = ALIGN(8);
+    __interrupt_stack_start = .;
+    *(.interrupt_stacks)
+    __interrupt_stack_end = .;
+    . = ALIGN(0x8);    /* Align the stack to 64 bits */
+    __stack_start = .;
+    . += DEFINED (__stack_size) ? __stack_size : _DEFAULT_STACK_SIZE;
+    . = ALIGN(0x8);
+    __stack_end = .;
+    _end = .;
+    __heap_start = .;
+    __heap_end = ORIGIN(RAM) + LENGTH(RAM);
+    __bss_end = .;
+  } > RAM
+
+  __bss_words = (__bss_end - __bss_start) >> 2;
+
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* DWARF 3 */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  .gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+  /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
+}

--- a/boards/MicroBit/microbit_zfp.gpr
+++ b/boards/MicroBit/microbit_zfp.gpr
@@ -52,14 +52,21 @@ library project MicroBit_ZFP is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/zfp_" & Build;
    for Library_Dir use "obj/zfp_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "zfp-microbit";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M0";
+   end Device_Configuration;
 
    Vendor                         := "Nordic";            -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -73,6 +80,7 @@ library project MicroBit_ZFP is
    Board                          := "MicroBit";          -- From command line
    Has_ZFP_Runtime                := "True";              -- From board definition
    Has_Ravenscar_SFP_Runtime      := "False";             -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "microbit";          -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/MicroBit/microbit_zfp.gpr
+++ b/boards/MicroBit/microbit_zfp.gpr
@@ -53,36 +53,84 @@ library project MicroBit_ZFP is
    end Compiler;
 
 
-   for Languages use ("Ada");
+   for Languages use ("Ada", "Asm_CPP");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/zfp_" & Build;
    for Library_Dir use "obj/zfp_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
 
-   Linker_Switches := ();
+   Linker_Switches := ("-T", Project'Project_dir & "/src/zfp/link.ld");
    for Target use "arm-eabi";
-   for Runtime ("Ada") use "zfp-microbit";
+   for Runtime ("Ada") use "zfp-cortex-m0";
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M0";
+      for Number_Of_Interrupts use "32";
+      for Interrupt ("0") use "adl_irq";
+      for Interrupt ("1") use "adl_irq";
+      for Interrupt ("2") use "adl_irq";
+      for Interrupt ("3") use "adl_irq";
+      for Interrupt ("4") use "adl_irq";
+      for Interrupt ("5") use "adl_irq";
+      for Interrupt ("6") use "adl_irq";
+      for Interrupt ("7") use "adl_irq";
+      for Interrupt ("8") use "adl_irq";
+      for Interrupt ("9") use "adl_irq";
+      for Interrupt ("10") use "adl_irq";
+      for Interrupt ("11") use "adl_irq";
+      for Interrupt ("12") use "adl_irq";
+      for Interrupt ("13") use "adl_irq";
+      for Interrupt ("14") use "adl_irq";
+      for Interrupt ("15") use "adl_irq";
+      for Interrupt ("16") use "adl_irq";
+      for Interrupt ("17") use "adl_irq";
+      for Interrupt ("18") use "adl_irq";
+      for Interrupt ("19") use "adl_irq";
+      for Interrupt ("20") use "adl_irq";
+      for Interrupt ("21") use "adl_irq";
+      for Interrupt ("22") use "adl_irq";
+      for Interrupt ("23") use "adl_irq";
+      for Interrupt ("24") use "adl_irq";
+      for Interrupt ("25") use "adl_irq";
+      for Interrupt ("26") use "adl_irq";
+      for Interrupt ("27") use "adl_irq";
+      for Interrupt ("28") use "adl_irq";
+      for Interrupt ("29") use "adl_irq";
+      for Interrupt ("30") use "adl_irq";
+      for Interrupt ("31") use "adl_irq";
+
+      for Memories use ("flash", "ram");
+
+      for Mem_Kind ("flash") use "rom";
+      for Address  ("flash") use "0x00000000";
+      for Size     ("flash") use "256K";
+
+      for Mem_Kind ("ram") use "ram";
+      for Address  ("ram") use "0x20000000";
+      for Size     ("ram") use "16K";
+
+      for Boot_Memory use "flash";
    end Device_Configuration;
 
    Vendor                         := "Nordic";            -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
+   Boot_Memory                    := "flash";             -- From default value
    Max_Mount_Name_Length          := "128";               -- From default value
    Runtime_Profile                := "zfp";               -- From command line
    Device_Name                    := "nRF51822xxAA";      -- From board definition
    Device_Family                  := "nRF51";             -- From board definition
-   Runtime_Name                   := "zfp-microbit";      -- From default value
+   Has_Ravenscar_SFP_Runtime      := "False";             -- From board definition
+   Runtime_Name                   := "zfp-cortex-m0";     -- From default value
    Has_Ravenscar_Full_Runtime     := "False";             -- From board definition
    CPU_Core                       := "ARM Cortex-M0";     -- From mcu definition
    Board                          := "MicroBit";          -- From command line
    Has_ZFP_Runtime                := "True";              -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "False";             -- From board definition
-   Use_Startup_Gen                := "False";             -- From command line
+   Number_Of_Interrupts           := "32";                -- From MCU definition
+   Has_Custom_Memory_Area_1       := "False";             -- From default value
+   Use_Startup_Gen                := "True";              -- From command line
    Max_Path_Length                := "1024";              -- From default value
-   Runtime_Name_Suffix            := "microbit";          -- From board definition
+   Runtime_Name_Suffix            := "cortex-m0";         -- From board definition
    Architecture                   := "ARM";               -- From board definition
 
    --  Project source directories

--- a/boards/MicroBit/src/zfp/adl_config.ads
+++ b/boards/MicroBit/src/zfp/adl_config.ads
@@ -2,18 +2,21 @@
 package ADL_Config is
    Vendor                         : constant String  := "Nordic";            -- From board definition
    Max_Mount_Points               : constant         := 2;                   -- From default value
+   Boot_Memory                    : constant String  := "flash";             -- From default value
    Max_Mount_Name_Length          : constant         := 128;                 -- From default value
    Runtime_Profile                : constant String  := "zfp";               -- From command line
    Device_Name                    : constant String  := "nRF51822xxAA";      -- From board definition
    Device_Family                  : constant String  := "nRF51";             -- From board definition
-   Runtime_Name                   : constant String  := "zfp-microbit";      -- From default value
+   Has_Ravenscar_SFP_Runtime      : constant String  := "False";             -- From board definition
+   Runtime_Name                   : constant String  := "zfp-cortex-m0";     -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "False";             -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M0";     -- From mcu definition
    Board                          : constant String  := "MicroBit";          -- From command line
    Has_ZFP_Runtime                : constant String  := "True";              -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "False";             -- From board definition
-   Use_Startup_Gen                : constant Boolean := False;               -- From command line
+   Number_Of_Interrupts           : constant         := 32;                  -- From MCU definition
+   Has_Custom_Memory_Area_1       : constant Boolean := False;               -- From default value
+   Use_Startup_Gen                : constant Boolean := True;                -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
-   Runtime_Name_Suffix            : constant String  := "microbit";          -- From board definition
+   Runtime_Name_Suffix            : constant String  := "cortex-m0";         -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition
 end ADL_Config;

--- a/boards/MicroBit/src/zfp/adl_config.ads
+++ b/boards/MicroBit/src/zfp/adl_config.ads
@@ -12,6 +12,7 @@ package ADL_Config is
    Board                          : constant String  := "MicroBit";          -- From command line
    Has_ZFP_Runtime                : constant String  := "True";              -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "False";             -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "microbit";          -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/MicroBit/src/zfp/crt0.S
+++ b/boards/MicroBit/src/zfp/crt0.S
@@ -1,0 +1,209 @@
+	.syntax unified
+	.cpu cortex-m0
+	.thumb
+
+	.text
+	.globl __vectors
+	.p2align 9
+	.section .vectors,"a"
+__vectors:
+	/* Cortex-M core interrupts */
+	.word   __stack_end          /* stack top address */
+	.word   _start               /* 1 Reset */
+	.word   fault                /* 2 NMI. */
+	.word   fault                /* 3 Hard fault. */
+	.word   fault                /* 4 Mem manage. */
+	.word   fault                /* 5 Bus fault. */
+	.word   fault                /* 6 Usage fault. */
+	.word   fault                /* 7 reserved. */
+	.word   fault                /* 8 reserved. */
+	.word   fault                /* 9 reserved. */
+	.word   fault                /* 10 reserved. */
+	.word   __gnat_sv_call_trap  /* 11 SVCall. */
+	.word   __gnat_bkpt_trap     /* 12 Breakpoint. */
+	.word   fault                /* 13 reserved. */
+	.word   __gnat_pend_sv_trap  /* 14 PendSV. */
+	.word   __gnat_sys_tick_trap /* 15 Systick. */
+	/* MCU interrupts */
+        .word __adl_irq_handler /* 0 */
+        .word __adl_irq_handler /* 1 */
+        .word __adl_irq_handler /* 2 */
+        .word __adl_irq_handler /* 3 */
+        .word __adl_irq_handler /* 4 */
+        .word __adl_irq_handler /* 5 */
+        .word __adl_irq_handler /* 6 */
+        .word __adl_irq_handler /* 7 */
+        .word __adl_irq_handler /* 8 */
+        .word __adl_irq_handler /* 9 */
+        .word __adl_irq_handler /* 10 */
+        .word __adl_irq_handler /* 11 */
+        .word __adl_irq_handler /* 12 */
+        .word __adl_irq_handler /* 13 */
+        .word __adl_irq_handler /* 14 */
+        .word __adl_irq_handler /* 15 */
+        .word __adl_irq_handler /* 16 */
+        .word __adl_irq_handler /* 17 */
+        .word __adl_irq_handler /* 18 */
+        .word __adl_irq_handler /* 19 */
+        .word __adl_irq_handler /* 20 */
+        .word __adl_irq_handler /* 21 */
+        .word __adl_irq_handler /* 22 */
+        .word __adl_irq_handler /* 23 */
+        .word __adl_irq_handler /* 24 */
+        .word __adl_irq_handler /* 25 */
+        .word __adl_irq_handler /* 26 */
+        .word __adl_irq_handler /* 27 */
+        .word __adl_irq_handler /* 28 */
+        .word __adl_irq_handler /* 29 */
+        .word __adl_irq_handler /* 30 */
+        .word __adl_irq_handler /* 31 */
+
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+   .weak      __adl_irq_handler
+   .thumb_set __adl_irq_handler,__gnat_irq_trap
+
+	.text
+
+   .weak      __unknown_interrupt_handler
+   .thumb_set __unknown_interrupt_handler,__gnat_irq_trap
+
+	.thumb_func
+.weak __gnat_irq_trap
+.type __gnat_irq_trap, %function
+__gnat_irq_trap:
+0:	b 0b
+	.size __gnat_irq_trap, . - __gnat_irq_trap
+
+	.thumb_func
+.weak __gnat_sv_call_trap
+.type __gnat_sv_call_trap, %function
+__gnat_sv_call_trap:
+0:	b 0b
+	.size __gnat_sv_call_trap, . - __gnat_sv_call_trap
+
+	.thumb_func
+.weak __gnat_pend_sv_trap
+.type __gnat_pend_sv_trap, %function
+__gnat_pend_sv_trap:
+0:	b 0b
+	.size __gnat_pend_sv_trap, . - __gnat_pend_sv_trap
+
+	.thumb_func
+.weak __gnat_sys_tick_trap
+.type __gnat_sys_tick_trap, %function
+__gnat_sys_tick_trap:
+0:	b 0b
+	.size __gnat_sys_tick_trap, . - __gnat_sys_tick_trap
+
+	.thumb_func
+fault:	b fault
+
+
+	.text
+	.thumb_func
+	.globl _start
+
+_start:
+
+	/* Set the stack pointer */
+	ldr	r1,=__stack_end
+	mov     sp, r1
+
+	/* Copy .data */
+	.thumb_func
+_startup_copy_data:
+	ldr	r0,=__data_start
+	ldr	r1,=__data_words
+	ldr	r2,=__data_load
+	cmp     r1,#0
+	beq     1f
+0:	ldr	r4,[r2]
+	str	r4,[r0]
+        adds    r2,#4
+        adds    r0,#4
+	subs	r1,r1,#1
+	bne	0b
+1:
+        .size _startup_copy_data, . - _startup_copy_data
+
+	/* Clear .bss */
+	.thumb_func
+_startup_clear_bss:
+	ldr	r0,=__bss_start
+	ldr	r1,=__bss_words
+	movs	r2,#0
+	cmp     r1,#0
+	beq     1f
+0:	str	r2,[r0]
+        adds    r0,#4
+	subs	r1,r1,#1
+	bne	0b
+1:
+        .size _startup_clear_bss, . - _startup_clear_bss
+
+	bl	main
+
+	bl	_exit
+
+hang:   b .

--- a/boards/MicroBit/src/zfp/link.ld
+++ b/boards/MicroBit/src/zfp/link.ld
@@ -1,0 +1,119 @@
+
+
+/* This is a ARM specific version of this file */
+
+/* This script replaces ld's default linker script, providing the
+   appropriate memory map and output format. */
+
+SEARCH_DIR(.)
+__DYNAMIC  =  0;
+
+_DEFAULT_STACK_SIZE = 2048;
+
+ENTRY(_start);
+
+MEMORY
+{
+  flash (rx) : ORIGIN = 0x0, LENGTH = 0x40000
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x4000
+}
+
+/*
+ * Boot memory (.text, .ro_data, interrupt vector): flash
+ * Main RAM memory (.data, .bss, stacks, interrupt stacks): flash
+ */
+
+SECTIONS
+{
+
+  .text :
+  {
+    KEEP (*(.vectors))
+    *(.text .text.* .gnu.linkonce.t*)
+    *(.gnu.warning)
+  } > flash
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } > flash
+  PROVIDE_HIDDEN (__exidx_start = .);
+  .ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } > flash
+  PROVIDE_HIDDEN (__exidx_end = .);
+
+  .rodata :
+  {
+    *(.lit)
+    *(.rodata .rodata.* .gnu.linkonce.r*)
+    . = ALIGN(0x4);
+    __rom_end = .;
+  } > flash
+
+  __data_load = LOADADDR(.data);
+  .data :
+  {
+    __data_start = .;
+    *(.data .data.* .gnu.linkonce.d*)
+
+    /* Ensure that the end of the data section is always word aligned.
+       Initial values are stored in 4-bytes blocks so we must guarantee
+       that these blocks do not fall out the section (otherwise they are
+       truncated and the initial data for the last block are lost). */
+
+    . = ALIGN(0x4);
+    __data_end = .;
+  } > ram AT> flash
+  __data_words = (__data_end - __data_start) >> 2;
+
+
+
+  .bss (NOLOAD): {
+   . = ALIGN(0x8);
+   __bss_start = .;
+
+   *(.bss .bss.*)
+   *(COMMON)
+
+   . = ALIGN(0x8);    /* Align the stack to 64 bits */
+   __bss_end = .;
+
+   __interrupt_stack_start = .;
+   *(.interrupt_stacks)
+   . = ALIGN(0x8);
+   __interrupt_stack_end = .;
+
+   __stack_start = .;
+   . += DEFINED (__stack_size) ? __stack_size : _DEFAULT_STACK_SIZE;
+   . = ALIGN(0x8);
+   __stack_end = .;
+
+   _end = .;
+   __heap_start = .;
+   __heap_end = ORIGIN(ram) + LENGTH(ram);
+  } > ram
+  __bss_words = (__bss_end - __bss_start) >> 2;
+
+
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* DWARF 3 */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  .gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+  /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
+}

--- a/boards/OpenMV2/openmv2_full.gpr
+++ b/boards/OpenMV2/openmv2_full.gpr
@@ -52,14 +52,21 @@ library project OpenMV2_Full is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/full_" & Build;
    for Library_Dir use "obj/full_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-full-openmv2";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M4F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project OpenMV2_Full is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "12000000";          -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "openmv2";           -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/OpenMV2/openmv2_full.gpr
+++ b/boards/OpenMV2/openmv2_full.gpr
@@ -66,6 +66,7 @@ library project OpenMV2_Full is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M4F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project OpenMV2_Full is
    Runtime_Profile                := "ravenscar-full";    -- From command line
    Device_Name                    := "STM32F427VGTx";     -- From board definition
    Device_Family                  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-full-openmv2"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M4F";    -- From mcu definition
    Board                          := "OpenMV2";           -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "12000000";          -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/OpenMV2/openmv2_sfp.gpr
+++ b/boards/OpenMV2/openmv2_sfp.gpr
@@ -52,14 +52,21 @@ library project OpenMV2_SFP is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/sfp_" & Build;
    for Library_Dir use "obj/sfp_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-sfp-openmv2";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M4F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project OpenMV2_SFP is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "12000000";          -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "openmv2";           -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/OpenMV2/openmv2_sfp.gpr
+++ b/boards/OpenMV2/openmv2_sfp.gpr
@@ -66,6 +66,7 @@ library project OpenMV2_SFP is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M4F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project OpenMV2_SFP is
    Runtime_Profile                := "ravenscar-sfp";     -- From command line
    Device_Name                    := "STM32F427VGTx";     -- From board definition
    Device_Family                  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-sfp-openmv2"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M4F";    -- From mcu definition
    Board                          := "OpenMV2";           -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "12000000";          -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/OpenMV2/src/full/adl_config.ads
+++ b/boards/OpenMV2/src/full/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 12000000;            -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "openmv2";           -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/OpenMV2/src/full/adl_config.ads
+++ b/boards/OpenMV2/src/full/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-full";    -- From command line
    Device_Name                    : constant String  := "STM32F427VGTx";     -- From board definition
    Device_Family                  : constant String  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-full-openmv2"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M4F";    -- From mcu definition
    Board                          : constant String  := "OpenMV2";           -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 12000000;            -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/OpenMV2/src/sfp/adl_config.ads
+++ b/boards/OpenMV2/src/sfp/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-sfp";     -- From command line
    Device_Name                    : constant String  := "STM32F427VGTx";     -- From board definition
    Device_Family                  : constant String  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-sfp-openmv2"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M4F";    -- From mcu definition
    Board                          : constant String  := "OpenMV2";           -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 12000000;            -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/OpenMV2/src/sfp/adl_config.ads
+++ b/boards/OpenMV2/src/sfp/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 12000000;            -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "openmv2";           -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/board_projects_generator.py
+++ b/boards/board_projects_generator.py
@@ -30,6 +30,7 @@ FOLDERS = {'Crazyflie': 'crazyflie',
            'STM32F769_Discovery': 'stm32f769_discovery',
            'NUCLEO_F446ZE':       'nucleo_f446ze'}
 
+USE_STARTUP_GEN = ['HiFive1']
 
 def gen_project(board_name, rts):
     assert board_name is not None, "board is undefined"
@@ -63,7 +64,8 @@ def gen_project(board_name, rts):
             "-s", source_dir_name,
             "-o", object_dir_name,
             "Board=%s" % board_name,
-            "Runtime_Profile=%s" % rts]
+            "Runtime_Profile=%s" % rts,
+            "Use_Startup_Gen=" + ("True" if board_name in USE_STARTUP_GEN else "False")]
     check_call(args)
 
 

--- a/boards/board_projects_generator.py
+++ b/boards/board_projects_generator.py
@@ -30,7 +30,7 @@ FOLDERS = {'Crazyflie': 'crazyflie',
            'STM32F769_Discovery': 'stm32f769_discovery',
            'NUCLEO_F446ZE':       'nucleo_f446ze'}
 
-USE_STARTUP_GEN = ['HiFive1']
+USE_STARTUP_GEN = ['HiFive1', 'MicroBit']
 
 def gen_project(board_name, rts):
     assert board_name is not None, "board is undefined"

--- a/boards/crazyflie/crazyflie_full.gpr
+++ b/boards/crazyflie/crazyflie_full.gpr
@@ -66,6 +66,7 @@ library project Crazyflie_Full is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M4F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project Crazyflie_Full is
    Runtime_Profile                := "ravenscar-full";    -- From command line
    Device_Name                    := "STM32F405RGTx";     -- From board definition
    Device_Family                  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-full-stm32f4"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M4F";    -- From mcu definition
    Board                          := "Crazyflie";         -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "8000000";           -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/crazyflie/crazyflie_full.gpr
+++ b/boards/crazyflie/crazyflie_full.gpr
@@ -52,14 +52,21 @@ library project Crazyflie_Full is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/full_" & Build;
    for Library_Dir use "obj/full_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-full-stm32f4";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M4F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project Crazyflie_Full is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "8000000";           -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f4";           -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/crazyflie/crazyflie_sfp.gpr
+++ b/boards/crazyflie/crazyflie_sfp.gpr
@@ -52,14 +52,21 @@ library project Crazyflie_SFP is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/sfp_" & Build;
    for Library_Dir use "obj/sfp_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-sfp-stm32f4";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M4F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project Crazyflie_SFP is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "8000000";           -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f4";           -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/crazyflie/crazyflie_sfp.gpr
+++ b/boards/crazyflie/crazyflie_sfp.gpr
@@ -66,6 +66,7 @@ library project Crazyflie_SFP is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M4F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project Crazyflie_SFP is
    Runtime_Profile                := "ravenscar-sfp";     -- From command line
    Device_Name                    := "STM32F405RGTx";     -- From board definition
    Device_Family                  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-sfp-stm32f4"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M4F";    -- From mcu definition
    Board                          := "Crazyflie";         -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "8000000";           -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/crazyflie/src/full/adl_config.ads
+++ b/boards/crazyflie/src/full/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f4";           -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/crazyflie/src/full/adl_config.ads
+++ b/boards/crazyflie/src/full/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-full";    -- From command line
    Device_Name                    : constant String  := "STM32F405RGTx";     -- From board definition
    Device_Family                  : constant String  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-full-stm32f4"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M4F";    -- From mcu definition
    Board                          : constant String  := "Crazyflie";         -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/crazyflie/src/sfp/adl_config.ads
+++ b/boards/crazyflie/src/sfp/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f4";           -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/crazyflie/src/sfp/adl_config.ads
+++ b/boards/crazyflie/src/sfp/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-sfp";     -- From command line
    Device_Name                    : constant String  := "STM32F405RGTx";     -- From board definition
    Device_Family                  : constant String  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-sfp-stm32f4"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M4F";    -- From mcu definition
    Board                          : constant String  := "Crazyflie";         -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/native/config_src/adl_config.ads
+++ b/boards/native/config_src/adl_config.ads
@@ -6,6 +6,7 @@ package ADL_Config is
    Board                          : constant String  := "Native";            -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From default value
    Has_Ravenscar_SFP_Runtime      : constant String  := "False";             -- From default value
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Architecture                   : constant String  := "Native";            -- From board definition
 end ADL_Config;

--- a/boards/native/native.gpr
+++ b/boards/native/native.gpr
@@ -52,6 +52,7 @@ library project Native is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj_" & Build;
@@ -59,12 +60,19 @@ library project Native is
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
 
+   Linker_Switches := ();
+
+   package Device_Configuration is
+      for CPU_Name use "None";
+   end Device_Configuration;
+
    Max_Mount_Points               := "2";                 -- From default value
    Max_Mount_Name_Length          := "128";               -- From default value
    Has_Ravenscar_Full_Runtime     := "False";             -- From default value
    Board                          := "Native";            -- From command line
    Has_ZFP_Runtime                := "False";             -- From default value
    Has_Ravenscar_SFP_Runtime      := "False";             -- From default value
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Architecture                   := "Native";            -- From board definition
 

--- a/boards/native/native.gpr
+++ b/boards/native/native.gpr
@@ -62,10 +62,6 @@ library project Native is
 
    Linker_Switches := ();
 
-   package Device_Configuration is
-      for CPU_Name use "None";
-   end Device_Configuration;
-
    Max_Mount_Points               := "2";                 -- From default value
    Max_Mount_Name_Length          := "128";               -- From default value
    Has_Ravenscar_Full_Runtime     := "False";             -- From default value

--- a/boards/nucleo_f446ze/nucleo_f446ze_full.gpr
+++ b/boards/nucleo_f446ze/nucleo_f446ze_full.gpr
@@ -66,6 +66,7 @@ library project NUCLEO_F446ZE_Full is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M4F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project NUCLEO_F446ZE_Full is
    Runtime_Profile                := "ravenscar-full";    -- From command line
    Device_Name                    := "STM32F407VGTx";     -- From board definition
    Device_Family                  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-full-stm32f4"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M4F";    -- From mcu definition
    Board                          := "NUCLEO_F446ZE";     -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "8000000";           -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/nucleo_f446ze/nucleo_f446ze_full.gpr
+++ b/boards/nucleo_f446ze/nucleo_f446ze_full.gpr
@@ -52,14 +52,21 @@ library project NUCLEO_F446ZE_Full is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/full_" & Build;
    for Library_Dir use "obj/full_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-full-stm32f4";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M4F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project NUCLEO_F446ZE_Full is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "8000000";           -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f4";           -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/nucleo_f446ze/nucleo_f446ze_sfp.gpr
+++ b/boards/nucleo_f446ze/nucleo_f446ze_sfp.gpr
@@ -52,14 +52,21 @@ library project NUCLEO_F446ZE_SFP is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/sfp_" & Build;
    for Library_Dir use "obj/sfp_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-sfp-stm32f4";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M4F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project NUCLEO_F446ZE_SFP is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "8000000";           -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f4";           -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/nucleo_f446ze/nucleo_f446ze_sfp.gpr
+++ b/boards/nucleo_f446ze/nucleo_f446ze_sfp.gpr
@@ -66,6 +66,7 @@ library project NUCLEO_F446ZE_SFP is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M4F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project NUCLEO_F446ZE_SFP is
    Runtime_Profile                := "ravenscar-sfp";     -- From command line
    Device_Name                    := "STM32F407VGTx";     -- From board definition
    Device_Family                  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-sfp-stm32f4"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M4F";    -- From mcu definition
    Board                          := "NUCLEO_F446ZE";     -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "8000000";           -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/nucleo_f446ze/src/full/adl_config.ads
+++ b/boards/nucleo_f446ze/src/full/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f4";           -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/nucleo_f446ze/src/full/adl_config.ads
+++ b/boards/nucleo_f446ze/src/full/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-full";    -- From command line
    Device_Name                    : constant String  := "STM32F407VGTx";     -- From board definition
    Device_Family                  : constant String  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-full-stm32f4"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M4F";    -- From mcu definition
    Board                          : constant String  := "NUCLEO_F446ZE";     -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/nucleo_f446ze/src/sfp/adl_config.ads
+++ b/boards/nucleo_f446ze/src/sfp/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f4";           -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/nucleo_f446ze/src/sfp/adl_config.ads
+++ b/boards/nucleo_f446ze/src/sfp/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-sfp";     -- From command line
    Device_Name                    : constant String  := "STM32F407VGTx";     -- From board definition
    Device_Family                  : constant String  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-sfp-stm32f4"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M4F";    -- From mcu definition
    Board                          : constant String  := "NUCLEO_F446ZE";     -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/stm32f407_discovery/src/full/adl_config.ads
+++ b/boards/stm32f407_discovery/src/full/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f4";           -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/stm32f407_discovery/src/full/adl_config.ads
+++ b/boards/stm32f407_discovery/src/full/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-full";    -- From command line
    Device_Name                    : constant String  := "STM32F407VGTx";     -- From board definition
    Device_Family                  : constant String  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-full-stm32f4"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M4F";    -- From mcu definition
    Board                          : constant String  := "STM32F407_Discovery"; -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/stm32f407_discovery/src/sfp/adl_config.ads
+++ b/boards/stm32f407_discovery/src/sfp/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f4";           -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/stm32f407_discovery/src/sfp/adl_config.ads
+++ b/boards/stm32f407_discovery/src/sfp/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-sfp";     -- From command line
    Device_Name                    : constant String  := "STM32F407VGTx";     -- From board definition
    Device_Family                  : constant String  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-sfp-stm32f4"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M4F";    -- From mcu definition
    Board                          : constant String  := "STM32F407_Discovery"; -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/stm32f407_discovery/stm32f407_discovery_full.gpr
+++ b/boards/stm32f407_discovery/stm32f407_discovery_full.gpr
@@ -66,6 +66,7 @@ library project STM32F407_Discovery_Full is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M4F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project STM32F407_Discovery_Full is
    Runtime_Profile                := "ravenscar-full";    -- From command line
    Device_Name                    := "STM32F407VGTx";     -- From board definition
    Device_Family                  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-full-stm32f4"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M4F";    -- From mcu definition
    Board                          := "STM32F407_Discovery"; -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "8000000";           -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/stm32f407_discovery/stm32f407_discovery_full.gpr
+++ b/boards/stm32f407_discovery/stm32f407_discovery_full.gpr
@@ -52,14 +52,21 @@ library project STM32F407_Discovery_Full is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/full_" & Build;
    for Library_Dir use "obj/full_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-full-stm32f4";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M4F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project STM32F407_Discovery_Full is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "8000000";           -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f4";           -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/stm32f407_discovery/stm32f407_discovery_sfp.gpr
+++ b/boards/stm32f407_discovery/stm32f407_discovery_sfp.gpr
@@ -66,6 +66,7 @@ library project STM32F407_Discovery_SFP is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M4F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project STM32F407_Discovery_SFP is
    Runtime_Profile                := "ravenscar-sfp";     -- From command line
    Device_Name                    := "STM32F407VGTx";     -- From board definition
    Device_Family                  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-sfp-stm32f4"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M4F";    -- From mcu definition
    Board                          := "STM32F407_Discovery"; -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "8000000";           -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/stm32f407_discovery/stm32f407_discovery_sfp.gpr
+++ b/boards/stm32f407_discovery/stm32f407_discovery_sfp.gpr
@@ -52,14 +52,21 @@ library project STM32F407_Discovery_SFP is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/sfp_" & Build;
    for Library_Dir use "obj/sfp_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-sfp-stm32f4";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M4F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project STM32F407_Discovery_SFP is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "8000000";           -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f4";           -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/stm32f429_discovery/src/full/adl_config.ads
+++ b/boards/stm32f429_discovery/src/full/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-full";    -- From command line
    Device_Name                    : constant String  := "STM32F429ZITx";     -- From board definition
    Device_Family                  : constant String  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-full-stm32f429disco"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M4F";    -- From mcu definition
    Board                          : constant String  := "STM32F429_Discovery"; -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/stm32f429_discovery/src/full/adl_config.ads
+++ b/boards/stm32f429_discovery/src/full/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f429disco";    -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/stm32f429_discovery/src/sfp/adl_config.ads
+++ b/boards/stm32f429_discovery/src/sfp/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f429disco";    -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/stm32f429_discovery/src/sfp/adl_config.ads
+++ b/boards/stm32f429_discovery/src/sfp/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-sfp";     -- From command line
    Device_Name                    : constant String  := "STM32F429ZITx";     -- From board definition
    Device_Family                  : constant String  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-sfp-stm32f429disco"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M4F";    -- From mcu definition
    Board                          : constant String  := "STM32F429_Discovery"; -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/stm32f429_discovery/stm32f429_discovery_full.gpr
+++ b/boards/stm32f429_discovery/stm32f429_discovery_full.gpr
@@ -66,6 +66,7 @@ library project STM32F429_Discovery_Full is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M4F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project STM32F429_Discovery_Full is
    Runtime_Profile                := "ravenscar-full";    -- From command line
    Device_Name                    := "STM32F429ZITx";     -- From board definition
    Device_Family                  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-full-stm32f429disco"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M4F";    -- From mcu definition
    Board                          := "STM32F429_Discovery"; -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "8000000";           -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/stm32f429_discovery/stm32f429_discovery_full.gpr
+++ b/boards/stm32f429_discovery/stm32f429_discovery_full.gpr
@@ -52,14 +52,21 @@ library project STM32F429_Discovery_Full is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/full_" & Build;
    for Library_Dir use "obj/full_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-full-stm32f429disco";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M4F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project STM32F429_Discovery_Full is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "8000000";           -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f429disco";    -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/stm32f429_discovery/stm32f429_discovery_sfp.gpr
+++ b/boards/stm32f429_discovery/stm32f429_discovery_sfp.gpr
@@ -52,14 +52,21 @@ library project STM32F429_Discovery_SFP is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/sfp_" & Build;
    for Library_Dir use "obj/sfp_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-sfp-stm32f429disco";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M4F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project STM32F429_Discovery_SFP is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "8000000";           -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f429disco";    -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/stm32f429_discovery/stm32f429_discovery_sfp.gpr
+++ b/boards/stm32f429_discovery/stm32f429_discovery_sfp.gpr
@@ -66,6 +66,7 @@ library project STM32F429_Discovery_SFP is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M4F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project STM32F429_Discovery_SFP is
    Runtime_Profile                := "ravenscar-sfp";     -- From command line
    Device_Name                    := "STM32F429ZITx";     -- From board definition
    Device_Family                  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-sfp-stm32f429disco"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M4F";    -- From mcu definition
    Board                          := "STM32F429_Discovery"; -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "8000000";           -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/stm32f469_discovery/src/full/adl_config.ads
+++ b/boards/stm32f469_discovery/src/full/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f469disco";    -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/stm32f469_discovery/src/full/adl_config.ads
+++ b/boards/stm32f469_discovery/src/full/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-full";    -- From command line
    Device_Name                    : constant String  := "STM32F469NIHx";     -- From board definition
    Device_Family                  : constant String  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-full-stm32f469disco"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M4F";    -- From mcu definition
    Board                          : constant String  := "STM32F469_Discovery"; -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/stm32f469_discovery/src/sfp/adl_config.ads
+++ b/boards/stm32f469_discovery/src/sfp/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f469disco";    -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/stm32f469_discovery/src/sfp/adl_config.ads
+++ b/boards/stm32f469_discovery/src/sfp/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-sfp";     -- From command line
    Device_Name                    : constant String  := "STM32F469NIHx";     -- From board definition
    Device_Family                  : constant String  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-sfp-stm32f469disco"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M4F";    -- From mcu definition
    Board                          : constant String  := "STM32F469_Discovery"; -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 8000000;             -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/stm32f469_discovery/stm32f469_discovery_full.gpr
+++ b/boards/stm32f469_discovery/stm32f469_discovery_full.gpr
@@ -52,14 +52,21 @@ library project STM32F469_Discovery_Full is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/full_" & Build;
    for Library_Dir use "obj/full_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-full-stm32f469disco";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M4F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project STM32F469_Discovery_Full is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "8000000";           -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f469disco";    -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/stm32f469_discovery/stm32f469_discovery_full.gpr
+++ b/boards/stm32f469_discovery/stm32f469_discovery_full.gpr
@@ -66,6 +66,7 @@ library project STM32F469_Discovery_Full is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M4F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project STM32F469_Discovery_Full is
    Runtime_Profile                := "ravenscar-full";    -- From command line
    Device_Name                    := "STM32F469NIHx";     -- From board definition
    Device_Family                  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-full-stm32f469disco"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M4F";    -- From mcu definition
    Board                          := "STM32F469_Discovery"; -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "8000000";           -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/stm32f469_discovery/stm32f469_discovery_sfp.gpr
+++ b/boards/stm32f469_discovery/stm32f469_discovery_sfp.gpr
@@ -66,6 +66,7 @@ library project STM32F469_Discovery_SFP is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M4F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project STM32F469_Discovery_SFP is
    Runtime_Profile                := "ravenscar-sfp";     -- From command line
    Device_Name                    := "STM32F469NIHx";     -- From board definition
    Device_Family                  := "STM32F4";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-sfp-stm32f469disco"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M4F";    -- From mcu definition
    Board                          := "STM32F469_Discovery"; -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "8000000";           -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/stm32f469_discovery/stm32f469_discovery_sfp.gpr
+++ b/boards/stm32f469_discovery/stm32f469_discovery_sfp.gpr
@@ -52,14 +52,21 @@ library project STM32F469_Discovery_SFP is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/sfp_" & Build;
    for Library_Dir use "obj/sfp_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-sfp-stm32f469disco";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M4F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project STM32F469_Discovery_SFP is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "8000000";           -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f469disco";    -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/stm32f746_discovery/src/full/adl_config.ads
+++ b/boards/stm32f746_discovery/src/full/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 25000000;            -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f746disco";    -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/stm32f746_discovery/src/full/adl_config.ads
+++ b/boards/stm32f746_discovery/src/full/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-full";    -- From command line
    Device_Name                    : constant String  := "STM32F746NGHx";     -- From board definition
    Device_Family                  : constant String  := "STM32F7";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-full-stm32f746disco"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M7F";    -- From mcu definition
    Board                          : constant String  := "STM32F746_Discovery"; -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 25000000;            -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/stm32f746_discovery/src/sfp/adl_config.ads
+++ b/boards/stm32f746_discovery/src/sfp/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 25000000;            -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f746disco";    -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/stm32f746_discovery/src/sfp/adl_config.ads
+++ b/boards/stm32f746_discovery/src/sfp/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-sfp";     -- From command line
    Device_Name                    : constant String  := "STM32F746NGHx";     -- From board definition
    Device_Family                  : constant String  := "STM32F7";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-sfp-stm32f746disco"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M7F";    -- From mcu definition
    Board                          : constant String  := "STM32F746_Discovery"; -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 25000000;            -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/stm32f746_discovery/stm32f746_discovery_full.gpr
+++ b/boards/stm32f746_discovery/stm32f746_discovery_full.gpr
@@ -66,6 +66,7 @@ library project STM32F746_Discovery_Full is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M7F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project STM32F746_Discovery_Full is
    Runtime_Profile                := "ravenscar-full";    -- From command line
    Device_Name                    := "STM32F746NGHx";     -- From board definition
    Device_Family                  := "STM32F7";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-full-stm32f746disco"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M7F";    -- From mcu definition
    Board                          := "STM32F746_Discovery"; -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "25000000";          -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/stm32f746_discovery/stm32f746_discovery_full.gpr
+++ b/boards/stm32f746_discovery/stm32f746_discovery_full.gpr
@@ -52,14 +52,21 @@ library project STM32F746_Discovery_Full is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/full_" & Build;
    for Library_Dir use "obj/full_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-full-stm32f746disco";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M7F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project STM32F746_Discovery_Full is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "25000000";          -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f746disco";    -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/stm32f746_discovery/stm32f746_discovery_sfp.gpr
+++ b/boards/stm32f746_discovery/stm32f746_discovery_sfp.gpr
@@ -52,14 +52,21 @@ library project STM32F746_Discovery_SFP is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/sfp_" & Build;
    for Library_Dir use "obj/sfp_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-sfp-stm32f746disco";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M7F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project STM32F746_Discovery_SFP is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "25000000";          -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f746disco";    -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/stm32f746_discovery/stm32f746_discovery_sfp.gpr
+++ b/boards/stm32f746_discovery/stm32f746_discovery_sfp.gpr
@@ -66,6 +66,7 @@ library project STM32F746_Discovery_SFP is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M7F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project STM32F746_Discovery_SFP is
    Runtime_Profile                := "ravenscar-sfp";     -- From command line
    Device_Name                    := "STM32F746NGHx";     -- From board definition
    Device_Family                  := "STM32F7";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-sfp-stm32f746disco"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M7F";    -- From mcu definition
    Board                          := "STM32F746_Discovery"; -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "25000000";          -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/stm32f769_discovery/src/full/adl_config.ads
+++ b/boards/stm32f769_discovery/src/full/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 25000000;            -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f769disco";    -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/stm32f769_discovery/src/full/adl_config.ads
+++ b/boards/stm32f769_discovery/src/full/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-full";    -- From command line
    Device_Name                    : constant String  := "STM32F769NIHx";     -- From board definition
    Device_Family                  : constant String  := "STM32F7";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-full-stm32f769disco"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M7F";    -- From mcu definition
    Board                          : constant String  := "STM32F769_Discovery"; -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 25000000;            -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/stm32f769_discovery/src/sfp/adl_config.ads
+++ b/boards/stm32f769_discovery/src/sfp/adl_config.ads
@@ -6,12 +6,13 @@ package ADL_Config is
    Runtime_Profile                : constant String  := "ravenscar-sfp";     -- From command line
    Device_Name                    : constant String  := "STM32F769NIHx";     -- From board definition
    Device_Family                  : constant String  := "STM32F7";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    Runtime_Name                   : constant String  := "ravenscar-sfp-stm32f769disco"; -- From default value
    Has_Ravenscar_Full_Runtime     : constant String  := "True";              -- From board definition
    CPU_Core                       : constant String  := "ARM Cortex-M7F";    -- From mcu definition
    Board                          : constant String  := "STM32F769_Discovery"; -- From command line
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
+   Number_Of_Interrupts           : constant         := 0;                   -- From default value
    High_Speed_External_Clock      : constant         := 25000000;            -- From board definition
    Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value

--- a/boards/stm32f769_discovery/src/sfp/adl_config.ads
+++ b/boards/stm32f769_discovery/src/sfp/adl_config.ads
@@ -13,6 +13,7 @@ package ADL_Config is
    Has_ZFP_Runtime                : constant String  := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      : constant String  := "True";              -- From board definition
    High_Speed_External_Clock      : constant         := 25000000;            -- From board definition
+   Use_Startup_Gen                : constant Boolean := False;               -- From command line
    Max_Path_Length                : constant         := 1024;                -- From default value
    Runtime_Name_Suffix            : constant String  := "stm32f769disco";    -- From board definition
    Architecture                   : constant String  := "ARM";               -- From board definition

--- a/boards/stm32f769_discovery/stm32f769_discovery_full.gpr
+++ b/boards/stm32f769_discovery/stm32f769_discovery_full.gpr
@@ -52,14 +52,21 @@ library project STM32F769_Discovery_Full is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/full_" & Build;
    for Library_Dir use "obj/full_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-full-stm32f769disco";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M7F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project STM32F769_Discovery_Full is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "25000000";          -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f769disco";    -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/boards/stm32f769_discovery/stm32f769_discovery_full.gpr
+++ b/boards/stm32f769_discovery/stm32f769_discovery_full.gpr
@@ -66,6 +66,7 @@ library project STM32F769_Discovery_Full is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M7F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project STM32F769_Discovery_Full is
    Runtime_Profile                := "ravenscar-full";    -- From command line
    Device_Name                    := "STM32F769NIHx";     -- From board definition
    Device_Family                  := "STM32F7";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-full-stm32f769disco"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M7F";    -- From mcu definition
    Board                          := "STM32F769_Discovery"; -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "25000000";          -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/stm32f769_discovery/stm32f769_discovery_sfp.gpr
+++ b/boards/stm32f769_discovery/stm32f769_discovery_sfp.gpr
@@ -66,6 +66,7 @@ library project STM32F769_Discovery_SFP is
 
    package Device_Configuration is
       for CPU_Name use "ARM Cortex-M7F";
+      for Number_Of_Interrupts use "0";
    end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
@@ -74,12 +75,13 @@ library project STM32F769_Discovery_SFP is
    Runtime_Profile                := "ravenscar-sfp";     -- From command line
    Device_Name                    := "STM32F769NIHx";     -- From board definition
    Device_Family                  := "STM32F7";           -- From board definition
+   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    Runtime_Name                   := "ravenscar-sfp-stm32f769disco"; -- From default value
    Has_Ravenscar_Full_Runtime     := "True";              -- From board definition
    CPU_Core                       := "ARM Cortex-M7F";    -- From mcu definition
    Board                          := "STM32F769_Discovery"; -- From command line
    Has_ZFP_Runtime                := "False";             -- From board definition
-   Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
+   Number_Of_Interrupts           := "0";                 -- From default value
    High_Speed_External_Clock      := "25000000";          -- From board definition
    Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value

--- a/boards/stm32f769_discovery/stm32f769_discovery_sfp.gpr
+++ b/boards/stm32f769_discovery/stm32f769_discovery_sfp.gpr
@@ -52,14 +52,21 @@ library project STM32F769_Discovery_SFP is
          "-fdata-sections");  -- Create a linker section for each data
    end Compiler;
 
+
    for Languages use ("Ada");
    for Create_Missing_Dirs use "True";
    for Object_Dir use "obj/sfp_" & Build;
    for Library_Dir use "obj/sfp_lib_" & Build;
    for Library_Kind use "static";
    for Library_Name use "ada_drivers_library";
+
+   Linker_Switches := ();
    for Target use "arm-eabi";
    for Runtime ("Ada") use "ravenscar-sfp-stm32f769disco";
+
+   package Device_Configuration is
+      for CPU_Name use "ARM Cortex-M7F";
+   end Device_Configuration;
 
    Vendor                         := "STMicro";           -- From board definition
    Max_Mount_Points               := "2";                 -- From default value
@@ -74,6 +81,7 @@ library project STM32F769_Discovery_SFP is
    Has_ZFP_Runtime                := "False";             -- From board definition
    Has_Ravenscar_SFP_Runtime      := "True";              -- From board definition
    High_Speed_External_Clock      := "25000000";          -- From board definition
+   Use_Startup_Gen                := "False";             -- From command line
    Max_Path_Length                := "1024";              -- From default value
    Runtime_Name_Suffix            := "stm32f769disco";    -- From board definition
    Architecture                   := "ARM";               -- From board definition

--- a/examples/HiFive1/hifive1_example.gpr
+++ b/examples/HiFive1/hifive1_example.gpr
@@ -2,7 +2,7 @@ with "../../boards/HiFive1/hifive1_zfp.gpr";
 
 project HiFive1_Example is
 
-  for Runtime ("ada") use "zfp-hifive1";
+  for Runtime ("ada") use HiFive1_ZFP'Runtime ("Ada");
   for Target use "riscv32-elf";
   for Main use ("main.adb");
   for Languages use ("Ada");
@@ -13,8 +13,10 @@ project HiFive1_Example is
   package Compiler renames HiFive1_ZFP.Compiler;
 
   package Linker is
-     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage",
-                                       "-Wl,--gc-sections");
+     for Default_Switches ("Ada") use
+       HiFive1_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections");
   end Linker;
 
   package Ide is

--- a/examples/MicroBit/BLE_beacon/BLE_beacon.gpr
+++ b/examples/MicroBit/BLE_beacon/BLE_beacon.gpr
@@ -2,7 +2,7 @@ with "../../../boards/MicroBit/microbit_zfp.gpr";
 
 project BLE_Beacon is
 
-  for Runtime ("ada") use "zfp-microbit";
+  for Runtime ("ada") use MicroBit_ZFP'Runtime ("Ada");
   for Target use "arm-eabi";
   for Main use ("main.adb");
   for Languages use ("Ada");
@@ -13,8 +13,10 @@ project BLE_Beacon is
   package Compiler renames MicroBit_ZFP.Compiler;
 
   package Linker is
-     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage",
-                                       "-Wl,--gc-sections");
+     for Default_Switches ("Ada") use
+       MicroBit_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections");
   end Linker;
 
   package Ide is

--- a/examples/MicroBit/analog_in/analog_in.gpr
+++ b/examples/MicroBit/analog_in/analog_in.gpr
@@ -2,7 +2,7 @@ with "../../../boards/MicroBit/microbit_zfp.gpr";
 
 project Analog_In is
 
-  for Runtime ("ada") use "zfp-microbit";
+  for Runtime ("ada") use MicroBit_ZFP'Runtime ("Ada");
   for Target use "arm-eabi";
   for Main use ("main.adb");
   for Languages use ("Ada");
@@ -13,8 +13,10 @@ project Analog_In is
   package Compiler renames MicroBit_ZFP.Compiler;
 
   package Linker is
-     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage",
-                                       "-Wl,--gc-sections");
+     for Default_Switches ("Ada") use
+       MicroBit_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections");
   end Linker;
 
   package Ide is

--- a/examples/MicroBit/analog_out/analog_out.gpr
+++ b/examples/MicroBit/analog_out/analog_out.gpr
@@ -2,7 +2,7 @@ with "../../../boards/MicroBit/microbit_zfp.gpr";
 
 project Analog_Out is
 
-  for Runtime ("ada") use "zfp-microbit";
+  for Runtime ("ada") use MicroBit_ZFP'Runtime ("Ada");
   for Target use "arm-eabi";
   for Main use ("main.adb");
   for Languages use ("Ada");
@@ -13,8 +13,10 @@ project Analog_Out is
   package Compiler renames MicroBit_ZFP.Compiler;
 
   package Linker is
-     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage",
-                                       "-Wl,--gc-sections");
+     for Default_Switches ("Ada") use
+       MicroBit_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections");
   end Linker;
 
   package Ide is

--- a/examples/MicroBit/buttons/buttons.gpr
+++ b/examples/MicroBit/buttons/buttons.gpr
@@ -2,7 +2,7 @@ with "../../../boards/MicroBit/microbit_zfp.gpr";
 
 project Buttons is
 
-  for Runtime ("ada") use "zfp-microbit";
+  for Runtime ("ada") use MicroBit_ZFP'Runtime ("Ada");
   for Target use "arm-eabi";
   for Main use ("main.adb");
   for Languages use ("Ada");
@@ -13,8 +13,10 @@ project Buttons is
   package Compiler renames MicroBit_ZFP.Compiler;
 
   package Linker is
-     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage",
-                                       "-Wl,--gc-sections");
+     for Default_Switches ("Ada") use
+       MicroBit_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections");
   end Linker;
 
   package Ide is

--- a/examples/MicroBit/digital_in/digital_in.gpr
+++ b/examples/MicroBit/digital_in/digital_in.gpr
@@ -2,7 +2,7 @@ with "../../../boards/MicroBit/microbit_zfp.gpr";
 
 project Digital_In is
 
-  for Runtime ("ada") use "zfp-microbit";
+  for Runtime ("ada") use MicroBit_ZFP'Runtime ("Ada");
   for Target use "arm-eabi";
   for Main use ("main.adb");
   for Languages use ("Ada");
@@ -13,8 +13,10 @@ project Digital_In is
   package Compiler renames MicroBit_ZFP.Compiler;
 
   package Linker is
-     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage",
-                                       "-Wl,--gc-sections");
+     for Default_Switches ("Ada") use
+       MicroBit_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections");
   end Linker;
 
   package Ide is

--- a/examples/MicroBit/digital_out/digital_out.gpr
+++ b/examples/MicroBit/digital_out/digital_out.gpr
@@ -2,7 +2,7 @@ with "../../../boards/MicroBit/microbit_zfp.gpr";
 
 project Digital_Out is
 
-  for Runtime ("ada") use "zfp-microbit";
+  for Runtime ("ada") use MicroBit_ZFP'Runtime ("Ada");
   for Target use "arm-eabi";
   for Main use ("main.adb");
   for Languages use ("Ada");
@@ -13,8 +13,10 @@ project Digital_Out is
   package Compiler renames MicroBit_ZFP.Compiler;
 
   package Linker is
-     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage",
-                                       "-Wl,--gc-sections");
+     for Default_Switches ("Ada") use
+       MicroBit_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections");
   end Linker;
 
   package Ide is

--- a/examples/MicroBit/follower/follower.gpr
+++ b/examples/MicroBit/follower/follower.gpr
@@ -2,7 +2,7 @@ with "../../../boards/MicroBit/microbit_zfp.gpr";
 
 project Follower is
 
-  for Runtime ("ada") use "zfp-microbit";
+  for Runtime ("ada") use MicroBit_ZFP'Runtime ("Ada");
   for Target use "arm-eabi";
   for Main use ("main.adb");
   for Languages use ("Ada");
@@ -13,8 +13,10 @@ project Follower is
   package Compiler renames MicroBit_ZFP.Compiler;
 
   package Linker is
-     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage",
-                                       "-Wl,--gc-sections");
+     for Default_Switches ("Ada") use
+       MicroBit_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections");
   end Linker;
 
   package Ide is

--- a/examples/MicroBit/music/music.gpr
+++ b/examples/MicroBit/music/music.gpr
@@ -2,7 +2,7 @@ with "../../../boards/MicroBit/microbit_zfp.gpr";
 
 project Music is
 
-  for Runtime ("ada") use "zfp-microbit";
+  for Runtime ("ada") use MicroBit_ZFP'Runtime ("Ada");
   for Target use "arm-eabi";
   for Main use ("main.adb");
   for Languages use ("Ada");
@@ -13,8 +13,10 @@ project Music is
   package Compiler renames MicroBit_ZFP.Compiler;
 
   package Linker is
-     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage",
-                                       "-Wl,--gc-sections");
+     for Default_Switches ("Ada") use
+       MicroBit_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections");
   end Linker;
 
   package Ide is

--- a/examples/MicroBit/neopixel/neopixel.gpr
+++ b/examples/MicroBit/neopixel/neopixel.gpr
@@ -2,7 +2,7 @@ with "../../../boards/MicroBit/microbit_zfp.gpr";
 
 project NeoPixel is
 
-  for Runtime ("ada") use "zfp-microbit";
+  for Runtime ("ada") use MicroBit_ZFP'Runtime ("Ada");
   for Target use "arm-eabi";
   for Main use ("main.adb");
   for Languages use ("Ada");
@@ -13,8 +13,10 @@ project NeoPixel is
   package Compiler renames MicroBit_ZFP.Compiler;
 
   package Linker is
-     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage",
-                                       "-Wl,--gc-sections");
+     for Default_Switches ("Ada") use
+       MicroBit_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections");
   end Linker;
 
   package Ide is

--- a/examples/MicroBit/servos/servos.gpr
+++ b/examples/MicroBit/servos/servos.gpr
@@ -2,7 +2,7 @@ with "../../../boards/MicroBit/microbit_zfp.gpr";
 
 project Servos is
 
-  for Runtime ("ada") use "zfp-microbit";
+  for Runtime ("ada") use MicroBit_ZFP'Runtime ("Ada");
   for Target use "arm-eabi";
   for Main use ("main.adb");
   for Languages use ("Ada");
@@ -13,8 +13,10 @@ project Servos is
   package Compiler renames MicroBit_ZFP.Compiler;
 
   package Linker is
-     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage",
-                                       "-Wl,--gc-sections");
+     for Default_Switches ("Ada") use
+       MicroBit_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections");
   end Linker;
 
   package Ide is

--- a/examples/MicroBit/text_scrolling/text_scrolling.gpr
+++ b/examples/MicroBit/text_scrolling/text_scrolling.gpr
@@ -2,7 +2,7 @@ with "../../../boards/MicroBit/microbit_zfp.gpr";
 
 project Text_Scrolling is
 
-  for Runtime ("ada") use "zfp-microbit";
+  for Runtime ("ada") use MicroBit_ZFP'Runtime ("Ada");
   for Target use "arm-eabi";
   for Main use ("main.adb");
   for Languages use ("Ada");
@@ -13,8 +13,11 @@ project Text_Scrolling is
   package Compiler renames MicroBit_ZFP.Compiler;
 
   package Linker is
-     for Default_Switches ("Ada") use ("-Wl,--print-memory-usage",
-                                       "-Wl,--gc-sections");
+     for Default_Switches ("Ada") use
+       MicroBit_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections",
+        "-U__gnat_irq_trap");
   end Linker;
 
   package Ide is

--- a/scripts/config/__init__.py
+++ b/scripts/config/__init__.py
@@ -78,20 +78,25 @@ class Database:
         out += "\n"
 
         # Device configuration
-        out += "   package Device_Configuration is\n"
-        out += '      for CPU_Name use "%s";\n' % self.get_config("CPU_Core");
+        if arch is not None and arch != "Native":
+            out += "   package Device_Configuration is\n"
+            out += '      for CPU_Name use "%s";\n' % self.get_config("CPU_Core");
+            out += '      for Number_Of_Interrupts use "%d";\n' % self.get_config("Number_Of_Interrupts");
 
-        if len(self.memory_names()):
-           out += '\n      for Memories use ("' + '", "'.join(self.memory_names())
-           out += '");\n'
+            for cnt in range(self.get_config("Number_Of_Interrupts")):
+                out += '      for Interrupt ("%d") use "%s";\n' % (cnt, "adl_irq")
 
-           for mem in self.memories:
-               out += '\n      for Mem_Kind ("%(name)s") use "%(kind)s";\n' % (mem)
-               out += '      for Address  ("%(name)s") use "%(addr)s";\n' % (mem)
-               out += '      for Size     ("%(name)s") use "%(size)s";\n' % (mem)
+            if len(self.memory_names()):
+               out += '\n      for Memories use ("' + '", "'.join(self.memory_names())
+               out += '");\n'
 
-           out += '\n      for Boot_Memory use "%s";\n' % self.get_config("Boot_Memory")
-        out += '   end Device_Configuration;\n\n'
+               for mem in self.memories:
+                   out += '\n      for Mem_Kind ("%(name)s") use "%(kind)s";\n' % (mem)
+                   out += '      for Address  ("%(name)s") use "%(addr)s";\n' % (mem)
+                   out += '      for Size     ("%(name)s") use "%(size)s";\n' % (mem)
+
+               out += '\n      for Boot_Memory use "%s";\n' % self.get_config("Boot_Memory")
+            out += '   end Device_Configuration;\n\n'
 
         # Config keys and values
         for key in self.configuration:

--- a/scripts/config/boards.py
+++ b/scripts/config/boards.py
@@ -151,7 +151,7 @@ def load_board_config(config):
         config.pre_define('Has_ZFP_Runtime', 'True', origin)
         config.pre_define('Has_Ravenscar_SFP_Runtime', 'False', origin)
         config.pre_define('Has_Ravenscar_Full_Runtime', 'False', origin)
-        config.pre_define('Runtime_Name_Suffix', 'hifive1', origin)
+        config.pre_define('Runtime_Name_Suffix', 'rv32imc', origin)
         config.add_memory('rom', 'board_flash', '0x20400000', '512M')
         config.add_source_dir('boards/HiFive1/src/', origin)
 

--- a/scripts/config/boards.py
+++ b/scripts/config/boards.py
@@ -140,7 +140,7 @@ def load_board_config(config):
         config.pre_define('Has_ZFP_Runtime', 'True', origin)
         config.pre_define('Has_Ravenscar_SFP_Runtime', 'False', origin)
         config.pre_define('Has_Ravenscar_Full_Runtime', 'False', origin)
-        config.pre_define('Runtime_Name_Suffix', 'microbit', origin)
+        config.pre_define('Runtime_Name_Suffix', 'cortex-m0', origin)
         config.add_source_dir('boards/MicroBit/src/', origin)
 
     elif board == "HiFive1":

--- a/scripts/config/devices.py
+++ b/scripts/config/devices.py
@@ -156,6 +156,7 @@ def load_device_config(config):
         src += ['arch/RISC-V/SiFive/svd/FE310/',
                 'arch/RISC-V/SiFive/devices/FE310/',
                 'arch/RISC-V/SiFive/drivers/']
+        config.add_memory('ram', 'RAM', '0x80000000', '16K')
 
     else:
         print "Unknown MCU device %s." % mcu

--- a/scripts/config/devices.py
+++ b/scripts/config/devices.py
@@ -152,6 +152,19 @@ def load_device_config(config):
                 'arch/ARM/Nordic/drivers/',
                 'arch/ARM/Nordic/svd/nrf51/']
 
+        config.pre_define('Number_Of_Interrupts', 32, origin)
+
+        if mcu.endswith ('AB'):
+            config.add_memory('rom', 'flash', '0x00000000', '128K')
+        else:
+            config.add_memory('rom', 'flash', '0x00000000', '256K')
+
+
+        if mcu.endswith ('AC'):
+            config.add_memory('ram', 'ram', '0x20000000', '32K')
+        else:
+            config.add_memory('ram', 'ram', '0x20000000', '16K')
+
     elif mcu == 'FE310':
         src += ['arch/RISC-V/SiFive/svd/FE310/',
                 'arch/RISC-V/SiFive/devices/FE310/',

--- a/scripts/project_wizard.py
+++ b/scripts/project_wizard.py
@@ -64,6 +64,8 @@ def mcu_config(config):
         load_cpu_config(config)
         load_device_config(config)
 
+        config.query_integer_key("Number_Of_Interrupts", default = 0)
+
     # TDOD: Is the SVD mapping available?
     # TODO: Does the user want to generate it?
 


### PR DESCRIPTION
startup-gen is a tool that generates crt0 and linker script from a
device configuration (CPU name, memory layout). The tool only works for
ZFP run-times right now.

This patch also switches the HiFive1 support to use startup-gen.