### PR TITLE
Add board feature to initialize the Crazyflie external SPI.

### DIFF
--- a/boards/crazyflie/src/stm32-board.adb
+++ b/boards/crazyflie/src/stm32-board.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                  Copyright (C) 2015, 2020 AdaCore                        --
+--                   Copyright (C) 2015-2020 AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -156,7 +156,7 @@ package body STM32.Board is
    end Initialize_I2C_GPIO;
 
    -------------------
-   -- TP_I2C_Config --
+   -- Configure_I2C --
    -------------------
 
    procedure Configure_I2C (Port : in out I2C_Port)
@@ -174,6 +174,10 @@ package body STM32.Board is
                others          => <>));
       end if;
    end Configure_I2C;
+
+   ------------------------
+   -- Initialize_EXT_SPI --
+   ------------------------
 
    procedure Initialize_EXT_SPI
    is
@@ -209,5 +213,21 @@ package body STM32.Board is
           CRC_Poly            => 0));
       EXT_SPI.Enable;
    end Initialize_EXT_SPI;
+
+   ----------------------
+   -- Configure_EXT_CS --
+   ----------------------
+
+   procedure Configure_EXT_CS (Pin : in out STM32.GPIO.GPIO_Point)
+   is
+   begin
+      STM32.Device.Enable_Clock (Pin);
+      STM32.GPIO.Configure_IO
+        (Pin,
+         (Mode        => STM32.GPIO.Mode_Out,
+          Resistors   => STM32.GPIO.Floating,
+          Output_Type => STM32.GPIO.Push_Pull,
+          Speed       => STM32.GPIO.Speed_50MHz));
+   end Configure_EXT_CS;
 
 end STM32.Board;

--- a/boards/crazyflie/src/stm32-board.adb
+++ b/boards/crazyflie/src/stm32-board.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                  Copyright (C) 2015, 2020 AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -40,6 +40,8 @@
 --                                                                          --
 --   COPYRIGHT(c) 2014 STMicroelectronics                                   --
 ------------------------------------------------------------------------------
+
+with HAL.SPI;
 
 package body STM32.Board is
 
@@ -172,5 +174,40 @@ package body STM32.Board is
                others          => <>));
       end if;
    end Configure_I2C;
+
+   procedure Initialize_EXT_SPI
+   is
+      EXT_SPI_Points : constant STM32.GPIO.GPIO_Points := (EXT_MISO,
+                                                           EXT_MOSI,
+                                                           EXT_SCK);
+
+   begin
+      STM32.Device.Enable_Clock (EXT_SPI_Points);
+      STM32.GPIO.Configure_IO -- values copied from openmv.adb
+        (EXT_SPI_Points,
+         (Mode           => STM32.GPIO.Mode_AF,
+          AF             => STM32.Device.GPIO_AF_SPI1_5,
+          Resistors      => STM32.GPIO.Pull_Down,  --  SPI low polarity?
+          AF_Speed       => STM32.GPIO.Speed_50MHz,
+          AF_Output_Type => STM32.GPIO.Push_Pull));
+
+      STM32.Device.Enable_Clock (EXT_SPI);
+      EXT_SPI.Disable;
+      EXT_SPI.Configure
+        ((Direction           => STM32.SPI.D2Lines_FullDuplex,
+          Mode                => STM32.SPI.Master,
+          Data_Size           => HAL.SPI.Data_Size_8b,
+          --  These two if SPI Mode 3
+          --  Clock_Polarity => STM32.SPI.High,
+          --  Clock_Phase => STM32.SPI.P2Edge,
+          --  These two if not SPI Mode 3
+          Clock_Polarity      => STM32.SPI.Low,
+          Clock_Phase         => STM32.SPI.P1Edge,
+          Slave_Management    => STM32.SPI.Software_Managed,
+          Baud_Rate_Prescaler => STM32.SPI.BRP_64,
+          First_Bit           => STM32.SPI.MSB,
+          CRC_Poly            => 0));
+      EXT_SPI.Enable;
+   end Initialize_EXT_SPI;
 
 end STM32.Board;

--- a/boards/crazyflie/src/stm32-board.ads
+++ b/boards/crazyflie/src/stm32-board.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                 Copyright (C) 2015-2016, AdaCore                         --
+--              Copyright (C) 2015-2016, 2020, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -130,6 +130,8 @@ package STM32.Board is
    ---------
    -- SPI --
    ---------
+
+   procedure Initialize_EXT_SPI;
 
    EXT_SPI  : SPI_Port renames SPI_1;
    EXT_SCK  : GPIO_Point renames PA5;

--- a/boards/crazyflie/src/stm32-board.ads
+++ b/boards/crazyflie/src/stm32-board.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---              Copyright (C) 2015-2016, 2020, AdaCore                      --
+--                 Copyright (C) 2015-2020, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -141,6 +141,10 @@ package STM32.Board is
    EXT_CS1  : GPIO_Point renames PB4;
    EXT_CS2  : GPIO_Point renames PB5;
    EXT_CS3  : GPIO_Point renames PB8;
+
+   procedure Configure_EXT_CS (Pin : in out GPIO_Point)
+   with Pre =>
+     Pin = EXT_CS0 or Pin = EXT_CS1 or Pin = EXT_CS2 or Pin = EXT_CS3;
 
    ---------
    -- USB --


### PR DESCRIPTION
This unit already contains procedures (`Initialize_I2C_GPIO`, `Configure_I2C`) to do the hard work of initializing I2C.

There was no need to initialize SPI, because the basic Crazyflie doesn’t use it; however, SPI is used to communicate with the various [decks](https://www.bitcraze.io/documentation/system/platform/cf2-expansiondecks/).

This patch introduces a procedure to initialize the external SPI port, and another to configure the required Chip Select pin.

Replaces pull request #346.