### PR TITLE
micro:bit: add an example for the accelerometer

### DIFF
--- a/boards/MicroBit/src/microbit-accelerometer.ads
+++ b/boards/MicroBit/src/microbit-accelerometer.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                       Copyright (C) 2018, AdaCore                        --
+--                    Copyright (C) 2018-2019, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -33,14 +33,7 @@ with MMA8653;
 
 package MicroBit.Accelerometer is
 
-   function Initialized return Boolean;
-   --  Return True if the Accelerometer is initialized and ready to use
-
-   procedure Initialize
-     with Post => Initialized;
-   --  Initialize the accelerometer using the micro:bit I2C port
-
-   function Data return MMA8653.All_Axes_Data
-     with Pre => Initialized;
+   function Data return MMA8653.All_Axes_Data;
+   --  Return the acceleration value for each of the three axes (X, Y, Z)
 
 end MicroBit.Accelerometer;

--- a/boards/MicroBit/src/microbit-display-symbols.adb
+++ b/boards/MicroBit/src/microbit-display-symbols.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2018-2019, AdaCore                      --
+--                       Copyright (C) 2019, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -29,36 +29,94 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with MicroBit.I2C;
-
-package body MicroBit.Accelerometer is
-
-   Acc  : MMA8653.MMA8653_Accelerometer (MicroBit.I2C.Controller);
-
-   procedure Initialize;
+package body MicroBit.Display.Symbols is
 
    ----------------
-   -- Initialize --
+   -- Left_Arrow --
    ----------------
 
-   procedure Initialize is
+   procedure Left_Arrow is
    begin
-      if not MicroBit.I2C.Initialized then
-         MicroBit.I2C.Initialize;
-      end if;
+      Set (0, 2);
+      Set (1, 2);
+      Set (2, 2);
+      Set (3, 2);
+      Set (4, 2);
+      Set (1, 2);
 
-      Acc.Configure (MMA8653.Two_G,
-                     MMA8653.High_Resolution,
-                     MMA8653.High_Resolution);
-   end Initialize;
+      Set (1, 1);
+      Set (2, 0);
+      Set (1, 3);
+      Set (2, 4);
+   end Left_Arrow;
 
-   ----------
-   -- Data --
-   ----------
+   -----------------
+   -- Right_Arrow --
+   -----------------
 
-   function Data return MMA8653.All_Axes_Data
-   is (Acc.Read_Data);
+   procedure Right_Arrow is
+   begin
+      Set (0, 2);
+      Set (1, 2);
+      Set (2, 2);
+      Set (3, 2);
+      Set (4, 2);
 
-begin
-   Initialize;
-end MicroBit.Accelerometer;
+      Set (3, 1);
+      Set (2, 0);
+      Set (3, 3);
+      Set (2, 4);
+   end Right_Arrow;
+
+   --------------
+   -- Up_Arrow --
+   --------------
+
+   procedure Up_Arrow is
+   begin
+      Set (2, 0);
+      Set (2, 1);
+      Set (2, 2);
+      Set (2, 3);
+      Set (2, 4);
+
+      Set (1, 1);
+      Set (0, 2);
+      Set (3, 1);
+      Set (4, 2);
+   end Up_Arrow;
+
+   ----------------
+   -- Down_Arrow --
+   ----------------
+
+   procedure Down_Arrow is
+   begin
+      Set (2, 0);
+      Set (2, 1);
+      Set (2, 2);
+      Set (2, 3);
+      Set (2, 4);
+
+      Set (1, 3);
+      Set (0, 2);
+      Set (3, 3);
+      Set (4, 2);
+   end Down_Arrow;
+
+   -----------
+   -- Smile --
+   -----------
+
+   procedure Smile is
+   begin
+      Set (1, 1);
+      Set (3, 1);
+      Set (0, 3);
+      Set (1, 4);
+      Set (2, 4);
+      Set (3, 4);
+      Set (4, 3);
+   end Smile;
+
+end MicroBit.Display.Symbols;

--- a/boards/MicroBit/src/microbit-display-symbols.ads
+++ b/boards/MicroBit/src/microbit-display-symbols.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2018-2019, AdaCore                      --
+--                       Copyright (C) 2019, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -29,36 +29,15 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with MicroBit.I2C;
+--  This package provides procedures to draw symbols on the MicroBit 5x5 LED
+--  display.
 
-package body MicroBit.Accelerometer is
+package MicroBit.Display.Symbols is
 
-   Acc  : MMA8653.MMA8653_Accelerometer (MicroBit.I2C.Controller);
+   procedure Left_Arrow;
+   procedure Right_Arrow;
+   procedure Up_Arrow;
+   procedure Down_Arrow;
+   procedure Smile;
 
-   procedure Initialize;
-
-   ----------------
-   -- Initialize --
-   ----------------
-
-   procedure Initialize is
-   begin
-      if not MicroBit.I2C.Initialized then
-         MicroBit.I2C.Initialize;
-      end if;
-
-      Acc.Configure (MMA8653.Two_G,
-                     MMA8653.High_Resolution,
-                     MMA8653.High_Resolution);
-   end Initialize;
-
-   ----------
-   -- Data --
-   ----------
-
-   function Data return MMA8653.All_Axes_Data
-   is (Acc.Read_Data);
-
-begin
-   Initialize;
-end MicroBit.Accelerometer;
+end MicroBit.Display.Symbols;

