### PR TITLE
PCD8544 LCD driver

### DIFF
--- a/components/src/screen/pcd8544/pcd8544.adb
+++ b/components/src/screen/pcd8544/pcd8544.adb
@@ -1,0 +1,398 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                    Copyright (C) 2020, AdaCore                           --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of AdaCore nor the names of its                  --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+package body PCD8544 is
+
+   -------------------
+   --  Chip_Select  --
+   -------------------
+
+   procedure Chip_Select (This : PCD8544_Device; Enabled : in Boolean)
+   is
+   begin
+      if This.CS /= null then
+         if Enabled then
+            This.CS.Clear;
+         else
+            This.CS.Set;
+         end if;
+      end if;
+   end Chip_Select;
+
+   -------------
+   --  Reset  --
+   -------------
+
+   procedure Reset (This : in out PCD8544_Device) is
+   begin
+      if This.RST /= null then
+         This.RST.Clear;
+         This.RST.Set;
+         --  The datasheet specifies 100ns minimum for reset but this was
+         --  unreliable in testing, so we use a longer delay.
+         This.Time.Delay_Microseconds (100);
+      end if;
+   end Reset;
+
+   ----------------
+   --  Transmit  --
+   ----------------
+
+   procedure Transmit (This : PCD8544_Device; Data : in UInt8) is
+      Status : SPI_Status;
+   begin
+      This.Chip_Select (True);
+      This.DC.Clear;
+      This.Port.Transmit (SPI_Data_8b'(1 => Data), Status);
+      This.Chip_Select (False);
+      if Status /= Ok then
+         raise SPI_Error with "PCD8544 SPI command transmit failed: " & Status'Image;
+      end if;
+   end Transmit;
+
+   ----------------
+   --  Transmit  --
+   ----------------
+
+   procedure Transmit (This : PCD8544_Device; Data : in UInt8_Array) is
+      Status : SPI_Status;
+   begin
+      This.Chip_Select (True);
+      This.DC.Set;
+      This.Port.Transmit (SPI_Data_8b (Data), Status);
+      This.Chip_Select (False);
+      if Status /= Ok then
+         raise SPI_Error with "PCD8544 SPI data transmit failed: " & Status'Image;
+      end if;
+   end Transmit;
+
+   ---------------------
+   --  Extended_Mode  --
+   ---------------------
+
+   procedure Extended_Mode (This : in out PCD8544_Device) is
+   begin
+      if This.FR.Extended_Mode /= True then
+         This.FR.Extended_Mode := True;
+         This.Transmit (PCD8544_CMD_FUNCTION or Convert (This.FR));
+      end if;
+   end Extended_Mode;
+
+   ------------------
+   --  Basic_Mode  --
+   ------------------
+
+   procedure Basic_Mode (This : in out PCD8544_Device) is
+   begin
+      if This.FR.Extended_Mode /= False then
+         This.FR.Extended_Mode := False;
+         This.Transmit (PCD8544_CMD_FUNCTION or Convert (This.FR));
+      end if;
+   end Basic_Mode;
+
+   --------------------
+   --  Set_Contrast  --
+   --------------------
+
+   procedure Set_Contrast
+     (This     : in out PCD8544_Device;
+      Contrast : in PCD8544_Contrast) is
+   begin
+      This.Extended_Mode;
+      This.Transmit (PCD8544_CMD_SET_VOP or Contrast);
+   end Set_Contrast;
+
+   ----------------
+   --  Set_Bias  --
+   ----------------
+
+   procedure Set_Bias
+     (This : in out PCD8544_Device;
+      Bias : in PCD8544_Bias) is
+   begin
+      This.Extended_Mode;
+      This.Transmit (PCD8544_CMD_SET_BIAS or Bias);
+   end Set_Bias;
+
+   -----------------------
+   --  Set_Temperature  --
+   -----------------------
+
+   procedure Set_Temperature
+     (This : in out PCD8544_Device;
+      TC   : in PCD8544_Temperature_Coefficient) is
+   begin
+      This.Extended_Mode;
+      This.Transmit (PCD8544_CMD_SET_TC or TC);
+   end Set_Temperature;
+
+   ------------------------
+   --  Set_Display_Mode  --
+   ------------------------
+
+   procedure Set_Display_Mode
+     (This   : in out PCD8544_Device;
+      Enable : in Boolean;
+      Invert : in Boolean) is
+   begin
+      This.Basic_Mode;
+      This.DR.Enable := Enable;
+      This.DR.Invert := Invert;
+      This.Transmit (PCD8544_CMD_DISPLAY or Convert (This.DR));
+   end Set_Display_Mode;
+
+   ------------------
+   --  Initialize  --
+   ------------------
+
+   procedure Initialize (This : in out PCD8544_Device) is
+      Default_FR : PCD8544_Function_Register;
+      Default_DR : PCD8544_Display_Register;
+   begin
+      This.DC.Clear;
+      This.Reset;
+
+      This.FR := Default_FR;
+      This.DR := Default_DR;
+
+      --  Power on must be separate from other commands.
+      This.FR.Power_Down := False;
+      This.Transmit (PCD8544_CMD_FUNCTION or Convert (This.FR));
+
+      This.Set_Contrast (PCD8544_Default_Contrast);
+      This.Set_Bias (PCD8544_Default_Bias);
+      This.Set_Temperature (PCD8544_Default_Temperature_Coefficient);
+
+      This.FR.Extended_Mode := False;
+      This.FR.Address_Mode  := Vertical;
+      This.Transmit (PCD8544_CMD_FUNCTION or Convert (This.FR));
+
+      This.Set_Display_Mode
+         (Enable => True,
+          Invert => True);
+
+      This.Device_Initialized := True;
+   end Initialize;
+
+   ------------------------
+   --  Write_Raw_Pixels  --
+   ------------------------
+
+   procedure Write_Raw_Pixels
+     (This : in out PCD8544_Device;
+      Data : UInt8_Array)
+   is
+   begin
+      This.Chip_Select (True);
+      This.Basic_Mode;
+      This.Transmit (PCD8544_CMD_SET_X or 0);
+      This.Transmit (PCD8544_CMD_SET_Y or 0);
+      This.Transmit (Data);
+      This.Chip_Select (False);
+   end Write_Raw_Pixels;
+
+   -------------------
+   --  Initialized  --
+   -------------------
+
+   overriding function Initialized (This : PCD8544_Device) return Boolean is
+     (This.Device_Initialized);
+
+   ------------------
+   --  Max_Layers  --
+   ------------------
+
+   overriding function Max_Layers (This : PCD8544_Device) return Positive is
+     (1);
+
+   -----------------
+   --  Supported  --
+   -----------------
+
+   overriding function Supported
+     (This : PCD8544_Device; Mode : FB_Color_Mode) return Boolean is
+     (Mode = HAL.Bitmap.M_1);
+
+   -----------------------
+   --  Set_Orientation  --
+   -----------------------
+
+   overriding procedure Set_Orientation
+     (This : in out PCD8544_Device; Orientation : Display_Orientation)
+   is
+   begin
+      null;
+   end Set_Orientation;
+
+   ----------------
+   --  Set_Mode  --
+   ----------------
+
+   overriding procedure Set_Mode
+     (This : in out PCD8544_Device; Mode : Wait_Mode) is null;
+
+   -------------
+   --  Width  --
+   -------------
+
+   overriding function Width (This : PCD8544_Device) return Positive is
+     (Device_Width);
+
+   --------------
+   --  Height  --
+   --------------
+
+   overriding function Height (This : PCD8544_Device) return Positive is
+     (Device_Height);
+
+   ---------------
+   --  Swapped  --
+   ---------------
+
+   overriding function Swapped (This : PCD8544_Device) return Boolean is
+     (False);
+
+   ----------------------
+   --  Set_Background  --
+   ----------------------
+
+   overriding procedure Set_Background (This : PCD8544_Device; R, G, B : UInt8)
+   is
+   begin
+      raise Program_Error;
+   end Set_Background;
+
+   ------------------------
+   --  Initialize_Layer  --
+   ------------------------
+
+   overriding procedure Initialize_Layer
+     (This   : in out PCD8544_Device;
+      Layer  : Positive;
+      Mode   : FB_Color_Mode;
+      X, Y   : Natural := 0;
+      Width  : Positive := Positive'Last;
+      Height : Positive := Positive'Last)
+   is
+      pragma Unreferenced (X, Y, Width, Height);
+   begin
+      if Layer /= 1 or else Mode /= M_1 then
+         raise Program_Error;
+      end if;
+      This.Memory_Layer.Actual_Width      := This.Width;
+      This.Memory_Layer.Actual_Height     := This.Height;
+      This.Memory_Layer.Addr              := This.Memory_Layer.Data'Address;
+      This.Memory_Layer.Actual_Color_Mode := Mode;
+
+      for I in This.Memory_Layer.Data'Range loop
+         This.Memory_Layer.Data (I) := 0;
+      end loop;
+      This.Layer_Initialized := True;
+   end Initialize_Layer;
+
+   -------------------
+   --  Initialized  --
+   -------------------
+
+   overriding function Initialized
+     (This  : PCD8544_Device;
+      Layer : Positive) return Boolean
+   is
+   begin
+      return Layer = 1 and then This.Layer_Initialized;
+   end Initialized;
+
+   --------------------
+   --  Update_Layer  --
+   --------------------
+
+   overriding procedure Update_Layer
+     (This      : in out PCD8544_Device;
+      Layer     : Positive;
+      Copy_Back : Boolean := False)
+   is
+      pragma Unreferenced (Copy_Back);
+   begin
+      if Layer /= 1 then
+         raise Program_Error;
+      end if;
+
+      This.Write_Raw_Pixels (This.Memory_Layer.Data);
+   end Update_Layer;
+
+   ------------------
+   --  Color_Mode  --
+   ------------------
+
+   overriding function Color_Mode
+     (This : PCD8544_Device; Layer : Positive) return FB_Color_Mode
+   is
+      pragma Unreferenced (This);
+   begin
+      if Layer /= 1 then
+         raise Program_Error;
+      end if;
+      return M_1;
+   end Color_Mode;
+
+   ---------------------
+   --  Hidden_Buffer  --
+   ---------------------
+
+   overriding function Hidden_Buffer
+     (This : in out PCD8544_Device; Layer : Positive)
+      return not null HAL.Bitmap.Any_Bitmap_Buffer
+   is
+   begin
+      if Layer /= 1 then
+         raise Program_Error;
+      end if;
+      return This.Memory_Layer'Unchecked_Access;
+   end Hidden_Buffer;
+
+   ---------------------
+   --  Update_Layers  --
+   ---------------------
+
+   overriding procedure Update_Layers (This : in out PCD8544_Device) is
+   begin
+      This.Update_Layer (1);
+   end Update_Layers;
+
+   ------------------
+   --  Pixel_Size  --
+   ------------------
+
+   overriding function Pixel_Size
+     (Display : PCD8544_Device; Layer : Positive) return Positive is
+     (1);
+
+end PCD8544;

--- a/components/src/screen/pcd8544/pcd8544.ads
+++ b/components/src/screen/pcd8544/pcd8544.ads
@@ -1,0 +1,217 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2020, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+--                                                                          --
+--  This is a driver for the PCD8544 monochrome LCD controller              --
+--                                                                          --
+--  Datasheet:                                                              --
+--  https://www.sparkfun.com/datasheets/LCD/Monochrome/Nokia5110.pdf        --
+--                                                                          --
+--  Use a SPI clock of 4 MHz or less. The SPI peripheral should be          --
+--  configured to transmit MSB-first, 8 bit data size, CPOL=0, CPHA=1       --
+--  This is sometimes referred to as a "Mode 1" SPI configuration.          --
+--                                                                          --
+--  Minimum transition time for RST, CS, and DC is 100ns. HAL.Time doesn't  --
+--  support nanosecond delays, so this module uses a delay of 1 microsecond --
+--  instead.                                                                --
+--                                                                          --
+--  CS may be null if it's connected to the SPI controller or tied to       --
+--  ground.                                                                 --
+--                                                                          --
+--  RST may be null if it's controlled externally or you only expect to     --
+--  Initialize once per power cycle.                                        --
+------------------------------------------------------------------------------
+
+with HAL;                  use HAL;
+with HAL.GPIO;             use HAL.GPIO;
+with HAL.SPI;              use HAL.SPI;
+with HAL.Framebuffer;      use HAL.Framebuffer;
+with HAL.Bitmap;           use HAL.Bitmap;
+with HAL.Time;             use HAL.Time;
+with Memory_Mapped_Bitmap; use Memory_Mapped_Bitmap;
+with PCD8544_Reg;          use PCD8544_Reg;
+
+package PCD8544 is
+   type PCD8544_Device
+     (Port    : not null Any_SPI_Port;
+      DC      : not null Any_GPIO_Point;
+      RST, CS : Any_GPIO_Point;
+      Time    : not null HAL.Time.Any_Delays)
+   is limited new HAL.Framebuffer.Frame_Buffer_Display with private;
+
+   type Any_PCD8544_Device is access all PCD8544_Device'Class;
+
+   --  See datasheet section 8.9 for contrast (Vop) values
+   subtype PCD8544_Contrast is UInt8 range 0 .. 127;
+   PCD8544_Default_Contrast : constant PCD8544_Contrast := 48;
+
+   --  See datasheet Table 4 for bias mux rate values. We default to 1:48 as
+   --  that reportedly works well on most LCDs.
+   subtype PCD8544_Bias is UInt8 range 0 .. 4;
+   PCD8544_Default_Bias : constant PCD8544_Bias := 3;
+
+   --  See datasheet Figure 7 for TC values. Use higher values at lower
+   --  temperatures.
+   subtype PCD8544_Temperature_Coefficient is UInt8 range 0 .. 3;
+   PCD8544_Default_Temperature_Coefficient :
+       constant PCD8544_Temperature_Coefficient := 0;
+
+   SPI_Error : exception;
+
+   Device_Width  : constant := 48;
+   Device_Height : constant := 84;
+
+   procedure Initialize
+       (This : in out PCD8544_Device);
+
+   procedure Set_Contrast
+       (This     : in out PCD8544_Device;
+        Contrast : in PCD8544_Contrast);
+
+   procedure Set_Bias
+       (This : in out PCD8544_Device;
+        Bias : in PCD8544_Bias);
+
+   procedure Set_Temperature
+       (This : in out PCD8544_Device;
+        TC   : in PCD8544_Temperature_Coefficient);
+
+   procedure Set_Display_Mode
+       (This   : in out PCD8544_Device;
+        Enable : in Boolean;
+        Invert : in Boolean);
+
+   overriding
+   function Max_Layers (This : PCD8544_Device) return Positive;
+
+   overriding
+   function Supported
+       (This : PCD8544_Device;
+        Mode : FB_Color_Mode)
+       return Boolean;
+
+   overriding
+   procedure Set_Orientation
+       (This        : in out PCD8544_Device;
+        Orientation : Display_Orientation);
+
+   overriding
+   procedure Set_Mode
+       (This : in out PCD8544_Device;
+        Mode : Wait_Mode);
+
+   overriding
+   function Initialized
+       (This : PCD8544_Device) return Boolean;
+
+   overriding
+   function Width
+       (This : PCD8544_Device) return Positive;
+
+   overriding
+   function Height
+       (This : PCD8544_Device) return Positive;
+
+   overriding
+   function Swapped
+       (This : PCD8544_Device) return Boolean;
+
+   overriding
+   procedure Set_Background
+       (This    : PCD8544_Device;
+        R, G, B : UInt8);
+
+   overriding
+   procedure Initialize_Layer
+       (This          : in out PCD8544_Device;
+        Layer         : Positive;
+        Mode          : FB_Color_Mode;
+        X, Y          : Natural := 0;
+        Width, Height : Positive := Positive'Last);
+
+   overriding
+   function Initialized
+       (This  : PCD8544_Device;
+        Layer : Positive) return Boolean;
+
+   overriding
+   procedure Update_Layer
+       (This      : in out PCD8544_Device;
+        Layer     : Positive;
+        Copy_Back : Boolean := False);
+
+   overriding
+   procedure Update_Layers
+       (This : in out PCD8544_Device);
+
+   overriding
+   function Color_Mode
+       (This  : PCD8544_Device;
+        Layer : Positive) return FB_Color_Mode;
+
+   overriding
+   function Hidden_Buffer
+       (This  : in out PCD8544_Device;
+        Layer : Positive)
+       return not null HAL.Bitmap.Any_Bitmap_Buffer;
+
+   overriding
+   function Pixel_Size
+       (Display : PCD8544_Device;
+        Layer   : Positive) return Positive;
+
+private
+
+   type PCD8544_Bitmap_Buffer is new Memory_Mapped_Bitmap_Buffer
+       with record
+         Data : UInt8_Array (1 .. ((Device_Width * Device_Height) / UInt8'Size));
+       end record;
+
+   type PCD8544_Device
+     (Port    : not null Any_SPI_Port;
+      DC      : not null Any_GPIO_Point;
+      RST, CS : Any_GPIO_Point;
+      Time    : not null HAL.Time.Any_Delays)
+   is limited new HAL.Framebuffer.Frame_Buffer_Display with
+      record
+         Memory_Layer       : aliased PCD8544_Bitmap_Buffer;
+         Device_Initialized : Boolean := False;
+         Layer_Initialized  : Boolean := False;
+         FR                 : PCD8544_Function_Register;
+         DR                 : PCD8544_Display_Register;
+      end record;
+
+   procedure Chip_Select (This : PCD8544_Device; Enabled : in Boolean);
+   procedure Reset (This : in out PCD8544_Device);
+   procedure Transmit (This : PCD8544_Device; Data : in UInt8);
+   procedure Transmit (This : PCD8544_Device; Data : in UInt8_Array);
+   procedure Extended_Mode (This : in out PCD8544_Device);
+   procedure Basic_Mode (This : in out PCD8544_Device);
+   procedure Write_Raw_Pixels (This : in out PCD8544_Device; Data : in UInt8_Array);
+end PCD8544;

--- a/components/src/screen/pcd8544/pcd8544_reg.ads
+++ b/components/src/screen/pcd8544/pcd8544_reg.ads
@@ -1,0 +1,85 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2020, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Unchecked_Conversion;
+with HAL;
+
+package PCD8544_Reg is
+
+   --  Basic mode
+   PCD8544_CMD_FUNCTION : constant := 2#0010_0000#;
+   PCD8544_CMD_DISPLAY  : constant := 2#0000_1000#;
+   PCD8544_CMD_SET_X    : constant := 2#1000_0000#;
+   PCD8544_CMD_SET_Y    : constant := 2#0100_0000#;
+
+   --  Extended mode
+   PCD8544_CMD_SET_TC   : constant := 2#0000_0100#;
+   PCD8544_CMD_SET_BIAS : constant := 2#0001_0000#;
+   PCD8544_CMD_SET_VOP  : constant := 2#1000_0000#;
+
+   type PCD8544_Address_Mode is (Horizontal, Vertical);
+
+   type PCD8544_Function_Register is record
+      Power_Down    : Boolean              := True;
+      Address_Mode  : PCD8544_Address_Mode := Horizontal;
+      Extended_Mode : Boolean              := False;
+      Reserved      : Boolean              := False;
+   end record;
+
+   for PCD8544_Function_Register use record
+      Reserved      at 0 range 3 .. 7;
+      Power_Down    at 0 range 2 .. 2;
+      Address_Mode  at 0 range 1 .. 1;
+      Extended_Mode at 0 range 0 .. 0;
+   end record;
+   for PCD8544_Function_Register'Size use 8;
+
+   type PCD8544_Display_Register is record
+      Enable    : Boolean := False;
+      Invert    : Boolean := False;
+      Reserved1 : Boolean := False;
+      Reserved2 : Boolean := False;
+   end record;
+
+   for PCD8544_Display_Register use record
+      Reserved2 at 0 range 3 .. 7;
+      Reserved1 at 0 range 1 .. 1;
+      Enable    at 0 range 2 .. 2;
+      Invert    at 0 range 0 .. 0;
+   end record;
+   for PCD8544_Display_Register'Size use 8;
+
+   function Convert is new Ada.Unchecked_Conversion
+     (PCD8544_Function_Register, HAL.UInt8);
+   function Convert is new Ada.Unchecked_Conversion
+     (PCD8544_Display_Register, HAL.UInt8);
+
+end PCD8544_Reg;

--- a/examples/stm32_h405/lcd_test/lcd_test.gpr
+++ b/examples/stm32_h405/lcd_test/lcd_test.gpr
@@ -1,0 +1,14 @@
+with "../../../boards/stm32_h405/stm32_h405_full.gpr";
+
+project LCD_Test is
+
+  for Runtime ("Ada") use STM32_H405_Full'Runtime("Ada");
+  for Target use "arm-eabi";
+  for Main use ("lcd_test.adb");
+  for Languages use ("Ada");
+  for Source_Dirs use ("src");
+  for Object_Dir use "obj/";
+  for Create_Missing_Dirs use "True";
+
+  package Compiler renames STM32_H405_Full.Compiler;
+end LCD_Test;

--- a/examples/stm32_h405/lcd_test/src/lcd_test.adb
+++ b/examples/stm32_h405/lcd_test/src/lcd_test.adb
@@ -1,0 +1,125 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2020, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with STM32.GPIO;   use STM32.GPIO;
+with STM32.SPI;    use STM32.SPI;
+with STM32.Device; use STM32.Device;
+with STM32_H405;   use STM32_H405;
+with HAL.Bitmap;   use HAL.Bitmap;
+with HAL.SPI;      use HAL.SPI;
+with PCD8544;      use PCD8544;
+with Ravenscar_Time;
+
+procedure LCD_Test is
+   procedure Configure_GPIO;
+   procedure Configure_SPI;
+
+   LCD_SPI : STM32.SPI.SPI_Port renames SPI_2;
+   LCD_CLK : GPIO_Point renames EXT2_16;
+   LCD_DIN : GPIO_Point renames EXT2_19;
+   LCD_RST : GPIO_Point renames EXT2_9;
+   LCD_CS  : GPIO_Point renames EXT2_17;
+   LCD_DC  : GPIO_Point renames EXT2_2;
+
+   procedure Configure_GPIO is
+   begin
+      Enable_Clock (LCD_DIN & LCD_CLK & LCD_RST & LCD_DC & LCD_CS);
+      Configure_IO (LCD_RST & LCD_DC & LCD_CS,
+         (Resistors   => Pull_Up,
+          Mode        => Mode_Out,
+          Output_Type => Push_Pull,
+          Speed       => Speed_25MHz));
+      Configure_IO (LCD_DIN & LCD_CLK,
+         (Resistors      => Pull_Up,
+          Mode           => Mode_AF,
+          AF_Output_Type => Push_Pull,
+          AF_Speed       => Speed_25MHz,
+          AF             => GPIO_AF_SPI2_5));
+   end Configure_GPIO;
+
+   procedure Configure_SPI is
+   begin
+      Enable_Clock (LCD_SPI);
+      Configure (LCD_SPI,
+         (Direction           => D2Lines_FullDuplex,
+          Mode                => Master,
+          Data_Size           => Data_Size_8b,
+          Clock_Polarity      => High,
+          Clock_Phase         => P2Edge,
+          Slave_Management    => Software_Managed,
+          Baud_Rate_Prescaler => BRP_8,
+          First_Bit           => MSB,
+          CRC_Poly            => 0));
+      Enable (LCD_SPI);
+   end Configure_SPI;
+
+   Display : PCD8544_Device
+      (Port => LCD_SPI'Access,
+       RST  => LCD_RST'Access,
+       CS   => LCD_CS'Access,
+       DC   => LCD_DC'Access,
+       Time => Ravenscar_Time.Delays);
+
+   Bitmap : Any_Bitmap_Buffer;
+
+   Cursor : Rect :=
+      (Position => (0, 0),
+       Width    => 8,
+       Height   => 8);
+begin
+   Configure_GPIO;
+   Configure_SPI;
+   Display.Initialize;
+   Display.Initialize_Layer
+      (Layer  => 1,
+       Mode   => M_1,
+       X      => 0,
+       Y      => 0,
+       Width  => Display.Width,
+       Height => Display.Height);
+
+   Bitmap := Display.Hidden_Buffer (1);
+
+   loop
+      for X in 0 .. ((Display.Width / Cursor.Width) - 1) loop
+         for Y in 0 .. ((Display.Height / Cursor.Height) - 1) loop
+            Bitmap.Set_Source (White);
+            Bitmap.Fill;
+
+            Cursor.Position := (X * Cursor.Width, Y * Cursor.Height);
+            Bitmap.Set_Source (Black);
+            Bitmap.Fill_Rect (Cursor);
+            Display.Update_Layers;
+            delay 0.250;
+         end loop;
+      end loop;
+   end loop;
+end LCD_Test;

--- a/scripts/build_all_examples.py
+++ b/scripts/build_all_examples.py
@@ -83,6 +83,7 @@ projects = [
 
             # Olimex STM32-H405
             "/examples/stm32_h405/blinky/blinky.gpr",
+            "/examples/stm32_h405/lcd_test/lcd_test.gpr",
 
             # STM32F469 Discovery
             "/boards/stm32f469_discovery/stm32f469_discovery_full.gpr",


### PR DESCRIPTION
This is my first attempt at a moderately complex driver, criticism is welcome. I've included an example that works on the STM32_H405 board I recently added. The GPIO pins in the example were chosen so that they should match up with the exposed SPI port on the Feather_STM32F405 board as well, but I haven't tested that yet.

These LCD modules are cheap from eBay, Amazon, SparkFun, Adafruit, etc. and sometimes go by the name "Nokia 5110 LCD"