### PR TITLE
Changes has been made to the i2c inicialization

### DIFF
--- a/boards/MicroBit/src/microbit-i2c.adb
+++ b/boards/MicroBit/src/microbit-i2c.adb
@@ -31,6 +31,7 @@
 
 with nRF.Device;
 with nRF.TWI;
+with nRF.GPIO; use nRF.GPIO;
 
 package body MicroBit.I2C is
 
@@ -52,14 +53,11 @@ package body MicroBit.I2C is
    ----------------
 
    procedure Initialize (S : Speed := S400kbps) is
-      Config   : GPIO_Configuration := (Mode => Mode_In,
-                                        Resistors => Pull_Up,
-                                        Input_Buffer => Input_Buffer_Connect,
-                                        Drive => Drive_S0D1,
-                                        Sense => Sense_Disabled);
-
-      GPIO_Pin_SCL : GPIO_Point := (Pin => MB_SCL.Pin);
-      GPIO_Pin_SDA : GPIO_Point := (Pin => MB_SDA.Pin);
+       Config   : constant GPIO_Configuration := (Mode => Mode_In,
+                                                  Resistors => Pull_Up,
+                                                  Input_Buffer => Input_Buffer_Connect,
+                                                  Drive => Drive_S0D1,
+                                                  Sense => Sense_Disabled);
    begin
       Device.Configure
         (SCL   => MB_SCL.Pin,
@@ -70,9 +68,9 @@ package body MicroBit.I2C is
                       when S400kbps => nRF.TWI.TWI_400kbps)
         );
 
-      --Inicialize the GPIO Pins for SCL & SDA
-      Configure_IO(GPIO_Pin_SCL, Config);
-      Configure_IO(GPIO_Pin_SDA, Config);
+      --  Initialize the GPIO Pins for SCL & SDA
+      Configure_IO(MB_SCL, Config);
+      Configure_IO(MB_SDA, Config);
 
       Device.Enable;
       Init_Done := True;

--- a/boards/MicroBit/src/microbit-i2c.adb
+++ b/boards/MicroBit/src/microbit-i2c.adb
@@ -53,11 +53,11 @@ package body MicroBit.I2C is
    ----------------
 
    procedure Initialize (S : Speed := S400kbps) is
-       Config   : constant GPIO_Configuration := (Mode => Mode_In,
-                                                  Resistors => Pull_Up,
-                                                  Input_Buffer => Input_Buffer_Connect,
-                                                  Drive => Drive_S0D1,
-                                                  Sense => Sense_Disabled);
+      Config   : constant GPIO_Configuration := (Mode => Mode_In,
+                                                 Resistors => Pull_Up,
+                                                 Input_Buffer => Input_Buffer_Connect,
+                                                 Drive => Drive_S0D1,
+                                                 Sense => Sense_Disabled);
    begin
       Device.Configure
         (SCL   => MB_SCL.Pin,
@@ -69,8 +69,8 @@ package body MicroBit.I2C is
         );
 
       --  Initialize the GPIO Pins for SCL & SDA
-      Configure_IO(MB_SCL, Config);
-      Configure_IO(MB_SDA, Config);
+      Configure_IO (MB_SCL, Config);
+      Configure_IO (MB_SDA, Config);
 
       Device.Enable;
       Init_Done := True;

--- a/boards/MicroBit/src/microbit-i2c.adb
+++ b/boards/MicroBit/src/microbit-i2c.adb
@@ -52,6 +52,14 @@ package body MicroBit.I2C is
    ----------------
 
    procedure Initialize (S : Speed := S400kbps) is
+      Config   : GPIO_Configuration := (Mode => Mode_In,
+                                        Resistors => Pull_Up,
+                                        Input_Buffer => Input_Buffer_Connect,
+                                        Drive => Drive_S0D1,
+                                        Sense => Sense_Disabled);
+
+      GPIO_Pin_SCL : GPIO_Point := (Pin => MB_SCL.Pin);
+      GPIO_Pin_SDA : GPIO_Point := (Pin => MB_SDA.Pin);
    begin
       Device.Configure
         (SCL   => MB_SCL.Pin,
@@ -61,6 +69,10 @@ package body MicroBit.I2C is
                       when S250kbps => nRF.TWI.TWI_250kbps,
                       when S400kbps => nRF.TWI.TWI_400kbps)
         );
+
+      --Inicialize the GPIO Pins for SCL & SDA
+      Configure_IO(GPIO_Pin_SCL, Config);
+      Configure_IO(GPIO_Pin_SDA, Config);
 
       Device.Enable;
       Init_Done := True;


### PR DESCRIPTION
Hello,

I'm Mario Vicente García and i'm doing a project with the University of Cantabria, Spain. 

Carrying out tests to try to send data through the I2C bus to control the motors of the maqueen robot (https://tienda.bricogeek.com/microbit/1271-robot-maqueen-para-microbit.html) using your library and the Microbit V1.3x, we realized that the initialization of the GPIO pins (SCA and SCL) is done incorrectly.

Trying to do a succesful master_transmit to the maqueen address (0x20), the function returned us a 0 (ERROR). Doing an I2C bus probe to see all available addresses on the bus, we realized that only the accelerometer address was available (0x1D), but the compass and maqueen motors addresses were not available.

According to the next manual, the relevant configuration for the pins is the GPIO DRIVE:

https://infocenter.nordicsemi.com/pdf/nRF51_RM_v3.0.pdf   (p.145, table 258)

So, applying the configuration on the SCL and SDA pins and doing again the probe of the I2C bus. We managed to see all the bus addresses correctly and successfully perform a master_transmit to the Maqueen motors.

Regards,
Mario