--- a/examples/MicroBit/accelerometer/README.md
+++ b/examples/MicroBit/accelerometer/README.md
@@ -1,0 +1,40 @@
+Accelerometer Example
+=====================
+
+In this example we will see how to use the accelerometer of the micro:bit. The
+accelerometer can, for instance, be used to know which way the micro:bit is
+oriented.
+
+Code
+====
+
+To get the acceleration value for all axes, we will just call the function
+`MicroBit.Accelerometer.Data`. This function returns a record with `X`, `Y`
+and `Z` field giving the value for each axis.
+
+
+```ada
+declare
+
+   Data : MMA8653.All_Axes_Data;
+   --  A variable to store the accelerometer data
+begin
+
+   --  Read Accelerometer data
+   Data := Accelerometer.Data;
+end;
+```
+
+We can then use the value in the record to get some information about the
+orientation of the micro:bit. For example, if the Y value is below `-200`
+the micro:bit is vertical.
+
+Note that the type used to store the values of the accelerometer is declared in
+the package `MMA8653` (the driver), so we have to `with` and `use` this package
+to be have acces to the operations for this type.
+
+```ada
+if Data.Y < -200 then
+   --  The micro:bit is vertical
+end if;
+```

--- a/examples/MicroBit/accelerometer/accelerometer.gpr
+++ b/examples/MicroBit/accelerometer/accelerometer.gpr
@@ -1,0 +1,28 @@
+with "../../../boards/MicroBit/microbit_zfp.gpr";
+
+project Accelerometer is
+
+  for Runtime ("ada") use MicroBit_ZFP'Runtime ("Ada");
+  for Target use "arm-eabi";
+  for Main use ("main.adb");
+  for Languages use ("Ada");
+  for Source_Dirs use ("src");
+  for Object_Dir use "obj";
+  for Create_Missing_Dirs use "True";
+
+  package Compiler renames MicroBit_ZFP.Compiler;
+
+  package Linker is
+     for Default_Switches ("Ada") use
+       MicroBit_ZFP.Linker_Switches &
+       ("-Wl,--print-memory-usage",
+        "-Wl,--gc-sections");
+  end Linker;
+
+  package Ide is
+    for Program_Host use ":1234";
+    for Communication_Protocol use "remote";
+    for Connection_Tool use "pyocd";
+  end Ide;
+
+end Accelerometer;

--- a/examples/MicroBit/accelerometer/src/main.adb
+++ b/examples/MicroBit/accelerometer/src/main.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2018-2019, AdaCore                      --
+--                       Copyright (C) 2019, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -29,36 +29,56 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with MicroBit.I2C;
+with MMA8653; use MMA8653;
 
-package body MicroBit.Accelerometer is
+with MicroBit.Display;
+with MicroBit.Display.Symbols;
+with MicroBit.Accelerometer;
+with MicroBit.Console;
+with MicroBit.Time;
 
-   Acc  : MMA8653.MMA8653_Accelerometer (MicroBit.I2C.Controller);
+use MicroBit;
 
-   procedure Initialize;
+procedure Main is
 
-   ----------------
-   -- Initialize --
-   ----------------
+   Data : MMA8653.All_Axes_Data;
 
-   procedure Initialize is
-   begin
-      if not MicroBit.I2C.Initialized then
-         MicroBit.I2C.Initialize;
+   Threshold : constant := 150;
+begin
+
+   loop
+
+      --  Read the accelerometer data
+      Data := Accelerometer.Data;
+
+      --  Print the data on the serial port
+      Console.Put_Line ("X:" & Data.X'Img & ASCII.HT &
+                        "Y:" & Data.Y'Img & ASCII.HT &
+                        "Z:" & Data.Z'Img);
+
+      --  Clear the LED matrix
+      Display.Clear;
+
+      --  Draw a symbol on the LED matrix depending on the orientation of the
+      --  micro:bit.
+      if Data.X > Threshold then
+         Display.Symbols.Left_Arrow;
+
+      elsif Data.X < -Threshold then
+         Display.Symbols.Right_Arrow;
+
+      elsif Data.Y > Threshold then
+         Display.Symbols.Up_Arrow;
+
+      elsif Data.Y < -Threshold then
+         Display.Symbols.Down_Arrow;
+
+      else
+         Display.Display ('X');
+
       end if;
 
-      Acc.Configure (MMA8653.Two_G,
-                     MMA8653.High_Resolution,
-                     MMA8653.High_Resolution);
-   end Initialize;
-
-   ----------
-   -- Data --
-   ----------
-
-   function Data return MMA8653.All_Axes_Data
-   is (Acc.Read_Data);
-
-begin
-   Initialize;
-end MicroBit.Accelerometer;
+      --  Do nothing for 100 miliseconds
+      Time.Sleep (100);
+   end loop;
+end Main;

--- a/scripts/build_all_examples.py
+++ b/scripts/build_all_examples.py
@@ -133,6 +133,7 @@ projects = [
             "/examples/MicroBit/servos/servos.gpr",
             "/examples/MicroBit/neopixel/neopixel.gpr",
             "/examples/MicroBit/follower/follower.gpr",
+            "/examples/MicroBit/accelerometer/accelerometer.gpr",
 
             # STM32 driver examples
             STM_DRIVERS + "/demo_adc_dma/demo_adc_dma.gpr",


### PR DESCRIPTION
The accelerometer init procedure is replaced by elaboration initialization to
match the interface of the other micro:bit features.