### PR TITLE
corrections to serial_io facilities

### DIFF
--- a/examples/shared/serial_ports/src/demo_serial_port_blocking.adb
+++ b/examples/shared/serial_ports/src/demo_serial_port_blocking.adb
@@ -53,7 +53,7 @@ procedure Demo_Serial_Port_Blocking is
    procedure Send (This : String) is
    begin
       Set (Outgoing, To => This);
-      Blocking.Send (COM, Outgoing'Access);
+      Blocking.Send (COM, Outgoing'Unchecked_Access);
       --  Send won't return until the entire message has been sent
    end Send;
 
@@ -61,11 +61,10 @@ begin
    Initialize_Hardware (COM);
    Configure (COM, Baud_Rate => 115_200);
 
-   Send ("Enter text, terminated by CR.");
-
    Incoming.Set_Terminator (To => ASCII.CR);
+   Send ("Enter text, terminated by CR.");
    loop
-      Blocking.Receive (COM, Incoming'Access);
+      Blocking.Receive (COM, Incoming'Unchecked_Access);
       Send ("Received : " & Incoming.Content);
    end loop;
 end Demo_Serial_Port_Blocking;

--- a/examples/shared/serial_ports/src/demo_serial_port_nonblocking.adb
+++ b/examples/shared/serial_ports/src/demo_serial_port_nonblocking.adb
@@ -47,15 +47,16 @@ use Serial_IO;
 procedure Demo_Serial_Port_Nonblocking is
 
    Incoming : aliased Message (Physical_Size => 1024);  -- arbitrary size
+   Outgoing : aliased Message (Physical_Size => 1024);  -- arbitrary size
 
    procedure Send (This : String);
 
    procedure Send (This : String) is
-      Outgoing : aliased Message (Physical_Size => 1024);  -- arbitrary size
    begin
       Set (Outgoing, To => This);
-      Nonblocking.Send (COM, Outgoing'Access);
+      Nonblocking.Send (COM, Outgoing'Unchecked_Access);
       Await_Transmission_Complete (Outgoing);
+      --  Send can/will return before the entire message has been sent
    end Send;
 
 begin
@@ -65,7 +66,7 @@ begin
    Incoming.Set_Terminator (To => ASCII.CR);
    Send ("Enter text, terminated by CR.");
    loop
-      Nonblocking.Receive (COM, Incoming'Access);
+      Nonblocking.Receive (COM, Incoming'Unchecked_Access);
       Await_Reception_Complete (Incoming);
       Send ("Received : " & Incoming.Content);
    end loop;

--- a/examples/shared/serial_ports/src/serial_io-blocking.ads
+++ b/examples/shared/serial_ports/src/serial_io-blocking.ads
@@ -64,7 +64,7 @@ package Serial_IO.Blocking is
 
    procedure Receive (This : in out Serial_Port;  Msg : not null access Message) with
      Post => Msg.Length <= Msg.Physical_Size and
-             Msg.Content_At (Msg.Length) /= Msg.Terminator;
+             (if Msg.Length > 0 then Msg.Content_At (Msg.Length) /= Msg.Terminator);
    --  Callers wait until all characters are received.
 
 private

--- a/examples/shared/serial_ports/src/serial_io-nonblocking.ads
+++ b/examples/shared/serial_ports/src/serial_io-nonblocking.ads
@@ -77,7 +77,10 @@ package Serial_IO.Nonblocking is
    procedure Receive
      (This : in out Serial_Port;
       Msg  : not null access Message)
-   with Inline;
+   with
+      Post => Msg.Length <= Msg.Physical_Size and
+              (if Msg.Length > 0 then Msg.Content_At (Msg.Length) /= Msg.Terminator),
+              Inline;
    --  Start receiving Msg.all content, ending when the specified
    --  Msg.Terminator character is received (it is not stored), or
    --  the physical capacity of Msg.all is reached


### PR DESCRIPTION
demo-*:
use Unchecked_Access in these specific demos

serial_io-blocking.ads:
correct postcondition on procedure Receive so that empty content is handled properly

serial_io-nonblocking.ads:
add postconditions to procedure Receive