### PR TITLE
STM32: Add preconditions on setting/driving GPIO pins actually be configured as an output

### DIFF
--- a/arch/ARM/STM32/drivers/stm32-gpio.ads
+++ b/arch/ARM/STM32/drivers/stm32-gpio.ads
@@ -174,23 +174,29 @@ package STM32.GPIO is
 
    overriding
    procedure Set (This : in out GPIO_Point) with
+     Pre => (Pin_IO_Mode (This) = Mode_Out),
+     Post => (This.Set = True),
      Inline;
    --  For This.Port.all, sets the output data register bit specified by
    --  This.Pin to one. Other pins are unaffected.
 
    overriding
    procedure Clear (This : in out GPIO_Point) with
+     Pre => (Pin_IO_Mode (This) = Mode_Out),
+     Post => (This.Set = False),
      Inline;
    --  For This.Port.all, sets the output data register bit specified by
    --  This.Pin to zero. Other pins are unaffected.
 
    overriding
    procedure Toggle (This : in out GPIO_Point) with
+     Pre => (Pin_IO_Mode (This) = Mode_Out),
      Inline;
    --  For This.Port.all, negates the output data register bit specified by
    --  This.Pin (one becomes zero and vice versa). Other pins are unaffected.
 
    procedure Drive (This : in out GPIO_Point; Condition : Boolean) with
+      Pre => (Pin_IO_Mode (This) = Mode_Out),
       Post => (This.Set = Condition),
       Inline;
    --  Drives This high or low (set or clear) based on the value of Condition


### PR DESCRIPTION
This adds preconditions that before trying to drive a GPIO pin as an output that it must actually be configured as an output. I had a problem where a pin was not getting configured correctly that the existing post condition on `Drive` was catching, but having caught it as a precondition that the port was actually an output would have been far more useful from a debug time as the post condition sent me on a couple of long rabbit holes before I realized the pin was in the wrong mode.

I'm not fully sure there is not a valid reason to call these without having set it as an output however. I can't seem to find one though. As an example at the moment any attempt to call `Drive` will fail if the pin isn't externally driven to the target state.

This works well with my admittedly simple test cases here, but if I've missed reasons why this doesn't work I'm happy to tweak it further (or just drop it if needed). Finally before the CLA bot complains the signed CLA was e-mailed in previously.