### PR TITLE
Add CRC unit for STM32F7x MCUs

### DIFF
--- a/arch/ARM/STM32/devices/stm32f7x/stm32-device.adb
+++ b/arch/ARM/STM32/devices/stm32f7x/stm32-device.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2026, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -1088,5 +1088,15 @@ package body STM32.Device is
       RCC_Periph.AHB1RSTR.ETHMACRST := True;
       RCC_Periph.AHB1RSTR.ETHMACRST := False;
    end Reset_Eth;
+
+   ------------------
+   -- Enable_Clock --
+   ------------------
+
+   procedure Enable_Clock (This : in out CRC_32) is
+      pragma Unreferenced (This);
+   begin
+      RCC_Periph.AHB1ENR.CRCEN := True;
+   end Enable_Clock;
 
 end STM32.Device;

--- a/arch/ARM/STM32/devices/stm32f7x/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f7x/stm32-device.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2018, AdaCore                     --
+--                     Copyright (C) 2015-2026, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --
@@ -39,8 +39,8 @@
 --   COPYRIGHT(c) 2014 STMicroelectronics                                   --
 ------------------------------------------------------------------------------
 
---  This file provides declarations for devices on the STM32F42xxx MCUs
---  manufactured by ST Microelectronics.  For example, an STM32F429.
+--  This file provides declarations for devices on the STM32F7x MCUs
+--  manufactured by ST Microelectronics.  For example, an STM32F746.
 
 private with ADL_Config;
 
@@ -60,6 +60,7 @@ with STM32.SPI.DMA;   use STM32.SPI.DMA;
 with STM32.I2S;       use STM32.I2S;
 with STM32.Timers;    use STM32.Timers;
 with STM32.RTC;       use STM32.RTC;
+with STM32.CRC;       use STM32.CRC;
 
 package STM32.Device is
    pragma Elaborate_Body;
@@ -541,6 +542,14 @@ package STM32.Device is
    procedure Enable_Clock (This : in out SAI_Port);
    procedure Reset (This : in out SAI_Port);
    function Get_Input_Clock (Periph : SAI_Port) return UInt32;
+
+   ---------
+   -- CRC --
+   ---------
+
+   CRC_Unit : CRC_32 with Volatile, Address => STM32_SVD.CRC_Base, Import;
+
+   procedure Enable_Clock (This : in out CRC_32);
 
    -----------
    -- SDMMC --

--- a/arch/ARM/STM32/drivers/crc_stm32f7/readme.txt
+++ b/arch/ARM/STM32/drivers/crc_stm32f7/readme.txt
@@ -1,0 +1,5 @@
+The CRC unit on the F7 devices (and others) has the additional ability
+to define the initial value and the polynomial value, but the same core
+capabilities of the F4 are present.
+
+TODO: enhance these source files to add the extra functionality of the F7x

