### PR TITLE
Significantly simplify Serial_IO.Nonblocking and revise associated files

### DIFF
--- a/examples/shared/serial_ports/src/demo_serial_port_blocking.adb
+++ b/examples/shared/serial_ports/src/demo_serial_port_blocking.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2016, AdaCore                      --
+--                    Copyright (C) 2015-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -53,20 +53,19 @@ procedure Demo_Serial_Port_Blocking is
    procedure Send (This : String) is
    begin
       Set (Outgoing, To => This);
-      Blocking.Put (COM, Outgoing'Unchecked_Access);
-      --  No need to wait for it here because the Put won't return until the
-      --  message has been sent
+      Send (COM, Outgoing'Access);
+      --  Send won't return until the entire message has been sent
    end Send;
 
 begin
-   Initialize (COM);
+   Initialize_Hardware (COM);
    Configure (COM, Baud_Rate => 115_200);
 
    Send ("Enter text, terminated by CR.");
 
-   Set_Terminator (Incoming, To => ASCII.CR);
+   Incoming.Set_Terminator (To => ASCII.CR);
    loop
-      Get (COM, Incoming'Unchecked_Access);
-      Send ("Received : " & Content (Incoming));
+      Receive (COM, Incoming'Access);
+      Send ("Received : " & Incoming.Content);
    end loop;
 end Demo_Serial_Port_Blocking;

--- a/examples/shared/serial_ports/src/demo_serial_port_nonblocking.adb
+++ b/examples/shared/serial_ports/src/demo_serial_port_nonblocking.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2016, AdaCore                      --
+--                    Copyright (C) 2015-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -29,8 +29,9 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
---  A demonstration of a higher-level USART interface, using non-blocking I/O.
---  The file declares the main procedure for the demonstration.
+--  A demonstration of a higher-level USART interface, using interrupts to
+--  achieve non-blocking I/O (calls to Send and Receive return potentially
+--  prior to I/O completion).  This file declares the main procedure.
 
 with Last_Chance_Handler;  pragma Unreferenced (Last_Chance_Handler);
 --  The "last chance handler" is the user-defined routine that is called when
@@ -51,25 +52,20 @@ procedure Demo_Serial_Port_Nonblocking is
       Outgoing : aliased Message (Physical_Size => 1024);  -- arbitrary size
    begin
       Set (Outgoing, To => This);
-      Put (COM, Outgoing'Unchecked_Access);
+      Send (COM, Outgoing'Access);
       Await_Transmission_Complete (Outgoing);
-      --  We must await xmit completion because Put does not wait
    end Send;
 
 begin
-   Initialize (COM);
-
+   Initialize_Hardware (COM);
    Configure (COM, Baud_Rate => 115_200);
 
+   Incoming.Set_Terminator (To => ASCII.CR);
    Send ("Enter text, terminated by CR.");
-
-   Set_Terminator (Incoming, To => ASCII.CR);
    loop
-      Get (COM, Incoming'Unchecked_Access);
+      Receive (COM, Incoming'Access);
       Await_Reception_Complete (Incoming);
-      --  We must await reception completion because Get does not wait
-
-      Send ("Received : " & Content (Incoming));
+      Send ("Received : " & Incoming.Content);
    end loop;
 end Demo_Serial_Port_Nonblocking;
 

--- a/examples/shared/serial_ports/src/demo_serial_port_streaming.adb
+++ b/examples/shared/serial_ports/src/demo_serial_port_streaming.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2016, AdaCore                          --
+--                    Copyright (C) 2016-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -59,10 +59,12 @@
 
 --  with GNAT.IO;                    use GNAT.IO;
 --  with GNAT.Serial_Communications; use GNAT.Serial_Communications;
+--  with Ada.Command_Line;           use Ada.Command_Line;
 --
---  procedure Host is
---     COM  : aliased Serial_Port;
---     COM3 : constant Port_Name := Name (3);
+--  procedure Streaming_Host is
+--     COM     : aliased Serial_Port;
+--     COM_Num : constant Port_Name := Name (Integer'Value (Argument (1)));
+--     --  hence one argument, correspopnding to a COM port number on Windows
 --
 --     Outgoing : String (1 .. 1024); -- arbitrary
 --     Last     : Natural;
@@ -110,14 +112,16 @@ with Serial_IO.Streaming;   use Serial_IO.Streaming;
 
 procedure Demo_Serial_Port_Streaming is
 begin
-   Initialize (COM);
+   Initialize_Hardware (COM);
    Configure (COM, Baud_Rate => 115_200);
 
    loop
       declare
+         --  get the incoming msg from the serial port
          Incoming : constant String := String'Input (COM'Access);
       begin
-         String'Output (COM'Access, "'" & Incoming & "'");
+         --  echo the received msg content
+         String'Output (COM'Access, "Received '" & Incoming & "'");
       end;
    end loop;
 end Demo_Serial_Port_Streaming;

--- a/examples/shared/serial_ports/src/peripherals_nonblocking.ads
+++ b/examples/shared/serial_ports/src/peripherals_nonblocking.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2016, AdaCore                      --
+--                    Copyright (C) 2015-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -31,6 +31,7 @@
 
 with Ada.Interrupts;        use Ada.Interrupts;
 with Ada.Interrupts.Names;  use Ada.Interrupts.Names;
+with System;                use System;
 
 with STM32.Device;          use STM32.Device;
 
@@ -40,14 +41,16 @@ use Serial_IO;
 
 package Peripherals_Nonblocking is
 
+   --  the USART selection is arbitrary but the AF number and the pins must
+   --  be those required by that USART
    Peripheral : aliased Serial_IO.Peripheral_Descriptor :=
                   (Transceiver    => USART_1'Access,
                    Transceiver_AF => GPIO_AF_USART1_7,
                    Tx_Pin         => PB6,
                    Rx_Pin         => PB7);
 
-   Transceiver_Interrupt : constant Interrupt_ID := USART1_Interrupt;
-
-   COM : Nonblocking.Serial_Port (Transceiver_Interrupt, Peripheral'Access);
+   COM : Nonblocking.Serial_Port (Device       => Peripheral'Access,
+                                  IRQ          => USART1_Interrupt,
+                                  IRQ_Priority => Interrupt_Priority'Last);
 
 end Peripherals_Nonblocking;

--- a/examples/shared/serial_ports/src/serial_io-nonblocking.adb
+++ b/examples/shared/serial_ports/src/serial_io-nonblocking.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2016, AdaCore                      --
+--                    Copyright (C) 2015-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -33,22 +33,14 @@ with STM32.Device; use STM32.Device;
 
 package body Serial_IO.Nonblocking is
 
-   ----------------
-   -- Initialize --
-   ----------------
+   -------------------------
+   -- Initialize_Hardware --
+   -------------------------
 
-   procedure Initialize (This : in out Serial_Port) is
+   procedure Initialize_Hardware (This : in out Serial_Port) is
    begin
-      Serial_IO.Initialize_Peripheral (This.Device);
-      This.Initialized := True;
-   end Initialize;
-
-   -----------------
-   -- Initialized --
-   -----------------
-
-   function Initialized (This : Serial_Port) return Boolean is
-     (This.Initialized);
+      Serial_IO.Initialize_Hardware (This.Device);
+   end Initialize_Hardware;
 
    ---------------
    -- Configure --
@@ -66,98 +58,47 @@ package body Serial_IO.Nonblocking is
       Serial_IO.Configure (This.Device, Baud_Rate, Parity, Data_Bits, End_Bits, Control);
    end Configure;
 
-   ---------
-   -- Put --
-   ---------
+   ---------------------
+   -- Acquire --
+   ---------------------
 
-   procedure Put (This : in out Serial_Port;  Msg : not null access Message) is
+   procedure Acquire (This : in out Serial_Port) is
    begin
-      This.Control.Start_Sending (Msg);
-   end Put;
+      This.Acquire;
+   end Acquire;
 
-   ---------
-   -- Get --
-   ---------
+   --------------------
+   -- Release --
+   --------------------
 
-   procedure Get (This : in out Serial_Port;  Msg : not null access Message) is
+   procedure Release (This : in out Serial_Port) is
    begin
-      This.Control.Start_Receiving (Msg);
-   end Get;
+      This.Release;
+   end Release;
+
+   ----------
+   -- Send --
+   ----------
+
+   procedure Send (This : in out Serial_Port;  Msg : not null access Message) is
+   begin
+      This.Start_Sending (Msg);
+   end Send;
 
    -------------
-   -- Sending --
+   -- Receive --
    -------------
 
-   function Sending (This : in out Serial_Port) return Boolean is
+   procedure Receive (This : in out Serial_Port;  Msg : not null access Message) is
    begin
-      return This.Control.Sending;
-   end Sending;
+      This.Start_Receiving (Msg);
+   end Receive;
 
-   ---------------
-   -- Receiving --
-   ---------------
+   -----------------
+   -- Serial_Port --
+   -----------------
 
-   function Receiving (This : in out Serial_Port) return Boolean is
-   begin
-      return This.Control.Receiving;
-   end Receiving;
-
-   ----------------
-   -- Controller --
-   ----------------
-
-   protected body Controller is
-
-      -------------------
-      -- Detect_Errors --
-      -------------------
-
-      procedure Detect_Errors (Is_Xmit_IRQ : Boolean) is
-      begin
-         if Status (Port.Device.Transceiver.all, Parity_Error_Indicated) and
-           Interrupt_Enabled (Port.Device.Transceiver.all, Parity_Error)
-         then
-            Clear_Status (Port.Device.Transceiver.all, Parity_Error_Indicated);
-            if Is_Xmit_IRQ then
-               Outgoing_Msg.Note_Error (Parity_Error_Detected);
-            else
-               Incoming_Msg.Note_Error (Parity_Error_Detected);
-            end if;
-         end if;
-
-         if Status (Port.Device.Transceiver.all, Framing_Error_Indicated) and
-           Interrupt_Enabled (Port.Device.Transceiver.all, Error)
-         then
-            Clear_Status (Port.Device.Transceiver.all, Framing_Error_Indicated);
-            if Is_Xmit_IRQ then
-               Outgoing_Msg.Note_Error (Frame_Error_Detected);
-            else
-               Incoming_Msg.Note_Error (Frame_Error_Detected);
-            end if;
-         end if;
-
-         if Status (Port.Device.Transceiver.all, USART_Noise_Error_Indicated) and
-           Interrupt_Enabled (Port.Device.Transceiver.all, Error)
-         then
-            Clear_Status (Port.Device.Transceiver.all, USART_Noise_Error_Indicated);
-            if Is_Xmit_IRQ then
-               Outgoing_Msg.Note_Error (Noise_Error_Detected);
-            else
-               Incoming_Msg.Note_Error (Noise_Error_Detected);
-            end if;
-         end if;
-
-         if Status (Port.Device.Transceiver.all, Overrun_Error_Indicated) and
-           Interrupt_Enabled (Port.Device.Transceiver.all, Error)
-         then
-            Clear_Status (Port.Device.Transceiver.all, Overrun_Error_Indicated);
-            if Is_Xmit_IRQ then
-               Outgoing_Msg.Note_Error (Overrun_Error_Detected);
-            else
-               Incoming_Msg.Note_Error (Overrun_Error_Detected);
-            end if;
-         end if;
-      end Detect_Errors;
+   protected body Serial_Port is
 
       -------------------------
       -- Handle_Transmission --
@@ -169,13 +110,12 @@ package body Serial_IO.Nonblocking is
          --    -- handle the extra byte required for the 9th bit
          --  else  -- 8 data bits so no extra byte involved
          Transmit
-           (Port.Device.Transceiver.all,
+           (Device.Transceiver.all,
             Character'Pos (Outgoing_Msg.Content_At (Next_Out)));
          Next_Out := Next_Out + 1;
          --  end if;
-         Awaiting_Transfer := Awaiting_Transfer - 1;
-         if Awaiting_Transfer = 0 then
-            Disable_Interrupts (Port.Device.Transceiver.all, Source => Transmission_Complete);
+         if Next_Out > Outgoing_Msg.Length then
+            Disable_Interrupts (Device.Transceiver.all, Source => Transmission_Complete);
             Outgoing_Msg.Signal_Transmission_Complete;
             Outgoing_Msg := null;
          end if;
@@ -186,7 +126,7 @@ package body Serial_IO.Nonblocking is
       ----------------------
 
       procedure Handle_Reception is
-         Received_Char : constant Character := Character'Val (Current_Input (Port.Device.Transceiver.all));
+         Received_Char : constant Character := Character'Val (Current_Input (Device.Transceiver.all));
       begin
          if Received_Char /= Terminator (Incoming_Msg.all) then
             Incoming_Msg.Append (Received_Char);
@@ -194,41 +134,41 @@ package body Serial_IO.Nonblocking is
 
          if Received_Char = Incoming_Msg.Terminator or
             Incoming_Msg.Length = Incoming_Msg.Physical_Size
-         then
-            --  reception complete
+         then -- reception complete
             loop
-               exit when not Status (Port.Device.Transceiver.all, Read_Data_Register_Not_Empty);
+               --  wait for device to clear the status
+               exit when not Status (Device.Transceiver.all, Read_Data_Register_Not_Empty);
             end loop;
-            Disable_Interrupts (Port.Device.Transceiver.all, Source => Received_Data_Not_Empty);
+            Disable_Interrupts (Device.Transceiver.all, Source => Received_Data_Not_Empty);
             Incoming_Msg.Signal_Reception_Complete;
             Incoming_Msg := null;
          end if;
       end Handle_Reception;
 
-      -----------------
-      -- IRQ_Handler --
-      -----------------
+      ---------
+      -- ISR --
+      ---------
 
-      procedure IRQ_Handler is
+      procedure ISR is
       begin
          --  check for data arrival
-         if Status (Port.Device.Transceiver.all, Read_Data_Register_Not_Empty) and
-           Interrupt_Enabled (Port.Device.Transceiver.all, Received_Data_Not_Empty)
+         if Status (Device.Transceiver.all, Read_Data_Register_Not_Empty) and
+           Interrupt_Enabled (Device.Transceiver.all, Received_Data_Not_Empty)
          then
             Detect_Errors (Is_Xmit_IRQ => False);
             Handle_Reception;
-            Clear_Status (Port.Device.Transceiver.all, Read_Data_Register_Not_Empty);
+            Clear_Status (Device.Transceiver.all, Read_Data_Register_Not_Empty);
          end if;
 
          --  check for transmission ready
-         if Status (Port.Device.Transceiver.all, Transmission_Complete_Indicated) and
-           Interrupt_Enabled (Port.Device.Transceiver.all, Transmission_Complete)
+         if Status (Device.Transceiver.all, Transmission_Complete_Indicated) and
+           Interrupt_Enabled (Device.Transceiver.all, Transmission_Complete)
          then
             Detect_Errors (Is_Xmit_IRQ => True);
             Handle_Transmission;
-            Clear_Status (Port.Device.Transceiver.all, Transmission_Complete_Indicated);
+            Clear_Status (Device.Transceiver.all, Transmission_Complete_Indicated);
          end if;
-      end IRQ_Handler;
+      end ISR;
 
       -------------------
       -- Start_Sending --
@@ -237,12 +177,11 @@ package body Serial_IO.Nonblocking is
       procedure Start_Sending (Msg : not null access Message) is
       begin
          Outgoing_Msg := Msg;
-         Awaiting_Transfer := Msg.Length;
          Next_Out := 1;
 
-         Enable_Interrupts (Port.Device.Transceiver.all, Parity_Error);
-         Enable_Interrupts (Port.Device.Transceiver.all, Error);
-         Enable_Interrupts (Port.Device.Transceiver.all, Transmission_Complete);
+         Enable_Interrupts (Device.Transceiver.all, Parity_Error);
+         Enable_Interrupts (Device.Transceiver.all, Error);
+         Enable_Interrupts (Device.Transceiver.all, Transmission_Complete);
       end Start_Sending;
 
       ---------------------
@@ -254,29 +193,80 @@ package body Serial_IO.Nonblocking is
          Incoming_Msg := Msg;
          Incoming_Msg.Clear;
 
-         Enable_Interrupts (Port.Device.Transceiver.all, Parity_Error);
-         Enable_Interrupts (Port.Device.Transceiver.all, Error);
-         Enable_Interrupts (Port.Device.Transceiver.all, Received_Data_Not_Empty);
+         Enable_Interrupts (Device.Transceiver.all, Parity_Error);
+         Enable_Interrupts (Device.Transceiver.all, Error);
+         Enable_Interrupts (Device.Transceiver.all, Received_Data_Not_Empty);
       end Start_Receiving;
 
       -------------
-      -- Sending --
+      -- Acquire --
       -------------
 
-      function Sending return Boolean is
+      entry Acquire when Available is
       begin
-         return Outgoing_Msg /= null;
-      end Sending;
+         Available := False;
+      end Acquire;
 
-      ---------------
-      -- Receiving --
-      ---------------
+      -------------
+      -- Release --
+      -------------
 
-      function Receiving return Boolean is
+      procedure Release is
       begin
-         return Incoming_Msg /= null;
-      end Receiving;
+         Available := True;
+      end Release;
 
-   end Controller;
+      -------------------
+      -- Detect_Errors --
+      -------------------
+
+      procedure Detect_Errors (Is_Xmit_IRQ : Boolean) is
+      begin
+         if Status (Device.Transceiver.all, Parity_Error_Indicated) and
+           Interrupt_Enabled (Device.Transceiver.all, Parity_Error)
+         then
+            Clear_Status (Device.Transceiver.all, Parity_Error_Indicated);
+            if Is_Xmit_IRQ then
+               Outgoing_Msg.Note_Error (Parity_Error_Detected);
+            else
+               Incoming_Msg.Note_Error (Parity_Error_Detected);
+            end if;
+         end if;
+
+         if Status (Device.Transceiver.all, Framing_Error_Indicated) and
+           Interrupt_Enabled (Device.Transceiver.all, Error)
+         then
+            Clear_Status (Device.Transceiver.all, Framing_Error_Indicated);
+            if Is_Xmit_IRQ then
+               Outgoing_Msg.Note_Error (Frame_Error_Detected);
+            else
+               Incoming_Msg.Note_Error (Frame_Error_Detected);
+            end if;
+         end if;
+
+         if Status (Device.Transceiver.all, USART_Noise_Error_Indicated) and
+           Interrupt_Enabled (Device.Transceiver.all, Error)
+         then
+            Clear_Status (Device.Transceiver.all, USART_Noise_Error_Indicated);
+            if Is_Xmit_IRQ then
+               Outgoing_Msg.Note_Error (Noise_Error_Detected);
+            else
+               Incoming_Msg.Note_Error (Noise_Error_Detected);
+            end if;
+         end if;
+
+         if Status (Device.Transceiver.all, Overrun_Error_Indicated) and
+           Interrupt_Enabled (Device.Transceiver.all, Error)
+         then
+            Clear_Status (Device.Transceiver.all, Overrun_Error_Indicated);
+            if Is_Xmit_IRQ then
+               Outgoing_Msg.Note_Error (Overrun_Error_Detected);
+            else
+               Incoming_Msg.Note_Error (Overrun_Error_Detected);
+            end if;
+         end if;
+      end Detect_Errors;
+
+   end Serial_Port;
 
 end Serial_IO.Nonblocking;

--- a/examples/shared/serial_ports/src/serial_io-nonblocking.ads
+++ b/examples/shared/serial_ports/src/serial_io-nonblocking.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2016, AdaCore                      --
+--                    Copyright (C) 2015-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -30,8 +30,8 @@
 ------------------------------------------------------------------------------
 
 --  This package defines an abstract data type for a "serial port" providing
---  non-blocking input (Get) and output (Put) procedures. The procedures are
---  considered non-blocking because they return to the caller (potentially)
+--  non-blocking input (Receive) and output (Send) procedures. The procedures
+--  are considered non-blocking because they return to the caller (potentially)
 --  before the entire message is received or sent.
 --
 --  The serial port abstraction is a wrapper around a USART peripheral,
@@ -40,26 +40,25 @@
 --  Interrupts are used to send and receive characters.
 --
 --  NB: clients must not send or receive messages until any prior sending or
---  receiving is completed. See the two functions Sending and Receiving and
---  the preconditions on Put and Get.
+--  receiving is completed. You can use the Acquire and Release procedures to
+--  acquire and release mutually exclusive access to the port, but note that
+--  such a need implies the use of Jorvik.
 
 with Message_Buffers; use Message_Buffers;
 with Ada.Interrupts;  use Ada.Interrupts;
+with System;          use System;
 
 package Serial_IO.Nonblocking is
    pragma Elaborate_Body;
 
    type Serial_Port
-     (IRQ    : Interrupt_ID;
-      Device : not null access Peripheral_Descriptor)
-   is tagged limited private;
+     (Device       : not null access Peripheral_Descriptor;
+      IRQ          : Interrupt_ID;
+      IRQ_Priority : Interrupt_Priority)
+   is limited private;
 
-   procedure Initialize (This : in out Serial_Port) with
-     Post => Initialized (This);
-
-   function Initialized (This : Serial_Port) return Boolean with Inline;
-
-   Serial_Port_Uninitialized : exception;
+   procedure Initialize_Hardware (This : in out Serial_Port);
+   --  A convenience wrapper for Serial_IO.Initialize_Hardware
 
    procedure Configure
      (This      : in out Serial_Port;
@@ -67,70 +66,61 @@ package Serial_IO.Nonblocking is
       Parity    : Parities     := No_Parity;
       Data_Bits : Word_Lengths := Word_Length_8;
       End_Bits  : Stop_Bits    := Stopbits_1;
-      Control   : Flow_Control := No_Flow_Control)
-     with
-       Pre => (Initialized (This) or else raise Serial_Port_Uninitialized);
+      Control   : Flow_Control := No_Flow_Control);
+   --  A convenience wrapper for Serial_IO.Configure
 
-   procedure Put (This : in out Serial_Port; Msg : not null access Message) with
-     Pre => (Initialized (This) or else raise Serial_Port_Uninitialized)
-            and then
-            not Sending (This),
-     Inline;
+   procedure Send
+     (This : in out Serial_Port;
+      Msg  : not null access Message)
+   with Inline;
+   --  Start sending the content of Msg.all, returning potentially
+   --  prior to the completion of the message transmission
 
-   procedure Get (This : in out Serial_Port;  Msg : not null access Message) with
-     Pre => (Initialized (This) or else raise Serial_Port_Uninitialized)
-            and then
-            not Receiving (This),
-     Inline;
+   procedure Receive
+     (This : in out Serial_Port;
+      Msg  : not null access Message)
+   with Inline;
+   --  Start receiving Msg.all content, ending when the specified
+   --  Msg.Terminator character is received (it is not stored), or
+   --  the physical capacity of Msg.all is reached
 
-   function Sending (This : in out Serial_Port) return Boolean;
-   --  Returns whether This is currently sending a message.
+   procedure Acquire (This : in out Serial_Port);
+   --  Acquire mutually exclusive access, suspending until acquired
 
-   function Receiving (This : in out Serial_Port) return Boolean;
-   --  Returns whether This is currently receiving a message.
+   procedure Release (This : in out Serial_Port);
+   --  Release mutually exclusive access
 
 private
 
-   --  The protected type defining the interrupt handling for sending and
-   --  receiving characters via the USART attached to the serial port. Each
-   --  serial port type a component of this protected type.
-   protected type Controller (IRQ : Interrupt_ID;  Port : access Serial_Port) is
+   protected type Serial_Port
+     (Device       : not null access Peripheral_Descriptor;
+      IRQ          : Interrupt_ID;
+      IRQ_Priority : Interrupt_Priority)
+   with
+      Interrupt_Priority => IRQ_Priority
+   is
 
-      pragma Interrupt_Priority;
+      entry Acquire;
+
+      procedure Release;
 
       procedure Start_Sending (Msg : not null access Message);
-      --  error: internal call cannot appear in precondition of protected operation
-      --  with Pre => not Sending;
 
       procedure Start_Receiving (Msg : not null access Message);
-      --  error: internal call cannot appear in precondition of protected operation
-      --  with Pre => not Receiving;
-
-      function Sending   return Boolean;
-      function Receiving return Boolean;
 
    private
 
-      Next_Out          : Positive;
-      Awaiting_Transfer : Natural;
-      Outgoing_Msg      : access Message;
-      Incoming_Msg      : access Message;
+      Available    : Boolean := True;
+      Next_Out     : Positive;
+      Outgoing_Msg : access Message;
+      Incoming_Msg : access Message;
 
       procedure Handle_Transmission with Inline;
-      procedure Handle_Reception with Inline;
+      procedure Handle_Reception    with Inline;
       procedure Detect_Errors (Is_Xmit_IRQ : Boolean) with Inline;
 
-      procedure IRQ_Handler with Attach_Handler => IRQ;
+      procedure ISR with Attach_Handler => IRQ;
 
-   end Controller;
-
-
-   type Serial_Port
-     (IRQ    : Interrupt_ID;
-      Device : not null access Peripheral_Descriptor)
-   is tagged limited record
-      Initialized : Boolean := False;
-      Control     : Controller (IRQ, Serial_Port'Access);
-   end record;
+   end Serial_Port;
 
 end Serial_IO.Nonblocking;

--- a/examples/shared/serial_ports/src/serial_io.adb
+++ b/examples/shared/serial_ports/src/serial_io.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2017, AdaCore                     --
+--                     Copyright (C) 2015-2022, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -33,11 +33,11 @@ with STM32.Device; use STM32.Device;
 
 package body Serial_IO is
 
-   ----------------
-   -- Initialize --
-   ----------------
+   -------------------------
+   -- Initialize_Hardware --
+   -------------------------
 
-   procedure Initialize_Peripheral (Device : access Peripheral_Descriptor) is
+   procedure Initialize_Hardware (Device : access Peripheral_Descriptor) is
       Configuration : GPIO_Port_Configuration;
       Device_Pins   : constant GPIO_Points := Device.Rx_Pin & Device.Tx_Pin;
    begin
@@ -51,7 +51,7 @@ package body Serial_IO is
                         Resistors      => Pull_Up);
 
       Configure_IO (Device_Pins, Configuration);
-   end Initialize_Peripheral;
+   end Initialize_Hardware;
 
    ---------------
    -- Configure --

--- a/examples/shared/serial_ports/src/serial_io.ads
+++ b/examples/shared/serial_ports/src/serial_io.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2016, AdaCore                      --
+--                    Copyright (C) 2015-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -42,7 +42,8 @@ package Serial_IO is
       Rx_Pin         : GPIO_Point;
    end record;
 
-   procedure Initialize_Peripheral (Device : access Peripheral_Descriptor);
+   procedure Initialize_Hardware (Device : access Peripheral_Descriptor);
+   --  enable clocks, configure GPIO pins, etc.
 
    procedure Configure
      (Device    : access Peripheral_Descriptor;


### PR DESCRIPTION
serial_io:
Use better name for hardware init routines

serial_io.nonblocking:
Implement primary type Serial_Port directly as a protected type.
Add discriminant for IRQ priority.
Simplify transmission routine (remove a protected variable).
Add Acquire/Release routines for use with Jorvik.
Remove pre/post for initialization since not work extra complexity for type impl.

demo mains:
Revise for name changes