### PR TITLE
Extensively refine code for these three serial I/O examples

### DIFF
--- a/examples/shared/serial_ports/host_app/README.md
+++ b/examples/shared/serial_ports/host_app/README.md
@@ -1,0 +1,3 @@
+This host application is for use specifically with the streaming Serial_Port demonstration main program running on the target board. This host app is required so that the string bounds are handled correctly.
+
+The other demonstration mains do not use streams. For those, use a host app such as TerraTerm or RealTerm.

--- a/examples/shared/serial_ports/host_app/host.adb
+++ b/examples/shared/serial_ports/host_app/host.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2016, AdaCore                          --
+--                   Copyright (C) 2016-2025, AdaCore                       --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -30,37 +30,117 @@
 ------------------------------------------------------------------------------
 
 --  This file contains the source code for an interactive program to be run on
---  a host computer, to communicate via serial port with a program running on
---  a target board. It uses streams to send and receive strings to/from the
---  target board program.
+--  a host computer. It communicates via a host serial port with the streaming
+--  demonstration program running on a target board. It uses streams to send
+--  and receive strings to/from the target board program for the sake of
+--  compatible handling of the bounds. This host program is only intended
+--  for the streaming demonstration, not for the other target demonstration
+--  programs.
 
---  The program can be connected to the target board with a serial cable that
---  presents a serial port to the host operating system. The "README.md" file
---  associated with this project describes such a cable.
+--  This program is to be built with a native machine compiler, not a
+--  cross-compiler. The program is known to work on Windows and should work
+--  on Linux as well, according to the comments in package GNAT.Communications.
 
---  You can change the COM port number, or even get it from the command line
---  as an argument, but it must match what the host OS sees from the USB-COM
---  cable. This program has been run successfully on Windows 7 but should run
---  on Linux as well.
+--  The host program requires a serial port to communicate with the serial port
+--  on the target board, so a cable is required. One way to do that is to use
+--  a special cable that makes a host USB port function like a serial port. The
+--  "README.md" file associated with this project describes such a cable, which
+--  was used in testing.
 
---  When running it, enter a string at the prompt (">") or just hit carriage
+--  On the command line invocation you must specify the host serial port number
+--  as an integer number (in any base if you use Ada syntax). That number must
+--  correspond to the host serial port connected to the target board. No other
+--  command line parameters are accepted.
+
+--  During execution, enter a string at the prompt (">") or just hit carriage
 --  return if you are ready to quit. If you do enter a string, it will be sent
 --  to the target board, along with the bounds. The program running on the
 --  target echos it back so this host app will show that response from the
 --  board.
+--
+--  Note that the baud rate for the host serial port is set below, and although
+--  arbitrary, must match the value set by the streaming demo program on the
+--  target board. That could be an additional host argument in the future. The
+--  target serial port is set to eight data bits, no parity, and one stop bit.
+--  Those settings are typically what a host serial port uses for defaults, but
+--  not necessarily.
 
 with GNAT.IO;                    use GNAT.IO;
 with GNAT.Serial_Communications; use GNAT.Serial_Communications;
+with Ada.Command_Line;
 
 procedure Host is
-   COM  : aliased Serial_Port;
-   COM3 : constant Port_Name := Name (3);
+
+   COM             : aliased Serial_Port;
+   Selected_Port   : Integer;
+   Valid_Selection : Boolean;
 
    Outgoing : String (1 .. 1024); -- arbitrary
