### PR TITLE
Fixes broken interrupt prio on cm0, now compat w/ cm4_7

### DIFF
--- a/arch/ARM/Nordic/drivers/nrf51-interrupts.adb
+++ b/arch/ARM/Nordic/drivers/nrf51-interrupts.adb
@@ -29,8 +29,8 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Cortex_M.NVIC;
 with System.Machine_Code; use System.Machine_Code;
+with HAL; use HAL;
 
 package body nRF51.Interrupts is
 

--- a/arch/ARM/Nordic/drivers/nrf51-interrupts.ads
+++ b/arch/ARM/Nordic/drivers/nrf51-interrupts.ads
@@ -29,7 +29,8 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with HAL; use HAL;
+
+with Cortex_M.NVIC; use Cortex_M.NVIC;
 
 package nRF51.Interrupts is
    type Interrupt_Name is
@@ -65,8 +66,6 @@ package nRF51.Interrupts is
       Unused_Interrupt_5,
       Unused_Interrupt_6,
       Unused_Interrupt_7);
-
-   subtype Interrupt_Priority is UInt8;
 
    procedure Set_Priority (Int : Interrupt_Name; Prio : Interrupt_Priority);
    procedure Enable (Int : Interrupt_Name);

--- a/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.adb
+++ b/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.adb
@@ -64,11 +64,13 @@ package body Cortex_M.NVIC is
       IPR_Index : constant Natural := IRQn / 4;
       IP_Index  : constant Natural := IRQn mod 4;
       IPR       : As_Array;
+      Value     : constant UInt32 :=
+        Shift_Left (Priority, 8 - NVIC_PRIO_BITS) and 16#FF#;
    begin
 
       IPR.IPR := NVIC_Periph.NVIC_IPR (IPR_Index);
 
-      IPR.Arr (IP_Index) := Priority;
+      IPR.Arr (IP_Index) := UInt8(Value);
 
       NVIC_Periph.NVIC_IPR (IPR_Index) := IPR.IPR;
    end Set_Priority;

--- a/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.ads
+++ b/arch/ARM/cortex_m/src/nvic_cm0/cortex_m-nvic.ads
@@ -46,8 +46,11 @@ with HAL;                  use HAL;
 
 package Cortex_M.NVIC is  -- the Nested Vectored Interrupt Controller
 
+   NVIC_PRIO_BITS : constant := 2;
+   -- All Cortex M0 parts have 2 bit priority mask
+
    subtype Interrupt_ID is Natural range 0 .. 31;
-   subtype Interrupt_Priority is UInt8;
+   subtype Interrupt_Priority is UInt32 range 0 .. (2**NVIC_PRIO_BITS-1);
 
    procedure Set_Priority
      (IRQn     : Interrupt_ID;


### PR DESCRIPTION
In my travels trying to make the cm4_7 and cm_0 NVIC APIs compatible, I found out that the cm0 Set_Priority was broken. It neglected to shift left the priority as required, so for the microbit examples, all interrupts were priority 0 (the least significant 6 bits of the prio ignore writes).

The Set_Priority API is compatible between implementations now, an as a bonus, the cm_0 implementation will warn if you specify an out of range priority.