### PR TITLE
Fix potential display coherency problem when D-cache is enabled

### DIFF
--- a/boards/stm32_common/dma2d/stm32-dma2d_bitmap.adb
+++ b/boards/stm32_common/dma2d/stm32-dma2d_bitmap.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2026, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -153,7 +153,8 @@ package body STM32.DMA2D_Bitmap is
                X      => Area.Position.X,
                Y      => Area.Position.Y,
                Width  => Area.Width,
-               Height => Area.Height);
+               Height => Area.Height,
+               Synchronous => True);
          else
             DMA2D_Fill_Rect
               (DMA_Buf,
@@ -161,7 +162,8 @@ package body STM32.DMA2D_Bitmap is
                X      => Area.Position.Y,
                Y      => Buffer.Width - Area.Position.X - Area.Width,
                Width  => Area.Height,
-               Height => Area.Width);
+               Height => Area.Width,
+               Synchronous => True);
          end if;
       else
          Parent (Buffer).Fill_Rect (Area);

--- a/boards/stm32_common/ltdc/framebuffer_ltdc.adb
+++ b/boards/stm32_common/ltdc/framebuffer_ltdc.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2026, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -32,6 +32,7 @@
 with STM32.DMA2D.Interrupt;
 with STM32.DMA2D.Polling;
 with STM32.SDRAM;           use STM32.SDRAM;
+with Cortex_M.Cache;
 
 package body Framebuffer_LTDC is
 
@@ -377,12 +378,18 @@ package body Framebuffer_LTDC is
             null;
          when 1 =>
             Display.Buffers (LCD_Layer, 2).Wait_Transfer;
+            Cortex_M.Cache.Clean_DCache
+              (Display.Buffers (LCD_Layer, 2).Addr,
+               Display.Buffers (LCD_Layer, 2).Buffer_Size);
             STM32.LTDC.Set_Frame_Buffer
               (Layer => LCD_Layer,
                Addr  => Display.Buffers (LCD_Layer, 2).Addr);
             Display.Current (LCD_Layer) := 2;
          when 2 =>
             Display.Buffers (LCD_Layer, 1).Wait_Transfer;
+            Cortex_M.Cache.Clean_DCache
+              (Display.Buffers (LCD_Layer, 1).Addr,
+               Display.Buffers (LCD_Layer, 1).Buffer_Size);
             STM32.LTDC.Set_Frame_Buffer
               (Layer => LCD_Layer,
                Addr  => Display.Buffers (LCD_Layer, 1).Addr);


### PR DESCRIPTION
Affects: stm32-dma2d_bitmap, framebuffer_ltdc

DMA2D_Fill_Rect was called without Synchronous => True, allowing DMA2D writes to the hidden framebuffer to still be in progress when Internal_Update_Layer flushed and handed the buffer to LTDC.  We need to change the call to Fill_Rect to use Synchronous => True, consistent with Fill.

After the calls to Wait_Transfer in procedure Internal_Update_Layer , we need a call to Clean_DCache covering the hidden buffer, before the call to Set_Frame_Buffer, ensuring CPU-written dirty cache lines are flushed to physical memory before LTDC DMA reads them.

Why Wait_Transfer alone is insufficient: Wait_Transfer waits for any in-progress DMA2D transfer to complete on that buffer, and then calls Clean_Invalidate_DCache. That's correct for a buffer the CPU is about to read (invalidate stale CPU-cache lines so it re-fetches DMA2D-written data). But for a buffer LTDC is about to read, we need Clean_DCache (flush CPU-dirty lines to physical memory without discarding them).  In other words, Clean_Invalidate is correct for the CPU-read case, and Clean only is correct for the LTDC-handoff case. The Clean_Invalidate_DCache inside Wait_Transfer becomes redundant given the subsequent Clean_DCache, but the synchronization barrier it provides is not. We still need to wait for DMA2D to finish before flipping.
