### PR TITLE
Use pragma instead of aspect for Interrupt_Priority on Serial_Port

### DIFF
--- a/examples/shared/serial_ports/src/serial_io-nonblocking.ads
+++ b/examples/shared/serial_ports/src/serial_io-nonblocking.ads
@@ -77,9 +77,11 @@ private
      (Device       : not null access USART;
       IRQ          : Interrupt_ID;
       IRQ_Priority : Interrupt_Priority)
-   with
-      Interrupt_Priority => IRQ_Priority
    is
+      pragma Interrupt_Priority (IRQ_Priority);
+      --  FIXME: this is supposed to be an aspect, however with FSF GNAT 12
+      --  the compiler does not have IRQ_Priority in scope when an aspect is
+      --  used and rejects it.
 
       procedure Start_Sending (Msg : not null access Message);
 

--- a/scripts/build_all_examples.py
+++ b/scripts/build_all_examples.py
@@ -5,7 +5,7 @@ import os
 import os.path
 import subprocess
 import sys
-import distutils.spawn
+import shutil
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -173,7 +173,7 @@ projects = [
             ]
 
 # Check if RISC-V32 compiler is available
-if distutils.spawn.find_executable("riscv64-elf-gnatls"):
+if shutil.which("riscv64-elf-gnatls"):
 
     # Add RISC-V32 projects
     projects += ["/examples/HiFive1/hifive1_example.gpr"]


### PR DESCRIPTION
The definition of Serial_Port uses the aspect Interrupt_Priority taking a value from the specified discriminants. However the discriminant is not visible in this scope. Use a pragma in the definition of the type instead where the discriminant is visible.

ref #466