### PR TITLE
Fix bug in STM32.EXTI#Enable_External_Event

### DIFF
--- a/arch/ARM/STM32/drivers/stm32-exti.adb
+++ b/arch/ARM/STM32/drivers/stm32-exti.adb
@@ -87,9 +87,9 @@ package body STM32.EXTI is
    begin
       EXTI_Periph.EMR.MR.Arr (Index)  := True;
       EXTI_Periph.RTSR.TR.Arr (Index) :=
-        Trigger in Interrupt_Rising_Edge  | Interrupt_Rising_Falling_Edge;
+        Trigger in Event_Rising_Edge  | Event_Rising_Falling_Edge;
       EXTI_Periph.FTSR.TR.Arr (Index) :=
-        Trigger in Interrupt_Falling_Edge | Interrupt_Rising_Falling_Edge;
+        Trigger in Event_Falling_Edge | Event_Rising_Falling_Edge;
    end Enable_External_Event;
 
    ----------------------------


### PR DESCRIPTION
I believe `Enable_External_Event` should check for `Event_*` triggers instead of `Interrupt_*`.