### PR TITLE
Cortex-M systick: Fix TICKINT values

### DIFF
--- a/arch/ARM/cortex_m/src/cm0/cortex_m_svd-systick.ads
+++ b/arch/ARM/cortex_m/src/cm0/cortex_m_svd-systick.ads
@@ -29,15 +29,14 @@ package Cortex_M_SVD.SysTick is
 
    --  Generate Tick Interrupt
    type CSR_TICKINT_Field is
-     (
+     (--  Counting down to zero asserts the SysTick exception request
+      Disable,
       --  Counting down to zero does not assert the SysTick exception request
-      Enable,
-      --  Counting down to zero asserts the SysTick exception request
-      Disable)
+      Enable)
      with Size => 1;
    for CSR_TICKINT_Field use
-     (Enable => 0,
-      Disable => 1);
+     (Disable => 0,
+      Enable => 1);
 
    --  Source to count from
    type CSR_CLKSOURCE_Field is
@@ -56,7 +55,7 @@ package Cortex_M_SVD.SysTick is
       --  Enable SysTick Timer
       ENABLE         : CSR_ENABLE_Field := Cortex_M_SVD.SysTick.Disable;
       --  Generate Tick Interrupt
-      TICKINT        : CSR_TICKINT_Field := Cortex_M_SVD.SysTick.Enable;
+      TICKINT        : CSR_TICKINT_Field := Cortex_M_SVD.SysTick.Disable;
       --  Source to count from
       CLKSOURCE      : CSR_CLKSOURCE_Field :=
                         Cortex_M_SVD.SysTick.External_Clk;

--- a/arch/ARM/cortex_m/src/cm4/cortex_m_svd-systick.ads
+++ b/arch/ARM/cortex_m/src/cm4/cortex_m_svd-systick.ads
@@ -29,15 +29,14 @@ package Cortex_M_SVD.SysTick is
 
    --  Generate Tick Interrupt
    type CSR_TICKINT_Field is
-     (
+     (--  Counting down to zero asserts the SysTick exception request
+      Disable,
       --  Counting down to zero does not assert the SysTick exception request
-      Enable,
-      --  Counting down to zero asserts the SysTick exception request
-      Disable)
+      Enable)
      with Size => 1;
    for CSR_TICKINT_Field use
-     (Enable => 0,
-      Disable => 1);
+     (Disable => 0,
+      Enable => 1);
 
    --  Source to count from
    type CSR_CLKSOURCE_Field is
@@ -56,7 +55,7 @@ package Cortex_M_SVD.SysTick is
       --  Enable SysTick Timer
       ENABLE         : CSR_ENABLE_Field := Cortex_M_SVD.SysTick.Disable;
       --  Generate Tick Interrupt
-      TICKINT        : CSR_TICKINT_Field := Cortex_M_SVD.SysTick.Enable;
+      TICKINT        : CSR_TICKINT_Field := Cortex_M_SVD.SysTick.Disable;
       --  Source to count from
       CLKSOURCE      : CSR_CLKSOURCE_Field := Cortex_M_SVD.SysTick.Cpu_Clk;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-systick.ads
+++ b/arch/ARM/cortex_m/src/cm4f/cortex_m_svd-systick.ads
@@ -29,15 +29,14 @@ package Cortex_M_SVD.SysTick is
 
    --  Generate Tick Interrupt
    type CSR_TICKINT_Field is
-     (
+     (--  Counting down to zero asserts the SysTick exception request
+      Disable,
       --  Counting down to zero does not assert the SysTick exception request
-      Enable,
-      --  Counting down to zero asserts the SysTick exception request
-      Disable)
+      Enable)
      with Size => 1;
    for CSR_TICKINT_Field use
-     (Enable => 0,
-      Disable => 1);
+     (Disable => 0,
+      Enable => 1);
 
    --  Source to count from
    type CSR_CLKSOURCE_Field is
@@ -56,7 +55,7 @@ package Cortex_M_SVD.SysTick is
       --  Enable SysTick Timer
       ENABLE         : CSR_ENABLE_Field := Cortex_M_SVD.SysTick.Disable;
       --  Generate Tick Interrupt
-      TICKINT        : CSR_TICKINT_Field := Cortex_M_SVD.SysTick.Enable;
+      TICKINT        : CSR_TICKINT_Field := Cortex_M_SVD.SysTick.Disable;
       --  Source to count from
       CLKSOURCE      : CSR_CLKSOURCE_Field := Cortex_M_SVD.SysTick.Cpu_Clk;
       --  unspecified

--- a/arch/ARM/cortex_m/src/cm7/cortex_m_svd-systick.ads
+++ b/arch/ARM/cortex_m/src/cm7/cortex_m_svd-systick.ads
@@ -29,15 +29,14 @@ package Cortex_M_SVD.SysTick is
 
    --  Generate Tick Interrupt
    type CSR_TICKINT_Field is
-     (
+     (--  Counting down to zero asserts the SysTick exception request
+      Disable,
       --  Counting down to zero does not assert the SysTick exception request
-      Enable,
-      --  Counting down to zero asserts the SysTick exception request
-      Disable)
+      Enable)
      with Size => 1;
    for CSR_TICKINT_Field use
-     (Enable => 0,
-      Disable => 1);
+     (Disable => 0,
+      Enable => 1);
 
    --  Source to count from
    type CSR_CLKSOURCE_Field is
@@ -56,7 +55,7 @@ package Cortex_M_SVD.SysTick is
       --  Enable SysTick Timer
       ENABLE         : CSR_ENABLE_Field := Cortex_M_SVD.SysTick.Disable;
       --  Generate Tick Interrupt
-      TICKINT        : CSR_TICKINT_Field := Cortex_M_SVD.SysTick.Enable;
+      TICKINT        : CSR_TICKINT_Field := Cortex_M_SVD.SysTick.Disable;
       --  Source to count from
       CLKSOURCE      : CSR_CLKSOURCE_Field := Cortex_M_SVD.SysTick.Cpu_Clk;
       --  unspecified


### PR DESCRIPTION
The fix was fixed in the SVD files [1] but not in ADL.

[1] https://github.com/AdaCore/svd2ada/commit/c2fb35bfc90dc68ed75172db15fd81ca3ada4e4d