### PR TITLE
Reduce optimization opportunities in Semihosting.

### DIFF
--- a/arch/ARM/cortex_m/src/semihosting.adb
+++ b/arch/ARM/cortex_m/src/semihosting.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2016, AdaCore                           --
+--                  Copyright (C) 2016-2020, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -262,7 +262,8 @@ package body Semihosting is
    -------------
 
    procedure Write_0 (Str : String) is
-      Data : UInt8_Array (Str'First .. Str'Last + 1);
+      type Byte_Array is new UInt8_Array with Volatile_Components;
+      Data : Byte_Array (Str'First .. Str'Last + 1);
       Ret  : SH_Word with Unreferenced;
    begin
       if not Semihosting_Enabled then


### PR DESCRIPTION
 This problem didn’t show up with GNAT CE 2019, but it does with FSF GCC 9.1.0 & 10.1.0: the output of semihosting is garbled if semihosting.adb is compiled with -O3, OK if compiled with -O0.

What should have been
```
One_Wire.Get_Info:
  13  46  71  31  0  0  0  135
Flow & ToF both initialized
Flow_Sensor_Task started
ToF_Sensor_Task started
```
came out as
```
??

P?
?? 

q
```

Setup: GDB 8.3 & 9.1 rsp, SEGGER J-Link Edu, SEGGER J-Link GDB Server V6.42 Command Line Version, macOS Catalina