### PR TITLE
Add support for use of VL53L0x heightfinder in Crazyflie flow deck v1

### DIFF
--- a/components/src/range_sensor/VL53L0X/vl53l0x.adb
+++ b/components/src/range_sensor/VL53L0X/vl53l0x.adb
@@ -912,7 +912,7 @@ package body VL53L0X is
       end if;
 
       while not Range_Value_Available (This) loop
-         Delay_Milliseconds (1);
+         This.Timing.Delay_Milliseconds (1);
       end loop;
 
       return Read_Range_Millimeters (This);

--- a/components/src/range_sensor/VL53L0X/vl53l0x.adb
+++ b/components/src/range_sensor/VL53L0X/vl53l0x.adb
@@ -34,7 +34,6 @@
 --   COPYRIGHT(c) 2016 STMicroelectronics                                   --
 ------------------------------------------------------------------------------
 
-with Ada.Real_Time;
 with Ada.Unchecked_Conversion;
 
 with HAL;        use HAL;
@@ -906,7 +905,6 @@ package body VL53L0X is
      (This : VL53L0X_Ranging_Sensor) return HAL.UInt16
    is
       Status : Boolean;
-      use type Ada.Real_Time.Time;
    begin
       Start_Range_Single_Millimeters (This, Status);
       if not Status then
@@ -914,7 +912,7 @@ package body VL53L0X is
       end if;
 
       while not Range_Value_Available (This) loop
-         delay until Ada.Real_Time.Clock + Ada.Real_Time.Milliseconds (1);
+         Delay_Milliseconds (1);
       end loop;
 
       return Read_Range_Millimeters (This);

--- a/components/src/range_sensor/VL53L0X/vl53l0x.adb
+++ b/components/src/range_sensor/VL53L0X/vl53l0x.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2017, AdaCore                           --
+--                 Copyright (C) 2017, 2020, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -28,11 +28,13 @@
 --   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
 --                                                                          --
 --                                                                          --
---  This file is based on X-CUBE-53L0A1 STM32Cube expansion                 --
+--  This file is based on X-CUBE-53L0A1 STM32Cube expansion, with some      --
+--  input from Crazyflie source.                                            --
 --                                                                          --
 --   COPYRIGHT(c) 2016 STMicroelectronics                                   --
 ------------------------------------------------------------------------------
 
+with Ada.Real_Time;
 with Ada.Unchecked_Conversion;
 
 with HAL;        use HAL;
@@ -351,6 +353,24 @@ package body VL53L0X is
          return Ret;
       end if;
    end Read_Id;
+
+   -------------------
+   -- Read_Revision --
+   -------------------
+
+   function Read_Revision (This : VL53L0X_Ranging_Sensor) return HAL.UInt8
+   is
+      Ret    : UInt8;
+      Status : Boolean;
+   begin
+      Read (This, REG_IDENTIFICATION_REVISION_ID, Ret, Status);
+
+      if not Status then
+         return 0;
+      else
+         return Ret;
+      end if;
+   end Read_Revision;
 
    ------------------------
    -- Set_Device_Address --
@@ -709,6 +729,76 @@ package body VL53L0X is
       end if;
    end Perform_Ref_Calibration;
 
