### PR TITLE
LSM303AGR driver implementation

### DIFF
--- a/components/src/motion/lsm303agr/lsm303agr.adb
+++ b/components/src/motion/lsm303agr/lsm303agr.adb
@@ -1,0 +1,201 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2020, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+package body LSM303AGR is
+   function To_Axis_Data is new Ada.Unchecked_Conversion (UInt10, Axis_Data);
+
+   function Read_Register
+     (This : LSM303AGR_Accelerometer'Class; Device_Address : I2C_Address;
+      Register_Addr : Register_Address) return UInt8;
+
+   procedure Write_Register
+     (This : LSM303AGR_Accelerometer'Class; Device_Address : I2C_Address;
+      Register_Addr : Register_Address; Val : UInt8);
+
+   function Check_Device_Id
+       (This : LSM303AGR_Accelerometer; Device_Address : I2C_Address;
+       WHO_AM_I_Register : Register_Address; Device_Id : Device_Identifier)
+      return Boolean;
+
+   function To_Multi_Byte_Read_Address
+     (Register_Addr : Register_Address) return UInt16;
+
+   procedure Configure (This : LSM303AGR_Accelerometer; Date_Rate : Data_Rate)
+   is
+      CTRLA : CTRL_REG1_A_Register;
+   begin
+      CTRLA.Xen  := 1;
+      CTRLA.Yen  := 1;
+      CTRLA.Zen  := 1;
+      CTRLA.LPen := 0;
+      CTRLA.ODR  := Date_Rate'Enum_Rep;
+
+      This.Write_Register
+        (Accelerometer_Address, CTRL_REG1_A, To_UInt8 (CTRLA));
+   end Configure;
+
+   procedure Assert_Status (Status : I2C_Status);
+   -------------------
+   -- Read_Register --
+   -------------------
+
+   function Read_Register
+     (This : LSM303AGR_Accelerometer'Class; Device_Address : I2C_Address;
+      Register_Addr : Register_Address) return UInt8
+   is
+      Data   : I2C_Data (1 .. 1);
+      Status : I2C_Status;
+   begin
+      This.Port.Mem_Read
+        (Addr          => Device_Address, Mem_Addr => UInt16 (Register_Addr),
+         Mem_Addr_Size => Memory_Size_8b, Data => Data, Status => Status);
+      Assert_Status (Status);
+
+      return Data (Data'First);
+   end Read_Register;
+
+   --------------------
+   -- Write_Register --
+   --------------------
+
+   procedure Write_Register
+     (This : LSM303AGR_Accelerometer'Class; Device_Address : I2C_Address;
+      Register_Addr : Register_Address; Val : UInt8)
+   is
+      Status : I2C_Status;
+   begin
+      This.Port.Mem_Write
+        (Addr          => Device_Address, Mem_Addr => UInt16 (Register_Addr),
+         Mem_Addr_Size => Memory_Size_8b, Data => (1 => Val),
+         Status        => Status);
+      Assert_Status (Status);
+
+   end Write_Register;
+
+   -----------------------------------
+   -- Check_Accelerometer_Device_Id --
+   -----------------------------------
+
+   function Check_Accelerometer_Device_Id
+     (This : LSM303AGR_Accelerometer) return Boolean
+   is
+   begin
+      return
+        Check_Device_Id
+          (This, Accelerometer_Address, WHO_AM_I_A, Accelerometer_Device_Id);
+   end Check_Accelerometer_Device_Id;
+
+   ----------------------------------
+   -- Check_Magnetometer_Device_Id --
+   ----------------------------------
+
+   function Check_Magnetometer_Device_Id
+     (This : LSM303AGR_Accelerometer) return Boolean
+   is
+   begin
+      return
+        Check_Device_Id
+          (This, Magnetometer_Address, WHO_AM_I_M, Magnetometer_Device_Id);
+   end Check_Magnetometer_Device_Id;
+
+   ---------------------
+   -- Check_Device_Id --
+   ---------------------
+
+   function Check_Device_Id
+     (This : LSM303AGR_Accelerometer; Device_Address : I2C_Address;
+      WHO_AM_I_Register : Register_Address; Device_Id : Device_Identifier)
+      return Boolean
+   is
+   begin
+      return
+        Read_Register (This, Device_Address, WHO_AM_I_Register) =
+        UInt8 (Device_Id);
+   end Check_Device_Id;
+
+   ------------------------
+   -- Read_Accelerometer --
+   ------------------------
+
+   function Read_Accelerometer
+     (This : LSM303AGR_Accelerometer) return All_Axes_Data
+   is
+      -------------
+      -- Convert --
+      -------------
+      function Convert (Low, High : UInt8) return Axis_Data;
+      function Convert (Low, High : UInt8) return Axis_Data is
+         Tmp : UInt10;
+      begin
+          -- TODO: support HiRes and LoPow modes
+          -- in conversion.
+         Tmp := UInt10 (Shift_Right (Low, 6));
+         Tmp := Tmp or UInt10 (High) * 2**2;
+         return To_Axis_Data (Tmp);
+      end Convert;
+
+      Status   : I2C_Status;
+      Data     : I2C_Data (1 .. 6) := (others => 0);
+      AxisData : All_Axes_Data     := (X => 0, Y => 0, Z => 0);
+   begin
+      This.Port.Mem_Read
+        (Addr          => Accelerometer_Address,
+         Mem_Addr      => To_Multi_Byte_Read_Address (OUT_X_L_A),
+         Mem_Addr_Size => Memory_Size_8b, Data => Data, Status => Status);
+      Assert_Status (Status);
+
+       -- LSM303AGR has its X-axis in the opposite direction
+       -- of the MMA8653FCR1 sensor.
+      AxisData.X := Convert (Data (1), Data (2)) * Axis_Data (-1);
+      AxisData.Y := Convert (Data (3), Data (4));
+      AxisData.Z := Convert (Data (5), Data (6));
+
+      return AxisData;
+   end Read_Accelerometer;
+
+   function To_Multi_Byte_Read_Address
+     (Register_Addr : Register_Address) return UInt16
+    -- Based on the i2c behavior of the sensor p.38,
+    -- high MSB address allows reading multiple bytes
+    -- from slave devices.
+
+   is
+   begin
+      return UInt16 (Register_Addr) or MULTI_BYTE_READ;
+   end To_Multi_Byte_Read_Address;
+
+   procedure Assert_Status (Status : I2C_Status) is
+   begin
+      if Status /= Ok then
+         --  No error handling...
+         raise Program_Error;
+      end if;
+   end Assert_Status;
+end LSM303AGR;

--- a/components/src/motion/lsm303agr/lsm303agr.ads
+++ b/components/src/motion/lsm303agr/lsm303agr.ads
@@ -1,0 +1,158 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2020, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+with HAL;     use HAL;
+with HAL.I2C; use HAL.I2C;
+
+private with Ada.Unchecked_Conversion;
+
+package LSM303AGR is
+    -- TODO: support other power modes HiRes/LoPower,
+    -- Specifically allowing them in configure procedure
+    -- and adjusting conversions after reading the
+    -- accelerometer sensor.
+    -- TODO: Add magnetometer support.
+
+   type Register_Address is new UInt8;
+   type Device_Identifier is new UInt8;
+   type Data_Rate is
+     (PowerDown, Freq_1, Freq_10, Freq_25, Freq_50, Freq_100, Freq_200,
+      Freq_400, Low_Power, Hi_Res_1k6_Low_power_5k3);
+
+   type Axis_Data is range -2**9 .. 2**9 - 1 with Size => 10;
+
+   type All_Axes_Data is record
+      X, Y, Z : Axis_Data;
+   end record;
+
+   type LSM303AGR_Accelerometer (Port : not null Any_I2C_Port) is
+     tagged limited private;
+
+   function Check_Accelerometer_Device_Id
+     (This : LSM303AGR_Accelerometer) return Boolean;
+
+   function Check_Magnetometer_Device_Id
+     (This : LSM303AGR_Accelerometer) return Boolean;
+
+   procedure Configure (This : LSM303AGR_Accelerometer; Date_Rate : Data_Rate);
+
+   function Read_Accelerometer
+     (This : LSM303AGR_Accelerometer) return All_Axes_Data;
+
+private
+   type LSM303AGR_Accelerometer (Port : not null Any_I2C_Port)
+   is tagged limited null record;
+
+   for Data_Rate use
+     (PowerDown => 0, Freq_1 => 1, Freq_10 => 2, Freq_25 => 3, Freq_50 => 4,
+      Freq_100 => 5, Freq_200 => 6, Freq_400 => 7, Low_Power => 8,
+      Hi_Res_1k6_Low_power_5k3 => 9);
+
+   Accelerometer_Address   : constant I2C_Address       := 16#32#;
+   Accelerometer_Device_Id : constant Device_Identifier := 2#0011_0011#;
+
+   Magnetometer_Address   : constant I2C_Address       := 16#3C#;
+   Magnetometer_Device_Id : constant Device_Identifier := 2#0100_0000#;
+
+   WHO_AM_I_A : constant Register_Address := 16#0F#;
+   WHO_AM_I_M : constant Register_Address := 16#4F#;
+
+   CTRL_REG1_A : constant Register_Address := 16#20#;
+   CTRL_REG2_A : constant Register_Address := 16#21#;
+   CTRL_REG3_A : constant Register_Address := 16#22#;
+   CTRL_REG4_A : constant Register_Address := 16#23#;
+   CTRL_REG5_A : constant Register_Address := 16#24#;
+   CTRL_REG6_A : constant Register_Address := 16#25#;
+
+   DATACAPTURE_A : constant Register_Address := 16#26#;
+   STATUS_REG_A  : constant Register_Address := 16#27#;
+   OUT_X_L_A     : constant Register_Address := 16#28#;
+   OUT_X_H_A     : constant Register_Address := 16#29#;
+   OUT_Y_L_A     : constant Register_Address := 16#2A#;
+   OUT_Y_H_A     : constant Register_Address := 16#2B#;
+   OUT_Z_L_A     : constant Register_Address := 16#2C#;
+   OUT_Z_H_A     : constant Register_Address := 16#2D#;
+
+   MULTI_BYTE_READ : constant := 2#1000_0000#;
+
+   NORMAL_MODE_DIVISOR : constant := 6;
+
+   type CTRL_REG1_A_Register is record
+      Xen  : Bit   := 0;
+      Yen  : Bit   := 0;
+      Zen  : Bit   := 0;
+      LPen : Bit   := 0;
+      ODR  : UInt4 := 0;
+   end record;
+
+   for CTRL_REG1_A_Register use record
+      Xen  at 0 range 0 .. 0;
+      Yen  at 0 range 1 .. 1;
+      Zen  at 0 range 2 .. 2;
+      LPen at 0 range 3 .. 3;
+      ODR  at 0 range 4 .. 7;
+   end record;
+
+   function To_UInt8 is new Ada.Unchecked_Conversion
+     (CTRL_REG1_A_Register, UInt8);
+   function To_Reg is new Ada.Unchecked_Conversion
+     (UInt8, CTRL_REG1_A_Register);
+
+   type STATUS_REG_A_Register is record
+      ZYXOVR : Bit := 0;
+      ZOVR   : Bit := 0;
+      YOVR   : Bit := 0;
+      XOVR   : Bit := 0;
+      ZYXDA  : Bit := 0;
+      ZDA    : Bit := 0;
+      YDA    : Bit := 0;
+      XDA    : Bit := 0;
+   end record;
+
+   for STATUS_REG_A_Register use record
+      XDA at 0 range 0 .. 0;
+      YDA at 0 range 1 .. 1;
+      ZDA at 0 range 2 .. 2;
+
+      ZYXDA at 0 range 3 .. 3;
+
+      XOVR at 0 range 4 .. 4;
+      YOVR at 0 range 5 .. 5;
+      ZOVR at 0 range 6 .. 6;
+
+      ZYXOVR at 0 range 7 .. 7;
+   end record;
+
+   function To_UInt8 is new Ada.Unchecked_Conversion
+     (STATUS_REG_A_Register, UInt8);
+   function To_Reg is new Ada.Unchecked_Conversion
+     (UInt8, STATUS_REG_A_Register);
+
+end LSM303AGR;


### PR DESCRIPTION
This is a work in progress to support the LSM303AGR accelerometer. Mainly needed for MicroBit v1.5 boards