### PR TITLE
Changes cm0 Interrupt_Priority to UInt32 subtype for compat w/ cm4_7

### DIFF
--- a/arch/ARM/Nordic/drivers/nrf51-interrupts.adb
+++ b/arch/ARM/Nordic/drivers/nrf51-interrupts.adb
@@ -29,8 +29,8 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Cortex_M.NVIC;
 with System.Machine_Code; use System.Machine_Code;
+with HAL; use HAL;
 
 package body nRF51.Interrupts is
 

--- a/arch/ARM/Nordic/drivers/nrf51-interrupts.ads
+++ b/arch/ARM/Nordic/drivers/nrf51-interrupts.ads
@@ -29,7 +29,8 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with HAL; use HAL;
+
+with Cortex_M.NVIC; use Cortex_M.NVIC;
 
 package nRF51.Interrupts is
    type Interrupt_Name is
@@ -65,8 +66,6 @@ package nRF51.Interrupts is
       Unused_Interrupt_5,
       Unused_Interrupt_6,
       Unused_Interrupt_7);
-
-   subtype Interrupt_Priority is UInt8;
 
    procedure Set_Priority (Int : Interrupt_Name; Prio : Interrupt_Priority);
    procedure Enable (Int : Interrupt_Name);

--- a/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.adb
+++ b/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.adb
@@ -68,7 +68,7 @@ package body Cortex_M.NVIC is
 
       IPR.IPR := NVIC_Periph.NVIC_IPR (IPR_Index);
 
-      IPR.Arr (IP_Index) := Priority;
+      IPR.Arr (IP_Index) := UInt8(Priority);
 
       NVIC_Periph.NVIC_IPR (IPR_Index) := IPR.IPR;
    end Set_Priority;

--- a/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.ads
+++ b/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.ads
@@ -47,7 +47,7 @@ with HAL;                  use HAL;
 package Cortex_M.NVIC is  -- the Nested Vectored Interrupt Controller
 
    subtype Interrupt_ID is Natural range 0 .. 31;
-   subtype Interrupt_Priority is UInt8;
+   subtype Interrupt_Priority is UInt32 range 0 .. Uint32(UInt8'Last);
 
    procedure Set_Priority
      (IRQn     : Interrupt_ID;


### PR DESCRIPTION
This would allow removal of last NVIC glue in the nRF family, but it does so with a little less safety.

Currently cm0 Interrupt_Priority is UInt8, in this patch it's a range subtype on UInt32. It would be a warning at compile time to specify an out-of-range value, but currently it's a compile time error.