### PR TITLE
Move 'for Target use xxx;' up

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install Python 3.x (required for the testsuite)
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.11'
 
     - run: python3 $PWD/scripts/build_all_examples.py
     - run: python3 $PWD/testsuite/run.py

--- a/boards/HiFive1/hifive1_zfp.gpr
+++ b/boards/HiFive1/hifive1_zfp.gpr
@@ -8,6 +8,7 @@ library project HiFive1_ZFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "riscv32-elf";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project HiFive1_ZFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ("-T", Project'Project_dir & "/src/zfp/link.ld");
-   for Target use "riscv32-elf";
    for Runtime ("Ada") use "light-rv32imac";
 
    package Device_Configuration is

--- a/boards/HiFive1_rev_B/hifive1_rev_b_zfp.gpr
+++ b/boards/HiFive1_rev_B/hifive1_rev_b_zfp.gpr
@@ -8,6 +8,7 @@ library project HiFive1_rev_B_ZFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "riscv32-elf";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project HiFive1_rev_B_ZFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ("-T", Project'Project_dir & "/src/zfp/link.ld");
-   for Target use "riscv32-elf";
    for Runtime ("Ada") use "light-rv32imac";
 
    package Device_Configuration is

--- a/boards/MicroBit/microbit_zfp.gpr
+++ b/boards/MicroBit/microbit_zfp.gpr
@@ -8,6 +8,7 @@ library project MicroBit_ZFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project MicroBit_ZFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ("-T", Project'Project_dir & "/src/zfp/link.ld");
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-cortex-m0";
 
    package Device_Configuration is

--- a/boards/NRF52_DK/nrf52_dk_zfp.gpr
+++ b/boards/NRF52_DK/nrf52_dk_zfp.gpr
@@ -8,6 +8,7 @@ library project NRF52_DK_ZFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project NRF52_DK_ZFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ("-T", Project'Project_dir & "/src/zfp/link.ld");
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-cortex-m4f";
 
    package Device_Configuration is

--- a/boards/OpenMV2/openmv2_full.gpr
+++ b/boards/OpenMV2/openmv2_full.gpr
@@ -8,6 +8,7 @@ library project OpenMV2_Full is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project OpenMV2_Full is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "embedded-openmv2";
 
    package Device_Configuration is

--- a/boards/OpenMV2/openmv2_sfp.gpr
+++ b/boards/OpenMV2/openmv2_sfp.gpr
@@ -8,6 +8,7 @@ library project OpenMV2_SFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project OpenMV2_SFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-tasking-openmv2";
 
    package Device_Configuration is

--- a/boards/Unleashed/unleashed_full.gpr
+++ b/boards/Unleashed/unleashed_full.gpr
@@ -8,6 +8,7 @@ library project Unleashed_Full is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "riscv32-elf";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project Unleashed_Full is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "riscv32-elf";
    for Runtime ("Ada") use "embedded-unleashed";
 
    package Device_Configuration is

--- a/boards/Unleashed/unleashed_sfp.gpr
+++ b/boards/Unleashed/unleashed_sfp.gpr
@@ -8,6 +8,7 @@ library project Unleashed_SFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "riscv32-elf";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project Unleashed_SFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "riscv32-elf";
    for Runtime ("Ada") use "light-tasking-unleashed";
 
    package Device_Configuration is

--- a/boards/Unleashed/unleashed_zfp.gpr
+++ b/boards/Unleashed/unleashed_zfp.gpr
@@ -8,6 +8,7 @@ library project Unleashed_ZFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "riscv32-elf";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project Unleashed_ZFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "riscv32-elf";
    for Runtime ("Ada") use "light-unleashed";
 
    package Device_Configuration is

--- a/boards/crazyflie/crazyflie_full.gpr
+++ b/boards/crazyflie/crazyflie_full.gpr
@@ -8,6 +8,7 @@ library project Crazyflie_Full is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project Crazyflie_Full is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "embedded-stm32f4";
 
    package Device_Configuration is

--- a/boards/crazyflie/crazyflie_sfp.gpr
+++ b/boards/crazyflie/crazyflie_sfp.gpr
@@ -8,6 +8,7 @@ library project Crazyflie_SFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project Crazyflie_SFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-tasking-stm32f4";
 
    package Device_Configuration is

--- a/boards/feather_stm32f405/feather_stm32f405_full.gpr
+++ b/boards/feather_stm32f405/feather_stm32f405_full.gpr
@@ -8,6 +8,7 @@ library project Feather_STM32F405_Full is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project Feather_STM32F405_Full is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "embedded-feather_stm32f405";
 
    package Device_Configuration is

--- a/boards/feather_stm32f405/feather_stm32f405_sfp.gpr
+++ b/boards/feather_stm32f405/feather_stm32f405_sfp.gpr
@@ -8,6 +8,7 @@ library project Feather_STM32F405_SFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project Feather_STM32F405_SFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-tasking-feather_stm32f405";
 
    package Device_Configuration is

--- a/boards/nucleo_f446ze/nucleo_f446ze_full.gpr
+++ b/boards/nucleo_f446ze/nucleo_f446ze_full.gpr
@@ -8,6 +8,7 @@ library project NUCLEO_F446ZE_Full is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project NUCLEO_F446ZE_Full is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "embedded-stm32f4";
 
    package Device_Configuration is

--- a/boards/nucleo_f446ze/nucleo_f446ze_sfp.gpr
+++ b/boards/nucleo_f446ze/nucleo_f446ze_sfp.gpr
@@ -8,6 +8,7 @@ library project NUCLEO_F446ZE_SFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project NUCLEO_F446ZE_SFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-tasking-stm32f4";
 
    package Device_Configuration is

--- a/boards/stm32_h405/stm32_h405_full.gpr
+++ b/boards/stm32_h405/stm32_h405_full.gpr
@@ -8,6 +8,7 @@ library project STM32_H405_Full is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32_H405_Full is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "embedded-stm32f4";
 
    package Device_Configuration is

--- a/boards/stm32_h405/stm32_h405_sfp.gpr
+++ b/boards/stm32_h405/stm32_h405_sfp.gpr
@@ -8,6 +8,7 @@ library project STM32_H405_SFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32_H405_SFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-tasking-stm32f4";
 
    package Device_Configuration is

--- a/boards/stm32f407_discovery/stm32f407_discovery_full.gpr
+++ b/boards/stm32f407_discovery/stm32f407_discovery_full.gpr
@@ -8,6 +8,7 @@ library project STM32F407_Discovery_Full is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32F407_Discovery_Full is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "embedded-stm32f4";
 
    package Device_Configuration is

--- a/boards/stm32f407_discovery/stm32f407_discovery_sfp.gpr
+++ b/boards/stm32f407_discovery/stm32f407_discovery_sfp.gpr
@@ -8,6 +8,7 @@ library project STM32F407_Discovery_SFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32F407_Discovery_SFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-tasking-stm32f4";
 
    package Device_Configuration is

--- a/boards/stm32f429_discovery/stm32f429_discovery_full.gpr
+++ b/boards/stm32f429_discovery/stm32f429_discovery_full.gpr
@@ -8,6 +8,7 @@ library project STM32F429_Discovery_Full is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32F429_Discovery_Full is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "embedded-stm32f429disco";
 
    package Device_Configuration is

--- a/boards/stm32f429_discovery/stm32f429_discovery_sfp.gpr
+++ b/boards/stm32f429_discovery/stm32f429_discovery_sfp.gpr
@@ -8,6 +8,7 @@ library project STM32F429_Discovery_SFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32F429_Discovery_SFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-tasking-stm32f429disco";
 
    package Device_Configuration is

--- a/boards/stm32f469_discovery/stm32f469_discovery_full.gpr
+++ b/boards/stm32f469_discovery/stm32f469_discovery_full.gpr
@@ -8,6 +8,7 @@ library project STM32F469_Discovery_Full is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32F469_Discovery_Full is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "embedded-stm32f469disco";
 
    package Device_Configuration is

--- a/boards/stm32f469_discovery/stm32f469_discovery_sfp.gpr
+++ b/boards/stm32f469_discovery/stm32f469_discovery_sfp.gpr
@@ -8,6 +8,7 @@ library project STM32F469_Discovery_SFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32F469_Discovery_SFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-tasking-stm32f469disco";
 
    package Device_Configuration is

--- a/boards/stm32f4xx_m/stm32f4xx_m_full.gpr
+++ b/boards/stm32f4xx_m/stm32f4xx_m_full.gpr
@@ -8,6 +8,7 @@ library project STM32F4XX_M_Full is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32F4XX_M_Full is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "embedded-stm32f4";
 
    package Device_Configuration is

--- a/boards/stm32f4xx_m/stm32f4xx_m_sfp.gpr
+++ b/boards/stm32f4xx_m/stm32f4xx_m_sfp.gpr
@@ -8,6 +8,7 @@ library project STM32F4XX_M_SFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32F4XX_M_SFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-tasking-stm32f4";
 
    package Device_Configuration is

--- a/boards/stm32f746_discovery/stm32f746_discovery_full.gpr
+++ b/boards/stm32f746_discovery/stm32f746_discovery_full.gpr
@@ -8,6 +8,7 @@ library project STM32F746_Discovery_Full is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32F746_Discovery_Full is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "embedded-stm32f746disco";
 
    package Device_Configuration is

--- a/boards/stm32f746_discovery/stm32f746_discovery_sfp.gpr
+++ b/boards/stm32f746_discovery/stm32f746_discovery_sfp.gpr
@@ -8,6 +8,7 @@ library project STM32F746_Discovery_SFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32F746_Discovery_SFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-tasking-stm32f746disco";
 
    package Device_Configuration is

--- a/boards/stm32f769_discovery/stm32f769_discovery_full.gpr
+++ b/boards/stm32f769_discovery/stm32f769_discovery_full.gpr
@@ -8,6 +8,7 @@ library project STM32F769_Discovery_Full is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32F769_Discovery_Full is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "embedded-stm32f769disco";
 
    package Device_Configuration is

--- a/boards/stm32f769_discovery/stm32f769_discovery_sfp.gpr
+++ b/boards/stm32f769_discovery/stm32f769_discovery_sfp.gpr
@@ -8,6 +8,7 @@ library project STM32F769_Discovery_SFP is
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+   for Target use "arm-eabi";
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures
@@ -61,7 +62,6 @@ library project STM32F769_Discovery_SFP is
    for Library_Name use "ada_drivers_library";
 
    Linker_Switches := ();
-   for Target use "arm-eabi";
    for Runtime ("Ada") use "light-tasking-stm32f769disco";
 
    package Device_Configuration is

--- a/scripts/config/__init__.py
+++ b/scripts/config/__init__.py
@@ -59,10 +59,9 @@ class Database:
 
         return out
 
-    def gpr_configuration(self, src_root_dir, extra_source_dir):
-        out = ""
+    def target(self):
         arch = self.get_config("Architecture")
-        runtime = self.get_config("Runtime_Name")
+        target = ""
 
         if arch is not None and arch != "Native":
             if arch == "ARM":
@@ -70,7 +69,12 @@ class Database:
             elif arch == "RISC-V":
                 target = "riscv32-elf"
 
-            out += "   for Target use \"%s\";\n" % target
+        return target
+
+    def gpr_configuration(self, src_root_dir, extra_source_dir):
+        out = ""
+        arch = self.get_config("Architecture")
+        runtime = self.get_config("Runtime_Name")
 
         if runtime is not None:
             out += "   for Runtime (\"Ada\") use \"%s\";\n" % runtime

--- a/scripts/project_wizard.py
+++ b/scripts/project_wizard.py
@@ -192,6 +192,11 @@ def ADL_configuration(config, project_directory, project_name,
    Build_Checks : Build_Checks_Type := external ("ADL_BUILD_CHECKS", "Disabled");
 
    --  Target architecture
+"""
+
+    gpr += '   for Target use \"%s\";' % config.target()
+
+    gpr += """
    Target := Project'Target;
 
    --  Callgraph info is not available on all architectures


### PR DESCRIPTION
to fix loading project in VSCode extension and avoid

> error: cannot set configuration attribute "Target" after it was referenced

See details in GPR issue 166.