### PR TITLE
Fix path to svd2ada binary in svd.mk

### DIFF
--- a/arch/svd.mk
+++ b/arch/svd.mk
@@ -8,21 +8,21 @@ all: svd
 
 svd:
 	rm -rf $(STM_DIR)/stm32*
-	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F40x.svd --boolean -o $(STM_DIR)/stm32f40x -p STM32_SVD --base-types-package HAL --gen-uint-always
-	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F429x.svd --boolean -o $(STM_DIR)/stm32f429x -p STM32_SVD --base-types-package HAL --gen-uint-always
-	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F46_79x.svd --boolean -o $(STM_DIR)/stm32f46_79x -p STM32_SVD --base-types-package HAL --gen-uint-always
-	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F7x.svd --boolean -o $(STM_DIR)/stm32f7x -p STM32_SVD --base-types-package HAL --gen-uint-always
-	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F7x9.svd --boolean -o $(STM_DIR)/stm32f7x9 -p STM32_SVD --base-types-package HAL --gen-uint-always
+	$(SVD2ADA_DIR)/bin/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F40x.svd --boolean -o $(STM_DIR)/stm32f40x -p STM32_SVD --base-types-package HAL --gen-uint-always
+	$(SVD2ADA_DIR)/bin/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F429x.svd --boolean -o $(STM_DIR)/stm32f429x -p STM32_SVD --base-types-package HAL --gen-uint-always
+	$(SVD2ADA_DIR)/bin/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F46_79x.svd --boolean -o $(STM_DIR)/stm32f46_79x -p STM32_SVD --base-types-package HAL --gen-uint-always
+	$(SVD2ADA_DIR)/bin/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F7x.svd --boolean -o $(STM_DIR)/stm32f7x -p STM32_SVD --base-types-package HAL --gen-uint-always
+	$(SVD2ADA_DIR)/bin/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F7x9.svd --boolean -o $(STM_DIR)/stm32f7x9 -p STM32_SVD --base-types-package HAL --gen-uint-always
 
 	rm -rf $(CORTEX_DIR)/cm*
-	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Cortex_M/cm0.svd --boolean -o $(CORTEX_DIR)/cm0 -p Cortex_M_SVD --base-types-package HAL --gen-uint-always
-	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Cortex_M/cm7.svd --boolean -o $(CORTEX_DIR)/cm7 -p Cortex_M_SVD --base-types-package HAL --gen-uint-always
-	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Cortex_M/cm4.svd --boolean -o $(CORTEX_DIR)/cm4 -p Cortex_M_SVD --base-types-package HAL --gen-uint-always
-	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Cortex_M/cm4f.svd --boolean -o $(CORTEX_DIR)/cm4f -p Cortex_M_SVD --base-types-package HAL --gen-uint-always
+	$(SVD2ADA_DIR)/bin/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Cortex_M/cm0.svd --boolean -o $(CORTEX_DIR)/cm0 -p Cortex_M_SVD --base-types-package HAL --gen-uint-always
+	$(SVD2ADA_DIR)/bin/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Cortex_M/cm7.svd --boolean -o $(CORTEX_DIR)/cm7 -p Cortex_M_SVD --base-types-package HAL --gen-uint-always
+	$(SVD2ADA_DIR)/bin/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Cortex_M/cm4.svd --boolean -o $(CORTEX_DIR)/cm4 -p Cortex_M_SVD --base-types-package HAL --gen-uint-always
+	$(SVD2ADA_DIR)/bin/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Cortex_M/cm4f.svd --boolean -o $(CORTEX_DIR)/cm4f -p Cortex_M_SVD --base-types-package HAL --gen-uint-always
 
 	rm -rf $(NORDIC_DIR)/nrf*
-	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Nordic/nrf51.svd --boolean -o $(NORDIC_DIR)/nrf51 -p NRF_SVD --base-types-package HAL --gen-uint-always
-	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Nordic/nrf52.svd --boolean -o $(NORDIC_DIR)/nrf52 -p NRF_SVD --base-types-package HAL --gen-uint-always
+	$(SVD2ADA_DIR)/bin/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Nordic/nrf51.svd --boolean -o $(NORDIC_DIR)/nrf51 -p NRF_SVD --base-types-package HAL --gen-uint-always
+	$(SVD2ADA_DIR)/bin/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/Nordic/nrf52.svd --boolean -o $(NORDIC_DIR)/nrf52 -p NRF_SVD --base-types-package HAL --gen-uint-always
 
 	rm -rf $(SIFIVE_DIR)/FE*
-	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/SiFive/FE310.svd --boolean -o $(SIFIVE_DIR)/FE310 -p FE310_SVD --base-types-package HAL --gen-uint-always
+	$(SVD2ADA_DIR)/bin/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/SiFive/FE310.svd --boolean -o $(SIFIVE_DIR)/FE310 -p FE310_SVD --base-types-package HAL --gen-uint-always


### PR DESCRIPTION
I believe svd.mk assumes outdated structure for svd2ada tool. Currently, binary is located in bin/ directory.

Running svd.mk updates many existing driver files. Is this expected or something is wrong?

I had problem running svd.mk, because STM32F7x9.svd in svd2ada/CMSIS-SVD/ST/ was corrupted or outdated. Here is the error i was getting:
```
Fatal error when parsing the SVD file:
STM32F7x9.svd:22934:7: Name differ for closing tag (expecting register, opened line 22567)
```

I fixed it by downloading recent version from [here](https://github.com/cmsis-svd/cmsis-svd-data/). I plan to make a pull request with this update to svd2ada repository soon.