### PR TITLE
STM32: Allow specifying the GPIO speed on PWM pins

### DIFF
--- a/arch/ARM/STM32/drivers/stm32-pwm.adb
+++ b/arch/ARM/STM32/drivers/stm32-pwm.adb
@@ -50,7 +50,8 @@ package body STM32.PWM is
 
    procedure Configure_PWM_GPIO
      (Output : GPIO_Point;
-      PWM_AF : GPIO_Alternate_Function);
+      PWM_AF : GPIO_Alternate_Function;
+      AF_Speed : Pin_Output_Speeds);
 
    --  TODO: move these two functions to the STM32.Device packages?
    function Has_APB2_Frequency  (This : Timer) return Boolean;
@@ -172,7 +173,8 @@ package body STM32.PWM is
       Channel   : Timer_Channel;
       Point     : GPIO_Point;
       PWM_AF    : GPIO_Alternate_Function;
-      Polarity  : Timer_Output_Compare_Polarity := High)
+      Polarity  : Timer_Output_Compare_Polarity := High;
+      AF_Speed  : Pin_Output_Speeds := Speed_100MHz)
    is
    begin
       This.Channel := Channel;
@@ -180,7 +182,7 @@ package body STM32.PWM is
 
       Enable_Clock (Point);
 
-      Configure_PWM_GPIO (Point, PWM_AF);
+      Configure_PWM_GPIO (Point, PWM_AF, AF_Speed);
 
       Configure_Channel_Output
         (This.Generator.all,
@@ -209,7 +211,8 @@ package body STM32.PWM is
       Polarity                 : Timer_Output_Compare_Polarity;
       Idle_State               : Timer_Capture_Compare_State;
       Complementary_Polarity   : Timer_Output_Compare_Polarity;
-      Complementary_Idle_State : Timer_Capture_Compare_State)
+      Complementary_Idle_State : Timer_Capture_Compare_State;
+      AF_Speed                 : Pin_Output_Speeds := Speed_100MHz)
    is
    begin
       This.Channel := Channel;
@@ -218,8 +221,8 @@ package body STM32.PWM is
       Enable_Clock (Point);
       Enable_Clock (Complementary_Point);
 
-      Configure_PWM_GPIO (Point, PWM_AF);
-      Configure_PWM_GPIO (Complementary_Point, PWM_AF);
+      Configure_PWM_GPIO (Point, PWM_AF, AF_Speed);
+      Configure_PWM_GPIO (Complementary_Point, PWM_AF, AF_Speed);
 
       Configure_Channel_Output
         (This.Generator.all,
@@ -319,7 +322,8 @@ package body STM32.PWM is
 
    procedure Configure_PWM_GPIO
      (Output : GPIO_Point;
-      PWM_AF : GPIO_Alternate_Function)
+      PWM_AF : GPIO_Alternate_Function;
+      AF_Speed : Pin_Output_Speeds)
    is
    begin
       Output.Configure_IO
@@ -327,7 +331,7 @@ package body STM32.PWM is
           AF             => PWM_AF,
           Resistors      => Floating,
           AF_Output_Type => Push_Pull,
-          AF_Speed       => Speed_100MHz));
+          AF_Speed       => AF_Speed));
    end Configure_PWM_GPIO;
 
    ----------------------------------

--- a/arch/ARM/STM32/drivers/stm32-pwm.ads
+++ b/arch/ARM/STM32/drivers/stm32-pwm.ads
@@ -95,7 +95,8 @@ package STM32.PWM is
       Channel   : Timer_Channel;
       Point     : GPIO_Point;
       PWM_AF    : GPIO_Alternate_Function;
-      Polarity  : Timer_Output_Compare_Polarity := High)
+      Polarity  : Timer_Output_Compare_Polarity := High;
+      AF_Speed  : Pin_Output_Speeds := Speed_100MHz)
      with Post => not Output_Enabled (This) and
                   Current_Duty_Cycle (This) = 0;
    --  Initializes the channel on the timer associated with This modulator,
@@ -115,7 +116,8 @@ package STM32.PWM is
       Polarity                 : Timer_Output_Compare_Polarity;
       Idle_State               : Timer_Capture_Compare_State;
       Complementary_Polarity   : Timer_Output_Compare_Polarity;
-      Complementary_Idle_State : Timer_Capture_Compare_State)
+      Complementary_Idle_State : Timer_Capture_Compare_State;
+      AF_Speed                 : Pin_Output_Speeds := Speed_100MHz)
      with Post => not Output_Enabled (This) and
                   not Complementary_Output_Enabled (This) and
                   Current_Duty_Cycle (This) = 0;


### PR DESCRIPTION
This allows you to set the GPIO output speed using the PWM wrapper package, rather then use the hard coded maximum output speed. It's done as an optional argument, so this shouldn't be a breaking or behavioral change for anyone.

I tested this on a STM32F405, using a 10KHz PWM at a variety of duty cycles, and saw the expected change in output slew speed. I can provide some scope captures if needed.

Before the CLA bot complains, I had e-mailed in the signed CLA.