+   ----------------------
+   -- Start_Continuous --
+   ----------------------
+
+   procedure Start_Continuous (This : VL53L0X.VL53L0X_Ranging_Sensor;
+                               Period_Ms : HAL.UInt32;
+                               Status : out Boolean) is
+      --  From vl53l0xStartContinuous() in
+      --  crazyflie-firmware/src/drivers/src/vl53l0x.c
+   begin
+      Write (This, 16#80#, UInt8'(16#01#), Status);
+      if Status then
+         Write (This, 16#ff#, UInt8'(16#01#), Status);
+      end if;
+      if Status then
+         Write (This, 16#00#, UInt8'(16#00#), Status);
+      end if;
+      if Status then
+         Write (This, 16#91#, UInt8'(This.Stop_Variable), Status);
+      end if;
+      if Status then
+         Write (This, 16#00#, UInt8'(16#01#), Status);
+      end if;
+      if Status then
+         Write (This, 16#ff#, UInt8'(16#00#), Status);
+      end if;
+      if Status then
+         Write (This, 16#80#, UInt8'(16#00#), Status);
+      end if;
+
+      if not Status then
+         return;
+      end if;
+      if Period_Ms /= 0 then
+         --  continuous timed mode
+         declare
+            procedure Set_Inter_Measurement_Period_Milliseconds;
+            --  The Crazyflie code indicates that this is a missing
+            --  function that they've inlined.
+            procedure Set_Inter_Measurement_Period_Milliseconds is
+               Osc_Calibrate_Val : UInt16;
+               Period : UInt32 := Period_Ms;
+            begin
+               Read (This, REG_OSC_CALIBRATE_VAL, Osc_Calibrate_Val, Status);
+               if Status and then Osc_Calibrate_Val /= 0 then
+                  Period := Period * UInt32 (Osc_Calibrate_Val);
+               end if;
+               if Status then
+                  Write
+                    (This, REG_SYSTEM_INTERMEASUREMENT_PERIOD, Period, Status);
+               end if;
+            end Set_Inter_Measurement_Period_Milliseconds;
+         begin
+            Set_Inter_Measurement_Period_Milliseconds;
+            if Status then
+               Write (This,
+                      REG_SYSRANGE_START,
+                      UInt8'(REG_SYSRANGE_MODE_TIMED),
+                      Status);
+            end if;
+         end;
+      else
+         --  continuous back-to-back mode
+         Write (This,
+                REG_SYSRANGE_START,
+                UInt8'(REG_SYSRANGE_MODE_BACKTOBACK),
+                Status);
+      end if;
+   end Start_Continuous;
+
    ------------------------------------
    -- Start_Range_Single_Millimeters --
    ------------------------------------
@@ -792,6 +882,7 @@ package body VL53L0X is
      (This : VL53L0X_Ranging_Sensor) return HAL.UInt16
    is
       Status : Boolean;
+      use type Ada.Real_Time.Time;
    begin
       Start_Range_Single_Millimeters (This, Status);
       if not Status then
@@ -799,7 +890,7 @@ package body VL53L0X is
       end if;
 
       while not Range_Value_Available (This) loop
-         null;
+         delay until Ada.Real_Time.Clock + Ada.Real_Time.Milliseconds (1);
       end loop;
 
       return Read_Range_Millimeters (This);

--- a/components/src/range_sensor/VL53L0X/vl53l0x.adb
+++ b/components/src/range_sensor/VL53L0X/vl53l0x.adb
@@ -65,6 +65,30 @@ package body VL53L0X is
       VHV_Init : UInt8;
       Status   : out Boolean);
 
+   ----------------------------
+   -- Get_GPIO_Functionality --
+   ----------------------------
+
+   function Get_GPIO_Functionality (This : VL53L0X_Ranging_Sensor)
+                                   return VL53L0X_GPIO_Functionality
+   is
+      Data   : UInt8;
+      Status : Boolean;
+      Result : VL53L0X_GPIO_Functionality := No_Interrupt;
+   begin
+      Read (This, REG_SYSTEM_INTERRUPT_CONFIG_GPIO, Data, Status);
+      if Status and then Data in 1 .. 4 then
+         case Data is
+            when 1 => Result := Level_Low;
+            when 2 => Result := Level_High;
+            when 3 => Result := Out_Of_Window;
+            when 4 => Result := New_Sample_Ready;
+            when others => null;
+         end case;
+      end if;
+      return Result;
+   end Get_GPIO_Functionality;
+
    ---------------
    -- I2C_Write --
    ---------------

--- a/components/src/range_sensor/VL53L0X/vl53l0x.ads
+++ b/components/src/range_sensor/VL53L0X/vl53l0x.ads
@@ -34,6 +34,7 @@
 ------------------------------------------------------------------------------
 
 with HAL.I2C;
+with HAL.Time;
 
 package VL53L0X is
 
@@ -45,7 +46,8 @@ package VL53L0X is
      with Size => 32;
 
    type VL53L0X_Ranging_Sensor
-     (Port  : not null HAL.I2C.Any_I2C_Port) is limited private;
+     (Port   : not null HAL.I2C.Any_I2C_Port;
+      Timing : not null HAL.Time.Any_Delays) is limited private;
 
    type VL53L0X_GPIO_Functionality is
      (No_Interrupt,
@@ -112,12 +114,6 @@ package VL53L0X is
    with Pre => Range_Value_Available (This);
    --  Read the available ranging value
 
-   generic
-      with procedure Delay_Milliseconds (Count : Positive) is <>;
-      --  Issue a relative delay for Count milliseconds. This formal
-      --  subprogram removes the dependency on Ada.Real_Time so that
-      --  this driver can be used with runtimes that do not have that
-      --  language-defined facility.
    function Read_Range_Single_Millimeters
      (This : VL53L0X_Ranging_Sensor) return HAL.UInt16
    with Pre => Get_GPIO_Functionality (This) = New_Sample_Ready;
@@ -307,7 +303,8 @@ private
       Part_UID_Lower                    : HAL.UInt32;
    end record;
 
-   type VL53L0X_Ranging_Sensor (Port : not null HAL.I2C.Any_I2C_Port)
+   type VL53L0X_Ranging_Sensor (Port   : not null HAL.I2C.Any_I2C_Port;
+                                Timing : not null HAL.Time.Any_Delays)
    is limited record
       --  Default address: can be changed by software
       I2C_Address            : HAL.I2C.I2C_Address := 16#52#;

--- a/components/src/range_sensor/VL53L0X/vl53l0x.ads
+++ b/components/src/range_sensor/VL53L0X/vl53l0x.ads
@@ -109,9 +109,15 @@ package VL53L0X is
 
    function Read_Range_Millimeters
      (This : VL53L0X_Ranging_Sensor) return HAL.UInt16
-     with Pre => Range_Value_Available (This);
+   with Pre => Range_Value_Available (This);
    --  Read the available ranging value
 
+   generic
+      with procedure Delay_Milliseconds (Count : Positive) is <>;
+      --  Issue a relative delay for Count milliseconds. This formal
+      --  subprogram removes the dependency on Ada.Real_Time so that
+      --  this driver can be used with runtimes that do not have that
+      --  language-defined facility.
    function Read_Range_Single_Millimeters
      (This : VL53L0X_Ranging_Sensor) return HAL.UInt16
    with Pre => Get_GPIO_Functionality (This) = New_Sample_Ready;

--- a/components/src/range_sensor/VL53L0X/vl53l0x.ads
+++ b/components/src/range_sensor/VL53L0X/vl53l0x.ads
@@ -54,6 +54,9 @@ package VL53L0X is
       Out_Of_Window,
       New_Sample_Ready);
 
+   function Get_GPIO_Functionality (This : VL53L0X_Ranging_Sensor)
+                                   return VL53L0X_GPIO_Functionality;
+
    type VL53L0X_Interrupt_Polarity is
      (Polarity_Low,
       Polarity_High);
@@ -77,26 +80,31 @@ package VL53L0X is
    procedure Static_Init
      (This          : in out VL53L0X_Ranging_Sensor;
       GPIO_Function : VL53L0X_GPIO_Functionality;
-      Status        : out Boolean);
+      Status        : out Boolean)
+   with Post => (if Status then Get_GPIO_Functionality (This) = GPIO_Function);
 
    procedure Perform_Ref_Calibration
      (This   : in out VL53L0X_Ranging_Sensor;
-      Status : out Boolean);
+      Status : out Boolean)
+   with Pre => Get_GPIO_Functionality (This) = New_Sample_Ready;
 
    procedure Start_Continuous
      (This      :     VL53L0X.VL53L0X_Ranging_Sensor;
       Period_Ms :     HAL.UInt32;
-      Status    : out Boolean);
+      Status    : out Boolean)
+   with Pre => Get_GPIO_Functionality (This) = New_Sample_Ready;
    --  Start cyclic reads.
    --  If Period_Ms is 0, run as fast as possible.
 
    procedure Start_Range_Single_Millimeters
      (This   : VL53L0X_Ranging_Sensor;
-      Status : out Boolean);
+      Status : out Boolean)
+   with Pre => Get_GPIO_Functionality (This) = New_Sample_Ready;
    --  Start a read operation on sensor
 
    function Range_Value_Available
-     (This : VL53L0X_Ranging_Sensor) return Boolean;
+     (This : VL53L0X_Ranging_Sensor) return Boolean
+   with Pre => Get_GPIO_Functionality (This) = New_Sample_Ready;
    --  Returns True when a new value is available
 
    function Read_Range_Millimeters
@@ -105,13 +113,15 @@ package VL53L0X is
    --  Read the available ranging value
 
    function Read_Range_Single_Millimeters
-     (This : VL53L0X_Ranging_Sensor) return HAL.UInt16;
+     (This : VL53L0X_Ranging_Sensor) return HAL.UInt16
+   with Pre => Get_GPIO_Functionality (This) = New_Sample_Ready;
 
    procedure Set_GPIO_Config
      (This          : in out VL53L0X_Ranging_Sensor;
       Functionality : VL53L0X_GPIO_Functionality;
       Polarity      : VL53L0X_Interrupt_Polarity;
-      Status        : out Boolean);
+      Status        : out Boolean)
+   with Post => (if Status then Get_GPIO_Functionality (This) = Functionality);
 
    procedure Clear_Interrupt_Mask
      (This : VL53L0X_Ranging_Sensor);
@@ -134,13 +144,15 @@ package VL53L0X is
    procedure Set_VCSEL_Pulse_Period_Pre_Range
      (This   : VL53L0X_Ranging_Sensor;
       Period : HAL.UInt8;
-      Status : out Boolean);
+      Status : out Boolean)
+   with Pre => Get_GPIO_Functionality (This) = New_Sample_Ready;
    --  Default period: 14 PCLKs
 
    procedure Set_VCSEL_Pulse_Period_Final_Range
      (This   : VL53L0X_Ranging_Sensor;
       Period : HAL.UInt8;
-      Status : out Boolean);
+      Status : out Boolean)
+   with Pre => Get_GPIO_Functionality (This) = New_Sample_Ready;
    --  Default period: 10 PCLKs
 
 private
