### PR TITLE
Use symbolic interrupt priority for SDMMC.

### DIFF
--- a/arch/ARM/STM32/drivers/sd/stm32-sdmmc_interrupt.ads
+++ b/arch/ARM/STM32/drivers/sd/stm32-sdmmc_interrupt.ads
@@ -34,6 +34,7 @@
 
 with HAL.SDMMC;           use HAL.SDMMC;
 with Ada.Interrupts;
+with System;
 
 limited with STM32.SDMMC;
 

--- a/arch/ARM/STM32/drivers/sd/stm32-sdmmc_interrupt.ads
+++ b/arch/ARM/STM32/drivers/sd/stm32-sdmmc_interrupt.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2016-2017, AdaCore                     --
+--                     Copyright (C) 2016-2021, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -44,9 +44,10 @@ package STM32.SDMMC_Interrupt is
    ------------------
 
    protected type SDMMC_Interrupt_Handler
-     (Interrupt_ID : Ada.Interrupts.Interrupt_ID)
+     (Interrupt_ID : Ada.Interrupts.Interrupt_ID;
+      Priority     : System.Interrupt_Priority)
    is
-      pragma Interrupt_Priority (250);
+      pragma Interrupt_Priority (Priority);
 
       procedure Set_Transfer_State (This : in out STM32.SDMMC.SDMMC_Controller);
       procedure Clear_Transfer_State;

--- a/boards/stm32_common/sdcard/sdcard.adb
+++ b/boards/stm32_common/sdcard/sdcard.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2021, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -39,9 +39,13 @@ with STM32.GPIO;              use STM32.GPIO;
 with STM32.SDMMC;             use STM32.SDMMC;
 with STM32.SDMMC_Interrupt;   use STM32.SDMMC_Interrupt;
 
+with System;
+
 package body SDCard is
 
-   SD_Interrupt_Handler : aliased SDMMC_Interrupt_Handler (SD_Interrupt);
+   SD_Interrupt_Handler : aliased SDMMC_Interrupt_Handler
+     (Interrupt_ID => SD_Interrupt,
+      Priority     => System.Interrupt_Priority'Last);
 
    ----------------
    -- Initialize --


### PR DESCRIPTION
This completes the change requested in #219, which slipped past!