### PR TITLE
Add interrupt support for Nordic GPIO.

### DIFF
--- a/arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.adb
+++ b/arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.adb
@@ -38,7 +38,8 @@ package body nRF.GPIO.Tasks_And_Events is
    -- Acknowledge_Channel_Interrupt --
    -----------------------------------
 
-   procedure Acknowledge_Channel_Interrupt (Chan : GPIOTE_Channel) is
+   procedure Acknowledge_Channel_Interrupt (Chan : GPIOTE_Channel)
+   is
    begin
       GPIOTE_Periph.EVENTS_IN (Integer (Chan)) := 0;
    end Acknowledge_Channel_Interrupt;
@@ -47,23 +48,25 @@ package body nRF.GPIO.Tasks_And_Events is
    -- Acknowledge_Port_Interrupt --
    --------------------------------
 
-   procedure Acknowledge_Port_Interrupt is
+   procedure Acknowledge_Port_Interrupt
+   is
    begin
       GPIOTE_Periph.EVENTS_PORT := 0;
    end Acknowledge_Port_Interrupt;
 
-   --------------------------
-   -- Channel_Event_Is_Set --
-   --------------------------
+   -----------------------
+   -- Channel_Event_Set --
+   -----------------------
 
-   function Channel_Event_Is_Set (Chan : GPIOTE_Channel) return Boolean is
-      (GPIOTE_Periph.EVENTS_IN (Integer (Chan)) /= 0);
+   function Channel_Event_Set (Chan : GPIOTE_Channel) return Boolean
+   is (GPIOTE_Periph.EVENTS_IN (Integer (Chan)) /= 0);
 
    -------------
    -- Disable --
    -------------
 
-   procedure Disable (Chan : GPIOTE_Channel) is
+   procedure Disable (Chan : GPIOTE_Channel)
+   is
    begin
       GPIOTE_Periph.CONFIG (Integer (Chan)).MODE := Disabled;
    end Disable;