-   Last     : Natural;
+   Last     : Natural range Outgoing'First - 1 .. Outgoing'Last;
+
+   procedure Get_Port_Number
+     (Selected_Port : out Integer;
+      Valid         : out Boolean);
+   --  Get the port number from the command line arguments (only one is
+   --  expected), ensuring that the argument is a well-formed integer with
+   --  the required range.
+   --
+   --  Note that it does not check whether a valid argument corresponds to an
+   --  existing host serial port. If it does not, GNAT.Serial_Communications
+   --  will raise Serial_Error when Open is called.
+
+   ---------------------
+   -- Get_Port_Number --
+   ---------------------
+
+   procedure Get_Port_Number
+     (Selected_Port : out Integer;
+      Valid         : out Boolean)
+   is
+      use Ada.Command_Line;
+   begin
+      Valid := False;
+      Selected_Port := 0;  -- won't be used unless the caller ignores Valid
+
+      if Argument_Count /= 1 then
+         Put_Line ("You must specify (only) the number of the COM port to open on this host.");
+         Put_Line ("For example, to specify COM3 the invocation would be:");
+         Put_Line ("    host 3");
+         Put_Line ("The following Windows PowerShell command lists all existing ports:");
+         Put_Line ("    [System.IO.Ports.SerialPort]::GetPortNames()");
+         return;
+      end if;
+
+      Well_Formed : begin
+         Selected_Port := Integer'Value (Argument (1));
+      exception
+         when others =>
+            Put_Line ("You must specify a syntactically valid (positive) integer value for the host COM port.");
+            return;
+      end Well_Formed;
+
+      if Selected_Port < 1 then
+         Put_Line ("You must specify a positive number for the host COM port.");
+         --  Because function Name from package GNAT.Serial_Communications
+         --  requires a positive value.
+         return;
+      end if;
+
+      Valid := True;
+   end Get_Port_Number;
+
 begin
-   COM.Open (COM3);
+   Get_Port_Number (Selected_Port, Valid_Selection);
+   if not Valid_Selection then
+      return;
+   end if;
+
+   COM.Open (Name (Selected_Port));
    COM.Set (Rate => B115200, Block => False);
+   --  The baud rate is arbitrary but must match the selection by the target
+   --  board's stream demonstration program. The other target serial port
+   --  settings are N81. That stop bit is likley critical to proper function
+   --  of the demo.
 
    loop
       Put ("> ");
@@ -74,7 +154,7 @@ begin
       declare
          Incoming : constant String := String'Input (COM'Access);
       begin
-         Put_Line ("From board: " & Incoming);
+         Put_Line ("Received from board: " & Incoming);
       end;
    end loop;
 

--- a/examples/shared/serial_ports/src/demo_serial_port_blocking.adb
+++ b/examples/shared/serial_ports/src/demo_serial_port_blocking.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2022, AdaCore                      --
+--                    Copyright (C) 2015-2025, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -37,11 +37,9 @@ with Last_Chance_Handler;  pragma Unreferenced (Last_Chance_Handler);
 --  an exception is propagated. We need it in the executable, therefore it
 --  must be somewhere in the closure of the context clauses.
 
-with Peripherals_Blocking;  use Peripherals_Blocking;
+with Peripherals_Blocking;  use Peripherals_Blocking; -- for COM
 with Serial_IO.Blocking;    use Serial_IO.Blocking;
 with Message_Buffers;       use Message_Buffers;
-
-use Serial_IO;
 
 procedure Demo_Serial_Port_Blocking is
 
@@ -53,18 +51,27 @@ procedure Demo_Serial_Port_Blocking is
    procedure Send (This : String) is
    begin
       Set (Outgoing, To => This);
