### PR TITLE
install_dependencies.py Support for utf-8 stdout returned text for Linux

### DIFF
--- a/scripts/install_dependencies.py
+++ b/scripts/install_dependencies.py
@@ -20,14 +20,14 @@ def run_program(argv, cwd=os.path.dirname(os.path.realpath(__file__))):
     stdout, stderr = p.communicate()
 
     try:
-        stdout = stdout.decode('ascii')
+        stdout = stdout.decode(sys.stdout.encoding)
     except UnicodeError:
-        return 'stdout is not ASCII'
+        return (-1, '', 'error decode stdout text')
 
     try:
-        stderr = stderr.decode('ascii')
+        stderr = stderr.decode(sys.stdout.encoding)
     except UnicodeError:
-        return 'stderr is not ASCII'
+        return (-1, '', 'error decode stderr text')
 
     return (p.returncode, stdout, stderr)
 


### PR DESCRIPTION
Linux uses UTF-8 encoding. Without these changes, the script raise with the next text:
```
Original exception was:
Traceback (most recent call last):
  File "install_dependencies.py", line 120, in <module>
    main(parser.parse_args())
  File "install_dependencies.py", line 100, in main
    ret = git_clone(repo, branch, dest, recursive)
  File "install_dependencies.py", line 42, in git_clone
    returncode, stdout, stderr = run_program(
ValueError: too many values to unpack (expected 3)
```