### PR TITLE
Rename cm0 NVIC api functions to match the cm4_cm7 impl

### DIFF
--- a/arch/ARM/Nordic/drivers/nrf51-interrupts.adb
+++ b/arch/ARM/Nordic/drivers/nrf51-interrupts.adb
@@ -55,7 +55,7 @@ package body nRF51.Interrupts is
 
    procedure Enable (Int : Interrupt_Name) is
    begin
-      Cortex_M.NVIC.Enable (Int'Enum_Rep);
+      Cortex_M.NVIC.Enable_Interrupt (Int'Enum_Rep);
    end Enable;
 
    -------------
@@ -64,7 +64,7 @@ package body nRF51.Interrupts is
 
    procedure Disable (Int : Interrupt_Name) is
    begin
-      Cortex_M.NVIC.Disable (Int'Enum_Rep);
+      Cortex_M.NVIC.Disable_Interrupt (Int'Enum_Rep);
    end Disable;
 
    -------------

--- a/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.adb
+++ b/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.adb
@@ -77,19 +77,19 @@ package body Cortex_M.NVIC is
    -- Enable_ --
    -------------
 
-   procedure Enable (IRQn : Interrupt_ID) is
+   procedure Enable_Interrupt (IRQn : Interrupt_ID) is
    begin
       NVIC_Periph.NVIC_ISER := Shift_Left (1, IRQn);
-   end Enable;
+   end Enable_Interrupt;
 
    -------------
    -- Disable --
    -------------
 
-   procedure Disable (IRQn : Interrupt_ID) is
+   procedure Disable_Interrupt (IRQn : Interrupt_ID) is
    begin
       NVIC_Periph.NVIC_ICER := Shift_Left (1, IRQn);
-   end Disable;
+   end Disable_Interrupt;
 
    -------------
    -- Enabled --
@@ -128,4 +128,3 @@ package body Cortex_M.NVIC is
    end Clear_Pending;
 
 end Cortex_M.NVIC;
-

--- a/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.ads
+++ b/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.ads
@@ -53,9 +53,9 @@ package Cortex_M.NVIC is  -- the Nested Vectored Interrupt Controller
      (IRQn     : Interrupt_ID;
       Priority : Interrupt_Priority) with Inline;
 
-   procedure Enable (IRQn : Interrupt_ID) with Inline;
+   procedure Enable_Interrupt (IRQn : Interrupt_ID) with Inline;
 
-   procedure Disable (IRQn : Interrupt_ID) with Inline;
+   procedure Disable_Interrupt (IRQn : Interrupt_ID) with Inline;
 
    function Enabled (IRQn : Interrupt_ID) return Boolean with Inline;
 
@@ -66,5 +66,3 @@ package Cortex_M.NVIC is  -- the Nested Vectored Interrupt Controller
    procedure Clear_Pending (IRQn : Interrupt_ID) with Inline;
 
 end Cortex_M.NVIC;
-
-


### PR DESCRIPTION
This allows for a unified driver in families that have members on both
sides. Useful for nRF family, but also should lower-end STM32 parts become
supported in the future.