### PR TITLE
Add enable, reset, configuration routines for Eth periph

### DIFF
--- a/arch/ARM/STM32/devices/stm32f40x/stm32-device.adb
+++ b/arch/ARM/STM32/devices/stm32f40x/stm32-device.adb
@@ -805,4 +805,30 @@ package body STM32.Device is
       RCC_Periph.AHB1RSTR.CRCRST := False;
    end Reset;
 
+   ----------------
+   -- Enable_Eth --
+   ----------------
+
+   procedure Enable_Eth
+     (MAC     : Boolean := True;
+      MAC_TX  : Boolean := True;
+      MAC_RX  : Boolean := True;
+      MAC_PTP : Boolean := True) is
+   begin
+      RCC_Periph.AHB1ENR.ETHMACEN := MAC;
+      RCC_Periph.AHB1ENR.ETHMACTXEN := MAC_TX;
+      RCC_Periph.AHB1ENR.ETHMACRXEN := MAC_RX;
+      RCC_Periph.AHB1ENR.ETHMACPTPEN := MAC_PTP;
+   end Enable_Eth;
+
+   ---------------
+   -- Reset_Eth --
+   ---------------
+
+   procedure Reset_Eth is
+   begin
+      RCC_Periph.AHB1RSTR.ETHMACRST := True;
+      RCC_Periph.AHB1RSTR.ETHMACRST := False;
+   end Reset_Eth;
+
 end STM32.Device;

--- a/arch/ARM/STM32/devices/stm32f40x/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f40x/stm32-device.ads
@@ -475,6 +475,24 @@ package STM32.Device is
 
    RTC : aliased RTC_Device;
 
+   --------------
+   -- Ethernet --
+   --------------
+
+   procedure Enable_Eth
+     (MAC     : Boolean := True;
+      MAC_TX  : Boolean := True;
+      MAC_RX  : Boolean := True;
+      MAC_PTP : Boolean := True);
+   --  Enable/disable Ethernet MAC clocks:
+   --  * MAC - Ethernet MAC clock enable
+   --  * MAC_TX - Ethernet Transmission clock enable
+   --  * MAC_RX - Ethernet Reception clock enable
+   --  * MAC_PTP - Ethernet PTP clock enable
+
+   procedure Reset_Eth;
+   --  Ethernet MAC reset
+
 private
 
    GPIO_AF_RTC_50Hz_0  : constant GPIO_Alternate_Function := 0;

--- a/arch/ARM/STM32/devices/stm32f42x/stm32-device.adb
+++ b/arch/ARM/STM32/devices/stm32f42x/stm32-device.adb
@@ -935,4 +935,30 @@ package body STM32.Device is
       RCC_Periph.AHB1RSTR.CRCRST := False;
    end Reset;
 
+   ----------------
+   -- Enable_Eth --
+   ----------------
+
+   procedure Enable_Eth
+     (MAC     : Boolean := True;
+      MAC_TX  : Boolean := True;
+      MAC_RX  : Boolean := True;
+      MAC_PTP : Boolean := True) is
+   begin
+      RCC_Periph.AHB1ENR.ETHMACEN := MAC;
+      RCC_Periph.AHB1ENR.ETHMACTXEN := MAC_TX;
+      RCC_Periph.AHB1ENR.ETHMACRXEN := MAC_RX;
+      RCC_Periph.AHB1ENR.ETHMACPTPEN := MAC_PTP;
+   end Enable_Eth;
+
+   ---------------
+   -- Reset_Eth --
+   ---------------
+
+   procedure Reset_Eth is
+   begin
+      RCC_Periph.AHB1RSTR.ETHMACRST := True;
+      RCC_Periph.AHB1RSTR.ETHMACRST := False;
+   end Reset_Eth;
+
 end STM32.Device;

--- a/arch/ARM/STM32/devices/stm32f42x/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f42x/stm32-device.ads
@@ -540,6 +540,24 @@ package STM32.Device is
 
    RTC : aliased RTC_Device;
 
+   --------------
+   -- Ethernet --
+   --------------
+
+   procedure Enable_Eth
+     (MAC     : Boolean := True;
+      MAC_TX  : Boolean := True;
+      MAC_RX  : Boolean := True;
+      MAC_PTP : Boolean := True);
+   --  Enable/disable Ethernet MAC clocks:
+   --  * MAC - Ethernet MAC clock enable
+   --  * MAC_TX - Ethernet Transmission clock enable
+   --  * MAC_RX - Ethernet Reception clock enable
+   --  * MAC_PTP - Ethernet PTP clock enable
+
+   procedure Reset_Eth;
+   --  Ethernet MAC reset
+
 private
 
    GPIO_AF_RTC_50Hz_0  : constant GPIO_Alternate_Function := 0;

--- a/arch/ARM/STM32/devices/stm32f46_79x/stm32-device.adb
+++ b/arch/ARM/STM32/devices/stm32f46_79x/stm32-device.adb
@@ -1080,4 +1080,30 @@ package body STM32.Device is
       RCC_Periph.AHB1RSTR.CRCRST := False;
    end Reset;
 
