### PR TITLE
Add missing procedures for CRC_32 for F7x

### DIFF
--- a/arch/ARM/STM32/devices/stm32f7x/stm32-device.adb
+++ b/arch/ARM/STM32/devices/stm32f7x/stm32-device.adb
@@ -1099,4 +1099,25 @@ package body STM32.Device is
       RCC_Periph.AHB1ENR.CRCEN := True;
    end Enable_Clock;
 
+   -------------------
+   -- Disable_Clock --
+   -------------------
+
+   procedure Disable_Clock (This : in out CRC_32) is
+      pragma Unreferenced (This);
+   begin
+      RCC_Periph.AHB1ENR.CRCEN := False;
+   end Disable_Clock;
+
+   -----------
+   -- Reset --
+   -----------
+
+   procedure Reset (This : in out CRC_32) is
+      pragma Unreferenced (This);
+   begin
+      RCC_Periph.AHB1RSTR.CRCRST := True;
+      RCC_Periph.AHB1RSTR.CRCRST := False;
+   end Reset;
+
 end STM32.Device;

--- a/arch/ARM/STM32/devices/stm32f7x/stm32-device.ads
+++ b/arch/ARM/STM32/devices/stm32f7x/stm32-device.ads
@@ -551,6 +551,10 @@ package STM32.Device is
 
    procedure Enable_Clock (This : in out CRC_32);
 
+   procedure Disable_Clock (This : in out CRC_32);
+
+   procedure Reset (This : in out CRC_32);
+
    -----------
    -- SDMMC --
    -----------


### PR DESCRIPTION
Unlike the other devices with a CRC unit, the F7x STM32.Device package had the Enable_Clock routine but not the Disable_Clock and Reset procedures. Adding them here...