@@ -161,12 +164,12 @@ package body nRF.GPIO.Tasks_And_Events is
    function Out_Task (Chan : GPIOTE_Channel) return Task_Type
    is (Task_Type (GPIOTE_Periph.TASKS_OUT (Integer (Chan))'Address));
 
-   -----------------------
-   -- Port_Event_Is_Set --
-   -----------------------
+   --------------------
+   -- Port_Event_Set --
+   --------------------
 
-   function Port_Event_Is_Set return Boolean is
-     (GPIOTE_Periph.EVENTS_PORT /= 0);
+   function Port_Event_Set return Boolean
+   is (GPIOTE_Periph.EVENTS_PORT /= 0);
 
    --------------
    -- In_Event --

--- a/arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.adb
+++ b/arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.adb
@@ -34,6 +34,31 @@ with HAL;              use HAL;
 
 package body nRF.GPIO.Tasks_And_Events is
 
+   -----------------------------------
+   -- Acknowledge_Channel_Interrupt --
+   -----------------------------------
+
+   procedure Acknowledge_Channel_Interrupt (Chan : GPIOTE_Channel) is
+   begin
+      GPIOTE_Periph.EVENTS_IN (Integer (Chan)) := 0;
+   end Acknowledge_Channel_Interrupt;
+
+   --------------------------------
+   -- Acknowledge_Port_Interrupt --
+   --------------------------------
+
+   procedure Acknowledge_Port_Interrupt is
+   begin
+      GPIOTE_Periph.EVENTS_PORT := 0;
+   end Acknowledge_Port_Interrupt;
+
+   --------------------------
+   -- Channel_Event_Is_Set --
+   --------------------------
+
+   function Channel_Event_Is_Set (Chan: GPIOTE_Channel) return Boolean is
+      (GPIOTE_Periph.EVENTS_IN (Integer (Chan)) /= 0);
+
    -------------
    -- Disable --
    -------------
@@ -42,6 +67,39 @@ package body nRF.GPIO.Tasks_And_Events is
    begin
       GPIOTE_Periph.CONFIG (Integer (Chan)).MODE := Disabled;
    end Disable;
+
+   -------------------------------
+   -- Disable_Channel_Interrupt --
+   -------------------------------
+
+   procedure Disable_Channel_Interrupt (Chan : GPIOTE_Channel)
+   is
+      INTENCLR : INTENCLR_Register renames GPIOTE_Periph.INTENCLR;
+   begin
+      INTENCLR.IN_K.Arr (Integer (Chan)) := Clear;
+   end Disable_Channel_Interrupt;
+
+   ----------------------------
+   -- Disable_Port_Interrupt --
+   ----------------------------
+
+   procedure Disable_Port_Interrupt
+   is
+      INTENCLR : INTENCLR_Register renames GPIOTE_Periph.INTENCLR;
+   begin
+      INTENCLR.PORT := Clear;
+   end Disable_Port_Interrupt;
+
+   ------------------------------
+   -- Enable_Channel_Interrupt --
+   ------------------------------
+
+   procedure Enable_Channel_Interrupt (Chan : GPIOTE_Channel)
+   is
+      INTENSET : INTENSET_Register renames GPIOTE_Periph.INTENSET;
+   begin
+      INTENSET.IN_K.Arr (Integer (Chan)) := Set;
+   end Enable_Channel_Interrupt;
 
    ------------------
    -- Enable_Event --
@@ -61,6 +119,17 @@ package body nRF.GPIO.Tasks_And_Events is
                           when Any_Change   => Toggle);
       CONFIG.MODE := Event;
    end Enable_Event;
+
+   ---------------------------
+   -- Enable_Port_Interrupt --
+   ---------------------------
+
+   procedure Enable_Port_Interrupt
+   is
+      INTENSET : INTENSET_Register renames GPIOTE_Periph.INTENSET;
+   begin
+      INTENSET.PORT := Set;
+   end Enable_Port_Interrupt;
 
    -----------------
    -- Enable_Task --
@@ -92,9 +161,16 @@ package body nRF.GPIO.Tasks_And_Events is
    function Out_Task (Chan : GPIOTE_Channel) return Task_Type
    is (Task_Type (GPIOTE_Periph.TASKS_OUT (Integer (Chan))'Address));
 
-     --------------
-     -- In_Event --
-     --------------
+   -----------------------
+   -- Port_Event_Is_Set --
+   -----------------------
+
+   function Port_Event_Is_Set return Boolean is
+     (GPIOTE_Periph.EVENTS_PORT /= 0);
+
+   --------------
+   -- In_Event --
+   --------------
 
    function In_Event (Chan : GPIOTE_Channel) return Event_Type
    is (Event_Type (GPIOTE_Periph.EVENTS_IN (Integer (Chan))'Address));

--- a/arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.adb
+++ b/arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.adb
@@ -56,7 +56,7 @@ package body nRF.GPIO.Tasks_And_Events is
    -- Channel_Event_Is_Set --
    --------------------------
 
-   function Channel_Event_Is_Set (Chan: GPIOTE_Channel) return Boolean is
+   function Channel_Event_Is_Set (Chan : GPIOTE_Channel) return Boolean is
       (GPIOTE_Periph.EVENTS_IN (Integer (Chan)) /= 0);
 
    -------------
@@ -76,7 +76,7 @@ package body nRF.GPIO.Tasks_And_Events is
    is
       INTENCLR : INTENCLR_Register renames GPIOTE_Periph.INTENCLR;
    begin
-      INTENCLR.IN_K.Arr (Integer (Chan)) := Clear;
+      INTENCLR.IN_k.Arr (Integer (Chan)) := Clear;
    end Disable_Channel_Interrupt;
 
    ----------------------------
@@ -98,7 +98,7 @@ package body nRF.GPIO.Tasks_And_Events is
    is
       INTENSET : INTENSET_Register renames GPIOTE_Periph.INTENSET;
    begin
-      INTENSET.IN_K.Arr (Integer (Chan)) := Set;
+      INTENSET.IN_k.Arr (Integer (Chan)) := Set;
    end Enable_Channel_Interrupt;
 
    ------------------

--- a/arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.ads
+++ b/arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.ads
@@ -47,11 +47,11 @@ package nRF.GPIO.Tasks_And_Events is
    --  If enabled, Channel interrupts are triggered when the Event is
    --  raised.
 
-   function Channel_Event_Is_Set (Chan : GPIOTE_Channel) return Boolean
+   function Channel_Event_Set (Chan : GPIOTE_Channel) return Boolean
    with Inline;
 
    procedure Acknowledge_Channel_Interrupt (Chan : GPIOTE_Channel)
-   with Pre => Channel_Event_Is_Set (Chan);
+   with Pre => Channel_Event_Set (Chan);
    --  All channel (and port) events share the same interrupt, so
    --  acknowledging another event's interrupt would lose the event.
 
@@ -62,7 +62,7 @@ package nRF.GPIO.Tasks_And_Events is
    --  Pin_Sense_Mode with which that pin was configured. No other
    --  configuration is required.
 
-   function Port_Event_Is_Set return Boolean
+   function Port_Event_Set return Boolean
    with Inline;
 
    procedure Acknowledge_Port_Interrupt;

--- a/arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.ads
+++ b/arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.ads
@@ -40,7 +40,34 @@ package nRF.GPIO.Tasks_And_Events is
    procedure Enable_Event (Chan     : GPIOTE_Channel;
                            GPIO_Pin : GPIO_Pin_Index;
                            Polarity : Event_Polarity);
-   --  When GPIO_Pin value changes the event associated with Chan is raised
+   --  When GPIO_Pin value changes (as specified by Polarity) the
+   --  event associated with Chan is raised.
+
+   procedure Enable_Channel_Interrupt (Chan : GPIOTE_Channel);
+   --  If enabled, Channel interrupts are triggered when the Event is
+   --  raised.
+
+   function Channel_Event_Is_Set (Chan: GPIOTE_Channel) return Boolean
+   with Inline;
+
+   procedure Acknowledge_Channel_Interrupt (Chan : GPIOTE_Channel)
+   with Pre => Channel_Event_Is_Set (Chan);
+   --  All channel (and port) events share the same interrupt, so
+   --  acknowledging another event's interrupt would lose the event.
+
+   procedure Disable_Channel_Interrupt (Chan : GPIOTE_Channel);
+
+   procedure Enable_Port_Interrupt;
+   --  The Port event occurs when any GPIO pin's state matches the
+   --  Pin_Sense_Mode with which that pin was configured. No other
+   --  configuration is required.
+
+   function Port_Event_Is_Set return Boolean
+   with Inline;
+
+   procedure Acknowledge_Port_Interrupt;
+
+   procedure Disable_Port_Interrupt;
 
    type Task_Action is (Set_Pin, Clear_Pin, Toggle_Pin);
    type Init_Value is (Init_Set, Init_Clear);

--- a/arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.ads
+++ b/arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.ads
@@ -47,7 +47,7 @@ package nRF.GPIO.Tasks_And_Events is
    --  If enabled, Channel interrupts are triggered when the Event is
    --  raised.
 
-   function Channel_Event_Is_Set (Chan: GPIOTE_Channel) return Boolean
+   function Channel_Event_Is_Set (Chan : GPIOTE_Channel) return Boolean
    with Inline;
 
    procedure Acknowledge_Channel_Interrupt (Chan : GPIOTE_Channel)


### PR DESCRIPTION
  * arch/ARM/Nordic/drivers/nrf_common/nrf-gpio-tasks_and_events.ad[sb]:
      Added subprograms to enable, test for presence, acknowledge and
      disable both channel and port interrupts.
