### PR TITLE
Add asynchronous reload/update capability to the LTDC and Framebuffer_LTDC packages

### DIFF
--- a/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.adb
+++ b/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.adb
@@ -235,6 +235,24 @@ package body STM32.LTDC is
       end if;
    end Reload_Config;
 
+   -------------------------
+   -- Reload_Config_Async --
+   -------------------------
+
+   procedure Reload_Config_Async is
+   begin
+      Sync.Apply_On_VSync;
+   end Reload_Config_Async;
+
+   ---------------------
+   -- Wait_For_Reload --
+   ---------------------
+
+   procedure Wait_For_Reload is
+   begin
+      Sync.Wait;
+   end Wait_For_Reload;
+
    ------------------
    -- To_LTDC_Mode --
    ------------------

--- a/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.adb
+++ b/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.adb
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                 Copyright (C) 2015-2016, AdaCore                         --
+--                 Copyright (C) 2015-2026, AdaCore                         --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --

--- a/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.ads
+++ b/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                    Copyright (C) 2015, AdaCore                           --
+--                  Copyright (C) 2015-2026, AdaCore                        --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --

--- a/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.ads
+++ b/arch/ARM/STM32/drivers/ltdc/stm32-ltdc.ads
@@ -110,6 +110,35 @@ package STM32.LTDC is
 
    procedure Reload_Config (Immediate : Boolean := False);
 
+   procedure Reload_Config_Async;
+   --  Request a register reload at the next vertical blank and return
+   --  immediately, without waiting for the LTDC to apply it. The caller
+   --  can then do other useful work while the LTDC finishes scanning
+   --  the current frame and performs the reload at vertical blank,
+   --  rather than stalling on a hardware-paced wait whose length is
+   --  determined by display timing rather than by anything the caller
+   --  controls.
+   --
+   --  The now-hidden buffer remains live to the LTDC until the swap
+   --  takes effect, so the caller must leave that buffer untouched
+   --  until Wait_For_Reload returns.
+   --
+   --  Prefer the synchronous Reload_Config (Immediate => False) when
+   --  the next operation must read or write the now-hidden buffer
+   --  (for example a Copy_Back of the newly visible image into the
+   --  new hidden buffer): it blocks until the LTDC confirms the
+   --  reload, so the buffer the caller treats as hidden really is no
+   --  longer being scanned out. Use Reload_Config (Immediate => True)
+   --  only at setup or configuration time, when an unconditional
+   --  reload that is not aligned to vertical blank is acceptable.
+
+   procedure Wait_For_Reload;
+   --  Block until the LTDC has applied a reload previously requested by
+   --  Reload_Config_Async. Returns immediately if no reload is pending. Call
+   --  before any operation that needs the new buffer to be visible, or that
+   --  must write into the now-hidden buffer that the LTDC may still be
+   --  scanning.
+
    function To_LTDC_Mode (HAL_Mode : HAL.Framebuffer.FB_Color_Mode)
                           return STM32.LTDC.Pixel_Format;
    --  Convert HAL.Framebuffer color mode to LTDC color mode

--- a/boards/stm32_common/ltdc/framebuffer_ltdc.adb
+++ b/boards/stm32_common/ltdc/framebuffer_ltdc.adb
@@ -486,6 +486,29 @@ package body Framebuffer_LTDC is
       end loop;
    end Update_Layers;
 
+   ------------------------
+   -- Update_Layer_Async --
+   ------------------------
+
+   procedure Update_Layer_Async
+     (Display : in out Frame_Buffer;
+      Layer   : Positive)
+   is
+   begin
+      Internal_Update_Layer (Display, Layer);
+      STM32.LTDC.Reload_Config_Async;
+   end Update_Layer_Async;
+
+   ---------------------
+   -- Wait_For_Update --
+   ---------------------
+
+   procedure Wait_For_Update (Display : in out Frame_Buffer) is
+      pragma Unreferenced (Display);
+   begin
+      STM32.LTDC.Wait_For_Reload;
+   end Wait_For_Update;
+
    ----------------
    -- Color_Mode --
    ----------------

--- a/boards/stm32_common/ltdc/framebuffer_ltdc.ads
+++ b/boards/stm32_common/ltdc/framebuffer_ltdc.ads
@@ -1,6 +1,6 @@
 ------------------------------------------------------------------------------
 --                                                                          --
---                     Copyright (C) 2015-2016, AdaCore                     --
+--                     Copyright (C) 2015-2026, AdaCore                     --
 --                                                                          --
 --  Redistribution and use in source and binary forms, with or without      --
 --  modification, are permitted provided that the following conditions are  --

--- a/boards/stm32_common/ltdc/framebuffer_ltdc.ads
+++ b/boards/stm32_common/ltdc/framebuffer_ltdc.ads
@@ -138,6 +138,33 @@ package Framebuffer_LTDC is
    --  Updates all initialized layers at once with their respective hidden
    --  buffer
 
+   procedure Update_Layer_Async
+     (Display : in out Frame_Buffer;
+      Layer   : Positive)
+     with Pre => Initialized (Display, Layer);
+   --  Like Update_Layer (without Copy_Back) but returns without waiting
+   --  for the LTDC to apply the swap. The caller can then do other
+   --  useful work while the LTDC finishes scanning the current frame
+   --  and performs the reload at vertical blank, rather than stalling
+   --  on a hardware-paced wait whose length is determined by display
+   --  timing.
+   --
+   --  Until the swap takes effect the LTDC keeps scanning what is now
+   --  the hidden buffer, so callers must not write to it until
+   --  Wait_For_Update has returned. There is no Copy_Back option:
+   --  copying into the now-hidden buffer would race with the
+   --  in-progress scanout.
+   --
+   --  Prefer the synchronous Update_Layer when the next operation must
+   --  read or write the now-hidden buffer (for example Update_Layer
+   --  with Copy_Back => True): it blocks until the LTDC has applied
+   --  the swap, so the buffer the caller treats as hidden really is
+   --  no longer being scanned out.
+
+   procedure Wait_For_Update (Display : in out Frame_Buffer);
+   --  Block until any reload requested by Update_Layer_Async has been
+   --  applied by the LTDC. No-op if no reload is pending.
+
    overriding function Color_Mode
      (Display : Frame_Buffer;
       Layer   : Positive) return HAL.Framebuffer.FB_Color_Mode


### PR DESCRIPTION
* STM32.LTDC:
  - Add procedures Reload_Config_Async and Wait_For_Reload

* Framebuffer_LTDC:
  - Add procedures Update_Layer_Async and Wait_For_Update.

The new asynchronous versions request a register reload at the next vertical blank and return immediately. The Wait_* routines block until the LTDC has applied a pending reload (or return immediately when none is pending).

Note that, in package Framebuffer_LTDC, the new procedures are not overriding. I did not add them to the abstract parent type in HAL.Framebuffer because there are numerous concrete type extensions that I am not familiar with, and it is not clear to me that all of them can do this asynchronous protocol.

Rationale: the current synchronous Reload_Config / Update_Layer must wait for the LTDC to confirm the swap, which is paced by the display timing and can amount to up to one full vertical refresh interval of CPU dead time per call. Callers that fully repaint each frame and never read the now-hidden buffer get nothing useful for that wait. The additional asynchronous API lets them pipeline the swap with the next frame's draw preparation, for example, or other work that does not touch the now-hidden buffer, and resync explicitly only when an operation actually needs the new buffer state. In a tight (eg, 50ms) periodic loop the time savings can be essentil to meeting the deadline.