--- a/arch/ARM/STM32/drivers/crc_stm32f7/stm32-crc-dma.adb
+++ b/arch/ARM/STM32/drivers/crc_stm32f7/stm32-crc-dma.adb
@@ -1,0 +1,158 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2017, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with STM32.Device;    use STM32.Device;
+
+package body STM32.CRC.DMA is
+
+   procedure Configure_DMA
+     (Controller : access DMA_Controller;
+      Stream     : DMA_Stream_Selector;
+      Data_Width : DMA_Data_Transfer_Widths);
+   --  Configures the DMA controller and stream for transfering memory blocks,
+   --  of the width specified, to the CRC processor.
+
+   ---------------------------
+   -- Transfer_Input_To_CRC --
+   ---------------------------
+
+   procedure Transfer_Input_To_CRC
+     (This          : in out CRC_32;
+      Controller    : access DMA_Controller;
+      Stream        : DMA_Stream_Selector;
+      Input_Address : System.Address;
+      Input_Length  : UInt16;
+      Data_Width    : DMA_Data_Transfer_Widths)
+   is
+   begin
+      Configure_DMA (Controller, Stream, Data_Width);
+      --  We configure the unit each time to ensure the data width is right.
+
+      Clear_All_Status (Controller.all, Stream);
+      --  Ensure previous calls or other use hasn't set any status flags.
+
+      Start_Transfer_with_Interrupts
+        (Controller.all,
+         Stream,
+         Source             => Input_Address,
+         Destination        => This.DR'Address,
+         Data_Count         => Input_Length,
+         Enabled_Interrupts => (Transfer_Complete_Interrupt => True,
+                                others                      => False));
+   end Transfer_Input_To_CRC;
+
+   ----------------
+   -- Update_CRC --
+   ----------------
+
+   procedure Update_CRC
+     (This       : in out CRC_32;
+      Controller : access DMA_Controller;
+      Stream     : DMA_Stream_Selector;
+      Input      : Block_32) is
+   begin
+      Transfer_Input_To_CRC
+        (This,
+         Controller,
+         Stream,
+         Input'Address,
+         Input'Length,
+         Data_Width => Words);
+   end Update_CRC;
+
+   ----------------
+   -- Update_CRC --
+   ----------------
+
+   procedure Update_CRC
+     (This       : in out CRC_32;
+      Controller : access DMA_Controller;
+      Stream     : DMA_Stream_Selector;
+      Input      : Block_16) is
+   begin
+      Transfer_Input_To_CRC
+        (This,
+         Controller,
+         Stream,
+         Input'Address,
+         Input'Length,
+         Data_Width => HalfWords);
+   end Update_CRC;
+
+   ----------------
+   -- Update_CRC --
+   ----------------
+
+   procedure Update_CRC
+     (This       : in out CRC_32;
+      Controller : access DMA_Controller;
+      Stream     : DMA_Stream_Selector;
+      Input      : Block_8) is
+   begin
+      Transfer_Input_To_CRC
+        (This,
+         Controller,
+         Stream,
+         Input'Address,
+         Input'Length,
+         Data_Width => Bytes);
+   end Update_CRC;
+
+   -------------------
+   -- Configure_DMA --
+   -------------------
+
+   procedure Configure_DMA
+     (Controller : access DMA_Controller;
+      Stream     : DMA_Stream_Selector;
+      Data_Width : DMA_Data_Transfer_Widths)
+   is
+      Config : DMA_Stream_Configuration;
+   begin
+      --  See app note AN4187 Table 3 for this configuration (other than the
+      --  channel number). It works, although it looks counterintuitive.
+
+      Config.Channel                      := Channel_0;  -- arbitrary
+      Config.Direction                    := Memory_To_Memory;
+      Config.Memory_Data_Format           := Data_Width;
+      Config.Peripheral_Data_Format       := Words;
+      Config.Increment_Peripheral_Address := True;
+      Config.Increment_Memory_Address     := False;
+      Config.Operation_Mode               := Normal_Mode;
+      Config.Priority                     := Priority_Very_High;
+      Config.FIFO_Enabled                 := False;
+      Config.Memory_Burst_Size            := Memory_Burst_Single;
+      Config.Peripheral_Burst_Size        := Peripheral_Burst_Single;
+
+      Configure (Controller.all, Stream, Config);
+   end Configure_DMA;
+
+end STM32.CRC.DMA;

