### PR TITLE
Add Cortex_M.Hints, which provides access to hint instructions

### DIFF
--- a/arch/ARM/cortex_m/src/cortex_m-hints.adb
+++ b/arch/ARM/cortex_m/src/cortex_m-hints.adb
@@ -1,0 +1,71 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                    Copyright (C) 2021, AdaCore                           --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+with System.Machine_Code; use System.Machine_Code;
+
+package body Cortex_M.Hints is
+
+   -----------
+   -- Yield --
+   -----------
+
+   procedure Yield is
+   begin
+      Asm ("yield", Volatile => True);
+   end Yield;
+
+   ----------------
+   -- Send_Event --
+   ----------------
+
+   procedure Send_Event is
+   begin
+      Asm ("sev", Volatile => True);
+   end Send_Event;
+
+   --------------------
+   -- Wait_For_Event --
+   --------------------
+
+   procedure Wait_For_Event is
+   begin
+      Asm ("wfe", Volatile => True);
+   end Wait_For_Event;
+
+   ------------------------
+   -- Wait_For_Interrupt --
+   ------------------------
+
+   procedure Wait_For_Interrupt is
+   begin
+      Asm ("wfi", Volatile => True);
+   end Wait_For_Interrupt;
+
+end Cortex_M.Hints;

--- a/arch/ARM/cortex_m/src/cortex_m-hints.ads
+++ b/arch/ARM/cortex_m/src/cortex_m-hints.ads
@@ -1,0 +1,70 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                    Copyright (C) 2021, AdaCore                           --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This file provides NOP-compatible hint functions for devices using the
+--  ARMv6-M, ARMv7-M, and ARMv8-M instruction sets.
+--
+--  Source:
+--
+--    ARMv6-M Architecture Reference Manual
+--    A6.6 Hint Instructions
+--    https://developer.arm.com/documentation/ddi0419/e
+
+package Cortex_M.Hints is
+
+   procedure Send_Event with Inline;
+   --  A6.7.57 SEV
+   --
+   --  Causes an event to be signaled to all CPUs within a multiprocessor
+   --  system.
+
+   procedure Wait_For_Event with Inline;
+   --  A6.7.75 WFE
+   --
+   --  Permits the processor to enter a low-power state until one of a number
+   --  of events occurs, including events signaled by the SEV instruction on
+   --  any processor in a multiprocessor system.
+
+   procedure Wait_For_Interrupt with Inline;
+   --  A6.7.76 WFI
+   --
+   --  Suspends execution until one of a number of events occurs.
+
+   procedure Yield with Inline;
+   --  A6.7.77 YIELD
+   --
+   --  Enables software with a multithreading capability to indicate to the
+   --  hardware that it is performing a task, for example a spinlock, that
+   --  could be swapped out to improve overall system performance.  Hardware
+   --  can use this hint to suspend and resume multiple code threads if it
+   --  supports the capability.
+
+end Cortex_M.Hints;


### PR DESCRIPTION
Send_Event, Wait_For_Event, Wait_For_Interrupt, and Yield are defined as "hint instructions" in the [ARMv6-M Architecture Reference Manual](https://developer.arm.com/documentation/ddi0419/e). This package just conveniently wraps them up as procedures, very similar to the Memory_Barriers package in the same directory.

When testing this package, I discovered that GNAT's `Inline` is really just a suggestion. Unless `-fomit-frame-pointer` is added to the compiler flags, five additional instructions are added to each of these calls to save and restore the link register. Here is the disassembled output of Wait_For_Interrupt annotated with source.
```
   procedure Wait_For_Interrupt is
     908:       b580            push    {r7, lr}
     90a:       af00            add     r7, sp, #0
      pragma Suppress (All_Checks);
   begin
      Asm ("wfi", Volatile => True);
     90c:       bf30            wfi
   end Wait_For_Interrupt;
     90e:       46bd            mov     sp, r7
     910:       bd80            pop     {r7, pc}
     912:       46c0            nop                     ; (mov r8, r8)
```

Even with `-fomit-frame-pointer`, this function still requires a `bl` branch with link to the `wfi` instruction, followed by a `bx lr` afterward.

Is there any aspect or pragma that can be used to cause GNAT to truly inline these instructions without branching or manipulating the stack?