### PR TITLE
Add pragma Preelaborate to all HAL packages.

### DIFF
--- a/hal/src/hal-audio.ads
+++ b/hal/src/hal-audio.ads
@@ -32,6 +32,7 @@
 with Interfaces; use Interfaces;
 
 package HAL.Audio is
+   pragma Preelaborate;
 
    type Audio_Buffer is array (Natural range <>) of Integer_16
      with Component_Size => 16, Alignment => 2;

--- a/hal/src/hal-bitmap.ads
+++ b/hal/src/hal-bitmap.ads
@@ -32,6 +32,7 @@
 with System;
 
 package HAL.Bitmap is
+   pragma Preelaborate;
 
    type Orientation_Mode is
      (Default,

--- a/hal/src/hal-block_drivers.ads
+++ b/hal/src/hal-block_drivers.ads
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 package HAL.Block_Drivers is
+   pragma Preelaborate;
 
    type Block_Driver is limited interface;
    type Any_Block_Driver is access all Block_Driver'Class;

--- a/hal/src/hal-dsi.ads
+++ b/hal/src/hal-dsi.ads
@@ -32,6 +32,7 @@
 --  Display Serial Interface
 
 package HAL.DSI is
+   pragma Preelaborate;
 
    subtype DSI_Virtual_Channel_ID is UInt2;
 

--- a/hal/src/hal-filesystem.ads
+++ b/hal/src/hal-filesystem.ads
@@ -32,6 +32,8 @@
 with System;
 
 package HAL.Filesystem is
+   pragma Preelaborate;
+
    type Status_Code is
      (OK,
       Non_Empty_Directory,

--- a/hal/src/hal-framebuffer.ads
+++ b/hal/src/hal-framebuffer.ads
@@ -32,6 +32,7 @@
 with HAL.Bitmap;
 
 package HAL.Framebuffer is
+   pragma Preelaborate;
 
    subtype FB_Color_Mode is HAL.Bitmap.Bitmap_Color_Mode range
      HAL.Bitmap.ARGB_8888 .. HAL.Bitmap.M_1;

--- a/hal/src/hal-gpio.ads
+++ b/hal/src/hal-gpio.ads
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 package HAL.GPIO is
+   pragma Preelaborate;
 
    type Capability is (Unknown_Mode, Input, Output,   -- Mode
                        Floating, Pull_Up, Pull_Down); -- Resistor

--- a/hal/src/hal-i2c.ads
+++ b/hal/src/hal-i2c.ads
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 package HAL.I2C is
+   pragma Preelaborate;
 
    type I2C_Status is
      (Ok,

--- a/hal/src/hal-real_time_clock.ads
+++ b/hal/src/hal-real_time_clock.ads
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 package HAL.Real_Time_Clock is
+   pragma Preelaborate;
 
    type RTC_Hour is mod 24;
    type RTC_Minute is mod 60;

--- a/hal/src/hal-sdmmc.ads
+++ b/hal/src/hal-sdmmc.ads
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 package HAL.SDMMC is
+   pragma Preelaborate;
 
    type SD_Error is
      (OK,

--- a/hal/src/hal-spi.ads
+++ b/hal/src/hal-spi.ads
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 package HAL.SPI is
+   pragma Preelaborate;
 
    type SPI_Status is
      (Ok,

--- a/hal/src/hal-time.ads
+++ b/hal/src/hal-time.ads
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 package HAL.Time is
+   pragma Preelaborate;
 
    type Delays is limited interface;
 

--- a/hal/src/hal-touch_panel.ads
+++ b/hal/src/hal-touch_panel.ads
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 package HAL.Touch_Panel is
+   pragma Preelaborate;
 
    type TP_Touch_State is record
       X      : Natural;

--- a/hal/src/hal-uart.ads
+++ b/hal/src/hal-uart.ads
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 package HAL.UART is
+   pragma Preelaborate;
 
    type UART_Status is
      (Ok,


### PR DESCRIPTION
Fixes #399. I used the pragma rather than an aspect just because the top level HAL package uses a pragma. Let me know if you'd prefer `with Preelaborate`.