+   ----------------
+   -- Enable_Eth --
+   ----------------
+
+   procedure Enable_Eth
+     (MAC     : Boolean := True;
+      MAC_TX  : Boolean := True;
+      MAC_RX  : Boolean := True;
+      MAC_PTP : Boolean := True) is
+   begin
+      RCC_Periph.AHB1ENR.ETHMACEN := MAC;
+      RCC_Periph.AHB1ENR.ETHMACTXEN := MAC_TX;
+      RCC_Periph.AHB1ENR.ETHMACRXEN := MAC_RX;
+      RCC_Periph.AHB1ENR.ETHMACPTPEN := MAC_PTP;
+   end Enable_Eth;
+
+   ---------------
+   -- Reset_Eth --
+   ---------------
+
+   procedure Reset_Eth is
+   begin
+      RCC_Periph.AHB1RSTR.ETHMACRST := True;
+      RCC_Periph.AHB1RSTR.ETHMACRST := False;
+   end Reset_Eth;
+
 end STM32.Device;

--- a/arch/ARM/STM32/devices/stm32f46_79x/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f46_79x/stm32-device.ads
@@ -629,6 +629,24 @@ package STM32.Device is
 
    RTC : aliased RTC_Device;
 
+   --------------
+   -- Ethernet --
+   --------------
+
+   procedure Enable_Eth
+     (MAC     : Boolean := True;
+      MAC_TX  : Boolean := True;
+      MAC_RX  : Boolean := True;
+      MAC_PTP : Boolean := True);
+   --  Enable/disable Ethernet MAC clocks:
+   --  * MAC - Ethernet MAC clock enable
+   --  * MAC_TX - Ethernet Transmission clock enable
+   --  * MAC_RX - Ethernet Reception clock enable
+   --  * MAC_PTP - Ethernet PTP clock enable
+
+   procedure Reset_Eth;
+   --  Ethernet MAC reset
+
 private
 
    GPIO_AF_RTC_50Hz_0  : constant GPIO_Alternate_Function := 0;

--- a/arch/ARM/STM32/devices/stm32f7x/stm32-device.adb
+++ b/arch/ARM/STM32/devices/stm32f7x/stm32-device.adb
@@ -1063,4 +1063,30 @@ package body STM32.Device is
       RCC_Periph.AHB2RSTR.DCMIRST := False;
    end Reset_DCMI;
 
+   ----------------
+   -- Enable_Eth --
+   ----------------
+
+   procedure Enable_Eth
+     (MAC     : Boolean := True;
+      MAC_TX  : Boolean := True;
+      MAC_RX  : Boolean := True;
+      MAC_PTP : Boolean := True) is
+   begin
+      RCC_Periph.AHB1ENR.ETHMACEN := MAC;
+      RCC_Periph.AHB1ENR.ETHMACTXEN := MAC_TX;
+      RCC_Periph.AHB1ENR.ETHMACRXEN := MAC_RX;
+      RCC_Periph.AHB1ENR.ETHMACPTPEN := MAC_PTP;
+   end Enable_Eth;
+
+   ---------------
+   -- Reset_Eth --
+   ---------------
+
+   procedure Reset_Eth is
+   begin
+      RCC_Periph.AHB1RSTR.ETHMACRST := True;
+      RCC_Periph.AHB1RSTR.ETHMACRST := False;
+   end Reset_Eth;
+
 end STM32.Device;

--- a/arch/ARM/STM32/devices/stm32f7x/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f7x/stm32-device.ads
@@ -611,6 +611,24 @@ package STM32.Device is
 
    RTC : aliased RTC_Device;
 
+   --------------
+   -- Ethernet --
+   --------------
+
+   procedure Enable_Eth
+     (MAC     : Boolean := True;
+      MAC_TX  : Boolean := True;
+      MAC_RX  : Boolean := True;
+      MAC_PTP : Boolean := True);
+   --  Enable/disable Ethernet MAC clocks:
+   --  * MAC - Ethernet MAC clock enable
+   --  * MAC_TX - Ethernet Transmission clock enable
+   --  * MAC_RX - Ethernet Reception clock enable
+   --  * MAC_PTP - Ethernet PTP clock enable
+
+   procedure Reset_Eth;
+   --  Ethernet MAC reset
+
 private
 
    HSE_VALUE : constant UInt32 := ADL_Config.High_Speed_External_Clock;

--- a/arch/ARM/STM32/drivers/stm32-syscfg.adb
+++ b/arch/ARM/STM32/drivers/stm32-syscfg.adb
@@ -132,4 +132,13 @@ package body STM32.SYSCFG is
       Clear_External_Interrupt (External_Line_Number'Val (GPIO_Pin'Pos (Pin)));
    end Clear_External_Interrupt;
 
+   --------------------
+   -- Configure_RMII --
+   --------------------
+
+   procedure Configure_RMII (RMII : Boolean := True) is
+   begin
+      STM32_SVD.SYSCFG.SYSCFG_Periph.PMC.MII_RMII_SEL := RMII;
+   end Configure_RMII;
+
 end STM32.SYSCFG;

--- a/arch/ARM/STM32/drivers/stm32-syscfg.ads
+++ b/arch/ARM/STM32/drivers/stm32-syscfg.ads
@@ -57,4 +57,9 @@ package STM32.SYSCFG is
 
    procedure Clear_External_Interrupt (Pin : GPIO_Pin) with Inline;
 
+   procedure Configure_RMII (RMII : Boolean := True);
+   --  Ethernet PHY interface selection:
+   --  * RMII=False - MII
+   --  * RMII=True  - RMII
+
 end STM32.SYSCFG;


### PR DESCRIPTION
To make ethernet driver independent on STM32_SVD.RCC and STM32_SVD.SYSCFG packages.