### PR TITLE
Correct speed for SDRAM GPIO pins at higher SDCLK speeds

### DIFF
--- a/boards/stm32_common/sdram/stm32-sdram.adb
+++ b/boards/stm32_common/sdram/stm32-sdram.adb
@@ -58,7 +58,7 @@ package body STM32.SDRAM is
       Configure_IO (SDRAM_PINS,
                     (Mode           => Mode_AF,
                      AF             => GPIO_AF_FMC_12,
-                     AF_Speed       => Speed_50MHz,
+                     AF_Speed       => Speed_Very_High,
                      AF_Output_Type => Push_Pull,
                      Resistors      => Pull_Up));
 
@@ -242,6 +242,5 @@ package body STM32.SDRAM is
 
       return Ret;
    end Reserve;
-
 
 end STM32.SDRAM;


### PR DESCRIPTION
With a SYSCLK at 216MHz, the SDCLK is 108MHz. A GPIO output speed of Speed_50MHz is insufficient for a 108MHz signal. 50MHZ is borderline, and can (does) cause signal integrity issues, especially on a board with marginal silicon. It should be Speed_100MHz or Speed_Very_High (the STM32F7 HAL uses GPIO_SPEED_FREQ_VERY_HIGH for FMC pins). 

I have observed this change to be necessary at a SYSCLK setting of 216MHz on an F746.