--- a/arch/ARM/STM32/drivers/crc_stm32f7/stm32-crc-dma.ads
+++ b/arch/ARM/STM32/drivers/crc_stm32f7/stm32-crc-dma.ads
@@ -1,0 +1,127 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2017, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  A driver for the Cyclic Redundancy Check CRC-32 calculation processor,
+--  using DMA to transfer the data to the CRC unit (instead of the CPU).
+
+--  Note this API is for the STM32 F4x family. Other STM MCUs have additional
+--  CRC capabilities.
+
+--  See also app note AN4187 "Using CRC through DMA"
+
+--  Example usage, assuming prior clock enabling for the CRC unit:
+
+--     Checksum_DMA : UInt32 := 0;
+--
+--     Data : constant Block_32 := ( .... );
+--
+--     ...
+--
+--     Enable_Clock (Controller);
+--
+--     Reset (Controller);
+--
+--     Reset_Calculator (CRC_Unit);  --  if need be
+--
+--     Update_CRC (CRC_Unit, Controller'Access, Stream, Input => Data);
+--
+--     DMA_IRQ_Handler.Await_Event (Next_DMA_Interrupt);
+--
+--     if Next_DMA_Interrupt /= Transfer_Complete_Interrupt then
+--        Panic;
+--     end if;
+--
+--     Checksum_DMA := Value (CRC_Unit);
+
+with STM32.DMA; use STM32.DMA;
+with System;
+
+package STM32.CRC.DMA is
+   pragma Elaborate_Body;
+
+   --  These routines use the specified controller and stream to transfer
+   --  all of the Input data components to This CRC unit, updating the
+   --  CRC value accordingly. At the end of the transfer the DMA interrupt
+   --  Transfer_Complete_Interrupt is triggered. Clients are expected to have
+   --  an application-defined handler for that interrupt, in order to await
+   --  completion of the transfer.
+
+   --  These routines can be called multiple times, back-to-back, presumably
+   --  with different input blocks, in order to update the value of the
+   --  calculated CRC checksum within the CRC processor. Each call will
+   --  result in a Transfer_Complete_Interrupt event.
+
+   --  Note that you can use a slice if the entire block is not intended for
+   --  transfer, but beware alignment boundaries to prevent copying of the
+   --  actual parameter into a temporary.
+
+   procedure Update_CRC
+     (This       : in out CRC_32;
+      Controller : access DMA_Controller;
+      Stream     : DMA_Stream_Selector;
+      Input      : Block_32);
+   --  Update the calculated CRC value based on all of the 32-bit components
+   --  of Input. Triggers the Transfer_Complete_Interrupt on completion.
+
+   procedure Update_CRC
+     (This       : in out CRC_32;
+      Controller : access DMA_Controller;
+      Stream     : DMA_Stream_Selector;
+      Input      : Block_16);
+   --  Update the calculated CRC value based on all of the 16-bit components
+   --  of Input. Triggers the Transfer_Complete_Interrupt on completion.
+
+   procedure Update_CRC
+     (This       : in out CRC_32;
+      Controller : access DMA_Controller;
+      Stream     : DMA_Stream_Selector;
+      Input      : Block_8);
+   --  Update the calculated CRC value based on all of the 8-bit components
+   --  of Input. Triggers the Transfer_Complete_Interrupt on completion.
+
+private
+
+   procedure Transfer_Input_To_CRC
+     (This          : in out CRC_32;
+      Controller    : access DMA_Controller;
+      Stream        : DMA_Stream_Selector;
+      Input_Address : System.Address;
+      Input_Length  : UInt16;
+      Data_Width    : DMA_Data_Transfer_Widths);
+   --  Configures the DMA controller and stream for transfering memory blocks,
+   --  of the width specified by Data_Width, to This CRC processor. Then uses
+   --  the controller and stream to transfer the data starting at Input_Address
+   --  to This CRC unit, updating the CRC value accordingly. The number of
+   --  Input memory items (of Data_Width size) to be transferred is specified
+   --  by Input_Length. At the end of the transfer the DMA interrupt
+   --  Transfer_Complete_Interrupt is triggered.
+
+end STM32.CRC.DMA;

--- a/arch/ARM/STM32/drivers/crc_stm32f7/stm32-crc.adb
+++ b/arch/ARM/STM32/drivers/crc_stm32f7/stm32-crc.adb
@@ -1,0 +1,135 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2017, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+package body STM32.CRC is
+
+   ----------------------
+   -- Reset_Calculator --
+   ----------------------
+
+   procedure Reset_Calculator (This : in out CRC_32) is
+   begin
+      This.CR.CR := True;
+   end Reset_Calculator;
+
+   -----------
+   -- Value --
+   -----------
+
+   function Value (This : CRC_32) return UInt32 is
+      (This.DR);
+
+   ----------------
+   -- Update_CRC --
+   ----------------
+
+   procedure Update_CRC
+     (This   : in out CRC_32;
+      Input  : UInt32;
+      Output : out UInt32)
+   is
+   begin
+      This.DR := Input;
+      --  Each write operation into the data register causes the device to
+      --  calculate a new CRC value based on the previous CRC value and Input,
+      --  so although this looks like a useless sequence that would just return
+      --  the Input value, it is necessary.
+      Output := This.DR;
+   end Update_CRC;
+
+   ----------------
+   -- Update_CRC --
+   ----------------
+
+   procedure Update_CRC
+     (This   : in out CRC_32;
+      Input  : Block_32;
+      Output : out UInt32)
+   is
+   begin
+      for K in Input'Range loop
+         This.DR := Input (K);
+      end loop;
+      Output := This.DR;
+   end Update_CRC;
+
+   ----------------
+   -- Update_CRC --
+   ----------------
+
+   procedure Update_CRC
+     (This   : in out CRC_32;
+      Input  : Block_16;
+      Output : out UInt32)
+   is
+   begin
+      for K in Input'Range loop
+         This.DR := UInt32 (Input (K));
+      end loop;
+      Output := This.DR;
+   end Update_CRC;
+
+   ----------------
+   -- Update_CRC --
+   ----------------
+
+   procedure Update_CRC
+     (This   : in out CRC_32;
+      Input  : Block_8;
+      Output : out UInt32)
+   is
+   begin
+      for K in Input'Range loop
+         This.DR := UInt32 (Input (K));
+      end loop;
+      Output := This.DR;
+   end Update_CRC;
+
+   --------------------------
+   -- Set_Independent_Data --
+   --------------------------
+
+   procedure Set_Independent_Data
+     (This  : in out CRC_32;
+      Value : UInt8)
+   is
+   begin
+      This.IDR.IDR := Value;
+   end Set_Independent_Data;
+
+   ----------------------
+   -- Independent_Data --
+   ----------------------
+
+   function Independent_Data (This : CRC_32) return UInt8 is
+     (This.IDR.IDR);
+
+end STM32.CRC;

--- a/arch/ARM/STM32/drivers/crc_stm32f7/stm32-crc.ads
+++ b/arch/ARM/STM32/drivers/crc_stm32f7/stm32-crc.ads
@@ -1,0 +1,115 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                       Copyright (C) 2017, AdaCore                        --
+--                                                                          --
+--  Redistribution and use in source and binary forms, with or without      --
+--  modification, are permitted provided that the following conditions are  --
+--  met:                                                                    --
+--     1. Redistributions of source code must retain the above copyright    --
+--        notice, this list of conditions and the following disclaimer.     --
+--     2. Redistributions in binary form must reproduce the above copyright --
+--        notice, this list of conditions and the following disclaimer in   --
+--        the documentation and/or other materials provided with the        --
+--        distribution.                                                     --
+--     3. Neither the name of the copyright holder nor the names of its     --
+--        contributors may be used to endorse or promote products derived   --
+--        from this software without specific prior written permission.     --
+--                                                                          --
+--   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS    --
+--   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT      --
+--   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR  --
+--   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT   --
+--   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, --
+--   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT       --
+--   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  --
+--   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  --
+--   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT    --
+--   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE  --
+--   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.   --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  A driver for the Cyclic Redundancy Check CRC-32 calculation processor.
+--  The CPU transfers the data to the CRC processor.
+
+--  Note this API is for the STM32 F4x family. Other STM MCUs have additional
+--  CRC capabilities.
+
+private with STM32_SVD.CRC;
+
+package STM32.CRC is
+   pragma Elaborate_Body;
+
+   type CRC_32 is limited private;
+
+   procedure Reset_Calculator (This : in out CRC_32) with
+     Post => Value (This) = 16#FFFF_FFFF#;
+   --  Reset the unit's calculator value to 16#FFFF_FFFF#. All previous
+   --  calculations due to calls to Update_CRC are lost. Does not affect
+   --  the contents of the unit's independent data.
+
+   function Value (This : CRC_32) return UInt32;
+   --  Returns the currently calculated CRC value, reflecting any prior calls
+   --  to Update_CRC. This is the same value returned via the Update_CRC.Output
+   --  parameter.
+
+   --  The Update_CRC routines can be called multiple times, back-to-back,
+   --  presumably with different input blocks, in order to update the value
+   --  of the calculated CRC checksum within the CRC processor with differing
+   --  input values.
+
+   procedure Update_CRC
+     (This   : in out CRC_32;
+      Input  : UInt32;
+      Output : out UInt32);
+   --  Updates the 32-bit CRC value in This from the 32-bit Input value and any
+   --  previously-calculated CRC value. Output is the resulting CRC-32 value.
+
+   type Block_32 is array (Positive range <>) of UInt32
+     with Component_Size => 32;
+
+   procedure Update_CRC
+     (This   : in out CRC_32;
+      Input  : Block_32;
+      Output : out UInt32);
+   --  Updates the 32-bit CRC value in This from the 32-bit Input values and
+   --  any previously-calculated CRC value. Output is the resulting CRC-32
+   --  value.
+
+   type Block_16 is array (Positive range <>) of UInt16
+     with Component_Size => 16;
+
+   procedure Update_CRC
+     (This   : in out CRC_32;
+      Input  : Block_16;
+      Output : out UInt32);
+   --  Updates the 32-bit CRC value in This from the 16-bit Input values and any
+   --  previously-calculated CRC value. Output is the resulting CRC-32 value.
+
+   type Block_8 is array (Positive range <>) of UInt8
+     with Component_Size => 8;
+
+   procedure Update_CRC
+     (This   : in out CRC_32;
+      Input  : Block_8;
+      Output : out UInt32);
+   --  Updates the 32-bit CRC value in This from the 8-bit Input values and any
+   --  previously-calculated CRC value. Output is the resulting CRC-32 value.
+
+   procedure Set_Independent_Data
+     (This  : in out CRC_32;
+      Value : UInt8);
+   --  Assign the internal "independent data" value. This value is an 8-bit
+   --  quantity that can be used for arbitrary purposes, eg temporary storage.
+   --  It is not affected by resetting the unit, nor is is affected by the CRC
+   --  calculations invoked by calls to Update_CRC, hence the "independent"
+   --  nature.
+
+   function Independent_Data (This : CRC_32) return UInt8;
+   --  Returns the current "independent data" value.
+
+private
+
+   type CRC_32 is new STM32_SVD.CRC.CRC_Peripheral;
+
+end STM32.CRC;

--- a/boards/stm32f746_discovery/stm32f746_discovery_full.gpr
+++ b/boards/stm32f746_discovery/stm32f746_discovery_full.gpr
@@ -114,6 +114,7 @@ library project STM32F746_Discovery_Full is
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/power_control_stm32f7", -- From MCU definition
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/ltdc/", -- From MCU definition
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/sai/", -- From MCU definition
+    Src_Dirs_Root & "/arch/ARM/STM32/drivers/crc_stm32f7/", -- manually added
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/sd/", -- From MCU definition
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/sd/sdmmc/", -- From MCU definition
     Src_Dirs_Root & "/middleware/src/filesystem", -- From middleware config

--- a/boards/stm32f746_discovery/stm32f746_discovery_sfp.gpr
+++ b/boards/stm32f746_discovery/stm32f746_discovery_sfp.gpr
@@ -114,6 +114,7 @@ library project STM32F746_Discovery_SFP is
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/power_control_stm32f7", -- From MCU definition
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/ltdc/", -- From MCU definition
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/sai/", -- From MCU definition
+    Src_Dirs_Root & "/arch/ARM/STM32/drivers/crc_stm32f7/", -- manually added
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/sd/", -- From MCU definition
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/sd/sdmmc/", -- From MCU definition
     Src_Dirs_Root & "/middleware/src/filesystem", -- From middleware config

--- a/boards/stm32f769_discovery/stm32f769_discovery_full.gpr
+++ b/boards/stm32f769_discovery/stm32f769_discovery_full.gpr
@@ -115,6 +115,7 @@ library project STM32F769_Discovery_Full is
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/ltdc/", -- From MCU definition
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/dsi/", -- From MCU definition
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/sai/", -- From MCU definition
+    Src_Dirs_Root & "/arch/ARM/STM32/drivers/crc_stm32f7/", -- manually added
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/sd/", -- From MCU definition
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/sd/sdmmc/", -- From MCU definition
     Src_Dirs_Root & "/middleware/src/filesystem", -- From middleware config

--- a/boards/stm32f769_discovery/stm32f769_discovery_sfp.gpr
+++ b/boards/stm32f769_discovery/stm32f769_discovery_sfp.gpr
@@ -115,6 +115,7 @@ library project STM32F769_Discovery_SFP is
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/ltdc/", -- From MCU definition
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/dsi/", -- From MCU definition
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/sai/", -- From MCU definition
+    Src_Dirs_Root & "/arch/ARM/STM32/drivers/crc_stm32f7/", -- manually added
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/sd/", -- From MCU definition
     Src_Dirs_Root & "/arch/ARM/STM32/drivers/sd/sdmmc/", -- From MCU definition
     Src_Dirs_Root & "/middleware/src/filesystem", -- From middleware config

--- a/scripts/config/devices.py
+++ b/scripts/config/devices.py
@@ -152,6 +152,7 @@ def load_device_config(config, source_dir):
                 'arch/ARM/STM32/drivers/ltdc/',
                 'arch/ARM/STM32/drivers/sai/',
                 'arch/ARM/STM32/drivers/sd/',
+                'arch/ARM/STM32/drivers/crc_stm32f7/',
                 'arch/ARM/STM32/drivers/sd/sdmmc/']
 
     elif mcu == 'STM32F769NIHx':
