### PR TITLE
Wait for STM32 timer output to be enabled before returning from enable procedure.

### DIFF
--- a/arch/ARM/STM32/drivers/stm32-timers.adb
+++ b/arch/ARM/STM32/drivers/stm32-timers.adb
@@ -184,6 +184,10 @@ package body STM32.Timers is
    procedure Enable_Main_Output (This : in out Timer) is
    begin
       This.BDTR.Main_Output_Enabled := True;
+
+      loop
+         exit when Main_Output_Enabled (This);
+      end loop;
    end Enable_Main_Output;
 
    -------------------------


### PR DESCRIPTION
RM0386 Rev 6 22.3.12 notes that there may be a delay before the BDTR.MOE bit reads as 1 after writing to it. The RM says that only a single instruction is needed, but testing has shown that this is incorrect.

With the previous code, calling Enable_Main_Output and then immediately calling a procedure to set a different part of the register could result in the MOE bit being inadvertently set low.