@@ -382,6 +394,7 @@ private
      (This     : VL53L0X_Ranging_Sensor;
       Period   : HAL.UInt8;
       Sequence : VL53L0x_Sequence_Step;
-      Status   : out Boolean);
+      Status   : out Boolean)
+   with Pre => Get_GPIO_Functionality (This) = New_Sample_Ready;
 
 end VL53L0X;

--- a/components/src/range_sensor/VL53L0X/vl53l0x.ads
+++ b/components/src/range_sensor/VL53L0X/vl53l0x.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2017, AdaCore                           --
+--                 Copyright (C) 2017, 2020, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -63,6 +63,8 @@ package VL53L0X is
 
    function Read_Id (This : VL53L0X_Ranging_Sensor) return HAL.UInt16;
 
+   function Read_Revision (This : VL53L0X_Ranging_Sensor) return HAL.UInt8;
+
    procedure Set_Device_Address
      (This   : in out VL53L0X_Ranging_Sensor;
       Addr   : HAL.I2C.I2C_Address;
@@ -80,6 +82,13 @@ package VL53L0X is
    procedure Perform_Ref_Calibration
      (This   : in out VL53L0X_Ranging_Sensor;
       Status : out Boolean);
+
+   procedure Start_Continuous
+     (This      :     VL53L0X.VL53L0X_Ranging_Sensor;
+      Period_Ms :     HAL.UInt32;
+      Status    : out Boolean);
+   --  Start cyclic reads.
+   --  If Period_Ms is 0, run as fast as possible.
 
    procedure Start_Range_Single_Millimeters
      (This   : VL53L0X_Ranging_Sensor;


### PR DESCRIPTION
The Crazyflie flow deck v1 uses a VL53L0x "time of flight" sensor as a rangefinder to measure the aircraft’s height.

The VL53L0x can be set to generate an interrupt when a measurement is available, but according to [this schematic](https://wiki.bitcraze.io/_media/projects:crazyflie2:expansionboards:flow-deck_reve.pdf) the GPIO concerned (IO_2 on the left side expansion port) is multiplexed. The Crazyflie software handles this by setting the VL53L0x to continuous running, sampling when required. This change adds `Start_Continuous` to initiate continuous running.

Additionally, because the code to determine whether a measurement is actually available depends on the VL53L0x’s GPIO being configured to "generate an interrupt" when a new sample is available, preconditions are added to make sure that this is the case (if it isn’t, the software will loop indefinitely waiting for the sample).