### PR TITLE
Add ISB to Memory_Barriers for sake of completeness

### DIFF
--- a/arch/ARM/cortex_m/src/memory_barriers.adb
+++ b/arch/ARM/cortex_m/src/memory_barriers.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                 Copyright (C) 2015-2026, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -40,7 +40,17 @@ package body Memory_Barriers is
    procedure Data_Synchronization_Barrier is
       pragma Suppress (All_Checks);
    begin
-      Asm ("DSB #0xF", Volatile => True);    -- 15 is 'Sy", ie "full system"
+      Asm ("DSB #0xF", Volatile => True);  -- 15 is 'Sy", ie "full system"
    end Data_Synchronization_Barrier;
+
+   -----------------------------------------
+   -- Instruction_Synchronization_Barrier --
+   -----------------------------------------
+
+   procedure Instruction_Synchronization_Barrier is
+      pragma Suppress (All_Checks);
+   begin
+      Asm ("ISB", Volatile => True);
+   end Instruction_Synchronization_Barrier;
 
 end Memory_Barriers;

--- a/arch/ARM/cortex_m/src/memory_barriers.ads
+++ b/arch/ARM/cortex_m/src/memory_barriers.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                 Copyright (C) 2015-2026, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -29,14 +29,18 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
---  This file provides utility functions for ARM Cortex microcontrollers
+--  This unit provides memory barrier routines for ARM Cortex microcontrollers
 
 package Memory_Barriers is
    pragma Preelaborate;
 
-   procedure Data_Synchronization_Barrier with Inline;
+   procedure Data_Synchronization_Barrier with Inline_Always;
    --  Injects instruction "DSB Sy" i.e., a "full system" domain barrier
 
+   procedure Instruction_Synchronization_Barrier with Inline_Always;
+   --  Injects instruction "ISB"
+
    procedure DSB renames Data_Synchronization_Barrier;
+   procedure ISB renames Instruction_Synchronization_Barrier;
 
 end Memory_Barriers;


### PR DESCRIPTION
And mark both routines as Inline_Always. Note that is a change for DSB which was just marked Inline, but these don't make sense when not inline.