### PR TITLE
Avoid losing input bytes in the UART on STM32F4xx.

### DIFF
--- a/arch/ARM/STM32/drivers/uart_stm32f4/stm32-usarts.adb
+++ b/arch/ARM/STM32/drivers/uart_stm32f4/stm32-usarts.adb
@@ -204,7 +204,7 @@ package body STM32.USARTs is
 
    procedure Transmit (This : in out USART;  Data : UInt9) is
    begin
-      This.Periph.DR.DR := Data;
+      This.Periph.DR := (DR => Data, others => 0);
    end Transmit;
 
    ---------


### PR DESCRIPTION
The compiler expands an assignment to part of the DR register to a read-modify-write sequence. However, reading DR has the side-effect of clearing the SR.RXNE bit, so sending a byte could result in the loss of input bytes.