@@ -167,6 +168,7 @@ def load_device_config(config, source_dir):
                 'arch/ARM/STM32/drivers/ltdc/',
                 'arch/ARM/STM32/drivers/dsi/',
                 'arch/ARM/STM32/drivers/sai/',
+                'arch/ARM/STM32/drivers/crc_stm32f7/',
                 'arch/ARM/STM32/drivers/sd/',
                 'arch/ARM/STM32/drivers/sd/sdmmc/']
 


### PR DESCRIPTION
The CRC unit on the F7x MCUs (and others) has the additional ability to define the initial value and the polynomial value, but the same core capabilities of the F4 are present. 

* devices/stm32f7x/stm32-device.adb and ads: 
  - Add declaration of CRC unit and procedure to enable the clock
  - Correct comment block header describing the package spec (it had said it was for F4x)

* arch/ARM/STM32/drivers/crc_stm32f7/*
  - Add new source folder and source files for the STM32 CRC unit package spec and body, with the DMA child package.
  - Add readme.txt decribing these new files, explaining that the F7x has additional capabilities but the same core 
    abilities as the F4x. These files are just a copy of the F4 sources, but that way we can enhance them to add the F7x 
    capabilities eventually, without precluding their use with Fx devices in the meantime. Worth exploring use of Ada's 
   static inheritance, using the F4 version as the parent type, but IFF the additional F7 capabilities don't require additional
   record components.

* boards/stm32f746_discovery/stm32f746_discovery_full.gpr:
    - Manually added source new folder for the F7x CRC
    
* scripts/config/devices.py:
  - Added source new folder for the F7x CRC