### PR TITLE
Pass the python environment down

### DIFF
--- a/examples/shared/common/gui/bitmapped_drawing.adb
+++ b/examples/shared/common/gui/bitmapped_drawing.adb
@@ -247,5 +247,4 @@ package body Bitmapped_Drawing is
       end if;
    end Draw_String;
 
-
 end Bitmapped_Drawing;

--- a/examples/shared/common/gui/bitmapped_drawing.ads
+++ b/examples/shared/common/gui/bitmapped_drawing.ads
@@ -76,4 +76,3 @@ package Bitmapped_Drawing is
       Fast       : Boolean := True);
 
 end Bitmapped_Drawing;
-

--- a/scripts/install_dependencies.py
+++ b/scripts/install_dependencies.py
@@ -71,7 +71,7 @@ git_repos = [("https://github.com/AdaCore/bb-runtimes",
               "community-2019",
               "bb-runtimes",
               False,
-              ["python", ROOT_DIR + "/bb-runtimes/install.py", "--arch=arm-eabi"]),
+              [sys.executable, ROOT_DIR + "/bb-runtimes/install.py", "--arch=arm-eabi"]),
              ]
 
 parser = argparse.ArgumentParser('Download and install dependencies')


### PR DESCRIPTION
This solves switching to Python 3 by accident when installing the dependencies, as mentioned in #318. This doesn't fix checking out the already existing branch though.

The newline removals were just cleanups I cherry picked as when I turned on some of the GNAT style checks they were causing the example to fail.

I signed and sent the CLA in today.