### PR TITLE
stm32: Add support to stop ADC conversions

### DIFF
--- a/arch/ARM/STM32/drivers/stm32-adc.adb
+++ b/arch/ARM/STM32/drivers/stm32-adc.adb
@@ -414,6 +414,15 @@ package body STM32.ADC is
       end if;
    end Start_Conversion;
 
+   ---------------------
+   -- Stop_Conversion --
+   ---------------------
+
+   procedure Stop_Conversion (This : in out Analog_To_Digital_Converter) is
+   begin
+      This.CR2.SWSTART := False;
+   end Stop_Conversion;
+
    ------------------------
    -- Conversion_Started --
    ------------------------

--- a/arch/ARM/STM32/drivers/stm32-adc.ads
+++ b/arch/ARM/STM32/drivers/stm32-adc.ads
@@ -321,6 +321,9 @@ package STM32.ADC is
      Pre => Enabled (This) and Regular_Conversions_Expected (This) > 0;
    --  Starts the conversion(s) for the regular channels
 
+   procedure Stop_Conversion (This : in out Analog_To_Digital_Converter);
+   --  Stops the conversion(s) for the regular channels
+
    function Conversion_Started (This : Analog_To_Digital_Converter)
      return Boolean;
    --  Returns whether the regular channels' conversions have started. Note


### PR DESCRIPTION
This is useful if you want to change the channel of a regular conversion in progress in a given ADC converter.

For example:
```
   RC_Conversion : Regular_Channel_Conversions :=
     (1 => (Channel => 3, Sample_Time => T));

   ...

   -- start regular conversions of channel 3
   Configure_Regular_Conversions (ADC_Converter, Continous => True,
      Trigger => Software_Ttriggered, Enable_EOC => False,
      Conversions => RC_Conversion);
   Start_Conversion (ADC_Converter);

   ...

   -- change to ADC channel 10:
   RC_Conversion (1).Channel := 10;
   Stop_Conversion (ADC_Converter);
   Configure_Regular_Conversions (ADC_Converter, Continous => True,
      Trigger => Software_Ttriggered, Enable_EOC => False,
      Conversions => RC_Conversion);
   Start_Conversion (ADC_Converter);
```
