### PR TITLE
Significantly simplify Serial_IO.Nonblocking and revise associated files

### DIFF
--- a/examples/shared/serial_ports/src/demo_serial_port_blocking.adb
+++ b/examples/shared/serial_ports/src/demo_serial_port_blocking.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2016, AdaCore                      --
+--                    Copyright (C) 2015-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -53,20 +53,19 @@ procedure Demo_Serial_Port_Blocking is
    procedure Send (This : String) is
    begin
       Set (Outgoing, To => This);
-      Blocking.Put (COM, Outgoing'Unchecked_Access);
-      --  No need to wait for it here because the Put won't return until the
-      --  message has been sent
+      Blocking.Send (COM, Outgoing'Access);
+      --  Send won't return until the entire message has been sent
    end Send;
 
 begin
-   Initialize (COM);
+   Initialize_Hardware (COM);
    Configure (COM, Baud_Rate => 115_200);
 
    Send ("Enter text, terminated by CR.");
 
-   Set_Terminator (Incoming, To => ASCII.CR);
+   Incoming.Set_Terminator (To => ASCII.CR);
    loop
-      Get (COM, Incoming'Unchecked_Access);
-      Send ("Received : " & Content (Incoming));
+      Blocking.Receive (COM, Incoming'Access);
+      Send ("Received : " & Incoming.Content);
    end loop;
 end Demo_Serial_Port_Blocking;

--- a/examples/shared/serial_ports/src/demo_serial_port_nonblocking.adb
+++ b/examples/shared/serial_ports/src/demo_serial_port_nonblocking.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2016, AdaCore                      --
+--                    Copyright (C) 2015-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -29,8 +29,9 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
---  A demonstration of a higher-level USART interface, using non-blocking I/O.
---  The file declares the main procedure for the demonstration.
+--  A demonstration of a higher-level USART interface, using interrupts to
+--  achieve non-blocking I/O (calls to Send and Receive return potentially
+--  prior to I/O completion). The file declares the main procedure.
 
 with Last_Chance_Handler;  pragma Unreferenced (Last_Chance_Handler);
 --  The "last chance handler" is the user-defined routine that is called when
@@ -40,6 +41,8 @@ with Last_Chance_Handler;  pragma Unreferenced (Last_Chance_Handler);
 with Peripherals_Nonblocking;    use Peripherals_Nonblocking;
 with Serial_IO.Nonblocking;      use Serial_IO.Nonblocking;
 with Message_Buffers;            use Message_Buffers;
+
+use Serial_IO;
 
 procedure Demo_Serial_Port_Nonblocking is
 
@@ -51,25 +54,20 @@ procedure Demo_Serial_Port_Nonblocking is
       Outgoing : aliased Message (Physical_Size => 1024);  -- arbitrary size
    begin
       Set (Outgoing, To => This);
-      Put (COM, Outgoing'Unchecked_Access);
+      Nonblocking.Send (COM, Outgoing'Access);
       Await_Transmission_Complete (Outgoing);
-      --  We must await xmit completion because Put does not wait
    end Send;
 
 begin
-   Initialize (COM);
-
+   Initialize_Hardware (COM);
    Configure (COM, Baud_Rate => 115_200);
 
-   Send ("Enter text, terminated by CR.");
-
-   Set_Terminator (Incoming, To => ASCII.CR);
+   Incoming.Set_Terminator (To => ASCII.CR);
+   Send ("Enter text, terminated by CR.");   
    loop
-      Get (COM, Incoming'Unchecked_Access);
+      Nonblocking.Receive (COM, Incoming'Access);
       Await_Reception_Complete (Incoming);
-      --  We must await reception completion because Get does not wait
-
-      Send ("Received : " & Content (Incoming));
+      Send ("Received : " & Incoming.Content);
    end loop;
 end Demo_Serial_Port_Nonblocking;
 

--- a/examples/shared/serial_ports/src/demo_serial_port_streaming.adb
+++ b/examples/shared/serial_ports/src/demo_serial_port_streaming.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2016, AdaCore                          --
+--                    Copyright (C) 2016-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -110,14 +110,16 @@ with Serial_IO.Streaming;   use Serial_IO.Streaming;
 
 procedure Demo_Serial_Port_Streaming is
 begin
-   Initialize (COM);
+   Initialize_Hardware (COM);
    Configure (COM, Baud_Rate => 115_200);
 
    loop
       declare
+         --  get the incoming msg from the serial port
          Incoming : constant String := String'Input (COM'Access);
       begin
-         String'Output (COM'Access, "'" & Incoming & "'");
+         --  echo the received msg content
+         String'Output (COM'Access, "Received '" & Incoming & "'");
       end;
    end loop;
 end Demo_Serial_Port_Streaming;

--- a/examples/shared/serial_ports/src/peripherals_blocking.ads
+++ b/examples/shared/serial_ports/src/peripherals_blocking.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                  Copyright (C) 2015-2016, AdaCore                        --
+--                  Copyright (C) 2015-2022, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -37,7 +37,8 @@ use Serial_IO;
 
 package Peripherals_Blocking is
 
-   --  the specific port, pins, and USART selections are arbitrary.
+   --  the USART selection is arbitrary but the AF number and the pins must
+   --  be those required by that USART
    Peripheral : aliased Serial_IO.Peripheral_Descriptor :=
                   (Transceiver    => USART_1'Access,
                    Transceiver_AF => GPIO_AF_USART1_7,

--- a/examples/shared/serial_ports/src/peripherals_nonblocking.ads
+++ b/examples/shared/serial_ports/src/peripherals_nonblocking.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2016, AdaCore                      --
+--                    Copyright (C) 2015-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -31,6 +31,7 @@
 
 with Ada.Interrupts;        use Ada.Interrupts;
 with Ada.Interrupts.Names;  use Ada.Interrupts.Names;
+with System;                use System;
 
 with STM32.Device;          use STM32.Device;
 
@@ -40,14 +41,16 @@ use Serial_IO;
 
 package Peripherals_Nonblocking is
 
+   --  the USART selection is arbitrary but the AF number and the pins must
+   --  be those required by that USART
    Peripheral : aliased Serial_IO.Peripheral_Descriptor :=
                   (Transceiver    => USART_1'Access,
                    Transceiver_AF => GPIO_AF_USART1_7,
                    Tx_Pin         => PB6,
                    Rx_Pin         => PB7);
 
-   Transceiver_Interrupt : constant Interrupt_ID := USART1_Interrupt;
-
-   COM : Nonblocking.Serial_Port (Transceiver_Interrupt, Peripheral'Access);
+   COM : Nonblocking.Serial_Port (Device       => Peripheral'Access,
+                                  IRQ          => USART1_Interrupt, 
+                                  IRQ_Priority => Interrupt_Priority'Last);
 
 end Peripherals_Nonblocking;

--- a/examples/shared/serial_ports/src/peripherals_streaming.ads
+++ b/examples/shared/serial_ports/src/peripherals_streaming.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                  Copyright (C) 2015-2016, AdaCore                        --
+--                  Copyright (C) 2015-2022, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -36,7 +36,8 @@ with Serial_IO.Streaming;
 
 package Peripherals_Streaming is
 
-   --  the specific port, pins, and USART selections are arbitrary.
+   --  the USART selection is arbitrary but the AF number and the pins must
+   --  be those required by that USART
    Peripheral : aliased Serial_IO.Peripheral_Descriptor :=
                   (Transceiver    => USART_1'Access,
                    Transceiver_AF => GPIO_AF_USART1_7,

--- a/examples/shared/serial_ports/src/serial_io-blocking.adb
+++ b/examples/shared/serial_ports/src/serial_io-blocking.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                  Copyright (C) 2015-2016, AdaCore                        --
+--                  Copyright (C) 2015-2022, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -34,22 +34,14 @@ with HAL;           use HAL;
 
 package body Serial_IO.Blocking is
 
-   ----------------
-   -- Initialize --
-   ----------------
+   -------------------------
+   -- Initialize_Hardware --
+   -------------------------
 
-   procedure Initialize (This : out Serial_Port) is
+   procedure Initialize_Hardware (This : out Serial_Port) is
    begin
-      Serial_IO.Initialize_Peripheral (This.Device);
-      This.Initialized := True;
-   end Initialize;
-
-   -----------------
-   -- Initialized --
-   -----------------
-
-   function Initialized (This : Serial_Port) return Boolean is
-     (This.Initialized);
+      Serial_IO.Initialize_Hardware (This.Device);
+   end Initialize_Hardware;
 
    ---------------
    -- Configure --
@@ -67,11 +59,11 @@ package body Serial_IO.Blocking is
       Serial_IO.Configure (This.Device, Baud_Rate, Parity, Data_Bits, End_Bits, Control);
    end Configure;
 
-   ---------
-   -- Put --
-   ---------
+   ----------
+   -- Send --
+   ----------
 
-   procedure Put (This : in out Serial_Port;  Msg : not null access Message) is
+   procedure Send (This : in out Serial_Port;  Msg : not null access Message) is
    begin
       for Next in 1 .. Msg.Length loop
          Await_Send_Ready (This.Device.Transceiver.all);
@@ -79,13 +71,13 @@ package body Serial_IO.Blocking is
            (This.Device.Transceiver.all,
             Character'Pos (Msg.Content_At (Next)));
       end loop;
-   end Put;
+   end Send;
 
-   ---------
-   -- Get --
-   ---------
+   -------------
+   -- Receive --
+   -------------
 
-   procedure Get (This : in out Serial_Port;  Msg : not null access Message) is
+   procedure Receive (This : in out Serial_Port;  Msg : not null access Message) is
       Received_Char : Character;
       Raw           : UInt9;
    begin
@@ -97,7 +89,7 @@ package body Serial_IO.Blocking is
          exit Receiving when Received_Char = Msg.Terminator;
          Msg.Append (Received_Char);
       end loop Receiving;
-   end Get;
+   end Receive;
 
    ----------------------
    -- Await_Send_Ready --

--- a/examples/shared/serial_ports/src/serial_io-blocking.ads
+++ b/examples/shared/serial_ports/src/serial_io-blocking.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                  Copyright (C) 2015-2016, AdaCore                        --
+--                    Copyright (C) 2015-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -48,12 +48,7 @@ package Serial_IO.Blocking is
    type Serial_Port (Device : not null access Peripheral_Descriptor) is
      tagged limited private;
 
-   procedure Initialize (This : out Serial_Port)
-     with Post => (Initialized (This));
-
-   function Initialized (This : Serial_Port) return Boolean with Inline;
-
-   Serial_Port_Uninitialized : exception;
+   procedure Initialize_Hardware (This : out Serial_Port);
 
    procedure Configure
      (This      : in out Serial_Port;
@@ -61,27 +56,20 @@ package Serial_IO.Blocking is
       Parity    : Parities     := No_Parity;
       Data_Bits : Word_Lengths := Word_Length_8;
       End_Bits  : Stop_Bits    := Stopbits_1;
-      Control   : Flow_Control := No_Flow_Control)
-     with
-       Pre => (Initialized (This) or else raise Serial_Port_Uninitialized);
+      Control   : Flow_Control := No_Flow_Control);
 
-   procedure Put (This : in out Serial_Port; Msg : not null access Message) with
-     Pre => (Initialized (This) or else raise Serial_Port_Uninitialized);
+   procedure Send (This : in out Serial_Port; Msg : not null access Message);
    --  Sends Msg.Length characters of Msg via USART attached to This. Callers
    --  wait until all characters are sent.
 
-   procedure Get (This : in out Serial_Port;  Msg : not null access Message) with
-     Pre  => (Initialized (This) or else raise Serial_Port_Uninitialized),
+   procedure Receive (This : in out Serial_Port;  Msg : not null access Message) with
      Post => Msg.Length <= Msg.Physical_Size and
              Msg.Content_At (Msg.Length) /= Msg.Terminator;
    --  Callers wait until all characters are received.
 
 private
 
-   type Serial_Port (Device : access Peripheral_Descriptor) is tagged limited
-      record
-         Initialized : Boolean := False;
-      end record;
+   type Serial_Port (Device : access Peripheral_Descriptor) is tagged limited null record;
 
    procedure Await_Send_Ready (This : USART) with Inline;
 

--- a/examples/shared/serial_ports/src/serial_io-nonblocking.ads
+++ b/examples/shared/serial_ports/src/serial_io-nonblocking.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2016, AdaCore                      --
+--                    Copyright (C) 2015-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -30,8 +30,8 @@
 ------------------------------------------------------------------------------
 
 --  This package defines an abstract data type for a "serial port" providing
---  non-blocking input (Get) and output (Put) procedures. The procedures are
---  considered non-blocking because they return to the caller (potentially)
+--  non-blocking input (Receive) and output (Send) procedures. The procedures
+--  are considered non-blocking because they return to the caller (potentially)
 --  before the entire message is received or sent.
 --
 --  The serial port abstraction is a wrapper around a USART peripheral,
@@ -40,26 +40,23 @@
 --  Interrupts are used to send and receive characters.
 --
 --  NB: clients must not send or receive messages until any prior sending or
---  receiving is completed. See the two functions Sending and Receiving and
---  the preconditions on Put and Get.
+--  receiving is completed.
 
 with Message_Buffers; use Message_Buffers;
 with Ada.Interrupts;  use Ada.Interrupts;
+with System;          use System;
 
 package Serial_IO.Nonblocking is
    pragma Elaborate_Body;
 
    type Serial_Port
-     (IRQ    : Interrupt_ID;
-      Device : not null access Peripheral_Descriptor)
-   is tagged limited private;
+     (Device       : not null access Peripheral_Descriptor;
+      IRQ          : Interrupt_ID;
+      IRQ_Priority : Interrupt_Priority)
+   is limited private;
 
-   procedure Initialize (This : in out Serial_Port) with
-     Post => Initialized (This);
-
-   function Initialized (This : Serial_Port) return Boolean with Inline;
-
-   Serial_Port_Uninitialized : exception;
+   procedure Initialize_Hardware (This : in out Serial_Port);
+   --  A convenience wrapper for Serial_IO.Initialize_Hardware
 
    procedure Configure
      (This      : in out Serial_Port;
@@ -67,70 +64,53 @@ package Serial_IO.Nonblocking is
       Parity    : Parities     := No_Parity;
       Data_Bits : Word_Lengths := Word_Length_8;
       End_Bits  : Stop_Bits    := Stopbits_1;
-      Control   : Flow_Control := No_Flow_Control)
-     with
-       Pre => (Initialized (This) or else raise Serial_Port_Uninitialized);
+      Control   : Flow_Control := No_Flow_Control);
+   --  A convenience wrapper for Serial_IO.Configure
 
-   procedure Put (This : in out Serial_Port; Msg : not null access Message) with
-     Pre => (Initialized (This) or else raise Serial_Port_Uninitialized)
-            and then
-            not Sending (This),
-     Inline;
+   procedure Send 
+     (This : in out Serial_Port; 
+      Msg  : not null access Message) 
+   with Inline;
+   --  Start sending the content of Msg.all, returning potentially
+   --  prior to the completion of the message transmission
 
-   procedure Get (This : in out Serial_Port;  Msg : not null access Message) with
-     Pre => (Initialized (This) or else raise Serial_Port_Uninitialized)
-            and then
-            not Receiving (This),
-     Inline;
-
-   function Sending (This : in out Serial_Port) return Boolean;
-   --  Returns whether This is currently sending a message.
-
-   function Receiving (This : in out Serial_Port) return Boolean;
-   --  Returns whether This is currently receiving a message.
+   procedure Receive 
+     (This : in out Serial_Port;  
+      Msg  : not null access Message) 
+   with Inline;
+   --  Start receiving Msg.all content, ending when the specified
+   --  Msg.Terminator character is received (it is not stored), or
+   --  the physical capacity of Msg.all is reached
 
 private
-
-   --  The protected type defining the interrupt handling for sending and
-   --  receiving characters via the USART attached to the serial port. Each
-   --  serial port type a component of this protected type.
-   protected type Controller (IRQ : Interrupt_ID;  Port : access Serial_Port) is
-
-      pragma Interrupt_Priority;
-
+  
+   protected type Serial_Port
+     (Device       : not null access Peripheral_Descriptor;
+      IRQ          : Interrupt_ID;
+      IRQ_Priority : Interrupt_Priority)
+   --  with
+   --     Interrupt_Priority => IRQ_Priority
+   is
+   
+      pragma Interrupt_Priority (IRQ_Priority);
+      --  use pragma as workaround for bug in CE_2021 frontend (V523-041)
+      
       procedure Start_Sending (Msg : not null access Message);
-      --  error: internal call cannot appear in precondition of protected operation
-      --  with Pre => not Sending;
 
       procedure Start_Receiving (Msg : not null access Message);
-      --  error: internal call cannot appear in precondition of protected operation
-      --  with Pre => not Receiving;
-
-      function Sending   return Boolean;
-      function Receiving return Boolean;
 
    private
-
-      Next_Out          : Positive;
-      Awaiting_Transfer : Natural;
-      Outgoing_Msg      : access Message;
-      Incoming_Msg      : access Message;
+   
+      Next_Out     : Positive;
+      Outgoing_Msg : access Message;
+      Incoming_Msg : access Message;
 
       procedure Handle_Transmission with Inline;
-      procedure Handle_Reception with Inline;
+      procedure Handle_Reception    with Inline;
       procedure Detect_Errors (Is_Xmit_IRQ : Boolean) with Inline;
 
-      procedure IRQ_Handler with Attach_Handler => IRQ;
+      procedure ISR with Attach_Handler => IRQ;
 
-   end Controller;
-
-
-   type Serial_Port
-     (IRQ    : Interrupt_ID;
-      Device : not null access Peripheral_Descriptor)
-   is tagged limited record
-      Initialized : Boolean := False;
-      Control     : Controller (IRQ, Serial_Port'Access);
-   end record;
+   end Serial_Port;
 
 end Serial_IO.Nonblocking;

--- a/examples/shared/serial_ports/src/serial_io-streaming.adb
+++ b/examples/shared/serial_ports/src/serial_io-streaming.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2016, AdaCore                          --
+--                    Copyright (C) 2016-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -34,22 +34,14 @@ with HAL;           use HAL;
 
 package body Serial_IO.Streaming is
 
-   ----------------
-   -- Initialize --
-   ----------------
+   -------------------------
+   -- Initialize_Hardware --
+   -------------------------
 
-   procedure Initialize (This : out Serial_Port) is
+   procedure Initialize_Hardware (This : out Serial_Port) is
    begin
-      Serial_IO.Initialize_Peripheral (This.Device);
-      This.Initialized := True;
-   end Initialize;
-
-   -----------------
-   -- Initialized --
-   -----------------
-
-   function Initialized (This : Serial_Port) return Boolean is
-     (This.Initialized);
+      Serial_IO.Initialize_Hardware (This.Device);
+   end Initialize_Hardware;
 
    ---------------
    -- Configure --
@@ -84,7 +76,7 @@ package body Serial_IO.Streaming is
 
    procedure Set_Read_Timeout
      (This : in out Serial_Port;
-      Wait : Time_Span := Time_Span_Last)
+      Wait : Time_Span)
    is
    begin
       This.Timeout := Wait;

--- a/examples/shared/serial_ports/src/serial_io-streaming.ads
+++ b/examples/shared/serial_ports/src/serial_io-streaming.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2016, AdaCore                          --
+--                    Copyright (C) 2016-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -46,10 +46,7 @@ package Serial_IO.Streaming is
    type Serial_Port (Device : not null access Peripheral_Descriptor) is
      new Ada.Streams.Root_Stream_Type with private;
 
-   procedure Initialize (This : out Serial_Port)
-     with Post => Initialized (This);
-
-   function Initialized (This : Serial_Port) return Boolean with Inline;
+   procedure Initialize_Hardware (This : out Serial_Port);
 
    procedure Configure
      (This      : in out Serial_Port;
@@ -57,18 +54,16 @@ package Serial_IO.Streaming is
       Parity    : Parities     := No_Parity;
       Data_Bits : Word_Lengths := Word_Length_8;
       End_Bits  : Stop_Bits    := Stopbits_1;
-      Control   : Flow_Control := No_Flow_Control)
-     with
-       Pre => Initialized (This);
+      Control   : Flow_Control := No_Flow_Control);
 
    procedure Set_Read_Timeout
      (This : in out Serial_Port;
-      Wait : Time_Span := Time_Span_Last);
+      Wait : Time_Span);
    --  Stream attributes that call Read (below) can either wait indefinitely or
    --  can be set to return any current values received after a given interval.
-   --  If the default value of Time_Span_Last is taken on a call, the effect is
-   --  essentially to wait forever, i.e., blocking. That is also the effect if
-   --  this routine is never called.
+   --  If the value Time_Span_Last is passed to Wait, the effect is essentially to wait
+   --  forever, i.e., blocking. That is also the effect if this routine is
+   --  never called.
 
    overriding
    procedure Read
@@ -84,10 +79,8 @@ package Serial_IO.Streaming is
 private
 
    type Serial_Port (Device : access Peripheral_Descriptor) is
-     new Ada.Streams.Root_Stream_Type with
-     record
-         Initialized : Boolean := False;
-         Timeout     : Time_Span := Time_Span_Last;
+     new Ada.Streams.Root_Stream_Type with record
+       Timeout : Time_Span := Time_Span_Last;
      end record;
 
    procedure Await_Send_Ready (This : USART) with Inline;
@@ -96,7 +89,7 @@ private
      (This      : USART;
       Timeout   : Time_Span := Time_Span_Last;
       Timed_Out : out Boolean)
-     with Inline;
+   with Inline;
 
    use Ada.Streams;
 

--- a/examples/shared/serial_ports/src/serial_io.adb
+++ b/examples/shared/serial_ports/src/serial_io.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2017, AdaCore                     --
+--                     Copyright (C) 2015-2022, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -33,11 +33,11 @@ with STM32.Device; use STM32.Device;
 
 package body Serial_IO is
 
-   ----------------
-   -- Initialize --
-   ----------------
+   -------------------------
+   -- Initialize_Hardware --
+   -------------------------
 
-   procedure Initialize_Peripheral (Device : access Peripheral_Descriptor) is
+   procedure Initialize_Hardware (Device : access Peripheral_Descriptor) is
       Configuration : GPIO_Port_Configuration;
       Device_Pins   : constant GPIO_Points := Device.Rx_Pin & Device.Tx_Pin;
    begin
@@ -51,7 +51,7 @@ package body Serial_IO is
                         Resistors      => Pull_Up);
 
       Configure_IO (Device_Pins, Configuration);
-   end Initialize_Peripheral;
+   end Initialize_Hardware;
 
    ---------------
    -- Configure --

--- a/examples/shared/serial_ports/src/serial_io.ads
+++ b/examples/shared/serial_ports/src/serial_io.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2016, AdaCore                      --
+--                    Copyright (C) 2015-2022, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -42,7 +42,8 @@ package Serial_IO is
       Rx_Pin         : GPIO_Point;
    end record;
 
-   procedure Initialize_Peripheral (Device : access Peripheral_Descriptor);
+   procedure Initialize_Hardware (Device : access Peripheral_Descriptor);
+   --  enable clocks, configure GPIO pins, etc.
 
    procedure Configure
      (Device    : access Peripheral_Descriptor;


### PR DESCRIPTION
serial_io:
Use better name for hardware init routines

serial_io.nonblocking:
Implement primary type Serial_Port directly as a protected type.
Add discriminant for IRQ priority.
Simplify transmission routine (remove a protected variable).
Remove pre/post for initialization since not worth extra complexity for type impl.
Use better names as replacements for Put/get.

serial_io.blocking:
Update names for procedures Put and Get to be same as those of package Nonblocking.
Update name for hardware init routine to be consistent with other packages.
Remove pre/post for initialization since not worth extra complexity for type impl.

serial_io.streaming:
Update names for procedures Put and Get to be same as in Blocking and Nonblocking.
Update name for hardware init routine to be consistent with other packages.
Remove pre/post for initialization since not worth extra complexity for type impl.

peripherals_nonblocking:
Specify new IRQ priority discriminant.
Remove unnecessary constant.
Improve comments.

peripherals_blocking:
Improve comments.

peripherals_streaming:
Improve comments.

demo mains:
Revise for name changes.
Improve comments.