### PR TITLE
Fix SDRAM timing setup during initialization

### DIFF
--- a/boards/stm32_common/sdram/stm32-sdram.adb
+++ b/boards/stm32_common/sdram/stm32-sdram.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2026, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -141,9 +141,7 @@ package body STM32.SDRAM is
       SDRAM_Conf      : FMC_SDRAM_Init_Config;
       SDCLK           : constant Unsigned_32 :=
         Unsigned_32 (STM32.Device.System_Clock_Frequencies.SYSCLK / 2);
-      SDPeriod_In_ns  : constant Unsigned_32 :=
-                          1_000_000_000 / SDCLK;
-      Refresh_Delay   : Unsigned_32;
+      SDPeriod_In_Ns  : constant Unsigned_32 := 1_000_000_000 / SDCLK;
 
    begin
       if Initialized then
@@ -171,22 +169,19 @@ package body STM32.SDRAM is
       --  100 MHz of SD clock frequency (200MHz / 2)
       --  1 Clock cycle = 1 / 100MHz = 10ns
 
-      Refresh_Delay :=
-        (SDRAM_Min_Delay_In_ns - SDPeriod_In_ns + 1) / SDPeriod_In_ns;
-
       Timing_Conf :=
         (
          --  2 Clock cycles for Load to Active delay
          LoadToActiveDelay    => 2,
 
-         --  min = 60ns: 6 * 10.0
-         ExitSelfRefreshDelay => FMC_SDRAM_Timing (Refresh_Delay),
-
-         --  in range [42ns, 120k ns] => using 4 * 11.1 ns
-         SelfRefreshTime      => 4,
-
-         --  min = 60ns
-         RowCycleDelay        => FMC_SDRAM_Timing (Refresh_Delay),
+         --  Each timing parameter is computed as a cycle count by dividing the
+         --  required minimum time (in ns) by the SDCLK period, using ceiling
+         --  division to ensure the minimum is always satisfied regardless of
+         --  clock frequency. The timing constants are defined in STM32.Board
+         --  and reflect the IS42S32400F SDRAM datasheet specifications.
+         ExitSelfRefreshDelay => FMC_SDRAM_Timing ((SDRAM_TXSR_In_Ns + SDPeriod_In_Ns - 1) / SDPeriod_In_Ns),
+         SelfRefreshTime      => FMC_SDRAM_Timing ((SDRAM_TRAS_In_Ns + SDPeriod_In_Ns - 1) / SDPeriod_In_Ns),
+         RowCycleDelay        => FMC_SDRAM_Timing ((SDRAM_TRC_In_Ns  + SDPeriod_In_Ns - 1) / SDPeriod_In_Ns),
 
          --  min = 20ns
          WriteRecoveryTime    => 2,
@@ -241,8 +236,7 @@ package body STM32.SDRAM is
    begin
       Initialize;
       Rounded_Size := Amount + Align;
-      Rounded_Size :=
-        Rounded_Size - Rounded_Size rem Align;
+      Rounded_Size := Rounded_Size - Rounded_Size rem Align;
 
       G_Base_Addr := G_Base_Addr + Rounded_Size;
 

--- a/boards/stm32_common/stm32f429disco/stm32-board.ads
+++ b/boards/stm32_common/stm32f429disco/stm32-board.ads
@@ -132,7 +132,12 @@ package STM32.Board is
    SDRAM_Read_Pipe       : constant STM32.FMC.FMC_SDRAM_Read_Pipe_Delay :=
                              STM32.FMC.FMC_ReadPipe_Delay_1;
    SDRAM_Refresh_Cnt     : constant := 1386;
-   SDRAM_Min_Delay_In_ns : constant := 70;
+
+   --  SDRAM AC timings (ns) for the on-board ISSI IS42S16400J
+   --  Values from the ST BSP in stm32f429i_discovery_sdram.c at SDCLK = 90 MHz:
+   SDRAM_TRAS_In_Ns      : constant := 42;  --  TRAS  
+   SDRAM_TRC_In_Ns       : constant := 70;  --  TRC   
+   SDRAM_TXSR_In_Ns      : constant := 70;  --  TXSR
 
    ---------------
    -- SPI5 Pins --

--- a/boards/stm32_common/stm32f429disco/stm32-board.ads
+++ b/boards/stm32_common/stm32f429disco/stm32-board.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                  Copyright (C) 2015-2016, AdaCore                        --
+--                  Copyright (C) 2015-2026, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -135,8 +135,8 @@ package STM32.Board is
 
    --  SDRAM AC timings (ns) for the on-board ISSI IS42S16400J
    --  Values from the ST BSP in stm32f429i_discovery_sdram.c at SDCLK = 90 MHz:
-   SDRAM_TRAS_In_Ns      : constant := 42;  --  TRAS  
-   SDRAM_TRC_In_Ns       : constant := 70;  --  TRC   
+   SDRAM_TRAS_In_Ns      : constant := 42;  --  TRAS
+   SDRAM_TRC_In_Ns       : constant := 70;  --  TRC
    SDRAM_TXSR_In_Ns      : constant := 70;  --  TXSR
 
    ---------------

--- a/boards/stm32_common/stm32f469disco/stm32-board.ads
+++ b/boards/stm32_common/stm32f469disco/stm32-board.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2018, AdaCore                     --
+--                     Copyright (C) 2015-2026, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --

--- a/boards/stm32_common/stm32f469disco/stm32-board.ads
+++ b/boards/stm32_common/stm32f469disco/stm32-board.ads
@@ -129,7 +129,11 @@ package STM32.Board is
    SDRAM_Read_Pipe       : constant STM32.FMC.FMC_SDRAM_Read_Pipe_Delay :=
                              STM32.FMC.FMC_ReadPipe_Delay_0;
    SDRAM_Refresh_Cnt     : constant := 16#0569#;
-   SDRAM_Min_Delay_In_ns : constant := 70;
+   --  SDRAM AC timings (ns) for the on-board Micron MT48LC4M32B2B5
+   --  Values from the ST BSP in stm32469i_discovery_sdram.c at SDCLK = 90 MHz:
+   SDRAM_TRAS_In_Ns      : constant := 42;  --  TRAS
+   SDRAM_TRC_In_Ns       : constant := 70;  --  TRC
+   SDRAM_TXSR_In_Ns      : constant := 70;  --  TXSR
 
    ---------
    -- I2C --

--- a/boards/stm32_common/stm32f746disco/stm32-board.ads
+++ b/boards/stm32_common/stm32f746disco/stm32-board.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                 Copyright (C) 2015-2018, AdaCore                         --
+--                 Copyright (C) 2015-2026, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -116,7 +116,9 @@ package STM32.Board is
    SDRAM_Read_Pipe       : constant STM32.FMC.FMC_SDRAM_Read_Pipe_Delay :=
                              STM32.FMC.FMC_ReadPipe_Delay_0;
    SDRAM_Refresh_Cnt     : constant := 1539;
-   SDRAM_Min_Delay_In_ns : constant := 60;
+   SDRAM_TRAS_In_Ns      : constant := 42;  --  IS42S32400F min self-refresh time
+   SDRAM_TRC_In_Ns       : constant := 60;  --  IS42S32400F min row cycle time
+   SDRAM_TXSR_In_Ns      : constant := 70;  --  IS42S32400F min exit self-refresh delay
 
    ---------
    -- I2C --

--- a/boards/stm32_common/stm32f746disco/stm32-board.ads
+++ b/boards/stm32_common/stm32f746disco/stm32-board.ads
@@ -116,9 +116,11 @@ package STM32.Board is
    SDRAM_Read_Pipe       : constant STM32.FMC.FMC_SDRAM_Read_Pipe_Delay :=
                              STM32.FMC.FMC_ReadPipe_Delay_0;
    SDRAM_Refresh_Cnt     : constant := 1539;
-   SDRAM_TRAS_In_Ns      : constant := 42;  --  IS42S32400F min self-refresh time
-   SDRAM_TRC_In_Ns       : constant := 60;  --  IS42S32400F min row cycle time
-   SDRAM_TXSR_In_Ns      : constant := 70;  --  IS42S32400F min exit self-refresh delay
+   --  SDRAM AC timings (ns) for the on-board Micron MT48LC4M32B2B5-6A
+   --  Values from the ST BSP in stm32746g_discovery_sdram.c at SDCLK = 100 MHz:
+   SDRAM_TRAS_In_Ns      : constant := 42;  --  TRAS
+   SDRAM_TRC_In_Ns       : constant := 60;  --  TRC
+   SDRAM_TXSR_In_Ns      : constant := 67;  --  TXSR
 
    ---------
    -- I2C --

--- a/boards/stm32_common/stm32f769disco/stm32-board.ads
+++ b/boards/stm32_common/stm32f769disco/stm32-board.ads
@@ -125,7 +125,11 @@ package STM32.Board is
    SDRAM_Read_Pipe       : constant STM32.FMC.FMC_SDRAM_Read_Pipe_Delay :=
                              STM32.FMC.FMC_ReadPipe_Delay_0;
    SDRAM_Refresh_Cnt     : constant := 16#0603#;
-   SDRAM_Min_Delay_In_ns : constant := 60;
+   --  SDRAM AC timings (ns) for the on-board Micron MT48LC4M32B2B5-6A
+   --  Values from the ST BSP in stm32f769i_discovery_sdram.c at SDCLK = 100 MHz:
+   SDRAM_TRAS_In_Ns      : constant := 42;  --  TRAS
+   SDRAM_TRC_In_Ns       : constant := 60;  --  TRC
+   SDRAM_TXSR_In_Ns      : constant := 67;  --  TXSR
 
    ---------
    -- I2C --

--- a/boards/stm32_common/stm32f769disco/stm32-board.ads
+++ b/boards/stm32_common/stm32f769disco/stm32-board.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                 Copyright (C) 2015-2018, AdaCore                         --
+--                 Copyright (C) 2015-2026, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --


### PR DESCRIPTION
stm32-sdram.adb: 
We now compute initialization values from the datasheet constants. Specifically, in procedure Initialize:

- ExitSelfRefreshDelay, SelfRefreshTime, and RowCycleDelay were all derived from a single SDRAM_Min_Delay_In_ns constant, improperly collapsing three distinct timing constraints (TXSR, TRAS, TRC) into one value. 

- SelfRefreshTime was also hardcoded to 4 cycles, valid only at 90 MHz SDCLK.

We replace those with per-parameter ceiling division over named board constants (SDRAM_TXSR_In_Ns, SDRAM_TRAS_In_Ns, SDRAM_TRC_In_Ns) so each constraint is satisfied independently at any clock frequency.

stm32-board.ads:

- add new SDRAM constants for the sake of the SDRAM initialization