### PR TITLE
Components: add I2C, SPI drivers for LPS25H barometric sensor.

### DIFF
--- a/components/src/environment/lps25h-i2c.adb
+++ b/components/src/environment/lps25h-i2c.adb
@@ -1,0 +1,244 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                    Copyright (C) 2021, AdaCore                           --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Unchecked_Conversion;
+with Interfaces;
+
+package body LPS25H.I2C is
+
+   use HAL;
+
+   --  Utility specs  --
+
+   generic
+      Register : HAL.UInt8;
+      type Register_Type is private;
+   procedure Write_Register (This   :     LPS25H_Barometric_Sensor_I2C;
+                             Value  :     Register_Type;
+                             Status : out Boolean);
+
+   procedure Write
+     (This   : LPS25H_Barometric_Sensor_I2C;
+      Index  : HAL.UInt8;
+      Data   : HAL.UInt8;
+      Status : out Boolean);
+
+   procedure Read
+     (This   : LPS25H_Barometric_Sensor_I2C;
+      Index  : HAL.UInt8;
+      Data   : out HAL.UInt8_Array;
+      Status : out Boolean);
+   procedure Read
+     (This   : LPS25H_Barometric_Sensor_I2C;
+      Index  : HAL.UInt8;
+      Data   : out HAL.UInt8;
+      Status : out Boolean);
+
+   --------------
+   -- Get_Data --
+   --------------
+
+   overriding
+   procedure Get_Data
+     (This   : in out LPS25H_Barometric_Sensor_I2C;
+      Press  :    out Pressure;
+      Temp   :    out Temperature;
+      Asl    :    out Altitude;
+      Status :    out Boolean)
+   is
+      Buf : HAL.UInt8_Array (0 .. 2) := (others => 0);
+   begin
+      --  Pressure
+      declare
+         type Integer_24 is range -(2 ** 23) .. 2 ** 23 - 1
+         with Size => 24;
+         subtype Buffer_3 is HAL.UInt8_Array (Buf'Range);
+         function Convert is new Ada.Unchecked_Conversion
+           (Buffer_3, Integer_24);
+      begin
+         This.Read (PRESS_OUT_XL or 2#1000_0000#,
+                    Buf,
+                    Status);
+         if not Status then
+            return;
+         end if;
+         Press := Float (Convert (Buf)) / 4096.0;
+      end;
+
+      --  Temperature
+      declare
+         subtype Buffer_2 is HAL.UInt8_Array (0 .. 1);
+         function Convert is new Ada.Unchecked_Conversion
+           (Buffer_2, Interfaces.Integer_16);
+      begin
+         This.Read (TEMP_OUT_L or 2#1000_0000#,
+                    Buf (0 .. 1),
+                    Status);
+         if not Status then
+            return;
+         end if;
+         Temp := 42.5 + Float (Convert (Buf (0 .. 1))) / 480.0;
+      end;
+
+      --  See Wikipedia, "Barometric formula": The pressure drops
+      --  approximately by 11.3 pascals per meter in first 1000 meters
+      --  above sea level.
+
+      --  See Wikipedia, "Atmospheric pressure": the standard atmosphere is
+      --  1013.25 mbar.
+
+      --  1 Pascal = 0.01 mbar
+      Asl := (1013.25 - Press) * (100.0 / 11.3);
+   end Get_Data;
+
+   ----------------
+   -- Initialize --
+   ----------------
+
+   overriding
+   procedure Initialize (This : in out LPS25H_Barometric_Sensor_I2C)
+   is
+      Data : UInt8;
+      Status : Boolean;
+   begin
+      This.Timing.Delay_Milliseconds (5); -- ?
+      This.I2C_Address := 2 * (16#5C# + (if This.Slave_Address_Odd
+                                         then 1
+                                         else 0));
+      This.Read (WHO_AM_I, Data, Status);
+      if not Status then
+         return;
+      end if;
+      if Data /= WAI_ID then
+         return;
+      end if;
+      declare
+         procedure Write_Ctrl_Reg1 is new Write_Register
+           (CTRL_REG1, Ctrl_Reg1_Register);
+      begin
+         Write_Ctrl_Reg1 (This,
+                          (PD => 1, ODR => Hz_25, BDU => 1, others => <>),
+                          Status);
+         if not Status then
+            return;
+         end if;
+      end;
+      This.Initialized := True;
+   end Initialize;
+
+   --  Utilities  --
+
+   --------------------
+   -- Write_Register --
+   --------------------
+
+   procedure Write_Register (This   :     LPS25H_Barometric_Sensor_I2C;
+                             Value  :     Register_Type;
+                             Status : out Boolean) is
+      pragma Assert (Register_Type'Size = 8);
+      function Convert is new Ada.Unchecked_Conversion
+        (Register_Type, HAL.UInt8);
+   begin
+      Write (This,
+             Index => Register,
+             Data => Convert (Value),
+             Status => Status);
+   end Write_Register;
+
+   -----------
+   -- Write --
+   -----------
+
+   procedure Write
+     (This   : LPS25H_Barometric_Sensor_I2C;
+      Index  : HAL.UInt8;
+      Data   : HAL.UInt8;
+      Status : out Boolean)
+   is
+      Outcome : HAL.I2C.I2C_Status;
+      use all type HAL.I2C.I2C_Status;
+      Buf : constant HAL.UInt8_Array := (1 => Index) & Data;
+   begin
+      This.Port.Mem_Write (Addr          => This.I2C_Address,
+                           Mem_Addr      => HAL.UInt16 (Index),
+                           Mem_Addr_Size => HAL.I2C.Memory_Size_8b,
+                           Data          => Buf,
+                           Status        => Outcome);
+      Status := Outcome = Ok;
+   end Write;
+
+   ----------
+   -- Read --
+   ----------
+
+   procedure Read
+     (This   : LPS25H_Barometric_Sensor_I2C;
+      Index  : HAL.UInt8;
+      Data   : out HAL.UInt8_Array;
+      Status : out Boolean)
+   is
+      Outcome : HAL.I2C.I2C_Status;
+      use all type HAL.I2C.I2C_Status;
+   begin
+      This.Port.Mem_Read (Addr          => This.I2C_Address,
+                          Mem_Addr      => UInt16 (Index),
+                          Mem_Addr_Size => HAL.I2C.Memory_Size_8b,
+                          Data          => Data,
+                          Status        => Outcome);
+      Status := Outcome = Ok;
+   end Read;
+
+   ----------
+   -- Read --
+   ----------
+
+   procedure Read
+     (This   : LPS25H_Barometric_Sensor_I2C;
+      Index  : HAL.UInt8;
+      Data   : out HAL.UInt8;
+      Status : out Boolean)
+   is
+      Outcome : HAL.I2C.I2C_Status;
+      use all type HAL.I2C.I2C_Status;
+      Buf : UInt8_Array (1 .. 1);
+   begin
+      This.Port.Mem_Read (Addr          => This.I2C_Address,
+                          Mem_Addr      => UInt16 (Index),
+                          Mem_Addr_Size => HAL.I2C.Memory_Size_8b,
+                          Data          => Buf,
+                          Status        => Outcome);
+      Status := Outcome = Ok;
+      if Status then
+         Data := Buf (1);
+      end if;
+   end Read;
+
+end LPS25H.I2C;

--- a/components/src/environment/lps25h-i2c.ads
+++ b/components/src/environment/lps25h-i2c.ads
@@ -1,0 +1,71 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                    Copyright (C) 2021, AdaCore                           --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  See LPS25H Datasheet DocID023722 Rev 6
+
+with HAL.I2C;
+with HAL.Time;
+
+package LPS25H.I2C is
+
+   type LPS25H_Barometric_Sensor_I2C
+     (Port              : not null HAL.I2C.Any_I2C_Port;
+      Slave_Address_Odd : Boolean;
+      Timing            : not null HAL.Time.Any_Delays)
+     is new LPS25H_Barometric_Sensor with private;
+   --  See Datasheet section 5.2.1 for slave address adjustment. The
+   --  address is given as 2#101_1101# if Slave_Address_Odd is true
+   --  (SDO is high), 2#101_1100# if false. Using the Ada Drivers
+   --  Library convention, where the 7 bits of the address used on the
+   --  wire are in bits 1 .. 7, this is 16#BA#, 16#B8# respectively.
+
+   overriding
+   procedure Initialize (This : in out LPS25H_Barometric_Sensor_I2C);
+
+   overriding
+   procedure Get_Data
+     (This   : in out LPS25H_Barometric_Sensor_I2C;
+      Press  :    out Pressure;
+      Temp   :    out Temperature;
+      Asl    :    out Altitude;
+      Status :    out Boolean);
+
+private
+
+   type LPS25H_Barometric_Sensor_I2C
+     (Port              : not null HAL.I2C.Any_I2C_Port;
+      Slave_Address_Odd : Boolean;
+      Timing            : not null HAL.Time.Any_Delays)
+      is new LPS25H_Barometric_Sensor with record
+         I2C_Address : HAL.I2C.I2C_Address;
+      end record;
+
+end LPS25H.I2C;

--- a/components/src/environment/lps25h-spi.adb
+++ b/components/src/environment/lps25h-spi.adb
@@ -1,0 +1,255 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                    Copyright (C) 2021, AdaCore                           --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Unchecked_Conversion;
+with Interfaces;
+
+package body LPS25H.SPI is
+
+   use HAL;
+
+   --  SPI direction and multiplicity masks: 'or' these into the
+   --  register to control the characteristics of the required
+   --  transfer with the LPS25H.
+   Read_Request       : constant := 2#1000_0000#;
+   Transfer_Multiples : constant := 2#0100_0000#;
+
+   --  Utility specs  --
+
+   generic
+      Register : HAL.UInt8;
+      type Register_Type is private;
+   procedure Write_Register (This   :     LPS25H_Barometric_Sensor_SPI;
+                             Value  :     Register_Type;
+                             Status : out Boolean);
+
+   procedure Write
+     (This   : LPS25H_Barometric_Sensor_SPI;
+      Index  : HAL.UInt8;
+      Data   : HAL.UInt8;
+      Status : out Boolean);
+
+   procedure Read
+     (This   : LPS25H_Barometric_Sensor_SPI;
+      Index  : HAL.UInt8;
+      Data   : out HAL.UInt8_Array;
+      Status : out Boolean);
+   procedure Read
+     (This   : LPS25H_Barometric_Sensor_SPI;
+      Index  : HAL.UInt8;
+      Data   : out HAL.UInt8;
+      Status : out Boolean);
+
+   --------------
+   -- Get_Data --
+   --------------
+
+   overriding
+   procedure Get_Data
+     (This   : in out LPS25H_Barometric_Sensor_SPI;
+      Press  :    out Pressure;
+      Temp   :    out Temperature;
+      Asl    :    out Altitude;
+      Status :    out Boolean)
+   is
+      Buf : HAL.UInt8_Array (0 .. 2) := (others => 0);
+   begin
+      --  Pressure
+      declare
+         type Integer_24 is range -(2 ** 23) .. 2 ** 23 - 1
+         with Size => 24;
+         subtype Buffer_3 is HAL.UInt8_Array (Buf'Range);
+         function Convert is new Ada.Unchecked_Conversion
+           (Buffer_3, Integer_24);
+      begin
+         --  bit 6 => read multiple bytes
+         This.Read (PRESS_OUT_XL or Transfer_Multiples,
+                    Buf,
+                    Status);
+         if not Status then
+            return;
+         end if;
+         Press := Float (Convert (Buf)) / 4096.0;
+      end;
+
+      --  Temperature
+      declare
+         subtype Buffer_2 is HAL.UInt8_Array (0 .. 1);
+         function Convert is new Ada.Unchecked_Conversion
+           (Buffer_2, Interfaces.Integer_16);
+      begin
+         --  bit 6 => read multiple bytes
+         This.Read (TEMP_OUT_L or Transfer_Multiples,
+                    Buf (0 .. 1),
+                    Status);
+         if not Status then
+            return;
+         end if;
+         Temp := 42.5 + Float (Convert (Buf (0 .. 1))) / 480.0;
+      end;
+
+      --  See Wikipedia, "Barometric formula": The pressure drops
+      --  approximately by 11.3 pascals per meter in first 1000 meters
+      --  above sea level.
+
+      --  See Wikipedia, "Atmospheric pressure": the standard atmosphere is
+      --  1013.25 mbar.
+
+      --  1 Pascal = 0.01 mbar
+      Asl := (1013.25 - Press) * (100.0 / 11.3);
+   end Get_Data;
+
+   ----------------
+   -- Initialize --
+   ----------------
+
+   overriding
+   procedure Initialize (This : in out LPS25H_Barometric_Sensor_SPI)
+   is
+      Data : UInt8;
+      Status : Boolean;
+   begin
+      This.Timing.Delay_Milliseconds (5); -- ?
+      This.Read (WHO_AM_I, Data, Status);
+      if not Status then
+         return;
+      end if;
+      if Data /= WAI_ID then
+         return;
+      end if;
+      declare
+         procedure Write_Ctrl_Reg1 is new Write_Register
+           (CTRL_REG1, Ctrl_Reg1_Register);
+      begin
+         Write_Ctrl_Reg1 (This,
+                          (PD => 1, ODR => Hz_25, BDU => 1, others => <>),
+                          Status);
+         if not Status then
+            return;
+         end if;
+      end;
+      This.Initialized := True;
+   end Initialize;
+
+   --  Utilities  --
+
+   --------------------
+   -- Write_Register --
+   --------------------
+
+   procedure Write_Register (This   :     LPS25H_Barometric_Sensor_SPI;
+                             Value  :     Register_Type;
+                             Status : out Boolean) is
+      pragma Assert (Register_Type'Size = 8);
+      function Convert is new Ada.Unchecked_Conversion
+        (Register_Type, HAL.UInt8);
+   begin
+      Write (This,
+             Index  => Register,
+             Data   => Convert (Value),
+             Status => Status);
+   end Write_Register;
+
+   -----------
+   -- Write --
+   -----------
+
+   procedure Write
+     (This   : LPS25H_Barometric_Sensor_SPI;
+      Index  : HAL.UInt8;
+      Data   : HAL.UInt8;
+      Status : out Boolean)
+   is
+      Outcome : HAL.SPI.SPI_Status;
+      use all type HAL.SPI.SPI_Status;
+      Buf : constant HAL.SPI.SPI_Data_8b := (Index, Data);
+   begin
+      This.CS.Clear;
+      This.Port.Transmit (Data   => Buf,
+                          Status => Outcome);
+      Status := Outcome = Ok;
+      This.CS.Set;
+   end Write;
+
+   ----------
+   -- Read --
+   ----------
+
+   procedure Read
+     (This   : LPS25H_Barometric_Sensor_SPI;
+      Index  : HAL.UInt8;
+      Data   : out HAL.UInt8_Array;
+      Status : out Boolean)
+   is
+      Outcome : HAL.SPI.SPI_Status;
+      Buf : HAL.SPI.SPI_Data_8b (Data'Range);
+      use all type HAL.SPI.SPI_Status;
+   begin
+      This.CS.Clear;
+      --  bit 7 => read
+      This.Port.Transmit
+        (Data   => HAL.SPI.SPI_Data_8b'((1 => Index or Read_Request)),
+         Status => Outcome);
+      Status := Outcome = Ok;
+      if Status then
+         This.Port.Receive (Data   => Buf,
+                            Status => Outcome);
+         Status := Outcome = Ok;
+         if Status then
+            for J in Buf'Range loop
+               Data (J) := Buf (J);
+            end loop;
+         end if;
+      end if;
+      This.CS.Set;
+   end Read;
+
+   ----------
+   -- Read --
+   ----------
+
+   procedure Read
+     (This   : LPS25H_Barometric_Sensor_SPI;
+      Index  : HAL.UInt8;
+      Data   : out HAL.UInt8;
+      Status : out Boolean)
+   is
+      Buf : UInt8_Array (1 .. 1);
+   begin
+      This.Read (Index  => Index,
+                 Data   => Buf,
+                 Status => Status);
+      if Status then
+         Data := Buf (1);
+      end if;
+   end Read;
+
+end LPS25H.SPI;

--- a/components/src/environment/lps25h-spi.ads
+++ b/components/src/environment/lps25h-spi.ads
@@ -1,0 +1,65 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                    Copyright (C) 2021, AdaCore                           --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  See LPS25H Datasheet DocID023722 Rev 6
+
+with HAL.GPIO;
+with HAL.SPI;
+with HAL.Time;
+
+package LPS25H.SPI is
+
+   type LPS25H_Barometric_Sensor_SPI
+     (Port   : not null HAL.SPI.Any_SPI_Port;
+      CS     : not null HAL.GPIO.Any_GPIO_Point;
+      Timing : not null HAL.Time.Any_Delays)
+     is new LPS25H_Barometric_Sensor with private;
+
+   overriding
+   procedure Initialize (This : in out LPS25H_Barometric_Sensor_SPI);
+
+   overriding
+   procedure Get_Data
+     (This   : in out LPS25H_Barometric_Sensor_SPI;
+      Press  :    out Pressure;
+      Temp   :    out Temperature;
+      Asl    :    out Altitude;
+      Status :    out Boolean);
+
+private
+
+   type LPS25H_Barometric_Sensor_SPI
+     (Port   : not null HAL.SPI.Any_SPI_Port;
+      CS     : not null HAL.GPIO.Any_GPIO_Point;
+      Timing : not null HAL.Time.Any_Delays)
+      is new LPS25H_Barometric_Sensor with null record;
+
+end LPS25H.SPI;

--- a/components/src/environment/lps25h.ads
+++ b/components/src/environment/lps25h.ads
@@ -1,0 +1,268 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                    Copyright (C) 2021, AdaCore                           --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+package LPS25H is
+
+   type LPS25H_Barometric_Sensor is abstract tagged limited private;
+
+   procedure Initialize (This : in out LPS25H_Barometric_Sensor) is abstract;
+
+   subtype Pressure is Float range 450.0 .. 1100.0;   --  in mBar
+   subtype Temperature is Float range -20.0 .. 80.0;  --  in degrees Celsius
+   subtype Altitude is Float range -8000.0 .. 8000.0; -- Metres above sea level
+
+   function Is_Initialized (This : LPS25H_Barometric_Sensor) return Boolean;
+
+   procedure Get_Data
+     (This   : in out LPS25H_Barometric_Sensor;
+      Press  :    out Pressure;
+      Temp   :    out Temperature;
+      Asl    :    out Altitude;
+      Status :    out Boolean) is abstract
+   with Pre'Class => Is_Initialized (This);
+
+private
+
+   type LPS25H_Barometric_Sensor is abstract tagged limited record
+      Initialized : Boolean := False;
+   end record;
+
+   function Is_Initialized (This : LPS25H_Barometric_Sensor) return Boolean
+   is (This.Initialized);
+
+   --  These register addresses are copied from the Crazyflie lps25h.h.
+
+   REF_P_XL       : constant := 16#08#;
+   REF_P_L        : constant := 16#09#;
+   REF_P_H        : constant := 16#0A#;
+
+   WHO_AM_I       : constant := 16#0F#;
+
+   RES_CONF       : constant := 16#10#;
+
+   CTRL_REG1      : constant := 16#20#;
+   CTRL_REG2      : constant := 16#21#;
+   CTRL_REG3      : constant := 16#22#;
+   CTRL_REG4      : constant := 16#23#;
+   INTERRUPT_CFG  : constant := 16#24#;
+   INT_SOURCE     : constant := 16#25#;
+   STATUS_REG     : constant := 16#27#;
+
+   PRESS_OUT_XL   : constant := 16#28#;
+   PRESS_OUT_L    : constant := 16#29#;
+   PRESS_OUT_H    : constant := 16#2A#;
+
+   TEMP_OUT_L     : constant := 16#2B#;
+   TEMP_OUT_H     : constant := 16#2C#;
+
+   FIFO_CTRL      : constant := 16#2E#;
+   FIFO_STATUS    : constant := 16#2F#;
+   THS_P_L        : constant := 16#30#;
+   THS_P_H        : constant := 16#31#;
+   RPDS_L         : constant := 16#39#;
+   RPDS_H         : constant := 16#3A#;
+
+   --  The expected response to a WHO_AM_I request
+
+   WAI_ID         : constant := 16#BD#;
+
+   type Bit is range 0 .. 1 with Size => 1;
+
+   type Zero_Bit is range 0 .. 0 with Size => 1;
+   type Zero_Bits is array (Natural range <>) of Zero_Bit
+   with Component_Size => 1;
+
+   --  Pressure and temperature internal average configuration
+   type Pressure_Resolution_Configuration is (Avg_8, Avg_32, Avg_128, Avg_512)
+   with Size => 2;
+   for Pressure_Resolution_Configuration use
+     (Avg_8 => 0, Avg_32 => 1, Avg_128 => 2, Avg_512 => 3);
+   type Temp_Resolution_Configuration is (Avg_8, Avg_16, Avg_32, Avg_64)
+   with Size => 2;
+   for Temp_Resolution_Configuration use
+     (Avg_8 => 0, Avg_16 => 1, Avg_32 => 2, Avg_64 => 3);
+   type Res_Conf_Register is record
+      AVGP     : Pressure_Resolution_Configuration := Avg_8;
+      AVGT     : Temp_Resolution_Configuration     := Avg_8;
+      Reserved : Zero_Bits (4 .. 7)                := (others => 0);
+   end record
+   with Size => 8;
+   for Res_Conf_Register use record
+      AVGP     at 0 range 0 .. 1;
+      AVGT     at 0 range 2 .. 3;
+      Reserved at 0 range 4 .. 7;
+   end record;
+
+   --  Control register 1
+   type Output_Data_Rate is (One_Shot, Hz_1, Hz_7, Hz_12p5, Hz_25)
+   with Size => 3;
+   for Output_Data_Rate use
+     (One_Shot => 0, Hz_1 => 1, Hz_7 => 2, Hz_12p5 => 3, Hz_25 => 4);
+   type Ctrl_Reg1_Register is record
+      SIM      : Bit              := 0;
+      RESET_AZ : Bit              := 0;
+      BDU      : Bit              := 0;
+      DIFF_EN  : Bit              := 0;
+      ODR      : Output_Data_Rate := One_Shot;
+      PD       : Bit              := 0;
+   end record
+   with Size => 8;
+   for Ctrl_Reg1_Register use record
+      SIM      at 0 range 0 .. 0;
+      RESET_AZ at 0 range 1 .. 1;
+      BDU      at 0 range 2 .. 2;
+      DIFF_EN  at 0 range 3 .. 3;
+      ODR      at 0 range 4 .. 6;
+      PD       at 0 range 7 .. 7;
+   end record;
+
+   --  Control register 2
+   type Ctrl_Reg2_Register is record
+      ONE_SHOT      : Bit := 0;
+      AUTO_ZERO     : Bit := 0;
+      SWRESET       : Bit := 0;
+      I2C_ENABLE    : Bit := 0; -- ?
+      FIFO_MEAN_DEC : Bit := 0;
+      WTM_EN        : Bit := 0;
+      FIFO_EN       : Bit := 0;
+      BOOT          : Bit := 0;
+   end record
+   with Size => 8;
+   for Ctrl_Reg2_Register use record
+      ONE_SHOT      at 0 range 0 .. 0;
+      AUTO_ZERO     at 0 range 1 .. 1;
+      SWRESET       at 0 range 2 .. 2;
+      I2C_ENABLE    at 0 range 3 .. 3;
+      FIFO_MEAN_DEC at 0 range 4 .. 4;
+      WTM_EN        at 0 range 5 .. 5;
+      FIFO_EN       at 0 range 6 .. 6;
+      BOOT          at 0 range 7 .. 7;
+   end record;
+
+   --  Control register 3
+   type Interrupt_Configuration is
+     (Data_Signal, Pressure_High, Pressure_Low, Pressure_Low_Or_High)
+   with Size => 2;
+   for Interrupt_Configuration use
+     (Data_Signal => 0, Pressure_High => 1,
+      Pressure_Low => 2, Pressure_Low_Or_High => 3);
+   type Ctrl_Reg3_Register is record
+      INT1     : Interrupt_Configuration := Data_Signal;
+      Reserved : Zero_Bits (2 .. 5)      := (others => 0);
+      PP_OD    : Bit                     := 0;
+      Int_H_L  : Bit                     := 0;
+   end record
+   with Size => 8;
+   for Ctrl_Reg3_Register use record
+      INT1     at 0 range 0 .. 1;
+      Reserved at 0 range 2 .. 5;
+      PP_OD    at 0 range 6 .. 6;
+      Int_H_L  at 0 range 7 .. 7;
+   end record;
+
+   --  Control register 4
+   type Ctrl_Reg4_Register is record
+      P1_DRDY    : Bit                := 0;
+      P1_OVERRUN : Bit                := 0;
+      P1_WTM     : Bit                := 0;
+      P1_EMPTY   : Bit                := 0;
+      Reserved   : Zero_Bits (4 .. 7) := (others => 0);
+   end record
+   with Size => 8;
+   for Ctrl_Reg4_Register use record
+      P1_DRDY    at 0 range 0 .. 0;
+      P1_OVERRUN at 0 range 1 .. 1;
+      P1_WTM     at 0 range 2 .. 2;
+      P1_EMPTY   at 0 range 3 .. 3;
+      Reserved   at 0 range 4 .. 7;
+   end record;
+
+   --  Bored now, leaving out Interrupt_CFG_Register, Int_Source_Register
+
+   --  Status register
+   type Status_Register is record
+      T_DA       : Bit                := 0;
+      P_DA       : Bit                := 0;
+      Reserved_1 : Zero_Bits (2 .. 3) := (others => 0);
+      T_OR       : Bit                := 0;
+      P_OR       : Bit                := 0;
+      Reserved_2 : Zero_Bits (6 .. 7) := (others => 0);
+   end record
+   with Size => 8;
+   for Status_Register use record
+      T_DA       at 0 range 0 .. 0;
+      P_DA       at 0 range 1 .. 1;
+      Reserved_1 at 0 range 2 .. 3;
+      T_OR       at 0 range 4 .. 4;
+      P_OR       at 0 range 5 .. 5;
+      Reserved_2 at 0 range 6 .. 7;
+   end record;
+
+   --  FIFO control register
+   type FIFO_Mode is (Bypass,
+                      FIFO,
+                      Stream,
+                      Stream_While_Trigger_Then_FIFO,
+                      Bypass_While_Trigger_Then_Stream,
+                      FIFO_Mean,
+                      Bypass_While_Trigger_Then_FIFO) with Size => 3;
+   for FIFO_Mode use (Bypass                           => 0,
+                      FIFO                             => 1,
+                      Stream                           => 2,
+                      Stream_While_Trigger_Then_FIFO   => 3,
+                      Bypass_While_Trigger_Then_Stream => 4,
+                      FIFO_Mean                        => 6,
+                      Bypass_While_Trigger_Then_FIFO   => 7);
+   type Watermark_Level is (Not_Used,
+                            Average_Over_2,
+                            Average_Over_4,
+                            Average_Over_8,
+                            Average_Over_16,
+                            Average_Over_32) with Size => 5;
+   for Watermark_Level use (Not_Used        => 0,
+                            Average_Over_2  => 2#00001#,
+                            Average_Over_4  => 2#00011#,
+                            Average_Over_8  => 2#00111#,
+                            Average_Over_16 => 2#01111#,
+                            Average_Over_32 => 2#11111#);
+   type FIFO_Ctrl_Register is record
+      WTM_POINT : Watermark_Level := Not_Used;
+      F_MODE    : FIFO_Mode       := Bypass;
+   end record
+   with Size => 8;
+   for FIFO_Ctrl_Register use record
+      WTM_POINT at 0 range 0 .. 4;
+      F_MODE    at 0 range 5 .. 7;
+   end record;
+
+   --  Left out FIFO Status
+
+end LPS25H;


### PR DESCRIPTION
These drivers don’t support FIFO operation; just call Get_Data to retrieve the latest value.

The altitude above sea level value returned by Get_Data assumes a (very) simplified model.