-      Blocking.Send (COM, Outgoing'Unchecked_Access);
+      Send (COM, Outgoing'Unchecked_Access);
       --  Send won't return until the entire message has been sent
    end Send;
 
 begin
-   Initialize_Hardware (COM);
-   Configure (COM, Baud_Rate => 115_200);
+   Serial_IO.Initialize_Hardware (Peripheral);
+   Serial_IO.Configure (COM.Device, Baud_Rate => 115_200);
+   --  This baud rate selection is entirely arbitrary. Note that you may have
+   --  to alter the settings of your host serial port to match this baud rate,
+   --  or just change the above to match whatever the host serial port has set
+   --  already. An application such as TerraTerm or RealTerm is helpful.
 
    Incoming.Set_Terminator (To => ASCII.CR);
    Send ("Enter text, terminated by CR.");
+   --  Note that you may have to alter the settings on your host serial port
+   --  so that the terminator char is not stripped off automatically by the
+   --  host driver, which may happen especially when CR is the terminator.
+   --  An application such as TerraTerm or RealTerm is helpful.
+
    loop
-      Blocking.Receive (COM, Incoming'Unchecked_Access);
+      Receive (COM, Incoming'Unchecked_Access);
       Send ("Received : " & Incoming.Content);
    end loop;
 end Demo_Serial_Port_Blocking;

--- a/examples/shared/serial_ports/src/peripherals_blocking.ads
+++ b/examples/shared/serial_ports/src/peripherals_blocking.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                  Copyright (C) 2015-2022, AdaCore                        --
+--                  Copyright (C) 2015-2025, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -39,12 +39,12 @@ package Peripherals_Blocking is
 
    --  the USART selection is arbitrary but the AF number and the pins must
    --  be those required by that USART
-   Peripheral : aliased Serial_IO.Peripheral_Descriptor :=
+   Peripheral : constant Serial_IO.Peripheral_Descriptor :=
                   (Transceiver    => USART_1'Access,
                    Transceiver_AF => GPIO_AF_USART1_7,
                    Tx_Pin         => PB6,
                    Rx_Pin         => PB7);
 
-   COM : Blocking.Serial_Port (Peripheral'Access);
+   COM : Blocking.Serial_Port (Peripheral.Transceiver);
 
 end Peripherals_Blocking;

--- a/examples/shared/serial_ports/src/peripherals_nonblocking.ads
+++ b/examples/shared/serial_ports/src/peripherals_nonblocking.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2022, AdaCore                      --
+--                    Copyright (C) 2015-2025, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -43,13 +43,13 @@ package Peripherals_Nonblocking is
 
    --  the USART selection is arbitrary but the AF number and the pins must
    --  be those required by that USART
-   Peripheral : aliased Serial_IO.Peripheral_Descriptor :=
+   Peripheral : constant Serial_IO.Peripheral_Descriptor :=
                   (Transceiver    => USART_1'Access,
                    Transceiver_AF => GPIO_AF_USART1_7,
                    Tx_Pin         => PB6,
                    Rx_Pin         => PB7);
 
-   COM : Nonblocking.Serial_Port (Device       => Peripheral'Access,
+   COM : Nonblocking.Serial_Port (Device       => Peripheral.Transceiver,
                                   IRQ          => USART1_Interrupt,
                                   IRQ_Priority => Interrupt_Priority'Last);
 

--- a/examples/shared/serial_ports/src/peripherals_streaming.ads
+++ b/examples/shared/serial_ports/src/peripherals_streaming.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                  Copyright (C) 2015-2022, AdaCore                        --
+--                   Copyright (C) 2015-2025, AdaCore                       --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -29,21 +29,19 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with STM32.Device;        use STM32.Device;
-
-with Serial_IO;           use Serial_IO;
-with Serial_IO.Streaming;
+with STM32.Device;
+with Serial_IO.Streaming; use Serial_IO;
 
 package Peripherals_Streaming is
 
    --  the USART selection is arbitrary but the AF number and the pins must
    --  be those required by that USART
-   Peripheral : aliased Serial_IO.Peripheral_Descriptor :=
-                  (Transceiver    => USART_1'Access,
-                   Transceiver_AF => GPIO_AF_USART1_7,
-                   Tx_Pin         => PB6,
-                   Rx_Pin         => PB7);
+   Peripheral : constant Serial_IO.Peripheral_Descriptor :=
+                  (Transceiver    => STM32.Device.USART_1'Access,
+                   Transceiver_AF => STM32.Device.GPIO_AF_USART1_7,
+                   Tx_Pin         => STM32.Device.PB6,
+                   Rx_Pin         => STM32.Device.PB7);
 
-   COM : aliased Streaming.Serial_Port (Peripheral'Access);
+   COM : aliased Streaming.Serial_Port (Peripheral.Transceiver);
 
 end Peripherals_Streaming;

--- a/examples/shared/serial_ports/src/serial_io-nonblocking.ads
+++ b/examples/shared/serial_ports/src/serial_io-nonblocking.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2022, AdaCore                      --
+--                    Copyright (C) 2015-2025, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -50,27 +50,14 @@ package Serial_IO.Nonblocking is
    pragma Elaborate_Body;
 
    type Serial_Port
-     (Device       : not null access Peripheral_Descriptor;
+     (Device       : not null access USART;
       IRQ          : Interrupt_ID;
       IRQ_Priority : Interrupt_Priority)
    is limited private;
 
-   procedure Initialize_Hardware (This : in out Serial_Port);
-   --  A convenience wrapper for Serial_IO.Initialize_Hardware
-
-   procedure Configure
-     (This      : in out Serial_Port;
-      Baud_Rate : Baud_Rates;
-      Parity    : Parities     := No_Parity;
-      Data_Bits : Word_Lengths := Word_Length_8;
-      End_Bits  : Stop_Bits    := Stopbits_1;
-      Control   : Flow_Control := No_Flow_Control);
-   --  A convenience wrapper for Serial_IO.Configure
-
    procedure Send
      (This : in out Serial_Port;
-      Msg  : not null access Message)
-   with Inline;
+      Msg  : not null access Message);
    --  Start sending the content of Msg.all, returning potentially
    --  prior to the completion of the message transmission
 
@@ -79,24 +66,20 @@ package Serial_IO.Nonblocking is
       Msg  : not null access Message)
    with
       Post => Msg.Length <= Msg.Physical_Size and
-              (if Msg.Length > 0 then Msg.Content_At (Msg.Length) /= Msg.Terminator),
-              Inline;
+              (if Msg.Length > 0 then Msg.Content_At (Msg.Length) /= Msg.Terminator);
    --  Start receiving Msg.all content, ending when the specified
-   --  Msg.Terminator character is received (it is not stored), or
-   --  the physical capacity of Msg.all is reached
+   --  Msg.Terminator character is received or the physical capacity
+   --  of Msg.all is reached. The terminator character is not stored.
 
 private
 
    protected type Serial_Port
-     (Device       : not null access Peripheral_Descriptor;
+     (Device       : not null access USART;
       IRQ          : Interrupt_ID;
       IRQ_Priority : Interrupt_Priority)
-   --  with
-      --  Interrupt_Priority => IRQ_Priority
+   with
+      Interrupt_Priority => IRQ_Priority
    is
-
-      pragma Interrupt_Priority (IRQ_Priority);
-      --  use pragma as workaround for bug in GNAT frontend (V523-041)
 
       procedure Start_Sending (Msg : not null access Message);
 

--- a/examples/shared/serial_ports/src/serial_io-nonblocking.ads
+++ b/examples/shared/serial_ports/src/serial_io-nonblocking.ads
@@ -92,11 +92,11 @@ private
       IRQ          : Interrupt_ID;
       IRQ_Priority : Interrupt_Priority)
    --  with
-   --     Interrupt_Priority => IRQ_Priority
+      --  Interrupt_Priority => IRQ_Priority
    is
 
       pragma Interrupt_Priority (IRQ_Priority);
-      --  use pragma as workaround for bug in CE_2021 frontend (V523-041)
+      --  use pragma as workaround for bug in GNAT frontend (V523-041)
 
       procedure Start_Sending (Msg : not null access Message);
 

--- a/examples/shared/serial_ports/src/serial_io-streaming.ads
+++ b/examples/shared/serial_ports/src/serial_io-streaming.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2016-2022, AdaCore                      --
+--                    Copyright (C) 2016-2025, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -43,27 +43,17 @@ with Ada.Real_Time; use Ada.Real_Time;
 package Serial_IO.Streaming is
    pragma Elaborate_Body;
 
-   type Serial_Port (Device : not null access Peripheral_Descriptor) is
+   type Serial_Port (Device : not null access USART) is
      new Ada.Streams.Root_Stream_Type with private;
-
-   procedure Initialize_Hardware (This : out Serial_Port);
-
-   procedure Configure
-     (This      : in out Serial_Port;
-      Baud_Rate : Baud_Rates;
-      Parity    : Parities     := No_Parity;
-      Data_Bits : Word_Lengths := Word_Length_8;
-      End_Bits  : Stop_Bits    := Stopbits_1;
-      Control   : Flow_Control := No_Flow_Control);
 
    procedure Set_Read_Timeout
      (This : in out Serial_Port;
       Wait : Time_Span);
    --  Stream attributes that call Read (below) can either wait indefinitely or
    --  can be set to return any current values received after a given interval.
-   --  If the value Time_Span_Last is passed to Wait, the effect is essentially to wait
-   --  forever, i.e., blocking. That is also the effect if this routine is
-   --  never called.
+   --  If the value Time_Span_Last is passed to Wait, the effect is essentially
+   --  to wait forever, i.e., blocking. That is also the effect if this routine
+   --  is never called.
 
    overriding
    procedure Read
@@ -78,15 +68,15 @@ package Serial_IO.Streaming is
 
 private
 
-   type Serial_Port (Device : access Peripheral_Descriptor) is
+   type Serial_Port (Device : access USART) is
      new Ada.Streams.Root_Stream_Type with record
        Timeout : Time_Span := Time_Span_Last;
      end record;
 
-   procedure Await_Send_Ready (This : USART) with Inline;
+   procedure Await_Send_Ready (This : access USART) with Inline;
 
    procedure Await_Data_Available
-     (This      : USART;
+     (This      : access USART;
       Timeout   : Time_Span := Time_Span_Last;
       Timed_Out : out Boolean)
    with Inline;

--- a/examples/shared/serial_ports/src/serial_io.adb
+++ b/examples/shared/serial_ports/src/serial_io.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2022, AdaCore                     --
+--                     Copyright (C) 2015-2025, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -37,7 +37,7 @@ package body Serial_IO is
    -- Initialize_Hardware --
    -------------------------
 
-   procedure Initialize_Hardware (Device : access Peripheral_Descriptor) is
+   procedure Initialize_Hardware (Device : Peripheral_Descriptor) is
       Configuration : GPIO_Port_Configuration;
       Device_Pins   : constant GPIO_Points := Device.Rx_Pin & Device.Tx_Pin;
    begin
@@ -58,24 +58,27 @@ package body Serial_IO is
    ---------------
 
    procedure Configure
-     (Device    : access Peripheral_Descriptor;
+     (Device    : access USART;
       Baud_Rate : Baud_Rates;
       Parity    : Parities     := No_Parity;
       Data_Bits : Word_Lengths := Word_Length_8;
       End_Bits  : Stop_Bits    := Stopbits_1;
       Control   : Flow_Control := No_Flow_Control)
    is
+      --  this is a convenience procedure, but the convenience includes
+      --  ensuring that the device is disabled and enabled at the appropriate
+      --  points
    begin
-      Disable (Device.Transceiver.all);
+      Device.Disable;
 
-      Set_Baud_Rate    (Device.Transceiver.all, Baud_Rate);
-      Set_Mode         (Device.Transceiver.all, Tx_Rx_Mode);
-      Set_Stop_Bits    (Device.Transceiver.all, End_Bits);
-      Set_Word_Length  (Device.Transceiver.all, Data_Bits);
-      Set_Parity       (Device.Transceiver.all, Parity);
-      Set_Flow_Control (Device.Transceiver.all, Control);
+      Device.Set_Baud_Rate    (Baud_Rate);
+      Device.Set_Mode         (Tx_Rx_Mode);
+      Device.Set_Stop_Bits    (End_Bits);
+      Device.Set_Word_Length  (Data_Bits);
+      Device.Set_Parity       (Parity);
+      Device.Set_Flow_Control (Control);
 
-      Enable (Device.Transceiver.all);
+      Device.Enable;
    end Configure;
 
 end Serial_IO;

--- a/examples/shared/serial_ports/src/serial_io.ads
+++ b/examples/shared/serial_ports/src/serial_io.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015-2022, AdaCore                      --
+--                    Copyright (C) 2015-2025, AdaCore                      --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -42,11 +42,11 @@ package Serial_IO is
       Rx_Pin         : GPIO_Point;
    end record;
 
-   procedure Initialize_Hardware (Device : access Peripheral_Descriptor);
+   procedure Initialize_Hardware (Device : Peripheral_Descriptor);
    --  enable clocks, configure GPIO pins, etc.
 
    procedure Configure
-     (Device    : access Peripheral_Descriptor;
+     (Device    : access USART;
       Baud_Rate : Baud_Rates;
       Parity    : Parities     := No_Parity;
       Data_Bits : Word_Lengths := Word_Length_8;


### PR DESCRIPTION
README.md
- Add new readme indicating that this host program is only intended for the
stream-based demo, and explaining how to use it

host.adb
- Add much more comments in the header block explaining how to use this program and
why it is needed
- Parameterize the host port number instead of hard-coding it

demo_serial_port_blocking.adb
- Use normalized procedure names for Send and Receive, for consistency with
other versions
- Add comments re: baud rate and other settings required

demo_serial_port_nonblocking.adb
- Better name for local procedure
- Add many more comments re: settings

demo_serial_port_streaming.adb
- Replace source code in comment header block with location of the actual
code and project file.
- Add comment re: serial port settings

peripherals_blocking.ads
- Peripheral should be a constant
- COM now references the USART designated by Peripheral

peripherals_nonblocking.ads
- Same as for peripherals_blocking.ads

peripherals_streaming.ads
- Same as for peripherals_blocking.ads

serial_io-blocking.ads
- Type Serial_Port now designates a USART rather than type Peripheral
- No longer provide call-through routines for the Serial_IO package's
Initialize_Hardware and Configure since client can easily call them. Better
separation of concerns as a result.
- Change signatures of internal routines to be access-to-USART

serial_io-blocking.adb
- Internal simplifications reflecting change to access discriminant now designating type USART
- Remove code for Initialize_Hardware and Configure, per removal from package spec

serial_io-nonblocking.ads
- Type Serial_Port now designates a USART rather than type Peripheral
- No longer provide call-through routines for Serial_IO packages
Initialize_Hardware and Configure since client can easily do so, and simplifies this package
- Change signatures of internal routines to be access-to-USART

serial_io-nonblocking.adb
- Internal simplifications reflecting change to access discriminant now designating type USART
- Remove code for Initialize_Hardware and Configure, per removal from package spec
- Use short-circuit control forms in ISR since don't need to check both conditions, should be
a little faster

serial_io-streaming.ads
- Type Serial_Port now designates a USART rather than type Peripheral
- No longer provide call-through routines for Serial_IO packages
Initialize_Hardware and Configure since client can easily do so, and simplifies this package
- Change signatures of internal routines to be access-to-USART

serial_io-streaming.adb
- Internal simplifications reflecting change to access discriminant now designating type USART
- Remove code for Initialize_Hardware and Configure, per removal from package spec

serial_io.ads
- Procedure Initialize_Hardware's formal parameter is no longer an access parameter
- Procedure Configure's first formal parameter is now access to USART

serial_io.adb
- Change to procedures' signatures as per spec
- Procedure Configure now uses distinguished receiver syntax for USART routines, much cleaner
